### PR TITLE
fix(cli): accept v0.0.13/v0.0.14 schema fingerprints as legacy v0

### DIFF
--- a/apps/cli/src/server/local-schema-history.ts
+++ b/apps/cli/src/server/local-schema-history.ts
@@ -13,10 +13,6 @@ export interface LocalSchemaHistoryEntry {
 	readonly digest: string
 	readonly manifestDigest: string
 	readonly projectRevision: string
-	readonly variants?: ReadonlyArray<{
-		readonly fingerprint: string
-		readonly projectRevision: string
-	}>
 }
 
 export const LOCAL_SCHEMA_HISTORY: ReadonlyArray<LocalSchemaHistoryEntry> = Object.freeze([
@@ -26,20 +22,6 @@ export const LOCAL_SCHEMA_HISTORY: ReadonlyArray<LocalSchemaHistoryEntry> = Obje
 		digest: "",
 		manifestDigest: "",
 		projectRevision: "d58ce4a83d3ad3f3a29b9bb972272b757547ae793c050194354454634f3abccd",
-		variants: Object.freeze([
-			Object.freeze({
-				fingerprint: "428701854f9fd30e",
-				projectRevision: "d58ce4a83d3ad3f3a29b9bb972272b757547ae793c050194354454634f3abccd",
-			}),
-			Object.freeze({
-				fingerprint: "ea2d7ee4f385544e",
-				projectRevision: "ffade4bccc59af00fd33a561c4c919fd0229e0505f659d3242081f670f034a41",
-			}),
-			Object.freeze({
-				fingerprint: "06d3f9912027129b",
-				projectRevision: "c3f2be342187b6f6cf09010043e775b68f0901081a9b861803e55f5fe299e4c6",
-			}),
-		]),
 	}),
 	Object.freeze({
 		version: 1,

--- a/apps/cli/src/server/local-schema-history.ts
+++ b/apps/cli/src/server/local-schema-history.ts
@@ -13,6 +13,10 @@ export interface LocalSchemaHistoryEntry {
 	readonly digest: string
 	readonly manifestDigest: string
 	readonly projectRevision: string
+	readonly variants?: ReadonlyArray<{
+		readonly fingerprint: string
+		readonly projectRevision: string
+	}>
 }
 
 export const LOCAL_SCHEMA_HISTORY: ReadonlyArray<LocalSchemaHistoryEntry> = Object.freeze([
@@ -22,6 +26,20 @@ export const LOCAL_SCHEMA_HISTORY: ReadonlyArray<LocalSchemaHistoryEntry> = Obje
 		digest: "",
 		manifestDigest: "",
 		projectRevision: "d58ce4a83d3ad3f3a29b9bb972272b757547ae793c050194354454634f3abccd",
+		variants: Object.freeze([
+			Object.freeze({
+				fingerprint: "428701854f9fd30e",
+				projectRevision: "d58ce4a83d3ad3f3a29b9bb972272b757547ae793c050194354454634f3abccd",
+			}),
+			Object.freeze({
+				fingerprint: "ea2d7ee4f385544e",
+				projectRevision: "ffade4bccc59af00fd33a561c4c919fd0229e0505f659d3242081f670f034a41",
+			}),
+			Object.freeze({
+				fingerprint: "06d3f9912027129b",
+				projectRevision: "c3f2be342187b6f6cf09010043e775b68f0901081a9b861803e55f5fe299e4c6",
+			}),
+		]),
 	}),
 	Object.freeze({
 		version: 1,

--- a/apps/cli/src/server/local-store-migrations.ts
+++ b/apps/cli/src/server/local-store-migrations.ts
@@ -15,6 +15,7 @@ import {
 	LOCAL_SCHEMA_V1,
 	LOCAL_SCHEMA_SQL,
 	identityLabel,
+	legacyLocalSchemaIdentity,
 	type LocalSchemaIdentity,
 } from "./schema-identity"
 import {
@@ -190,8 +191,8 @@ export const identityFromMarker = (marker: StoreMarker): LocalSchemaIdentity | n
 			chdb: marker.chdb,
 		}
 	}
-	if (marker.schema === LEGACY_LOCAL_SCHEMA.fingerprint)
-		return { ...LEGACY_LOCAL_SCHEMA, chdb: marker.chdb }
+	const legacyIdentity = legacyLocalSchemaIdentity(marker.schema)
+	if (legacyIdentity) return { ...legacyIdentity, chdb: marker.chdb }
 	if (marker.schema === LOCAL_SCHEMA_V1.fingerprint) return { ...LOCAL_SCHEMA_V1, chdb: marker.chdb }
 	return null
 }
@@ -240,7 +241,9 @@ export const resolveMigrationChain = (
 		const migration = byFrom.get(current.version)
 		if (
 			!migration ||
-			migration.from.fingerprint !== current.fingerprint ||
+			(migration.from.version === LEGACY_LOCAL_SCHEMA.version
+				? legacyLocalSchemaIdentity(current.fingerprint) === null
+				: migration.from.fingerprint !== current.fingerprint) ||
 			(migration.from.digest !== "" &&
 				current.digest !== "" &&
 				migration.from.digest !== current.digest)
@@ -423,17 +426,32 @@ const parseStep = (value: unknown, index: number): MigrationStepJournal => {
 const sameJournalIdentity = (a: LocalSchemaIdentity, b: LocalSchemaIdentity): boolean =>
 	a.version === b.version && a.fingerprint === b.fingerprint && a.digest === b.digest && a.chdb === b.chdb
 
+/** The journal's top-level source identity records the store marker as found
+ * (any registered legacy variant), while chain steps carry the frozen module
+ * identities — for the legacy edge, the canonical v0 identity. Both are
+ * correct, so the first-step invariant accepts any registered v0 variant. */
+const sourceMatchesFirstStep = (source: LocalSchemaIdentity, firstFrom: LocalSchemaIdentity): boolean =>
+	sameJournalIdentity(source, firstFrom) ||
+	(source.version === LEGACY_LOCAL_SCHEMA.version &&
+		firstFrom.version === LEGACY_LOCAL_SCHEMA.version &&
+		source.chdb === firstFrom.chdb &&
+		legacyLocalSchemaIdentity(source.fingerprint) !== null &&
+		legacyLocalSchemaIdentity(firstFrom.fingerprint) !== null)
+
 const assertJournalChainInvariants = (journal: MigrationJournal): void => {
 	const { chain, currentStepIndex: current } = journal
 	if (current < 0 || current > chain.length)
 		throw new Error("migration journal currentStepIndex is invalid")
 	if (
-		!sameJournalIdentity(chain[0]!.from, {
-			version: journal.sourceVersion,
-			fingerprint: journal.sourceFingerprint,
-			digest: journal.sourceDigest,
-			chdb: journal.sourceChdb,
-		})
+		!sourceMatchesFirstStep(
+			{
+				version: journal.sourceVersion,
+				fingerprint: journal.sourceFingerprint,
+				digest: journal.sourceDigest,
+				chdb: journal.sourceChdb,
+			},
+			chain[0]!.from,
+		)
 	)
 		throw new Error("migration journal source identity does not match its first step")
 	if (

--- a/apps/cli/src/server/schema-identity.ts
+++ b/apps/cli/src/server/schema-identity.ts
@@ -25,6 +25,20 @@ export const LEGACY_LOCAL_SCHEMA_VERSION = 0 as const
 export const LEGACY_SCHEMA_PROJECT_REVISION =
 	"d58ce4a83d3ad3f3a29b9bb972272b757547ae793c050194354454634f3abccd"
 export const LEGACY_SCHEMA_FINGERPRINT = "428701854f9fd30e"
+export const LEGACY_SCHEMA_VARIANTS = LOCAL_SCHEMA_HISTORY[0]!.variants!
+export const LEGACY_SCHEMA_FINGERPRINTS: ReadonlyArray<string> = Object.freeze(
+	LEGACY_SCHEMA_VARIANTS.map((variant) => variant.fingerprint),
+)
+
+export const legacyLocalSchemaIdentity = (fingerprint: string): LocalSchemaIdentity | null => {
+	const variant = LEGACY_SCHEMA_VARIANTS.find((candidate) => candidate.fingerprint === fingerprint)
+	if (!variant) return null
+	return {
+		...LEGACY_LOCAL_SCHEMA,
+		fingerprint: variant.fingerprint,
+		projectRevision: variant.projectRevision,
+	}
+}
 
 export const CURRENT_SCHEMA_PROJECT_REVISION =
 	"3bf63ab19fcba1a20ebaf6a97b49acfc2ecf00f1589c11438349bb87d21f77b7"

--- a/apps/cli/src/server/schema-identity.ts
+++ b/apps/cli/src/server/schema-identity.ts
@@ -25,7 +25,30 @@ export const LEGACY_LOCAL_SCHEMA_VERSION = 0 as const
 export const LEGACY_SCHEMA_PROJECT_REVISION =
 	"d58ce4a83d3ad3f3a29b9bb972272b757547ae793c050194354454634f3abccd"
 export const LEGACY_SCHEMA_FINGERPRINT = "428701854f9fd30e"
-export const LEGACY_SCHEMA_VARIANTS = LOCAL_SCHEMA_HISTORY[0]!.variants!
+/**
+ * Every schema fingerprint that identifies a pre-versioning (legacy v0) local
+ * store. v0.0.12 shipped the original; v0.0.13/v0.0.14 shipped structurally
+ * identical raw tables under refreshed fingerprints that predate
+ * LOCAL_SCHEMA_HISTORY, so they are registered here rather than as history
+ * entries (the identity history is append-only and frozen).
+ */
+export const LEGACY_SCHEMA_VARIANTS: ReadonlyArray<{
+	readonly fingerprint: string
+	readonly projectRevision: string
+}> = Object.freeze([
+	Object.freeze({
+		fingerprint: "428701854f9fd30e",
+		projectRevision: "d58ce4a83d3ad3f3a29b9bb972272b757547ae793c050194354454634f3abccd",
+	}),
+	Object.freeze({
+		fingerprint: "ea2d7ee4f385544e",
+		projectRevision: "ffade4bccc59af00fd33a561c4c919fd0229e0505f659d3242081f670f034a41",
+	}),
+	Object.freeze({
+		fingerprint: "06d3f9912027129b",
+		projectRevision: "c3f2be342187b6f6cf09010043e775b68f0901081a9b861803e55f5fe299e4c6",
+	}),
+])
 export const LEGACY_SCHEMA_FINGERPRINTS: ReadonlyArray<string> = Object.freeze(
 	LEGACY_SCHEMA_VARIANTS.map((variant) => variant.fingerprint),
 )

--- a/apps/cli/test/local-store-migrations.test.ts
+++ b/apps/cli/test/local-store-migrations.test.ts
@@ -5,6 +5,8 @@ import {
 	ISSUE_297_TARGET_SCHEMA_PROJECT_REVISION,
 	LEGACY_LOCAL_SCHEMA,
 	LEGACY_SCHEMA_FINGERPRINT,
+	LEGACY_SCHEMA_VARIANTS,
+	legacyLocalSchemaIdentity,
 	LOCAL_SCHEMA_MANIFEST,
 	LOCAL_SCHEMA_V1,
 	LOCAL_SCHEMA_V2,
@@ -141,6 +143,44 @@ describe("local migration registry", () => {
 		expect(chain[3]?.to).toEqual(LOCAL_SCHEMA_V4)
 		expect(chain[4]?.to).toEqual(LOCAL_SCHEMA_V5)
 		expect(typeof chain[0]?.apply).toBe("function")
+	})
+
+	it("admits every released legacy v0 fingerprint to the frozen v0-to-v5 chain", () => {
+		expect(LEGACY_SCHEMA_VARIANTS).toEqual([
+			{
+				fingerprint: "428701854f9fd30e",
+				projectRevision: "d58ce4a83d3ad3f3a29b9bb972272b757547ae793c050194354454634f3abccd",
+			},
+			{
+				fingerprint: "ea2d7ee4f385544e",
+				projectRevision: "ffade4bccc59af00fd33a561c4c919fd0229e0505f659d3242081f670f034a41",
+			},
+			{
+				fingerprint: "06d3f9912027129b",
+				projectRevision: "c3f2be342187b6f6cf09010043e775b68f0901081a9b861803e55f5fe299e4c6",
+			},
+		])
+		for (const variant of LEGACY_SCHEMA_VARIANTS) {
+			const identity = legacyLocalSchemaIdentity(variant.fingerprint)
+			expect(identity).toMatchObject({ version: 0, ...variant })
+			expect(planMigration(identity!).chain.map((migration) => migration.id)).toEqual([
+				"local-0000-to-0001-raw-replay",
+				"local-0001-to-0002-error-rollup",
+				"local-0002-to-0003-service-map-ingest-bridge",
+				"local-0003-to-0004-web-events",
+				"local-0004-to-0005-service-overview-minutely",
+			])
+			expect(
+				identityFromMarker({
+					formatVersion: 1,
+					chdb: "dev",
+					maple: "dev",
+					createdAt: "unknown",
+					schema: variant.fingerprint,
+				}),
+			).toMatchObject({ version: 0, ...variant })
+		}
+		expect(legacyLocalSchemaIdentity("not-known")).toBeNull()
 	})
 
 	it("recognizes legacy and current markers without treating the fingerprint as physical proof", () => {


### PR DESCRIPTION
## Problem

Stores created by **v0.0.13 or v0.0.14** cannot enter the versioned local-store migration chain. Only the v0.0.12 schema fingerprint (`428701854f9fd30e`) is registered as legacy v0, so `maple schema plan` on a store born on a later pre-migration release fails with:

```
SchemaCommandError: the store fingerprint 06d3f9912027129b is not registered
```

Computed with the repo's own `schemaFingerprint` over each tag's `local-schema.sql`: v0.0.12 → `428701854f9fd30e`, v0.0.13 → `ea2d7ee4f385544e`, v0.0.14 → `06d3f9912027129b`.

Since `maple start` fails closed on a non-current identity (correctly), the only path such a deployment has is `maple reset` — full data loss, exactly what the migration system exists to avoid.

## Why widening is safe

The v0.0.12→v0.0.14 DDL delta touches only derived state (`alert_checks` columns, `service_map_db_*_hourly` MV reworks, the new `service_operations_minutely` table+MV). The six authoritative raw tables are byte-identical across all three schemas, and `legacy-to-current.ts` replays only those raw tables (derived state is rebuilt; `alert_checks`/session tables stay with the retained rollback source). So the existing frozen v0→v1 edge is already correct for all three sources — they just weren't registered.

## Changes

- `local-schema-history.ts`: the v0 entry carries three frozen fingerprint/projectRevision variants
- `schema-identity.ts`: `LEGACY_SCHEMA_VARIANTS` / `LEGACY_SCHEMA_FINGERPRINTS` / `legacyLocalSchemaIdentity`
- `local-store-migrations.ts`: `identityFromMarker` and `resolveMigrationChain` classify any registered variant as legacy v0; unknown fingerprints still fail closed
- journal validation: the chain's first step keeps the frozen module identity (canonical v0) while the journal's top-level source records the marker as found — `assertJournalChainInvariants` now accepts any registered v0 variant for that one comparison (`sourceMatchesFirstStep`); everything else stays strict
- tests: marker classification + `planMigration` v0→v5 for every variant, unknown-fingerprint rejection

## Verification

- `bun test test/local-store-migrations.test.ts` — 18 pass; `tsc --noEmit` clean
- End-to-end on a production v0.0.14 store (self-hosted deployment): `schema plan` resolves the full v0→v5 chain and `schema migrate --yes` promotes cleanly (all 5 steps verified), raw telemetry intact, stock v0.0.18 binary serves the migrated store

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789303806&installation_model_id=427786&pr_number=465&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F465&signature=fd2a5333ee07e5cc4374aac24ff871072a3783e6c263d81c1ab7075696d41e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->