### PR TITLE
fix(cli): create the Maple home before first-run startup touches its siblings

### DIFF
--- a/apps/cli/src/commands/server.ts
+++ b/apps/cli/src/commands/server.ts
@@ -348,6 +348,14 @@ export const start = Command.make("start", {
 			)
 			const pidPath = pidFilePath(dataDir)
 
+			// First run: `~/.maple` does not exist yet, and everything startup touches
+			// before the data dir itself — the PID file, the `--background` log, the
+			// restore/reset transactions, the migration journal, the maintenance lock —
+			// is a *sibling* of the data dir, i.e. lives in that missing parent. Create
+			// it up front so first-run ordering is a stated precondition rather than a
+			// side effect of whichever helper happens to run first.
+			yield* fs.makeDirectory(dirname(dataDir), { recursive: true })
+
 			// Already-running guard.
 			const existingPid = yield* readPid(fs, pidPath)
 			if (Option.isSome(existingPid) && isProcessAlive(existingPid.value)) {

--- a/apps/cli/test/archive-pins.test.ts
+++ b/apps/cli/test/archive-pins.test.ts
@@ -241,6 +241,23 @@ describe("maintenance lock", () => {
 		})
 	})
 
+	// First run on a clean machine: `~/.maple` does not exist, so the lock — a
+	// *sibling* of `~/.maple/data` — has no parent to be created in. `maple start`
+	// reconciles checkpoint recovery under this lock before it creates any
+	// directory, so an ENOENT here is a hard startup failure, not a warning.
+	it("acquires the lock when the data dir's parent does not exist yet", async () => {
+		const root = mkdtempSync(join(tmpdir(), "maple-first-run-lock-test-"))
+		const dataDir = join(root, ".maple", "data")
+		try {
+			ok(!existsSync(dirname(dataDir)), "precondition: the maple home is absent")
+			const result = await withMaintenanceLock(dataDir, newCheckpointId(), async () => "done")
+			strictEqual(result, "done")
+			ok(!existsSync(`${dataDir}.maple-maintenance-lock`), "maintenance lock released")
+		} finally {
+			rmSync(root, { recursive: true, force: true })
+		}
+	})
+
 	it("releases the lock even when the task throws", async () => {
 		await withDataDir(async (dataDir) => {
 			await rejects(

--- a/apps/cli/test/checkpoints.test.ts
+++ b/apps/cli/test/checkpoints.test.ts
@@ -805,6 +805,21 @@ describe("live restore transaction reconciliation", () => {
 		})
 	})
 
+	// `maple start` reconciles recovery before it creates any directory, so on a
+	// clean machine this runs with `~/.maple` itself absent — and every path it
+	// touches (transaction journal, quarantine, maintenance lock) is a sibling of
+	// the data dir, living in that missing parent.
+	it("is a no-op on first run, when the data dir's parent does not exist yet", async () => {
+		const root = mkdtempSync(join(tmpdir(), "maple-first-run-recovery-test-"))
+		const dataDir = join(root, ".maple", "data")
+		try {
+			ok(!existsSync(dirname(dataDir)), "precondition: the maple home is absent")
+			await Effect.runPromise(reconcileCheckpointRecovery(dataDir))
+		} finally {
+			rmSync(root, { recursive: true, force: true })
+		}
+	})
+
 	it("preserves an interrupted pre-ready restore and leaves the old live store selected", async () => {
 		await withDataDir(async (dataDir) => {
 			const operationId = newCheckpointOperationId()


### PR DESCRIPTION
Reported from a fresh install: the first `maple start` on a machine with no `~/.maple` dies with a bare filesystem error.

```
ERROR (#3): @maple/cli/ServerError: ENOENT: no such file or directory,
mkdir '/Users/…/.maple/data.maple-maintenance-lock'
```

## Why it happens

`start` reconciles checkpoint recovery *before* it creates any directory — deliberately, so a restore or reset transaction is settled before reset/compatibility/dirty-store logic runs. That reconciliation takes the maintenance lock, and the lock — like the PID file, the `--background` log, the restore/reset transactions and the migration journal — is a **sibling** of the data dir. On first run its parent (`~/.maple`) does not exist, so the `mkdir` fails.

`acquireMaintenance` has created that parent since v0.0.15 (`9b5ea73`), so the crash only reproduces on older builds — the report is from a Homebrew install still on 0.0.13. There was no test holding the invariant, and it was an emergent property of one helper rather than a stated precondition of startup.

## Change

- `start` creates the data dir's parent as its first filesystem step. The data dir itself is still created where it was, after recovery reconciliation, so restore/reset reconciliation keeps seeing the tree exactly as it left it.
- Two regression tests, both against a data dir whose parent is absent: maintenance-lock acquisition, and recovery reconciliation. Removing the parent creation from `acquireMaintenance` makes both fail with the reported ENOENT.

## Verification

- `bun run test` in `apps/cli` — 434 pass, 0 fail.
- `bun typecheck` in `apps/cli` — clean.
- `HOME=<empty dir> maple start` from source: creates `~/.maple/data` and reaches chDB open (which then stops on `libchdb not found`, expected in a source checkout — release bundles ship it). Before the fix the same run on 0.0.13's code path stops at the lock `mkdir`.

Note for the reporter: the Homebrew tap is still serving 0.0.13, several tags behind. `brew upgrade` will only pick this up once the tap formula is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789156272&installation_model_id=427786&pr_number=446&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F446&signature=893b59c51ea48218d58f642cdf7531a676a3fcf3739150a5743c675d61c6edfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->