### PR TITLE
feat(ios): Home, Alerts hub, incident detail — the app rethink

### DIFF
--- a/apps/api/src/routes/v2/alert-deliveries.http.ts
+++ b/apps/api/src/routes/v2/alert-deliveries.http.ts
@@ -34,7 +34,14 @@ export const HttpV2AlertDeliveriesLive = HttpApiBuilder.group(MapleApiV2, "alert
 				const tenant = yield* CurrentTenant.Context
 				const page = yield* paginateOffsetQuery(query, ({ limit, offset }) =>
 					readModels
-						.listDeliveryEvents(tenant.orgId, { limit, offset })
+						.listDeliveryEvents(tenant.orgId, {
+							...(query.incident_id !== undefined
+								? { incidentId: query.incident_id }
+								: undefined),
+							...(query.rule_id !== undefined ? { ruleId: query.rule_id } : undefined),
+							limit,
+							offset,
+						})
 						.pipe(Effect.map((response) => response.events.map(toV2Delivery))),
 				)
 				return { object: "list" as const, ...page }

--- a/apps/api/src/services/alerts/AlertReadModelsService.test.ts
+++ b/apps/api/src/services/alerts/AlertReadModelsService.test.ts
@@ -125,6 +125,17 @@ describe("AlertReadModelsService", () => {
 			assert.strictEqual(deliveries.events[0]?.id, DELIVERY)
 			assert.strictEqual(deliveries.events[0]?.destinationName, "Primary webhook")
 			assert.strictEqual(deliveries.events[0]?.responseCode, 204)
+
+			// The incident filter is what the mobile incident timeline reads.
+			const forNew = yield* readModels.listDeliveryEvents(ORG, { incidentId: INCIDENT_NEW })
+			assert.deepStrictEqual(
+				forNew.events.map((event) => event.id),
+				[DELIVERY],
+			)
+			const forOld = yield* readModels.listDeliveryEvents(ORG, { incidentId: INCIDENT_OLD })
+			assert.deepStrictEqual(forOld.events, [])
+			const forRule = yield* readModels.listDeliveryEvents(ORG, { ruleId: RULE })
+			assert.strictEqual(forRule.events.length, 1)
 			assert.deepStrictEqual(contexts, [])
 		}).pipe(Effect.provide(makeLayer(testDb, contexts)))
 	})

--- a/apps/api/src/services/alerts/AlertReadModelsService.ts
+++ b/apps/api/src/services/alerts/AlertReadModelsService.ts
@@ -80,6 +80,8 @@ export interface ListAlertIncidentsOptions {
 export interface ListAlertDeliveryEventsOptions {
 	readonly limit?: number
 	readonly offset?: number
+	readonly incidentId?: AlertIncidentId
+	readonly ruleId?: AlertRuleId
 }
 
 export interface AlertReadModelsServiceApi {
@@ -473,7 +475,17 @@ export class AlertReadModelsService extends Context.Service<
 				db
 					.select()
 					.from(alertDeliveryEvents)
-					.where(eq(alertDeliveryEvents.orgId, orgId))
+					.where(
+						and(
+							eq(alertDeliveryEvents.orgId, orgId),
+							options.incidentId === undefined
+								? undefined
+								: eq(alertDeliveryEvents.incidentId, options.incidentId),
+							options.ruleId === undefined
+								? undefined
+								: eq(alertDeliveryEvents.ruleId, options.ruleId),
+						),
+					)
 					.orderBy(desc(alertDeliveryEvents.createdAt), desc(alertDeliveryEvents.id))
 					.limit(options.limit ?? 100)
 					.offset(options.offset ?? 0),

--- a/apps/ios/Maple/App/MapleApp.swift
+++ b/apps/ios/Maple/App/MapleApp.swift
@@ -6,15 +6,27 @@ import SwiftUI
 struct MapleApp: App {
 	@State private var clerk: Clerk
 	@State private var session: SessionController
+	@State private var navigation = AppNavigation()
 
 	init() {
 		// `Clerk.shared` traps until `configure` has run, and Swift evaluates
 		// stored-property default values *before* this body — so `clerk` must be
 		// assigned here rather than inline, or the app crashes on launch.
+		//
+		// Fixture mode (`MAPLE_FIXTURES=1` in the scheme environment) skips
+		// Clerk and the network entirely: a well-formed but dead key keeps the
+		// SDK quiet, and the session is pinned to `.ready`. Used for previews,
+		// screenshots, and working on screens without a signed-in org.
+		let tokens = ClerkTokenProvider()
+		if FixtureAPI.isEnabled {
+			_clerk = State(initialValue: Clerk.configure(publishableKey: FixtureSession.publishableKey))
+			_session = State(initialValue: SessionController.fixture(api: FixtureAPI(), tokens: tokens))
+			return
+		}
+
 		let clerk = Clerk.configure(publishableKey: AppConfig.clerkPublishableKey)
 		_clerk = State(initialValue: clerk)
 
-		let tokens = ClerkTokenProvider()
 		// The client is constructed once: it holds no per-org state, because the
 		// organization travels in the token rather than in a header.
 		let api: any MapleAPI
@@ -31,6 +43,7 @@ struct MapleApp: App {
 			RootView()
 				.environment(clerk)
 				.environment(session)
+				.environment(navigation)
 		}
 	}
 }

--- a/apps/ios/Maple/App/RootView.swift
+++ b/apps/ios/Maple/App/RootView.swift
@@ -51,16 +51,23 @@ struct RootView: View {
 	}
 }
 
+/// Three tabs, in the order the questions get asked: is anything wrong
+/// (Home), which service (Services), why (Alerts). Everything the web app does
+/// beyond those stays on the web.
 struct MainTabView: View {
-	@Environment(SessionController.self) private var session
+	@Environment(AppNavigation.self) private var navigation
 
 	var body: some View {
-		TabView {
-			Tab("Services", systemImage: "square.stack.3d.up") {
+		@Bindable var navigation = navigation
+		TabView(selection: $navigation.tab) {
+			Tab("Home", systemImage: "waveform.path.ecg", value: AppTab.home) {
+				HomeView()
+			}
+			Tab("Services", systemImage: "square.stack.3d.up", value: AppTab.services) {
 				ServicesListView()
 			}
-			Tab("Issues", systemImage: "exclamationmark.triangle") {
-				IssuesListView()
+			Tab("Alerts", systemImage: "bell", value: AppTab.alerts) {
+				AlertsHubView()
 			}
 		}
 	}

--- a/apps/ios/Maple/App/Route.swift
+++ b/apps/ios/Maple/App/Route.swift
@@ -1,0 +1,76 @@
+import MapleAPI
+import SwiftUI
+
+/// Every push destination in the app.
+///
+/// One enum, registered once per `NavigationStack` via `mapleDestinations()`,
+/// so a service row on Home, an incident's service link, and the Services tab
+/// all resolve the same way — and adding a screen is one case, not a hunt
+/// through every stack for a missing `navigationDestination`.
+enum Route: Hashable {
+	case service(name: String, window: TimeWindow = .default)
+	case issue(id: String)
+	case incident(id: String)
+	case anomaly(id: String)
+	/// The Alerts tab, opened on a specific segment. Handled by the tab
+	/// switcher rather than by push — see `AppNavigation`.
+	case alerts(AlertsSegment)
+}
+
+enum AlertsSegment: String, CaseIterable, Identifiable, Hashable {
+	case incidents
+	case errors
+	case anomalies
+
+	var id: String { rawValue }
+
+	var title: String {
+		switch self {
+		case .incidents: "Incidents"
+		case .errors: "Errors"
+		case .anomalies: "Anomalies"
+		}
+	}
+}
+
+extension View {
+	func mapleDestinations() -> some View {
+		navigationDestination(for: Route.self) { route in
+			switch route {
+			case .service(let name, let window):
+				ServiceDetailView(serviceName: name, window: window)
+			case .issue(let id):
+				IssueDetailView(issueID: id)
+			case .incident(let id):
+				IncidentDetailView(incidentID: id)
+			case .anomaly(let id):
+				AnomalyDetailView(anomalyID: id)
+			case .alerts:
+				// Cross-tab: Home asks the tab bar to switch. Rendering it inline
+				// would nest a hub inside a stack.
+				EmptyView()
+			}
+		}
+	}
+}
+
+/// Cross-tab navigation state. Home's "3 new issues" row switches to the Alerts
+/// tab on the Errors segment; that's a tab change plus a segment change, which
+/// no `NavigationStack` can express, so it lives here.
+@MainActor
+@Observable
+final class AppNavigation {
+	var tab: AppTab = .home
+	var alertsSegment: AlertsSegment = .incidents
+
+	func open(_ segment: AlertsSegment) {
+		alertsSegment = segment
+		tab = .alerts
+	}
+}
+
+enum AppTab: Hashable {
+	case home
+	case services
+	case alerts
+}

--- a/apps/ios/Maple/Auth/SessionController.swift
+++ b/apps/ios/Maple/Auth/SessionController.swift
@@ -45,10 +45,27 @@ final class SessionController {
 
 	let api: any MapleAPI
 	private let tokens: ClerkTokenProvider
+	/// True when the phase is pinned by `fixture(api:tokens:)` and Clerk's
+	/// state must be ignored.
+	private let isFixture: Bool
 
 	init(api: any MapleAPI, tokens: ClerkTokenProvider) {
 		self.api = api
 		self.tokens = tokens
+		self.isFixture = false
+	}
+
+	private init(fixtureAPI: any MapleAPI, tokens: ClerkTokenProvider) {
+		self.api = fixtureAPI
+		self.tokens = tokens
+		self.isFixture = true
+		self.phase = .ready(organizationId: FixtureSession.organizationId)
+	}
+
+	/// A session that is already signed in to a fixture organization and never
+	/// consults Clerk. See `FixtureAPI`.
+	static func fixture(api: any MapleAPI, tokens: ClerkTokenProvider) -> SessionController {
+		SessionController(fixtureAPI: api, tokens: tokens)
 	}
 
 	var activeOrganization: Organization? {
@@ -71,6 +88,7 @@ final class SessionController {
 	/// is `@Observable`, so SwiftUI re-runs the enclosing `.task(id:)` for us
 	/// rather than needing a subscription.
 	func refresh() async {
+		if isFixture { return }
 		guard Clerk.shared.user != nil else {
 			phase = .signedOut
 			memberships = []

--- a/apps/ios/Maple/Components/AlertFormatting.swift
+++ b/apps/ios/Maple/Components/AlertFormatting.swift
@@ -1,0 +1,221 @@
+import Foundation
+import MapleAPI
+import OpenAPIRuntime
+import SwiftUI
+
+/// The unit an alert's observed value and threshold are read in. Mirrors
+/// `apps/api/src/services/alerts/alert-signal-display.ts`: the unit travels
+/// with the label because the same facts decide both — deriving them
+/// separately is how a value and its threshold drift apart.
+enum SignalUnit {
+	case ratio
+	case milliseconds
+	case perMinute
+	case apdex
+	case count
+	case plain
+
+	func format(_ value: Double?) -> String {
+		guard let value, value.isFinite else { return "—" }
+		switch self {
+		case .ratio: return Format.errorRate(value)
+		case .milliseconds: return Format.latency(value)
+		case .perMinute: return Format.count(value) + "/min"
+		case .apdex: return String(format: "%.2f", value)
+		case .count, .plain: return Format.count(value)
+		}
+	}
+}
+
+struct SignalDisplay {
+	let label: String
+	let unit: SignalUnit
+
+	/// From the incident alone. `builder_query` / `raw_query` say only "this
+	/// rule runs a query", so they read as a plain number until the rule
+	/// arrives with its draft.
+	init(signal: AlertSignalType) {
+		switch signal {
+		case .errorRate: self.init(label: "Error rate", unit: .ratio)
+		case .p95Latency: self.init(label: "p95 latency", unit: .milliseconds)
+		case .p99Latency: self.init(label: "p99 latency", unit: .milliseconds)
+		case .apdex: self.init(label: "Apdex", unit: .apdex)
+		case .throughput: self.init(label: "Throughput", unit: .perMinute)
+		case .builderQuery: self.init(label: "Query", unit: .plain)
+		case .rawQuery: self.init(label: "Raw query", unit: .plain)
+		}
+	}
+
+	/// From the rule, which knows what a builder query measures.
+	init(rule: AlertRule) {
+		switch rule.signalType {
+		case .builderQuery:
+			guard let draft = rule.queryBuilderDraft?.value else {
+				self.init(signal: .builderQuery)
+				return
+			}
+			let aggregation = (draft["aggregation"] as? String)?.trimmingCharacters(in: .whitespaces) ?? ""
+			let name = (draft["name"] as? String)?.trimmingCharacters(in: .whitespaces) ?? ""
+			let source = draft["dataSource"] as? String
+			let unit: SignalUnit
+			if source == "traces", aggregation.hasSuffix("_duration") {
+				unit = .milliseconds
+			} else if source == "traces", aggregation == "error_rate" {
+				unit = .ratio
+			} else if aggregation == "count" {
+				unit = .count
+			} else {
+				unit = .plain
+			}
+			let label: String
+			if let metric = draft["metricName"] as? String, !metric.isEmpty, !aggregation.isEmpty {
+				label = "\(aggregation)(\(metric))"
+			} else if !aggregation.isEmpty {
+				label = aggregation.replacingOccurrences(of: "_", with: " ")
+			} else {
+				label = name.isEmpty ? "Query" : name
+			}
+			self.init(label: label, unit: unit)
+		case .rawQuery:
+			self.init(label: rule.rawQueryReducer?.rawValue ?? "Raw query", unit: .plain)
+		default:
+			self.init(signal: rule.signalType)
+		}
+	}
+
+	init(label: String, unit: SignalUnit) {
+		self.label = label
+		self.unit = unit
+	}
+}
+
+extension AlertComparator {
+	/// The operator as it reads in a headline: `9.0% > 5.0%`.
+	var glyph: String {
+		switch self {
+		case .gt: ">"
+		case .gte: "≥"
+		case .lt: "<"
+		case .lte: "≤"
+		case .eq: "="
+		case .neq: "≠"
+		case .between: "in"
+		case .notBetween: "outside"
+		}
+	}
+}
+
+extension AlertSeverity {
+	var label: String { rawValue.capitalized }
+	var tint: Color {
+		switch self {
+		case .critical: Token.destructive
+		case .warning: Token.severityWarn
+		}
+	}
+}
+
+extension AnomalyIncidentSeverity {
+	var label: String { rawValue.capitalized }
+	var tint: Color {
+		switch self {
+		case .critical: Token.destructive
+		case .warning: Token.severityWarn
+		}
+	}
+}
+
+extension AnomalySignalType {
+	var label: String {
+		switch self {
+		case .errorRate: "Error rate"
+		case .latencyP95: "p95 latency"
+		case .throughput: "Throughput"
+		case .errorSpike: "Error spike"
+		case .logVolume: "Log volume"
+		}
+	}
+
+	var unit: SignalUnit {
+		switch self {
+		case .errorRate: .ratio
+		case .latencyP95: .milliseconds
+		case .throughput: .perMinute
+		case .errorSpike, .logVolume: .count
+		}
+	}
+}
+
+extension AlertEventType {
+	var label: String {
+		switch self {
+		case .trigger: "Triggered"
+		case .resolve: "Resolved"
+		case .renotify: "Re-notified"
+		case .test: "Test"
+		}
+	}
+}
+
+extension AlertDestinationType {
+	var label: String {
+		switch self {
+		case .slackBot: "Slack"
+		case .pagerduty: "PagerDuty"
+		case .webhook: "Webhook"
+		case .hazelOauth: "Hazel"
+		case .discord: "Discord"
+		case .email: "Email"
+		}
+	}
+}
+
+extension Format {
+	/// A timeline stamp: `11:44` today, `Aug 15, 11:44` otherwise. One line,
+	/// always — the timeline's date column is fixed-width.
+	static func timelineTime(_ timestamp: String) -> String {
+		guard let date = ResolvedTimeWindow.parse(timestamp) else { return "—" }
+		if Calendar.current.isDateInToday(date) {
+			return date.formatted(date: .omitted, time: .shortened)
+		}
+		return date.formatted(.dateTime.month(.abbreviated).day().hour().minute())
+	}
+
+	/// "32m", "3h 12m", "2d 4h" — how long something has been going on. Terse
+	/// like `lastSeen`, but two units once it passes an hour, because "3h" for
+	/// an incident hides whether it's fresh or nearly four.
+	static func duration(from startText: String, to endText: String? = nil) -> String {
+		guard let start = ResolvedTimeWindow.parse(startText) else { return "—" }
+		let end = endText.flatMap(ResolvedTimeWindow.parse) ?? Date()
+		return duration(seconds: end.timeIntervalSince(start))
+	}
+
+	static func duration(seconds: TimeInterval) -> String {
+		let total = max(0, Int(seconds))
+		if total < 60 { return "<1m" }
+		let minutes = total / 60
+		if minutes < 60 { return "\(minutes)m" }
+		let hours = minutes / 60
+		if hours < 24 {
+			let rest = minutes % 60
+			return rest == 0 ? "\(hours)h" : "\(hours)h \(rest)m"
+		}
+		let days = hours / 24
+		let rest = hours % 24
+		return rest == 0 ? "\(days)d" : "\(days)d \(rest)h"
+	}
+
+	/// The comparison as a sentence fragment: `9.0% > 5.0%`, or `— > 5.0%`
+	/// when nothing has been observed yet.
+	static func breach(observed: Double?, comparator: AlertComparator, threshold: Double, upper: Double?, unit: SignalUnit)
+		-> String
+	{
+		let observedText = unit.format(observed)
+		switch comparator {
+		case .between, .notBetween:
+			return "\(observedText) \(comparator.glyph) \(unit.format(threshold))–\(unit.format(upper))"
+		default:
+			return "\(observedText) \(comparator.glyph) \(unit.format(threshold))"
+		}
+	}
+}

--- a/apps/ios/Maple/Components/LoadableView.swift
+++ b/apps/ios/Maple/Components/LoadableView.swift
@@ -196,3 +196,33 @@ struct DroppedSignalGlyph: View {
 		.accessibilityHidden(true)
 	}
 }
+
+extension SessionController {
+	/// Run a screen's load and turn the outcome into a `LoadState`.
+	///
+	/// This is the do/catch every model used to carry by hand: a 401 re-mints
+	/// the token and retries once; a second 401 signs out; a cancellation
+	/// (window change, org switch) yields `nil` so the caller leaves the
+	/// current state alone rather than flashing a placeholder.
+	func perform<T>(_ work: () async throws -> T) async -> LoadState<T>? {
+		do {
+			return .loaded(try await work())
+		} catch is CancellationError {
+			return nil
+		} catch let error as MapleAPIError {
+			guard await handle(error) else { return .failed(error) }
+			do {
+				return .loaded(try await work())
+			} catch is CancellationError {
+				return nil
+			} catch let error as MapleAPIError {
+				if error.requiresReauthentication { await signOutLocally() }
+				return .failed(error)
+			} catch {
+				return .failed(.transport(error))
+			}
+		} catch {
+			return .failed(.transport(error))
+		}
+	}
+}

--- a/apps/ios/Maple/Components/Sparkline.swift
+++ b/apps/ios/Maple/Components/Sparkline.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// A 1px line with no axes, ticks, or dots — the "shape of the last hour" that
+/// sits beside a number. Nil-safe: an empty or single-point series draws a
+/// flat baseline rather than nothing, so a row never changes height when data
+/// hasn't arrived.
+struct Sparkline: View {
+	let values: [Double]
+	var tint: Color = Token.mutedForeground
+	/// A horizontal reference (the alert threshold) in the same units as
+	/// `values`. Drawn as a dashed hairline.
+	var reference: Double? = nil
+	var fills: Bool = true
+
+	var body: some View {
+		Canvas { context, size in
+			let points = values.filter(\.isFinite)
+			guard points.count >= 2 else {
+				var flat = Path()
+				flat.move(to: CGPoint(x: 0, y: size.height - 0.5))
+				flat.addLine(to: CGPoint(x: size.width, y: size.height - 0.5))
+				context.stroke(flat, with: .color(tint.opacity(0.35)), lineWidth: 1)
+				return
+			}
+
+			var low = points.min() ?? 0
+			var high = points.max() ?? 1
+			if let reference {
+				low = min(low, reference)
+				high = max(high, reference)
+			}
+			// Always include zero for rates and counts: a series that wobbles
+			// between 4.9% and 5.1% should not look like a cliff.
+			low = min(low, 0)
+			if high == low { high = low + 1 }
+
+			let inset: CGFloat = 1
+			let usableHeight = size.height - inset * 2
+			func y(_ value: Double) -> CGFloat {
+				inset + usableHeight * CGFloat(1 - (value - low) / (high - low))
+			}
+			let step = size.width / CGFloat(points.count - 1)
+
+			var line = Path()
+			for (index, value) in points.enumerated() {
+				let point = CGPoint(x: CGFloat(index) * step, y: y(value))
+				if index == 0 { line.move(to: point) } else { line.addLine(to: point) }
+			}
+
+			if fills {
+				var area = line
+				area.addLine(to: CGPoint(x: size.width, y: size.height))
+				area.addLine(to: CGPoint(x: 0, y: size.height))
+				area.closeSubpath()
+				context.fill(
+					area,
+					with: .linearGradient(
+						Gradient(colors: [tint.opacity(0.18), tint.opacity(0)]),
+						startPoint: .zero,
+						endPoint: CGPoint(x: 0, y: size.height)
+					)
+				)
+			}
+
+			context.stroke(line, with: .color(tint), style: StrokeStyle(lineWidth: 1, lineJoin: .round))
+
+			if let reference {
+				var rule = Path()
+				let ry = y(reference)
+				rule.move(to: CGPoint(x: 0, y: ry))
+				rule.addLine(to: CGPoint(x: size.width, y: ry))
+				context.stroke(
+					rule,
+					with: .color(Token.mutedForeground.opacity(0.7)),
+					style: StrokeStyle(lineWidth: 1, dash: [2, 3])
+				)
+			}
+		}
+		.accessibilityHidden(true)
+	}
+}

--- a/apps/ios/Maple/Features/Alerts/AlertsHubView.swift
+++ b/apps/ios/Maple/Features/Alerts/AlertsHubView.swift
@@ -1,0 +1,76 @@
+import MapleAPI
+import SwiftUI
+
+/// The triage hub: incidents, error issues, and anomalies under one tab with a
+/// segmented switch. Each segment owns its data and its toolbar; the hub owns
+/// the stack and the segment.
+struct AlertsHubView: View {
+	@Environment(AppNavigation.self) private var navigation
+
+	var body: some View {
+		@Bindable var navigation = navigation
+		NavigationStack {
+			ZStack {
+				Token.background.ignoresSafeArea()
+				VStack(spacing: 0) {
+					SegmentedControl(selection: $navigation.alertsSegment)
+						.padding(.horizontal, 16)
+						.padding(.top, 8)
+						.padding(.bottom, 10)
+					Hairline()
+					switch navigation.alertsSegment {
+					case .incidents: IncidentsListView()
+					case .errors: IssuesListContent()
+					case .anomalies: AnomaliesListView()
+					}
+				}
+			}
+			.navigationBarTitleDisplayMode(.inline)
+			.toolbar {
+				ToolbarItem(placement: .principal) {
+					OrganizationSwitcherButton(fallbackTitle: "Alerts")
+				}
+			}
+			.mapleDestinations()
+		}
+	}
+}
+
+/// Maple's segmented toggle: hairline frame, the active segment lifted one
+/// tonal step. No system `Picker` — its capsule and its font would be the
+/// only two non-Maple pixels on the screen.
+struct SegmentedControl: View {
+	@Binding var selection: AlertsSegment
+	@Namespace private var namespace
+
+	var body: some View {
+		HStack(spacing: 2) {
+			ForEach(AlertsSegment.allCases) { segment in
+				Button {
+					withAnimation(.snappy(duration: 0.22)) { selection = segment }
+				} label: {
+					Text(segment.title)
+						.font(Typo.smallMedium)
+						.foregroundStyle(selection == segment ? Token.foreground : Token.mutedForeground)
+						.frame(maxWidth: .infinity)
+						.frame(height: 28)
+						.background {
+							if selection == segment {
+								RoundedRectangle(cornerRadius: Token.Radius.sm)
+									.fill(Token.muted)
+									.matchedGeometryEffect(id: "segment", in: namespace)
+							}
+						}
+						.contentShape(.rect)
+				}
+				.buttonStyle(.plain)
+			}
+		}
+		.padding(2)
+		.background(Token.card, in: .rect(cornerRadius: Token.Radius.md))
+		.overlay(
+			RoundedRectangle(cornerRadius: Token.Radius.md)
+				.stroke(Token.border, lineWidth: Token.hairline)
+		)
+	}
+}

--- a/apps/ios/Maple/Features/Alerts/AnomaliesListView.swift
+++ b/apps/ios/Maple/Features/Alerts/AnomaliesListView.swift
@@ -1,0 +1,147 @@
+import MapleAPI
+import SwiftUI
+
+@MainActor
+@Observable
+final class AnomaliesListModel {
+	private(set) var state: LoadState<[AnomalyIncident]> = .loading
+	var openOnly = true {
+		didSet { if openOnly != oldValue { Task { await load() } } }
+	}
+
+	private let api: any MapleAPI
+	private let session: SessionController
+
+	init(api: any MapleAPI, session: SessionController) {
+		self.api = api
+		self.session = session
+	}
+
+	func load(showPlaceholder: Bool = true) async {
+		if showPlaceholder && !state.hasContent { state = .loading }
+		let next = await session.perform {
+			try await self.api.anomalyIncidents(
+				status: self.openOnly ? .open : nil,
+				serviceName: nil,
+				window: self.openOnly ? nil : TimeWindow.last7Days.resolve(),
+				limit: 50,
+				cursor: nil
+			).items
+		}
+		guard let next else { return }
+		if case .loaded(let items) = next, items.isEmpty {
+			state = .empty
+		} else {
+			state = next
+		}
+	}
+}
+
+struct AnomaliesListView: View {
+	@Environment(SessionController.self) private var session
+	@State private var model: AnomaliesListModel?
+
+	var body: some View {
+		Group {
+			if let model {
+				LoadableView(
+					state: model.state,
+					emptyTitle: model.openOnly ? "No anomalies" : "Nothing detected",
+					emptyMessage: model.openOnly
+						? "Every monitored signal is inside its baseline."
+						: "No anomalies in the last 7 days.",
+					retry: { Task { await model.load() } }
+				) { anomalies in
+					ScrollView {
+						LazyVStack(spacing: 0) {
+							ForEach(anomalies, id: \.id) { anomaly in
+								NavigationLink(value: Route.anomaly(id: anomaly.id)) {
+									AnomalyRow(anomaly: anomaly)
+								}
+								.buttonStyle(RowButtonStyle())
+								Hairline()
+							}
+						}
+					}
+					.scrollContentBackground(.hidden)
+				}
+				.refreshable { await model.load(showPlaceholder: false) }
+				.toolbar {
+					ToolbarItem(placement: .topBarTrailing) {
+						Button {
+							model.openOnly.toggle()
+						} label: {
+							Text(model.openOnly ? "Open" : "7 days")
+								.font(Typo.smallMedium)
+								.foregroundStyle(model.openOnly ? Token.primary : Token.foreground)
+						}
+					}
+				}
+			} else {
+				SkeletonList()
+			}
+		}
+		.task(id: session.dataGeneration) {
+			let model = model ?? AnomaliesListModel(api: session.api, session: session)
+			self.model = model
+			await model.load()
+		}
+	}
+}
+
+struct AnomalyRow: View {
+	let anomaly: AnomalyIncident
+
+	private var isOpen: Bool { anomaly.status == .open }
+	private var tint: Color { isOpen ? anomaly.severity.tint : Token.mutedForeground }
+	private var unit: SignalUnit { anomaly.signalType.unit }
+
+	var body: some View {
+		HStack(alignment: .top, spacing: 12) {
+			Rectangle()
+				.fill(isOpen ? anomaly.severity.tint : .clear)
+				.frame(width: 2)
+
+			VStack(alignment: .leading, spacing: 5) {
+				HStack(alignment: .firstTextBaseline, spacing: 8) {
+					HStack(spacing: 6) {
+						ServiceDot(serviceName: anomaly.serviceName)
+						Text(anomaly.serviceName)
+							.font(Typo.bodyMedium)
+							.foregroundStyle(isOpen ? Token.foreground : Token.mutedForeground)
+							.lineLimit(1)
+					}
+					Spacer(minLength: 4)
+					Text(
+						isOpen
+							? Format.duration(from: anomaly.firstTriggeredAt)
+							: "resolved \(Format.lastSeen(anomaly.resolvedAt ?? anomaly.lastTriggeredAt))"
+					)
+					.font(Typo.tiny)
+					.tabularNumbers()
+					.foregroundStyle(Token.mutedForeground)
+				}
+
+				HStack(spacing: 8) {
+					MapleBadge(text: anomaly.signalType.label, tint: tint)
+					if !anomaly.deploymentEnv.isEmpty {
+						Text(anomaly.deploymentEnv)
+							.font(Typo.tiny)
+							.foregroundStyle(Token.mutedForeground)
+							.lineLimit(1)
+					}
+					Spacer(minLength: 0)
+					Text("\(unit.format(anomaly.lastObservedValue)) vs \(unit.format(anomaly.baselineMedian))")
+						.font(Typo.tiny)
+						.tabularNumbers()
+						.foregroundStyle(tint)
+						.lineLimit(1)
+				}
+			}
+		}
+		.padding(.trailing, 16)
+		.padding(.vertical, 12)
+		.frame(minHeight: 64)
+		.contentShape(.rect)
+	}
+}

--- a/apps/ios/Maple/Features/Alerts/AnomalyDetailView.swift
+++ b/apps/ios/Maple/Features/Alerts/AnomalyDetailView.swift
@@ -1,0 +1,270 @@
+import Charts
+import MapleAPI
+import SwiftUI
+
+struct AnomalyDetail {
+	var anomaly: AnomalyIncident
+	var timeseries: AnomalyIncidentTimeseries?
+	var linkedIssue: ErrorIssueDetail?
+}
+
+@MainActor
+@Observable
+final class AnomalyDetailModel {
+	private(set) var state: LoadState<AnomalyDetail> = .loading
+
+	let anomalyID: String
+	private let api: any MapleAPI
+	private let session: SessionController
+
+	init(anomalyID: String, api: any MapleAPI, session: SessionController) {
+		self.anomalyID = anomalyID
+		self.api = api
+		self.session = session
+	}
+
+	func load(showPlaceholder: Bool = true) async {
+		if showPlaceholder && !state.hasContent { state = .loading }
+		let next = await session.perform { () -> AnomalyDetail in
+			let anomaly = try await self.api.anomalyIncident(id: self.anomalyID)
+			async let series = self.api.anomalyIncidentTimeseries(id: anomaly.id)
+			async let issue: ErrorIssueDetail? = {
+				guard let id = anomaly.errorIssueId else { return nil }
+				return try? await self.api.issue(id: id)
+			}()
+			return AnomalyDetail(anomaly: anomaly, timeseries: try? await series, linkedIssue: await issue)
+		}
+		if let next { state = next }
+	}
+}
+
+struct AnomalyDetailView: View {
+	let anomalyID: String
+
+	@Environment(SessionController.self) private var session
+	@State private var model: AnomalyDetailModel?
+
+	var body: some View {
+		ZStack {
+			Token.background.ignoresSafeArea()
+			if let model {
+				LoadableView(
+					state: model.state,
+					emptyTitle: "Not found",
+					emptyMessage: "This anomaly no longer exists.",
+					retry: { Task { await model.load() } }
+				) { detail in
+					AnomalyDetailContent(detail: detail)
+				}
+				.refreshable { await model.load(showPlaceholder: false) }
+			} else {
+				SkeletonList()
+			}
+		}
+		.navigationTitle("Anomaly")
+		.navigationBarTitleDisplayMode(.inline)
+		.task(id: session.dataGeneration) {
+			let model = model ?? AnomalyDetailModel(anomalyID: anomalyID, api: session.api, session: session)
+			self.model = model
+			await model.load()
+		}
+	}
+}
+
+private struct AnomalyDetailContent: View {
+	let detail: AnomalyDetail
+
+	private var anomaly: AnomalyIncident { detail.anomaly }
+	private var isOpen: Bool { anomaly.status == .open }
+	private var unit: SignalUnit { anomaly.signalType.unit }
+
+	var body: some View {
+		ScrollView {
+			VStack(alignment: .leading, spacing: 28) {
+				header
+				chart
+				facts
+				if let issue = detail.linkedIssue {
+					VStack(alignment: .leading, spacing: 10) {
+						SectionLabel("Linked issue").padding(.horizontal, 16)
+						NavigationLink(value: Route.issue(id: issue.id)) {
+							HStack(alignment: .top, spacing: 10) {
+								SeverityBadge(severity: issue.severity).frame(width: 56, alignment: .leading)
+								VStack(alignment: .leading, spacing: 4) {
+									Text(issue.exceptionType.isEmpty ? issue.errorLabel : issue.exceptionType)
+										.font(Typo.bodyMedium)
+										.foregroundStyle(Token.foreground)
+										.lineLimit(1)
+									Text(issue.exceptionMessage)
+										.font(Typo.small)
+										.foregroundStyle(Token.mutedForeground)
+										.lineLimit(2)
+								}
+								Spacer(minLength: 0)
+							}
+							.padding(.horizontal, 16)
+							.padding(.vertical, 12)
+							.contentShape(.rect)
+						}
+						.buttonStyle(RowButtonStyle())
+						Hairline()
+					}
+				}
+			}
+			.padding(.vertical, 16)
+		}
+		.scrollContentBackground(.hidden)
+	}
+
+	private var header: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			HStack(spacing: 6) {
+				MapleBadge(text: anomaly.severity.label, tint: anomaly.severity.tint)
+				MapleBadge(text: isOpen ? "Open" : "Resolved", tint: isOpen ? Token.destructive : Token.success)
+				Spacer()
+				Text(
+					isOpen
+						? "open \(Format.duration(from: anomaly.firstTriggeredAt))"
+						: "lasted \(Format.duration(from: anomaly.firstTriggeredAt, to: anomaly.resolvedAt))"
+				)
+				.font(Typo.tiny)
+				.tabularNumbers()
+				.foregroundStyle(Token.mutedForeground)
+			}
+			Text("\(anomaly.signalType.label) on \(anomaly.serviceName)")
+				.font(Typo.monoTitle)
+				.foregroundStyle(Token.foreground)
+				.fixedSize(horizontal: false, vertical: true)
+			HStack(alignment: .firstTextBaseline, spacing: 8) {
+				Text(unit.format(anomaly.lastObservedValue))
+					.font(Typo.smallSemibold)
+					.tabularNumbers()
+					.foregroundStyle(isOpen ? anomaly.severity.tint : Token.mutedForeground)
+				Text("vs baseline \(unit.format(anomaly.baselineMedian))")
+					.font(Typo.small)
+					.foregroundStyle(Token.mutedForeground)
+			}
+			NavigationLink(value: Route.service(name: anomaly.serviceName, window: .lastHour)) {
+				HStack(spacing: 6) {
+					ServiceDot(serviceName: anomaly.serviceName, size: 7)
+					Text(anomaly.serviceName)
+						.font(Typo.smallMedium)
+						.foregroundStyle(Token.foreground)
+					Image(systemName: "chevron.right")
+						.font(.system(size: 9, weight: .semibold))
+						.foregroundStyle(Token.mutedForeground.opacity(0.6))
+				}
+			}
+			.buttonStyle(.plain)
+		}
+		.padding(.horizontal, 16)
+	}
+
+	private struct Bucket: Identifiable {
+		let id: String
+		let date: Date
+		let value: Double
+	}
+
+	@ViewBuilder
+	private var chart: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			SectionLabel("Signal").padding(.horizontal, 16)
+			if let series = detail.timeseries {
+				let buckets = series.buckets.compactMap { bucket -> Bucket? in
+					guard let date = ResolvedTimeWindow.parse(bucket.bucket) else { return nil }
+					return Bucket(id: bucket.bucket, date: date, value: bucket.value)
+				}
+				if buckets.count < 2 {
+					Text("Not enough data to chart.")
+						.font(Typo.small)
+						.foregroundStyle(Token.mutedForeground)
+						.padding(.horizontal, 16)
+				} else {
+					Chart {
+						ForEach(buckets) { bucket in
+							AreaMark(x: .value("Time", bucket.date), y: .value("Value", bucket.value))
+								.foregroundStyle(
+									.linearGradient(
+										colors: [anomaly.severity.tint.opacity(0.18), .clear], startPoint: .top, endPoint: .bottom
+									)
+								)
+								.interpolationMethod(.monotone)
+							LineMark(x: .value("Time", bucket.date), y: .value("Value", bucket.value))
+								.foregroundStyle(anomaly.severity.tint)
+								.lineStyle(StrokeStyle(lineWidth: 1.25))
+								.interpolationMethod(.monotone)
+						}
+						RuleMark(y: .value("Baseline", series.baselineMedian))
+							.foregroundStyle(Token.mutedForeground.opacity(0.6))
+							.lineStyle(StrokeStyle(lineWidth: 1, dash: [1, 3]))
+						RuleMark(y: .value("Threshold", series.thresholdValue))
+							.foregroundStyle(Token.mutedForeground.opacity(0.9))
+							.lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+							.annotation(position: .top, alignment: .trailing) {
+								Text(unit.format(series.thresholdValue))
+									.font(Typo.micro)
+									.tabularNumbers()
+									.foregroundStyle(Token.mutedForeground)
+							}
+					}
+					.chartXAxis {
+						AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+							AxisGridLine().foregroundStyle(Token.border)
+							AxisValueLabel(format: .dateTime.hour().minute())
+								.font(Typo.micro)
+								.foregroundStyle(Token.mutedForeground)
+						}
+					}
+					.chartYAxis {
+						AxisMarks(position: .leading, values: .automatic(desiredCount: 3)) { value in
+							AxisGridLine().foregroundStyle(Token.border)
+							AxisValueLabel {
+								if let number = value.as(Double.self) {
+									Text(unit.format(number))
+										.font(Typo.micro)
+										.tabularNumbers()
+										.foregroundStyle(Token.mutedForeground)
+								}
+							}
+						}
+					}
+					.frame(height: 150)
+					.padding(.horizontal, 16)
+				}
+			} else {
+				Text("Timeseries unavailable.")
+					.font(Typo.small)
+					.foregroundStyle(Token.mutedForeground)
+					.padding(.horizontal, 16)
+			}
+		}
+	}
+
+	private var facts: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			SectionLabel("Detector").padding(.horizontal, 16)
+			VStack(spacing: 0) {
+				DetailRow("Opened at", unit.format(anomaly.openedValue))
+				Hairline()
+				DetailRow("Threshold", unit.format(anomaly.thresholdValue))
+				Hairline()
+				DetailRow("Baseline σ", unit.format(anomaly.baselineSigma))
+				Hairline()
+				if !anomaly.deploymentEnv.isEmpty {
+					DetailRow("Environment", anomaly.deploymentEnv)
+					Hairline()
+				}
+				if anomaly.reopenCount > 0 {
+					DetailRow("Reopened", "\(Int(anomaly.reopenCount))×")
+					Hairline()
+				}
+				if let reason = anomaly.resolveReason {
+					DetailRow("Resolved by", reason.rawValue.replacingOccurrences(of: "_", with: " "))
+					Hairline()
+				}
+			}
+			.padding(.horizontal, 16)
+		}
+	}
+}

--- a/apps/ios/Maple/Features/Alerts/IncidentDetailView.swift
+++ b/apps/ios/Maple/Features/Alerts/IncidentDetailView.swift
@@ -1,0 +1,746 @@
+import Charts
+import MapleAPI
+import SwiftUI
+
+/// Everything the "why" screen needs, gathered in one pass.
+struct IncidentDetail {
+	var incident: AlertIncident
+	var rule: AlertRule?
+	var display: SignalDisplay
+	/// The rule's own evaluations around the incident, oldest first.
+	var checks: [AlertCheck]
+	/// The service the incident is about, when the rule names exactly one
+	/// (or when the group key is a service name). Drives the "what changed on
+	/// the service" section; nil means that section is skipped.
+	var serviceName: String?
+	var errorRate: [Double]
+	var p95: [Double]
+	var throughput: [Double]
+	var telemetryWindow: ResolvedTimeWindow?
+	var linkedIssue: ErrorIssueDetail?
+	var recentIssues: [ErrorIssue]
+	var failingOperations: [BreakdownItem]
+	var deliveries: [AlertDelivery]
+}
+
+@MainActor
+@Observable
+final class IncidentDetailModel {
+	private(set) var state: LoadState<IncidentDetail> = .loading
+
+	let incidentID: String
+	private let api: any MapleAPI
+	private let session: SessionController
+
+	init(incidentID: String, api: any MapleAPI, session: SessionController) {
+		self.incidentID = incidentID
+		self.api = api
+		self.session = session
+	}
+
+	func load(showPlaceholder: Bool = true) async {
+		if showPlaceholder && !state.hasContent { state = .loading }
+		if let next = await session.perform({ try await self.fetch() }) {
+			state = next
+		}
+	}
+
+	private func fetch() async throws -> IncidentDetail {
+		let incident = try await api.alertIncident(id: incidentID)
+		let rule = try? await api.alertRule(id: incident.ruleId)
+		let display = rule.map(SignalDisplay.init(rule:)) ?? SignalDisplay(signal: incident.signalType)
+
+		// The window the story happens in: an hour of run-up, then until it
+		// resolved (or now). Capped at a day so a week-old incident doesn't
+		// pull a week of buckets.
+		let opened = ResolvedTimeWindow.parse(incident.firstTriggeredAt) ?? Date()
+		let closed = incident.resolvedAt.flatMap(ResolvedTimeWindow.parse) ?? Date()
+		let end = min(closed.addingTimeInterval(15 * 60), Date())
+		let start = max(opened.addingTimeInterval(-3600), end.addingTimeInterval(-24 * 3600))
+		let window = ResolvedTimeWindow(start: snapMinute(start), end: snapMinute(end))
+
+		let serviceName = Self.serviceName(for: incident, rule: rule)
+
+		async let checksTask = api.alertRuleChecks(
+			ruleId: incident.ruleId, groupKey: incident.groupKey, since: window.start, limit: 100
+		)
+		async let deliveriesTask = api.alertDeliveries(incidentId: incident.id, limit: 50)
+		async let linkedIssueTask: ErrorIssueDetail? = {
+			guard let id = incident.errorIssueId else { return nil }
+			return try? await api.issue(id: id)
+		}()
+
+		var errorRate: [Double] = []
+		var p95: [Double] = []
+		var throughput: [Double] = []
+		var recentIssues: [ErrorIssue] = []
+		var failing: [BreakdownItem] = []
+
+		if let serviceName {
+			async let errorTask = api.traceTimeseries(
+				TraceTimeseriesRequest(aggregation: .errorRate, window: window, serviceName: serviceName)
+			)
+			async let p95Task = api.traceTimeseries(
+				TraceTimeseriesRequest(aggregation: .p95Duration, window: window, serviceName: serviceName)
+			)
+			async let countTask = api.traceTimeseries(
+				TraceTimeseriesRequest(aggregation: .count, window: window, serviceName: serviceName)
+			)
+			async let issuesTask = api.issues(
+				query: IssueQuery(serviceName: serviceName, actionableOnly: true, sort: .lastSeen),
+				window: window,
+				limit: 5,
+				cursor: nil
+			)
+			async let breakdownTask = api.traceBreakdown(
+				TraceBreakdownRequest(
+					aggregation: .count, groupBy: .spanName, window: window, serviceName: serviceName, hasError: true,
+					limit: 5
+				)
+			)
+			errorRate = (try? await errorTask.values) ?? []
+			p95 = (try? await p95Task.values) ?? []
+			throughput = (try? await countTask.values) ?? []
+			recentIssues = ((try? await issuesTask.items) ?? []).filter { $0.id != incident.errorIssueId }
+			failing = (try? await breakdownTask.data) ?? []
+		}
+
+		return IncidentDetail(
+			incident: incident,
+			rule: rule,
+			display: display,
+			checks: (try? await checksTask) ?? [],
+			serviceName: serviceName,
+			errorRate: errorRate,
+			p95: p95,
+			throughput: throughput,
+			telemetryWindow: serviceName == nil ? nil : window,
+			linkedIssue: await linkedIssueTask,
+			recentIssues: recentIssues,
+			failingOperations: failing,
+			deliveries: (try? await deliveriesTask) ?? []
+		)
+	}
+
+	/// A grouped-by-service rule puts the service in the group key; a rule
+	/// scoped to one service names it. Anything broader has no single service
+	/// to tell a story about.
+	private static func serviceName(for incident: AlertIncident, rule: AlertRule?) -> String? {
+		if let rule, rule.serviceNames.count == 1 { return rule.serviceNames[0] }
+		if let group = incident.groupKey, group != "__total__", let rule,
+			rule.groupBy != nil, rule.serviceNames.isEmpty || rule.serviceNames.contains(group)
+		{
+			return group
+		}
+		return nil
+	}
+
+	private func snapMinute(_ date: Date) -> Date {
+		Date(timeIntervalSince1970: (date.timeIntervalSince1970 / 60).rounded(.down) * 60)
+	}
+}
+
+struct IncidentDetailView: View {
+	let incidentID: String
+
+	@Environment(SessionController.self) private var session
+	@State private var model: IncidentDetailModel?
+
+	var body: some View {
+		ZStack {
+			Token.background.ignoresSafeArea()
+			if let model {
+				LoadableView(
+					state: model.state,
+					emptyTitle: "Not found",
+					emptyMessage: "This incident no longer exists.",
+					retry: { Task { await model.load() } }
+				) { detail in
+					IncidentDetailContent(detail: detail)
+				}
+				.refreshable { await model.load(showPlaceholder: false) }
+			} else {
+				SkeletonList()
+			}
+		}
+		.navigationTitle("Incident")
+		.navigationBarTitleDisplayMode(.inline)
+		.toolbar {
+			if let detail = model?.state.value {
+				ToolbarItem(placement: .topBarTrailing) {
+					ShareLink(item: shareText(detail)) {
+						Image(systemName: "square.and.arrow.up")
+							.font(.system(size: 14, weight: .medium))
+							.foregroundStyle(Token.foreground)
+					}
+				}
+			}
+		}
+		.task(id: session.dataGeneration) {
+			let model = model ?? IncidentDetailModel(incidentID: incidentID, api: session.api, session: session)
+			self.model = model
+			await model.load()
+		}
+	}
+
+	private func shareText(_ detail: IncidentDetail) -> String {
+		let incident = detail.incident
+		let breach = Format.breach(
+			observed: incident.lastObservedValue,
+			comparator: incident.comparator,
+			threshold: incident.threshold,
+			upper: incident.thresholdUpper,
+			unit: detail.display.unit
+		)
+		let service = detail.serviceName.map { " on \($0)" } ?? ""
+		let state = incident.status == .open ? "open \(Format.duration(from: incident.firstTriggeredAt))" : "resolved"
+		return "\(incident.ruleName) — \(detail.display.label) \(breach)\(service) · \(incident.severity.label), \(state)"
+	}
+}
+
+private struct IncidentDetailContent: View {
+	let detail: IncidentDetail
+
+	var body: some View {
+		ScrollView {
+			VStack(alignment: .leading, spacing: 28) {
+				IncidentHeader(detail: detail)
+				WhatTheRuleSaw(detail: detail)
+				if detail.telemetryWindow != nil {
+					WhatChanged(detail: detail)
+				}
+				LikelyCause(detail: detail)
+				IncidentTimeline(detail: detail)
+				RuleFacts(detail: detail)
+			}
+			.padding(.vertical, 16)
+		}
+		.scrollContentBackground(.hidden)
+	}
+}
+
+private struct Block<Content: View>: View {
+	let title: String
+	@ViewBuilder let content: Content
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			SectionLabel(title)
+				.padding(.horizontal, 16)
+			content
+		}
+	}
+}
+
+private struct IncidentHeader: View {
+	let detail: IncidentDetail
+
+	private var incident: AlertIncident { detail.incident }
+	private var isOpen: Bool { incident.status == .open }
+	private var tint: Color { isOpen ? incident.severity.tint : Token.mutedForeground }
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			HStack(spacing: 6) {
+				MapleBadge(text: incident.severity.label, tint: incident.severity.tint)
+				MapleBadge(
+					text: isOpen ? "Open" : "Resolved",
+					tint: isOpen ? Token.destructive : Token.success
+				)
+				Spacer()
+				Text(
+					isOpen
+						? "open \(Format.duration(from: incident.firstTriggeredAt))"
+						: "lasted \(Format.duration(from: incident.firstTriggeredAt, to: incident.resolvedAt))"
+				)
+				.font(Typo.tiny)
+				.tabularNumbers()
+				.foregroundStyle(Token.mutedForeground)
+			}
+
+			Text(incident.ruleName)
+				.font(Typo.monoTitle)
+				.foregroundStyle(Token.foreground)
+				.fixedSize(horizontal: false, vertical: true)
+
+			HStack(alignment: .firstTextBaseline, spacing: 8) {
+				Text(detail.display.label)
+					.font(Typo.small)
+					.foregroundStyle(Token.mutedForeground)
+				Text(
+					Format.breach(
+						observed: incident.lastObservedValue,
+						comparator: incident.comparator,
+						threshold: incident.threshold,
+						upper: incident.thresholdUpper,
+						unit: detail.display.unit
+					)
+				)
+				.font(Typo.smallSemibold)
+				.tabularNumbers()
+				.foregroundStyle(tint)
+			}
+
+			if let serviceName = detail.serviceName {
+				NavigationLink(value: Route.service(name: serviceName, window: .lastHour)) {
+					HStack(spacing: 6) {
+						ServiceDot(serviceName: serviceName, size: 7)
+						Text(serviceName)
+							.font(Typo.smallMedium)
+							.foregroundStyle(Token.foreground)
+						Image(systemName: "chevron.right")
+							.font(.system(size: 9, weight: .semibold))
+							.foregroundStyle(Token.mutedForeground.opacity(0.6))
+					}
+				}
+				.buttonStyle(.plain)
+			} else if let rule = detail.rule, !rule.serviceNames.isEmpty {
+				Text(rule.serviceNames.joined(separator: ", "))
+					.font(Typo.small)
+					.foregroundStyle(Token.mutedForeground)
+					.lineLimit(2)
+			}
+		}
+		.padding(.horizontal, 16)
+	}
+}
+
+/// The rule's own observations with its threshold — the one chart that
+/// exists for every signal type, because it's what the rule evaluated rather
+/// than a re-query.
+private struct WhatTheRuleSaw: View {
+	let detail: IncidentDetail
+
+	private struct Point: Identifiable {
+		let id: String
+		let date: Date
+		let value: Double
+		let breached: Bool
+	}
+
+	private var points: [Point] {
+		detail.checks.compactMap { check in
+			guard let value = check.observedValue, let date = ResolvedTimeWindow.parse(check.timestamp) else {
+				return nil
+			}
+			return Point(id: check.timestamp, date: date, value: value, breached: check.status == .breached)
+		}
+	}
+
+	var body: some View {
+		Block(title: "What the rule saw") {
+			let points = points
+			if points.count < 2 {
+				Text("Not enough evaluations to chart yet.")
+					.font(Typo.small)
+					.foregroundStyle(Token.mutedForeground)
+					.padding(.horizontal, 16)
+			} else {
+				VStack(alignment: .leading, spacing: 8) {
+					Chart {
+						ForEach(points) { point in
+							AreaMark(x: .value("Time", point.date), y: .value("Value", point.value))
+								.foregroundStyle(
+									.linearGradient(
+										colors: [detail.incident.severity.tint.opacity(0.18), .clear],
+										startPoint: .top,
+										endPoint: .bottom
+									)
+								)
+								.interpolationMethod(.monotone)
+							LineMark(x: .value("Time", point.date), y: .value("Value", point.value))
+								.foregroundStyle(detail.incident.severity.tint)
+								.lineStyle(StrokeStyle(lineWidth: 1.25))
+								.interpolationMethod(.monotone)
+						}
+						ForEach(points.filter(\.breached)) { point in
+							PointMark(x: .value("Time", point.date), y: .value("Value", point.value))
+								.foregroundStyle(detail.incident.severity.tint)
+								.symbolSize(10)
+						}
+						RuleMark(y: .value("Threshold", detail.incident.threshold))
+							.foregroundStyle(Token.mutedForeground.opacity(0.8))
+							.lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+							.annotation(position: .top, alignment: .trailing) {
+								Text(detail.display.unit.format(detail.incident.threshold))
+									.font(Typo.micro)
+									.tabularNumbers()
+									.foregroundStyle(Token.mutedForeground)
+							}
+						if let upper = detail.incident.thresholdUpper {
+							RuleMark(y: .value("Upper", upper))
+								.foregroundStyle(Token.mutedForeground.opacity(0.8))
+								.lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+						}
+					}
+					.chartXAxis {
+						AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+							AxisGridLine().foregroundStyle(Token.border)
+							AxisValueLabel(format: .dateTime.hour().minute())
+								.font(Typo.micro)
+								.foregroundStyle(Token.mutedForeground)
+						}
+					}
+					.chartYAxis {
+						AxisMarks(position: .leading, values: .automatic(desiredCount: 3)) { value in
+							AxisGridLine().foregroundStyle(Token.border)
+							AxisValueLabel {
+								if let number = value.as(Double.self) {
+									Text(detail.display.unit.format(number))
+										.font(Typo.micro)
+										.tabularNumbers()
+										.foregroundStyle(Token.mutedForeground)
+								}
+							}
+						}
+					}
+					.frame(height: 150)
+					.padding(.horizontal, 16)
+
+					HStack(spacing: 12) {
+						Legend(text: "\(points.filter(\.breached).count) breached", tint: detail.incident.severity.tint)
+						Legend(text: "\(points.filter { !$0.breached }.count) healthy", tint: Token.mutedForeground)
+						if let rule = detail.rule {
+							Spacer(minLength: 0)
+							Text("\(rule.windowMinutes)m window · \(rule.consecutiveBreachesRequired) to open")
+								.font(Typo.micro)
+								.tabularNumbers()
+								.foregroundStyle(Token.mutedForeground.opacity(0.7))
+						}
+					}
+					.padding(.horizontal, 16)
+				}
+			}
+		}
+	}
+
+	private struct Legend: View {
+		let text: String
+		let tint: Color
+
+		var body: some View {
+			HStack(spacing: 5) {
+				Circle().fill(tint).frame(width: 5, height: 5)
+				Text(text)
+					.font(Typo.micro)
+					.tabularNumbers()
+					.foregroundStyle(Token.mutedForeground)
+			}
+		}
+	}
+}
+
+/// The service's three golden signals over the same window, so a latency
+/// alert can show that errors spiked too, or that traffic did.
+private struct WhatChanged: View {
+	let detail: IncidentDetail
+
+	var body: some View {
+		Block(title: "What changed on \(detail.serviceName ?? "the service")") {
+			StatGrid(columns: 3) {
+				SignalTile(
+					label: "Error rate",
+					value: SignalUnit.ratio.format(detail.errorRate.latest),
+					valueTint: detail.errorRate.latest.map(Tone.errorRate) ?? Token.mutedForeground,
+					values: detail.errorRate,
+					tint: Token.chartError
+				)
+				SignalTile(
+					label: "p95",
+					value: SignalUnit.milliseconds.format(detail.p95.latest),
+					valueTint: detail.p95.latest.map { Tone.latency($0, scale: .p95) } ?? Token.mutedForeground,
+					values: detail.p95,
+					tint: Token.chartP95
+				)
+				SignalTile(
+					label: "Requests",
+					value: SignalUnit.count.format(detail.throughput.latest),
+					values: detail.throughput,
+					tint: Token.mutedForeground
+				)
+			}
+			.padding(.horizontal, 16)
+		}
+	}
+}
+
+/// A stat tile with the shape of the window under the number.
+struct SignalTile: View {
+	let label: String
+	let value: String
+	var valueTint: Color = Token.foreground
+	let values: [Double]
+	let tint: Color
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			Text(label).sectionLabelStyle().lineLimit(1)
+			Text(value)
+				.font(Typo.statValue)
+				.tabularNumbers()
+				.foregroundStyle(valueTint)
+				.lineLimit(1)
+				.minimumScaleFactor(0.6)
+			Sparkline(values: values, tint: tint)
+				.frame(height: 24)
+		}
+		.frame(maxWidth: .infinity, alignment: .leading)
+		.padding(.horizontal, 12)
+		.padding(.vertical, 12)
+		.background(Token.card)
+	}
+}
+
+extension Array where Element == Double {
+	/// The most recent finite bucket, for a tile whose number should read as
+	/// "now" rather than "over the window".
+	var latest: Double? { last(where: \.isFinite) }
+}
+
+private struct LikelyCause: View {
+	let detail: IncidentDetail
+
+	private var hasAnything: Bool {
+		detail.linkedIssue != nil || !detail.recentIssues.isEmpty || !detail.failingOperations.isEmpty
+	}
+
+	var body: some View {
+		Block(title: "Likely cause") {
+			if !hasAnything {
+				Text(
+					detail.serviceName == nil
+						? "This rule spans several services, so there is no single service to correlate."
+						: "No error issues or failing operations in the window."
+				)
+				.font(Typo.small)
+				.foregroundStyle(Token.mutedForeground)
+				.padding(.horizontal, 16)
+			}
+
+			if let linked = detail.linkedIssue {
+				VStack(alignment: .leading, spacing: 6) {
+					Text("Linked issue")
+						.font(Typo.micro)
+						.foregroundStyle(Token.mutedForeground.opacity(0.7))
+						.padding(.horizontal, 16)
+					NavigationLink(value: Route.issue(id: linked.id)) {
+						LinkedIssueRow(issue: linked)
+					}
+					.buttonStyle(RowButtonStyle())
+					Hairline()
+				}
+			}
+
+			if !detail.recentIssues.isEmpty {
+				VStack(alignment: .leading, spacing: 6) {
+					Text("Errors in the window")
+						.font(Typo.micro)
+						.foregroundStyle(Token.mutedForeground.opacity(0.7))
+						.padding(.horizontal, 16)
+					VStack(spacing: 0) {
+						ForEach(detail.recentIssues, id: \.id) { issue in
+							NavigationLink(value: Route.issue(id: issue.id)) {
+								IssueRow(issue: issue, showsService: false)
+							}
+							.buttonStyle(RowButtonStyle())
+							Hairline()
+						}
+					}
+				}
+			}
+
+			if !detail.failingOperations.isEmpty {
+				VStack(alignment: .leading, spacing: 6) {
+					Text("Failing operations")
+						.font(Typo.micro)
+						.foregroundStyle(Token.mutedForeground.opacity(0.7))
+						.padding(.horizontal, 16)
+					BreakdownList(items: detail.failingOperations, unit: .count, tint: Token.chartError)
+				}
+			}
+		}
+	}
+}
+
+private struct LinkedIssueRow: View {
+	let issue: ErrorIssueDetail
+
+	var body: some View {
+		HStack(alignment: .top, spacing: 10) {
+			SeverityBadge(severity: issue.severity)
+				.frame(width: 56, alignment: .leading)
+			VStack(alignment: .leading, spacing: 4) {
+				Text(issue.exceptionType.isEmpty ? issue.errorLabel : issue.exceptionType)
+					.font(Typo.bodyMedium)
+					.foregroundStyle(Token.foreground)
+					.lineLimit(1)
+				Text(issue.exceptionMessage)
+					.font(Typo.small)
+					.foregroundStyle(Token.mutedForeground)
+					.lineLimit(2)
+			}
+			Spacer(minLength: 0)
+		}
+		.padding(.horizontal, 16)
+		.padding(.vertical, 12)
+		.contentShape(.rect)
+	}
+}
+
+/// Ranked bars, from the web's breakdown lists: name, value, and a bar scaled
+/// to the largest entry.
+struct BreakdownList: View {
+	let items: [BreakdownItem]
+	let unit: SignalUnit
+	let tint: Color
+
+	var body: some View {
+		let peak = items.map(\.value).max() ?? 1
+		VStack(spacing: 0) {
+			ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+				VStack(alignment: .leading, spacing: 5) {
+					HStack(alignment: .firstTextBaseline) {
+						Text(item.name.isEmpty ? "(unnamed)" : item.name)
+							.font(Typo.small)
+							.foregroundStyle(Token.foreground)
+							.lineLimit(1)
+						Spacer(minLength: 8)
+						Text(unit.format(item.value))
+							.font(Typo.smallMedium)
+							.tabularNumbers()
+							.foregroundStyle(Token.foreground)
+					}
+					GeometryReader { proxy in
+						Rectangle()
+							.fill(tint.opacity(0.7))
+							.frame(width: max(2, proxy.size.width * CGFloat(peak > 0 ? item.value / peak : 0)))
+					}
+					.frame(height: 3)
+				}
+				.padding(.horizontal, 16)
+				.padding(.vertical, 8)
+				Hairline()
+			}
+		}
+	}
+}
+
+/// Trigger / re-notify / resolve, and where each went.
+private struct IncidentTimeline: View {
+	let detail: IncidentDetail
+
+	private struct Event: Identifiable {
+		let id: String
+		let at: String
+		let title: String
+		let detail: String?
+		let tint: Color
+	}
+
+	private var events: [Event] {
+		var events: [Event] = []
+		let incident = detail.incident
+		events.append(
+			Event(id: "opened", at: incident.firstTriggeredAt, title: "Opened", detail: nil, tint: incident.severity.tint)
+		)
+		for delivery in detail.deliveries {
+			let ok = delivery.status == .success
+			events.append(
+				Event(
+					id: delivery.id,
+					at: delivery.attemptedAt ?? delivery.scheduledAt,
+					title: "\(delivery.eventType.label) → \(delivery.destinationName)",
+					detail: ok
+						? delivery.destinationType.label
+						: (delivery.errorMessage ?? delivery.status.rawValue.capitalized),
+					tint: ok ? Token.mutedForeground : Token.destructive
+				)
+			)
+		}
+		if let resolved = incident.resolvedAt {
+			events.append(Event(id: "resolved", at: resolved, title: "Resolved", detail: nil, tint: Token.success))
+		}
+		return events.sorted { $0.at < $1.at }
+	}
+
+	var body: some View {
+		Block(title: "Timeline") {
+			VStack(spacing: 0) {
+				ForEach(events) { event in
+					HStack(alignment: .firstTextBaseline, spacing: 10) {
+						Text(Format.timelineTime(event.at))
+							.font(Typo.tiny)
+							.tabularNumbers()
+							.foregroundStyle(Token.mutedForeground)
+							.lineLimit(1)
+							.frame(width: 96, alignment: .leading)
+						Circle()
+							.fill(event.tint)
+							.frame(width: 5, height: 5)
+							.offset(y: -1)
+						VStack(alignment: .leading, spacing: 2) {
+							Text(event.title)
+								.font(Typo.small)
+								.foregroundStyle(Token.foreground)
+								.lineLimit(1)
+							if let detail = event.detail {
+								Text(detail)
+									.font(Typo.tiny)
+									.foregroundStyle(event.tint == Token.destructive ? Token.destructive : Token.mutedForeground)
+									.lineLimit(2)
+							}
+						}
+						Spacer(minLength: 0)
+					}
+					.padding(.horizontal, 16)
+					.padding(.vertical, 8)
+					Hairline()
+				}
+				if detail.deliveries.isEmpty {
+					Text("No notifications were sent for this incident.")
+						.font(Typo.tiny)
+						.foregroundStyle(Token.mutedForeground.opacity(0.7))
+						.padding(.horizontal, 16)
+						.padding(.top, 8)
+				}
+			}
+		}
+	}
+}
+
+private struct RuleFacts: View {
+	let detail: IncidentDetail
+
+	var body: some View {
+		Block(title: "Rule") {
+			VStack(spacing: 0) {
+				DetailRow(
+					"Condition",
+					"\(detail.display.label) \(detail.incident.comparator.glyph) \(detail.display.unit.format(detail.incident.threshold))"
+				)
+				Hairline()
+				if let rule = detail.rule {
+					DetailRow("Window", "\(rule.windowMinutes)m, min \(rule.minimumSampleCount) samples")
+					Hairline()
+					DetailRow("Opens after", "\(rule.consecutiveBreachesRequired) consecutive breaches")
+					Hairline()
+					DetailRow("Resolves after", "\(rule.consecutiveHealthyRequired) healthy checks")
+					Hairline()
+					if !rule.environments.isEmpty {
+						DetailRow("Environments", rule.environments.joined(separator: ", "))
+						Hairline()
+					}
+					if let notes = rule.notes, !notes.isEmpty {
+						DetailRow("Notes", notes)
+						Hairline()
+					}
+				}
+				if let count = detail.incident.lastSampleCount {
+					DetailRow("Last sample", "\(Format.count(count)) samples")
+					Hairline()
+				}
+			}
+			.padding(.horizontal, 16)
+		}
+	}
+}

--- a/apps/ios/Maple/Features/Alerts/IncidentsListView.swift
+++ b/apps/ios/Maple/Features/Alerts/IncidentsListView.swift
@@ -1,0 +1,208 @@
+import MapleAPI
+import SwiftUI
+
+@MainActor
+@Observable
+final class IncidentsListModel {
+	private(set) var state: LoadState<[IncidentCard]> = .loading
+	private(set) var isLoadingMore = false
+
+	/// Open only by default: the hub is for triage, and history is one tap
+	/// away. Resolved incidents are still listed after the open ones when
+	/// the filter is off.
+	var openOnly = true {
+		didSet { if openOnly != oldValue { Task { await load() } } }
+	}
+
+	private var nextCursor: String?
+	private var hasMore = false
+	private var rules: [String: AlertRule] = [:]
+
+	private let api: any MapleAPI
+	private let session: SessionController
+
+	init(api: any MapleAPI, session: SessionController) {
+		self.api = api
+		self.session = session
+	}
+
+	func load(showPlaceholder: Bool = true) async {
+		if showPlaceholder && !state.hasContent { state = .loading }
+		nextCursor = nil
+		let next = await session.perform { () -> [IncidentCard] in
+			async let rulesTask = self.api.alertRules(limit: 100, cursor: nil)
+			let page = try await self.api.alertIncidents(
+				status: self.openOnly ? .open : nil, ruleId: nil, limit: 30, cursor: nil
+			)
+			self.rules = Dictionary(
+				((try? await rulesTask.items) ?? []).map { ($0.id, $0) },
+				uniquingKeysWith: { first, _ in first }
+			)
+			self.nextCursor = page.nextCursor
+			self.hasMore = page.hasMore
+			return page.items.map(self.card)
+		}
+		guard let next else { return }
+		if case .loaded(let cards) = next, cards.isEmpty {
+			state = .empty
+		} else {
+			state = next
+		}
+	}
+
+	func loadMore() async {
+		guard hasMore, !isLoadingMore, let cursor = nextCursor, let existing = state.value else { return }
+		isLoadingMore = true
+		defer { isLoadingMore = false }
+		guard
+			let page = try? await api.alertIncidents(
+				status: openOnly ? .open : nil, ruleId: nil, limit: 30, cursor: cursor
+			)
+		else {
+			hasMore = false
+			return
+		}
+		nextCursor = page.nextCursor
+		hasMore = page.hasMore
+		state = .loaded(existing + page.items.map(card))
+	}
+
+	var canLoadMore: Bool { hasMore }
+
+	private func card(_ incident: AlertIncident) -> IncidentCard {
+		let rule = rules[incident.ruleId]
+		return IncidentCard(
+			incident: incident,
+			serviceNames: rule?.serviceNames ?? [],
+			display: rule.map(SignalDisplay.init(rule:)) ?? SignalDisplay(signal: incident.signalType),
+			observations: []
+		)
+	}
+}
+
+struct IncidentsListView: View {
+	@Environment(SessionController.self) private var session
+	@State private var model: IncidentsListModel?
+
+	var body: some View {
+		Group {
+			if let model {
+				LoadableView(
+					state: model.state,
+					emptyTitle: model.openOnly ? "No open alerts" : "No incidents",
+					emptyMessage: model.openOnly
+						? "Every alert rule is within its threshold."
+						: "No alert rule has fired yet.",
+					skeletonRowHeight: 72,
+					retry: { Task { await model.load() } }
+				) { cards in
+					ScrollView {
+						LazyVStack(spacing: 0) {
+							ForEach(cards) { card in
+								NavigationLink(value: Route.incident(id: card.id)) {
+									IncidentRow(card: card)
+								}
+								.buttonStyle(RowButtonStyle())
+								Hairline()
+							}
+							if model.canLoadMore {
+								SkeletonList(rowHeight: 72, rows: 2)
+									.frame(height: 144)
+									.task { await model.loadMore() }
+							}
+						}
+					}
+					.scrollContentBackground(.hidden)
+				}
+				.refreshable { await model.load(showPlaceholder: false) }
+				.toolbar {
+					ToolbarItem(placement: .topBarTrailing) {
+						Button {
+							model.openOnly.toggle()
+						} label: {
+							Text(model.openOnly ? "Open" : "All")
+								.font(Typo.smallMedium)
+								.foregroundStyle(model.openOnly ? Token.primary : Token.foreground)
+						}
+					}
+				}
+			} else {
+				SkeletonList(rowHeight: 72)
+			}
+		}
+		.task(id: session.dataGeneration) {
+			let model = model ?? IncidentsListModel(api: session.api, session: session)
+			self.model = model
+			await model.load()
+		}
+	}
+}
+
+/// Severity lane, rule name, age or resolution, services, breach.
+struct IncidentRow: View {
+	let card: IncidentCard
+
+	private var incident: AlertIncident { card.incident }
+	private var isOpen: Bool { incident.status == .open }
+	private var tint: Color { isOpen ? incident.severity.tint : Token.mutedForeground }
+
+	var body: some View {
+		HStack(alignment: .top, spacing: 12) {
+			Rectangle()
+				.fill(isOpen ? incident.severity.tint : .clear)
+				.frame(width: 2)
+
+			VStack(alignment: .leading, spacing: 5) {
+				HStack(alignment: .firstTextBaseline, spacing: 8) {
+					Text(incident.ruleName)
+						.font(Typo.bodyMedium)
+						.foregroundStyle(isOpen ? Token.foreground : Token.mutedForeground)
+						.lineLimit(1)
+					Spacer(minLength: 4)
+					if isOpen {
+						Text(Format.duration(from: incident.firstTriggeredAt))
+							.font(Typo.tiny)
+							.tabularNumbers()
+							.foregroundStyle(Token.mutedForeground)
+					} else {
+						Text("resolved \(Format.lastSeen(incident.resolvedAt ?? incident.lastTriggeredAt))")
+							.font(Typo.tiny)
+							.tabularNumbers()
+							.foregroundStyle(Token.mutedForeground)
+					}
+				}
+
+				HStack(spacing: 8) {
+					MapleBadge(text: incident.severity.label, tint: tint)
+					if let first = card.serviceNames.first {
+						HStack(spacing: 5) {
+							ServiceDot(serviceName: first, size: 6)
+							Text(card.serviceNames.count > 1 ? "\(first) +\(card.serviceNames.count - 1)" : first)
+								.font(Typo.tiny)
+								.foregroundStyle(Token.mutedForeground)
+								.lineLimit(1)
+						}
+					}
+					Spacer(minLength: 0)
+					Text(
+						Format.breach(
+							observed: incident.lastObservedValue,
+							comparator: incident.comparator,
+							threshold: incident.threshold,
+							upper: incident.thresholdUpper,
+							unit: card.display.unit
+						)
+					)
+					.font(Typo.tiny)
+					.tabularNumbers()
+					.foregroundStyle(tint)
+					.lineLimit(1)
+				}
+			}
+		}
+		.padding(.trailing, 16)
+		.padding(.vertical, 12)
+		.frame(minHeight: 64)
+		.contentShape(.rect)
+	}
+}

--- a/apps/ios/Maple/Features/Home/HomeModel.swift
+++ b/apps/ios/Maple/Features/Home/HomeModel.swift
@@ -1,0 +1,221 @@
+import Foundation
+import MapleAPI
+
+/// One open incident as Home shows it: the incident, the services its rule
+/// covers, and the rule's last hour of observations for the sparkline.
+struct IncidentCard: Identifiable, Hashable {
+	let incident: AlertIncident
+	let serviceNames: [String]
+	let display: SignalDisplay
+	/// Observed values from the rule's own checks, oldest first. Empty until
+	/// loaded, and stays empty for a rule whose checks failed to load — the
+	/// card is still worth showing.
+	var observations: [Double]
+
+	var id: String { incident.id }
+
+	static func == (lhs: IncidentCard, rhs: IncidentCard) -> Bool {
+		lhs.incident == rhs.incident && lhs.observations == rhs.observations && lhs.serviceNames == rhs.serviceNames
+	}
+
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(incident.id)
+		hasher.combine(incident.lastTriggeredAt)
+	}
+}
+
+/// What Home knows about the org right now.
+struct HomeSnapshot {
+	var services: [Service]
+	var incidents: [IncidentCard]
+	/// Error issues first seen inside the last 24 hours.
+	var newIssues: Int
+	/// Actionable issues seen in the last 24 hours that are older than that.
+	var activeIssues: Int
+	var openAnomalies: Int
+	var loadedAt: Date
+
+	// MARK: Derived
+
+	var unhealthy: [Service] { services.filter { health(of: $0) == .unhealthy } }
+	var degraded: [Service] { services.filter { health(of: $0) == .degraded } }
+	var criticalIncidents: [IncidentCard] { incidents.filter { $0.incident.severity == .critical } }
+
+	/// Services that need attention, worst first. Health first, then error
+	/// rate, then volume — the same ordering as the Services tab.
+	var attention: [Service] {
+		(unhealthy + degraded).sorted { a, b in
+			let ha = health(of: a)
+			let hb = health(of: b)
+			if ha != hb { return ha == .unhealthy }
+			if a.errorRate != b.errorRate { return a.errorRate > b.errorRate }
+			return a.throughput > b.throughput
+		}
+	}
+
+	/// The overall status Home leads with. Worst thing wins: a critical
+	/// incident beats a degraded service, no data beats everything — an org
+	/// that stopped sending is not healthy, it's dark.
+	var status: OverallStatus {
+		if services.isEmpty && incidents.isEmpty { return .noData }
+		if !criticalIncidents.isEmpty || !unhealthy.isEmpty { return .critical }
+		if !incidents.isEmpty || !degraded.isEmpty { return .degraded }
+		return .healthy
+	}
+
+	var headline: String {
+		switch status {
+		case .noData:
+			return "No telemetry in the last hour"
+		case .healthy:
+			return services.count == 1 ? "Your service is healthy" : "All \(services.count) services healthy"
+		case .degraded:
+			let count = degraded.count
+			if count == 0 { return incidents.count == 1 ? "1 open alert" : "\(incidents.count) open alerts" }
+			return count == 1 ? "1 service degraded" : "\(count) services degraded"
+		case .critical:
+			let count = unhealthy.count
+			if count == 0 {
+				return criticalIncidents.count == 1 ? "1 critical alert" : "\(criticalIncidents.count) critical alerts"
+			}
+			return count == 1 ? "1 service unhealthy" : "\(count) services unhealthy"
+		}
+	}
+
+	/// The second line: everything the headline didn't say, as counts.
+	var subheadline: String {
+		var parts: [String] = []
+		let critical = criticalIncidents.count
+		let warnings = incidents.count - critical
+		if status == .critical, !unhealthy.isEmpty, critical > 0 {
+			parts.append(critical == 1 ? "1 critical alert" : "\(critical) critical alerts")
+		}
+		if warnings > 0 { parts.append(warnings == 1 ? "1 warning" : "\(warnings) warnings") }
+		if status == .critical, !degraded.isEmpty { parts.append("\(degraded.count) degraded") }
+		if newIssues > 0 { parts.append(newIssues == 1 ? "1 new issue" : "\(newIssues) new issues") }
+		if openAnomalies > 0 { parts.append(openAnomalies == 1 ? "1 anomaly" : "\(openAnomalies) anomalies") }
+		if parts.isEmpty {
+			switch status {
+			case .noData: return "Nothing reported by any service."
+			case .healthy: return "No open alerts, nothing new to triage."
+			case .degraded, .critical: return "No other signals out of range."
+			}
+		}
+		return parts.joined(separator: " · ")
+	}
+
+	private func health(of service: Service) -> ServiceHealth {
+		ServiceHealth(errorRate: service.errorRate, p95LatencyMs: service.p95LatencyMs)
+	}
+}
+
+enum OverallStatus {
+	case noData
+	case healthy
+	case degraded
+	case critical
+}
+
+@MainActor
+@Observable
+final class HomeModel {
+	private(set) var state: LoadState<HomeSnapshot> = .loading
+
+	private let api: any MapleAPI
+	private let session: SessionController
+
+	/// Home is always "now": an hour for rates, a day for what's new. There is
+	/// no time picker on purpose — a picker answers "what happened", and that
+	/// is a question for the other tabs.
+	static let rateWindow = TimeWindow.lastHour
+	static let recentWindow = TimeWindow.last24Hours
+
+	init(api: any MapleAPI, session: SessionController) {
+		self.api = api
+		self.session = session
+	}
+
+	func load(showPlaceholder: Bool = true) async {
+		if showPlaceholder && !state.hasContent { state = .loading }
+		if let next = await session.perform({ try await self.fetch() }) {
+			state = next
+		}
+	}
+
+	private func fetch() async throws -> HomeSnapshot {
+		let now = Date()
+		let rates = Self.rateWindow.resolve(now: now)
+		let recent = Self.recentWindow.resolve(now: now)
+
+		// Services and open incidents are the screen. The rest is decoration
+		// and must not take the screen down with it.
+		async let servicesTask = api.services(window: rates, limit: 100)
+		async let incidentsTask = api.alertIncidents(status: .open, ruleId: nil, limit: 50, cursor: nil)
+		async let rulesTask = api.alertRules(limit: 100, cursor: nil)
+		async let issuesTask = api.issues(
+			query: IssueQuery(actionableOnly: true, sort: .lastSeen), window: recent, limit: 100, cursor: nil
+		)
+		async let anomaliesTask = api.anomalyIncidents(
+			status: .open, serviceName: nil, window: nil, limit: 100, cursor: nil
+		)
+
+		let services = try await servicesTask.items
+		let incidents = try await incidentsTask.items
+		let rules = Dictionary(
+			((try? await rulesTask.items) ?? []).map { ($0.id, $0) },
+			uniquingKeysWith: { first, _ in first }
+		)
+		let issues = (try? await issuesTask.items) ?? []
+		let anomalies = (try? await anomaliesTask.items) ?? []
+
+		let dayAgo = recent.start
+		let newIssues = issues.filter { issue in
+			guard let firstSeen = ResolvedTimeWindow.parse(issue.firstSeenAt) else { return false }
+			return firstSeen >= dayAgo
+		}.count
+
+		var cards = incidents.map { incident in
+			let rule = rules[incident.ruleId]
+			return IncidentCard(
+				incident: incident,
+				serviceNames: rule?.serviceNames ?? [],
+				display: rule.map(SignalDisplay.init(rule:)) ?? SignalDisplay(signal: incident.signalType),
+				observations: []
+			)
+		}
+		// Critical first, then most recently triggered.
+		cards.sort { a, b in
+			if a.incident.severity != b.incident.severity { return a.incident.severity == .critical }
+			return a.incident.lastTriggeredAt > b.incident.lastTriggeredAt
+		}
+
+		// One checks request per card, bounded: the first eight cards are the
+		// ones on screen; the rest get a sparkline when tapped into.
+		let observations = await withTaskGroup(of: (Int, [Double]).self, returning: [Int: [Double]].self) { group in
+			for (index, card) in cards.prefix(8).enumerated() {
+				group.addTask { [api] in
+					let checks = try? await api.alertRuleChecks(
+						ruleId: card.incident.ruleId,
+						groupKey: card.incident.groupKey,
+						since: rates.start,
+						limit: 60
+					)
+					return (index, (checks ?? []).compactMap(\.observedValue))
+				}
+			}
+			var result: [Int: [Double]] = [:]
+			for await (index, values) in group { result[index] = values }
+			return result
+		}
+		for (index, values) in observations { cards[index].observations = values }
+
+		return HomeSnapshot(
+			services: services,
+			incidents: cards,
+			newIssues: newIssues,
+			activeIssues: max(0, issues.count - newIssues),
+			openAnomalies: anomalies.count,
+			loadedAt: now
+		)
+	}
+}

--- a/apps/ios/Maple/Features/Home/HomeView.swift
+++ b/apps/ios/Maple/Features/Home/HomeView.swift
@@ -1,0 +1,381 @@
+import MapleAPI
+import SwiftUI
+
+/// The pulse. Everything above the fold answers "is anything wrong right now";
+/// everything below it is the shortest path to "why".
+struct HomeView: View {
+	@Environment(SessionController.self) private var session
+	@Environment(AppNavigation.self) private var navigation
+	@State private var model: HomeModel?
+
+	var body: some View {
+		NavigationStack {
+			ZStack {
+				Token.background.ignoresSafeArea()
+				if let model {
+					LoadableView(
+						state: model.state,
+						emptyTitle: "Nothing yet",
+						emptyMessage: "No services have reported telemetry.",
+						retry: { Task { await model.load() } }
+					) { snapshot in
+						HomeContent(snapshot: snapshot)
+					}
+					.refreshable { await model.load(showPlaceholder: false) }
+				} else {
+					SkeletonList()
+				}
+			}
+			.navigationBarTitleDisplayMode(.inline)
+			.toolbar {
+				ToolbarItem(placement: .principal) {
+					OrganizationSwitcherButton(fallbackTitle: "Maple")
+				}
+			}
+			.mapleDestinations()
+		}
+		.task(id: session.dataGeneration) {
+			let model = model ?? HomeModel(api: session.api, session: session)
+			self.model = model
+			await model.load()
+			// Home is a status board: keep it current while it's on screen.
+			// `.task` is cancelled when the tab goes away, so this never runs
+			// in the background.
+			while !Task.isCancelled {
+				try? await Task.sleep(for: .seconds(60))
+				guard !Task.isCancelled else { break }
+				await model.load(showPlaceholder: false)
+			}
+		}
+	}
+}
+
+private struct HomeContent: View {
+	let snapshot: HomeSnapshot
+	@Environment(AppNavigation.self) private var navigation
+
+	var body: some View {
+		ScrollView {
+			VStack(alignment: .leading, spacing: 28) {
+				StatusHeadline(snapshot: snapshot)
+					.padding(.horizontal, 16)
+
+				if !snapshot.incidents.isEmpty {
+					HomeSection(title: "Open alerts", count: snapshot.incidents.count) {
+						VStack(spacing: 8) {
+							ForEach(snapshot.incidents) { card in
+								NavigationLink(value: Route.incident(id: card.id)) {
+									IncidentCardView(card: card)
+								}
+								.buttonStyle(.plain)
+							}
+						}
+						.padding(.horizontal, 16)
+					}
+				}
+
+				HomeSection(
+					title: "Needs attention",
+					count: snapshot.attention.isEmpty ? nil : snapshot.attention.count
+				) {
+					if snapshot.attention.isEmpty {
+						QuietRow(
+							text: snapshot.services.isEmpty
+								? "No services reported in the last hour."
+								: "All \(snapshot.services.count) services within thresholds."
+						)
+					} else {
+						VStack(spacing: 0) {
+							ForEach(snapshot.attention.prefix(6), id: \.name) { service in
+								NavigationLink(value: Route.service(name: service.name, window: .lastHour)) {
+									AttentionRow(service: service)
+								}
+								.buttonStyle(RowButtonStyle())
+								Hairline()
+							}
+						}
+					}
+				}
+
+				HomeSection(title: "Last 24 hours", count: nil) {
+					VStack(spacing: 0) {
+						CountRow(
+							count: snapshot.newIssues,
+							singular: "new error issue",
+							plural: "new error issues",
+							detail: snapshot.activeIssues > 0 ? "\(snapshot.activeIssues) still active" : nil,
+							tint: snapshot.newIssues > 0 ? Token.foreground : Token.mutedForeground
+						) { navigation.open(.errors) }
+						Hairline()
+						CountRow(
+							count: snapshot.openAnomalies,
+							singular: "anomaly open",
+							plural: "anomalies open",
+							detail: nil,
+							tint: snapshot.openAnomalies > 0 ? Token.foreground : Token.mutedForeground
+						) { navigation.open(.anomalies) }
+						Hairline()
+					}
+				}
+
+				Text("Updated \(snapshot.loadedAt.formatted(date: .omitted, time: .shortened))")
+					.font(Typo.tiny)
+					.tabularNumbers()
+					.foregroundStyle(Token.mutedForeground.opacity(0.6))
+					.padding(.horizontal, 16)
+			}
+			.padding(.top, 8)
+			.padding(.bottom, 24)
+		}
+		.scrollContentBackground(.hidden)
+	}
+}
+
+/// The one place the display face carries a sentence, and the one place the
+/// screen's colour is allowed to be loud.
+private struct StatusHeadline: View {
+	let snapshot: HomeSnapshot
+
+	private var tint: Color {
+		switch snapshot.status {
+		case .noData: Token.mutedForeground
+		case .healthy: Token.success
+		case .degraded: Token.severityWarn
+		case .critical: Token.destructive
+		}
+	}
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			HStack(alignment: .firstTextBaseline, spacing: 10) {
+				Circle()
+					.fill(tint)
+					.frame(width: 8, height: 8)
+					.offset(y: -2)
+				Text(snapshot.headline)
+					.font(Typo.pageTitle)
+					.foregroundStyle(Token.foreground)
+					.fixedSize(horizontal: false, vertical: true)
+			}
+			Text(snapshot.subheadline)
+				.font(Typo.small)
+				.tabularNumbers()
+				.foregroundStyle(Token.mutedForeground)
+				.padding(.leading, 18)
+		}
+		.padding(.top, 12)
+		.accessibilityElement(children: .combine)
+	}
+}
+
+private struct HomeSection<Content: View>: View {
+	let title: String
+	let count: Int?
+	@ViewBuilder let content: Content
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			HStack(spacing: 6) {
+				SectionLabel(title)
+				if let count {
+					Text("\(count)")
+						.font(Typo.microMedium)
+						.tabularNumbers()
+						.foregroundStyle(Token.mutedForeground.opacity(0.7))
+				}
+			}
+			.padding(.horizontal, 16)
+			content
+		}
+	}
+}
+
+/// An open incident: severity lane, rule name and age, the services it covers,
+/// then the breach in the signal's own unit beside the last hour of what the
+/// rule saw.
+struct IncidentCardView: View {
+	let card: IncidentCard
+
+	private var incident: AlertIncident { card.incident }
+
+	var body: some View {
+		HStack(alignment: .top, spacing: 0) {
+			Rectangle()
+				.fill(incident.severity.tint)
+				.frame(width: 2)
+
+			VStack(alignment: .leading, spacing: 8) {
+				HStack(alignment: .firstTextBaseline, spacing: 8) {
+					Text(incident.ruleName)
+						.font(Typo.bodyMedium)
+						.foregroundStyle(Token.foreground)
+						.lineLimit(1)
+					Spacer(minLength: 4)
+					Text(Format.duration(from: incident.firstTriggeredAt))
+						.font(Typo.tiny)
+						.tabularNumbers()
+						.foregroundStyle(Token.mutedForeground)
+				}
+
+				HStack(spacing: 6) {
+					if let first = card.serviceNames.first {
+						ServiceDot(serviceName: first, size: 6)
+						Text(serviceLabel)
+							.font(Typo.tiny)
+							.foregroundStyle(Token.mutedForeground)
+							.lineLimit(1)
+					} else {
+						Text("All services")
+							.font(Typo.tiny)
+							.foregroundStyle(Token.mutedForeground)
+					}
+					if let group = incident.groupKey, group != "__total__" {
+						Text("· \(group)")
+							.font(Typo.tiny)
+							.foregroundStyle(Token.mutedForeground)
+							.lineLimit(1)
+					}
+				}
+
+				HStack(alignment: .bottom, spacing: 12) {
+					VStack(alignment: .leading, spacing: 2) {
+						Text(card.display.label)
+							.font(Typo.micro)
+							.foregroundStyle(Token.mutedForeground.opacity(0.7))
+						Text(
+							Format.breach(
+								observed: incident.lastObservedValue,
+								comparator: incident.comparator,
+								threshold: incident.threshold,
+								upper: incident.thresholdUpper,
+								unit: card.display.unit
+							)
+						)
+						.font(Typo.smallSemibold)
+						.tabularNumbers()
+						.foregroundStyle(incident.severity.tint)
+					}
+					Spacer(minLength: 0)
+					Sparkline(values: card.observations, tint: incident.severity.tint, reference: incident.threshold)
+						.frame(width: 96, height: 28)
+				}
+			}
+			.padding(.leading, 12)
+			.padding(.trailing, 12)
+			.padding(.vertical, 12)
+		}
+		.background(Token.card, in: .rect(cornerRadius: Token.Radius.lg))
+		.overlay(
+			RoundedRectangle(cornerRadius: Token.Radius.lg)
+				.stroke(Token.border, lineWidth: Token.hairline)
+		)
+		.contentShape(.rect)
+	}
+
+	private var serviceLabel: String {
+		let names = card.serviceNames
+		if names.count <= 2 { return names.joined(separator: ", ") }
+		return "\(names[0]), \(names[1]) +\(names.count - 2)"
+	}
+}
+
+private struct AttentionRow: View {
+	let service: Service
+
+	private var health: ServiceHealth {
+		ServiceHealth(errorRate: service.errorRate, p95LatencyMs: service.p95LatencyMs)
+	}
+
+	var body: some View {
+		HStack(spacing: 12) {
+			Rectangle()
+				.fill(health == .unhealthy ? Token.destructive : .clear)
+				.frame(width: 2)
+			ServiceDot(serviceName: service.name)
+			Text(service.name)
+				.font(Typo.bodyMedium)
+				.foregroundStyle(Token.foreground)
+				.lineLimit(1)
+			HealthDot(health: health)
+			Spacer(minLength: 8)
+			HStack(spacing: 14) {
+				Metric(label: "err", value: Format.errorRate(service.errorRate), tint: Tone.errorRate(service.errorRate))
+				Metric(
+					label: "p95",
+					value: Format.latency(service.p95LatencyMs),
+					tint: Tone.latency(service.p95LatencyMs, scale: .p95)
+				)
+			}
+		}
+		.padding(.trailing, 16)
+		.frame(minHeight: 48)
+		.contentShape(.rect)
+	}
+
+	private struct Metric: View {
+		let label: String
+		let value: String
+		let tint: Color
+
+		var body: some View {
+			VStack(alignment: .trailing, spacing: 1) {
+				Text(value)
+					.font(Typo.smallSemibold)
+					.tabularNumbers()
+					.foregroundStyle(tint)
+				Text(label)
+					.font(Typo.micro)
+					.foregroundStyle(Token.mutedForeground.opacity(0.6))
+			}
+			.frame(minWidth: 52, alignment: .trailing)
+		}
+	}
+}
+
+private struct CountRow: View {
+	let count: Int
+	let singular: String
+	let plural: String
+	let detail: String?
+	let tint: Color
+	let action: () -> Void
+
+	var body: some View {
+		Button(action: action) {
+			HStack(alignment: .firstTextBaseline, spacing: 8) {
+				Text("\(count)")
+					.font(Typo.statValue)
+					.tabularNumbers()
+					.foregroundStyle(tint)
+					.frame(minWidth: 36, alignment: .leading)
+				Text(count == 1 ? singular : plural)
+					.font(Typo.body)
+					.foregroundStyle(Token.foreground)
+				if let detail {
+					Text("· \(detail)")
+						.font(Typo.small)
+						.foregroundStyle(Token.mutedForeground)
+				}
+				Spacer(minLength: 0)
+				Image(systemName: "chevron.right")
+					.font(.system(size: 11, weight: .semibold))
+					.foregroundStyle(Token.mutedForeground.opacity(0.5))
+			}
+			.padding(.horizontal, 16)
+			.frame(minHeight: 52)
+			.contentShape(.rect)
+		}
+		.buttonStyle(RowButtonStyle())
+	}
+}
+
+private struct QuietRow: View {
+	let text: String
+
+	var body: some View {
+		Text(text)
+			.font(Typo.small)
+			.foregroundStyle(Token.mutedForeground)
+			.padding(.horizontal, 16)
+	}
+}

--- a/apps/ios/Maple/Features/Issues/IssuesListView.swift
+++ b/apps/ios/Maple/Features/Issues/IssuesListView.swift
@@ -67,40 +67,24 @@ final class IssuesListModel {
 	var canLoadMore: Bool { hasMore }
 }
 
-struct IssuesListView: View {
+/// The Errors segment of the Alerts hub. Content only — the hub owns the
+/// `NavigationStack`, the org switcher, and the destinations; this view
+/// contributes its rows and its own filter menu.
+struct IssuesListContent: View {
 	@Environment(SessionController.self) private var session
 	@State private var model: IssuesListModel?
 
 	var body: some View {
-		NavigationStack {
-			ZStack {
-				Token.background.ignoresSafeArea()
-				if let model {
-					content(model)
-				} else {
-					SkeletonList(rowHeight: 56)
-				}
-			}
-			.navigationTitle("Issues")
-			.navigationBarTitleDisplayMode(.inline)
-			.toolbar {
-				// The organization occupies the title slot: it is the context for
-				// everything on screen, the tab bar already names the screen, and
-				// a leading item here gets collapsed into an overflow menu — which
-				// is where a switcher goes to be undiscoverable.
-				ToolbarItem(placement: .principal) {
-					OrganizationSwitcherButton(fallbackTitle: "Issues")
-				}
-				if let model {
-					ToolbarItem(placement: .topBarTrailing) {
-						FilterMenu(model: model)
+		Group {
+			if let model {
+				content(model)
+					.toolbar {
+						ToolbarItem(placement: .topBarTrailing) {
+							FilterMenu(model: model)
+						}
 					}
-				}
-			}
-			.navigationDestination(for: IssueRoute.self) { route in
-				switch route {
-				case .detail(let id): IssueDetailView(issueID: id)
-				}
+			} else {
+				SkeletonList(rowHeight: 56)
 			}
 		}
 		.task(id: session.dataGeneration) {
@@ -124,7 +108,7 @@ struct IssuesListView: View {
 			ScrollView {
 				LazyVStack(spacing: 0) {
 					ForEach(issues, id: \.id) { issue in
-						NavigationLink(value: IssueRoute.detail(id: issue.id)) {
+						NavigationLink(value: Route.issue(id: issue.id)) {
 							IssueRow(issue: issue, showsService: true)
 						}
 						.buttonStyle(RowButtonStyle())

--- a/apps/ios/Maple/Features/Services/ServiceDetailView.swift
+++ b/apps/ios/Maple/Features/Services/ServiceDetailView.swift
@@ -1,13 +1,22 @@
 import MapleAPI
 import SwiftUI
 
+struct ServiceDetail {
+	var service: Service
+	var errorRate: [Double]
+	var p95: [Double]
+	var throughput: [Double]
+	/// Open incidents whose rule names this service (or is grouped on it).
+	var incidents: [IncidentCard]
+	var issues: [ErrorIssue]
+	var slowestOperations: [BreakdownItem]
+	var failingOperations: [BreakdownItem]
+}
+
 @MainActor
 @Observable
 final class ServiceDetailModel {
-	private(set) var state: LoadState<Service> = .loading
-	/// This service's open issues. Fetching them here is what makes the screen
-	/// worth opening — the metrics alone are already on the list row.
-	private(set) var issues: [ErrorIssue] = []
+	private(set) var state: LoadState<ServiceDetail> = .loading
 
 	let serviceName: String
 	var window: TimeWindow
@@ -24,30 +33,67 @@ final class ServiceDetailModel {
 
 	func load(showPlaceholder: Bool = true) async {
 		if showPlaceholder && !state.hasContent { state = .loading }
-
-		do {
-			let resolved = window.resolve()
-			async let serviceTask = api.service(named: serviceName, window: resolved)
-			async let issuesTask = api.issues(
-				query: IssueQuery(serviceName: serviceName, actionableOnly: true),
-				window: resolved,
-				limit: 10,
-				cursor: nil
-			)
-
-			let service = try await serviceTask
-			issues = ((try? await issuesTask) ?? Page(items: [], hasMore: false, nextCursor: nil)).items
-			state = .loaded(service)
-		} catch is CancellationError {
-		} catch let error as MapleAPIError {
-			if await session.handle(error) {
-				await load(showPlaceholder: false)
-			} else {
-				state = .failed(error)
-			}
-		} catch {
-			state = .failed(.transport(error))
+		if let next = await session.perform({ try await self.fetch() }) {
+			state = next
 		}
+	}
+
+	private func fetch() async throws -> ServiceDetail {
+		let resolved = window.resolve()
+		let name = serviceName
+
+		// The service itself is the screen; everything else is context that
+		// degrades to "nothing here" rather than to an error.
+		async let serviceTask = api.service(named: name, window: resolved)
+		async let issuesTask = api.issues(
+			query: IssueQuery(serviceName: name, actionableOnly: true), window: resolved, limit: 10, cursor: nil
+		)
+		async let errorTask = api.traceTimeseries(
+			TraceTimeseriesRequest(aggregation: .errorRate, window: resolved, serviceName: name)
+		)
+		async let p95Task = api.traceTimeseries(
+			TraceTimeseriesRequest(aggregation: .p95Duration, window: resolved, serviceName: name)
+		)
+		async let countTask = api.traceTimeseries(
+			TraceTimeseriesRequest(aggregation: .count, window: resolved, serviceName: name)
+		)
+		async let slowTask = api.traceBreakdown(
+			TraceBreakdownRequest(aggregation: .p95Duration, groupBy: .spanName, window: resolved, serviceName: name, limit: 5)
+		)
+		async let failingTask = api.traceBreakdown(
+			TraceBreakdownRequest(
+				aggregation: .count, groupBy: .spanName, window: resolved, serviceName: name, hasError: true, limit: 5
+			)
+		)
+		async let incidentsTask = api.alertIncidents(status: .open, ruleId: nil, limit: 50, cursor: nil)
+		async let rulesTask = api.alertRules(limit: 100, cursor: nil)
+
+		let service = try await serviceTask
+		let rules = Dictionary(
+			((try? await rulesTask.items) ?? []).map { ($0.id, $0) },
+			uniquingKeysWith: { first, _ in first }
+		)
+		let incidents = ((try? await incidentsTask.items) ?? []).compactMap { incident -> IncidentCard? in
+			guard let rule = rules[incident.ruleId] else { return nil }
+			let scoped = rule.serviceNames.contains(name)
+			let grouped = incident.groupKey == name
+			let global = rule.serviceNames.isEmpty && !rule.excludeServiceNames.contains(name) && incident.groupKey == nil
+			guard scoped || grouped || global else { return nil }
+			return IncidentCard(
+				incident: incident, serviceNames: rule.serviceNames, display: SignalDisplay(rule: rule), observations: []
+			)
+		}
+
+		return ServiceDetail(
+			service: service,
+			errorRate: (try? await errorTask.values) ?? [],
+			p95: (try? await p95Task.values) ?? [],
+			throughput: (try? await countTask.values) ?? [],
+			incidents: incidents,
+			issues: (try? await issuesTask.items) ?? [],
+			slowestOperations: (try? await slowTask.data) ?? [],
+			failingOperations: (try? await failingTask.data) ?? []
+		)
 	}
 }
 
@@ -67,8 +113,8 @@ struct ServiceDetailView: View {
 					emptyTitle: "No data",
 					emptyMessage: "This service reported nothing in \(model.window.phrase).",
 					retry: { Task { await model.load() } }
-				) { service in
-					ServiceDetailContent(service: service, issues: model.issues, window: model.window)
+				) { detail in
+					ServiceDetailContent(detail: detail, window: model.window)
 				}
 				.refreshable { await model.load(showPlaceholder: false) }
 			} else {
@@ -84,23 +130,31 @@ struct ServiceDetailView: View {
 						.font(Typo.monoTitle)
 						.foregroundStyle(Token.foreground)
 						.lineLimit(1)
-					if let service = model?.state.value {
+					if let service = model?.state.value?.service {
 						HealthDot(
-							health: ServiceHealth(
-								errorRate: service.errorRate,
-								p95LatencyMs: service.p95LatencyMs
-							)
+							health: ServiceHealth(errorRate: service.errorRate, p95LatencyMs: service.p95LatencyMs)
 						)
 					}
+				}
+			}
+			if let model {
+				ToolbarItem(placement: .topBarTrailing) {
+					TimeWindowMenu(
+						window: Binding(
+							get: { model.window },
+							set: { newValue in
+								model.window = newValue
+								Task { await model.load() }
+							}
+						)
+					)
 				}
 			}
 		}
 		.task(id: session.dataGeneration) {
 			let model =
 				model
-				?? ServiceDetailModel(
-					serviceName: serviceName, window: window, api: session.api, session: session
-				)
+				?? ServiceDetailModel(serviceName: serviceName, window: window, api: session.api, session: session)
 			self.model = model
 			await model.load()
 		}
@@ -108,30 +162,46 @@ struct ServiceDetailView: View {
 }
 
 private struct ServiceDetailContent: View {
-	let service: Service
-	let issues: [ErrorIssue]
+	let detail: ServiceDetail
 	let window: TimeWindow
+
+	private var service: Service { detail.service }
 
 	var body: some View {
 		ScrollView {
 			VStack(alignment: .leading, spacing: 24) {
 				section("Golden signals") {
-					StatGrid(columns: 2) {
-						StatTile(
+					// The number is the window aggregate the API computed; the
+					// line under it is the shape of that window.
+					StatGrid(columns: 3) {
+						SignalTile(
 							label: "Error rate",
 							value: Format.errorRate(service.errorRate),
-							tint: Tone.errorRate(service.errorRate)
+							valueTint: Tone.errorRate(service.errorRate),
+							values: detail.errorRate,
+							tint: Token.chartError
 						)
-						StatTile(label: "Throughput", value: Format.throughput(service.throughput))
+						SignalTile(
+							label: "p95",
+							value: Format.latency(service.p95LatencyMs),
+							valueTint: Tone.latency(service.p95LatencyMs, scale: .p95),
+							values: detail.p95,
+							tint: Token.chartP95
+						)
+						SignalTile(
+							label: "Throughput",
+							value: Format.throughput(service.throughput),
+							values: detail.throughput,
+							tint: Token.mutedForeground
+						)
+					}
+					.padding(.horizontal, 16)
+
+					StatGrid(columns: 3) {
 						StatTile(
 							label: "p50",
 							value: Format.latency(service.p50LatencyMs),
 							tint: Tone.latency(service.p50LatencyMs, scale: .p50)
-						)
-						StatTile(
-							label: "p95",
-							value: Format.latency(service.p95LatencyMs),
-							tint: Tone.latency(service.p95LatencyMs, scale: .p95)
 						)
 						StatTile(
 							label: "p99",
@@ -141,6 +211,51 @@ private struct ServiceDetailContent: View {
 						StatTile(label: "Errors", value: Format.count(service.errorCount))
 					}
 					.padding(.horizontal, 16)
+				}
+
+				if !detail.incidents.isEmpty {
+					section("Open alerts") {
+						VStack(spacing: 8) {
+							ForEach(detail.incidents) { card in
+								NavigationLink(value: Route.incident(id: card.id)) {
+									IncidentCardView(card: card)
+								}
+								.buttonStyle(.plain)
+							}
+						}
+						.padding(.horizontal, 16)
+					}
+				}
+
+				section("Open issues") {
+					if detail.issues.isEmpty {
+						Text("Nothing needs attention in \(window.phrase).")
+							.font(Typo.small)
+							.foregroundStyle(Token.mutedForeground)
+							.padding(.horizontal, 16)
+					} else {
+						VStack(spacing: 0) {
+							ForEach(detail.issues, id: \.id) { issue in
+								NavigationLink(value: Route.issue(id: issue.id)) {
+									IssueRow(issue: issue, showsService: false)
+								}
+								.buttonStyle(RowButtonStyle())
+								Hairline()
+							}
+						}
+					}
+				}
+
+				if !detail.failingOperations.isEmpty {
+					section("Failing operations") {
+						BreakdownList(items: detail.failingOperations, unit: .count, tint: Token.chartError)
+					}
+				}
+
+				if !detail.slowestOperations.isEmpty {
+					section("Slowest operations (p95)") {
+						BreakdownList(items: detail.slowestOperations, unit: .milliseconds, tint: Token.chartP95)
+					}
 				}
 
 				section("Volume") {
@@ -165,34 +280,10 @@ private struct ServiceDetailContent: View {
 					}
 					.padding(.horizontal, 16)
 				}
-
-				section("Open issues") {
-					if issues.isEmpty {
-						Text("Nothing needs attention in \(window.phrase).")
-							.font(Typo.small)
-							.foregroundStyle(Token.mutedForeground)
-							.padding(.horizontal, 16)
-					} else {
-						VStack(spacing: 0) {
-							ForEach(issues, id: \.id) { issue in
-								NavigationLink(value: IssueRoute.detail(id: issue.id)) {
-									IssueRow(issue: issue, showsService: false)
-								}
-								.buttonStyle(RowButtonStyle())
-								Hairline()
-							}
-						}
-					}
-				}
 			}
 			.padding(.vertical, 16)
 		}
 		.scrollContentBackground(.hidden)
-		.navigationDestination(for: IssueRoute.self) { route in
-			switch route {
-			case .detail(let id): IssueDetailView(issueID: id)
-			}
-		}
 	}
 
 	@ViewBuilder
@@ -205,8 +296,4 @@ private struct ServiceDetailContent: View {
 			content()
 		}
 	}
-}
-
-enum IssueRoute: Hashable {
-	case detail(id: String)
 }

--- a/apps/ios/Maple/Features/Services/ServicesListView.swift
+++ b/apps/ios/Maple/Features/Services/ServicesListView.swift
@@ -112,9 +112,7 @@ struct ServicesListView: View {
 					}
 				}
 			}
-			.navigationDestination(for: String.self) { name in
-				ServiceDetailView(serviceName: name, window: model?.window ?? .default)
-			}
+			.mapleDestinations()
 		}
 		// Re-runs on org switch, which is what clears one org's services before
 		// the next org's arrive.
@@ -144,7 +142,7 @@ struct ServicesListView: View {
 						.padding(.top, 48)
 					} else {
 						ForEach(visible, id: \.name) { service in
-							NavigationLink(value: service.name) {
+							NavigationLink(value: Route.service(name: service.name, window: model.window)) {
 								ServiceRow(
 									service: service,
 									openIssues: model.openIssueCounts[service.name] ?? 0

--- a/apps/ios/Maple/Fixtures/FixtureAPI.swift
+++ b/apps/ios/Maple/Fixtures/FixtureAPI.swift
@@ -1,0 +1,589 @@
+import Foundation
+import MapleAPI
+
+/// A deterministic in-memory `MapleAPI` for previews, screenshots, and running
+/// the app without a Clerk session (`MAPLE_FIXTURES=1` in the scheme's
+/// environment). One believable org: nine services, one critical incident,
+/// one warning, a couple of issues, an anomaly.
+///
+/// The data is generated relative to `now` so timestamps always read as
+/// current, and seeded so the same shapes appear on every launch.
+struct FixtureAPI: MapleAPI {
+	static let isEnabled = ProcessInfo.processInfo.environment["MAPLE_FIXTURES"] == "1"
+
+	private let now: Date
+	private let latency: Duration
+
+	init(now: Date = Date(), latency: Duration = .milliseconds(350)) {
+		self.now = now
+		self.latency = latency
+	}
+
+	// MARK: Services
+
+	private struct Seed {
+		let name: String
+		let namespace: String
+		let throughput: Double
+		let errorRate: Double
+		let p50: Double
+		let p95: Double
+		let p99: Double
+	}
+
+	private static let seeds: [Seed] = [
+		Seed(name: "checkout-api", namespace: "commerce", throughput: 42.1, errorRate: 0.091, p50: 84, p95: 640, p99: 1_480),
+		Seed(name: "search", namespace: "discovery", throughput: 118.4, errorRate: 0.004, p50: 210, p95: 1_340, p99: 2_900),
+		Seed(name: "payments", namespace: "commerce", throughput: 9.7, errorRate: 0.012, p50: 120, p95: 410, p99: 880),
+		Seed(name: "web", namespace: "edge", throughput: 380.2, errorRate: 0.0007, p50: 32, p95: 140, p99: 320),
+		Seed(name: "auth", namespace: "platform", throughput: 61.0, errorRate: 0.0002, p50: 18, p95: 61, p99: 140),
+		Seed(name: "catalog", namespace: "commerce", throughput: 27.5, errorRate: 0, p50: 44, p95: 190, p99: 410),
+		Seed(name: "notifications", namespace: "platform", throughput: 3.2, errorRate: 0.001, p50: 90, p95: 380, p99: 720),
+		Seed(name: "worker", namespace: "platform", throughput: 14.9, errorRate: 0, p50: 400, p95: 900, p99: 1_900),
+		Seed(name: "ingest-gateway", namespace: "edge", throughput: 1_240.0, errorRate: 0.0001, p50: 6, p95: 21, p99: 58),
+	]
+
+	private func service(_ seed: Seed, window: ResolvedTimeWindow) -> Service {
+		let seconds = window.end.timeIntervalSince(window.start)
+		let spans = seed.throughput * seconds
+		return Service(
+			deploymentEnvironments: ["production"],
+			errorCount: (spans * seed.errorRate).rounded(),
+			errorRate: seed.errorRate,
+			hasSampling: false,
+			name: seed.name,
+			object: .service,
+			p50LatencyMs: seed.p50,
+			p95LatencyMs: seed.p95,
+			p99LatencyMs: seed.p99,
+			samplingWeight: 1,
+			serviceNamespaces: [seed.namespace],
+			spanCount: spans.rounded(),
+			throughput: seed.throughput,
+			tracedThroughput: seed.throughput
+		)
+	}
+
+	func services(window: ResolvedTimeWindow, limit: Int) async throws -> Page<Service> {
+		try await pause()
+		return Page(items: Self.seeds.map { service($0, window: window) }, hasMore: false, nextCursor: nil)
+	}
+
+	func service(named name: String, window: ResolvedTimeWindow) async throws -> Service {
+		try await pause()
+		guard let seed = Self.seeds.first(where: { $0.name == name }) else {
+			throw MapleAPIError.decoding(NSError(domain: "fixtures", code: 404))
+		}
+		return service(seed, window: window)
+	}
+
+	// MARK: Issues
+
+	private var issues: [ErrorIssue] {
+		[
+			issue(
+				id: "iss_checkout_timeout", service: "checkout-api", type: "PaymentGatewayTimeout",
+				message: "upstream payments/authorize exceeded 5000ms", frame: "checkout/authorize.ts:142",
+				severity: .critical, state: .triage, count: 1_842, firstSeen: -50 * 60, lastSeen: -40, incident: true
+			),
+			issue(
+				id: "iss_checkout_null", service: "checkout-api", type: "TypeError",
+				message: "Cannot read properties of undefined (reading 'currency')", frame: "checkout/cart.ts:88",
+				severity: .high, state: .todo, count: 96, firstSeen: -6 * 3600, lastSeen: -180, incident: false
+			),
+			issue(
+				id: "iss_search_es", service: "search", type: "ElasticsearchException",
+				message: "circuit_breaking_exception: [parent] Data too large", frame: "search/query.ts:211",
+				severity: .medium, state: .inProgress, count: 41, firstSeen: -3 * 86_400, lastSeen: -900, incident: false
+			),
+			issue(
+				id: "iss_payments_decline", service: "payments", type: "CardDeclined",
+				message: "insufficient_funds", frame: "payments/charge.ts:57",
+				severity: .low, state: .triage, count: 12_004, firstSeen: -20 * 86_400, lastSeen: -30, incident: false
+			),
+		]
+	}
+
+	private func issue(
+		id: String, service: String, type: String, message: String, frame: String, severity: IssueSeverity,
+		state: WorkflowState, count: Double, firstSeen: TimeInterval, lastSeen: TimeInterval, incident: Bool
+	) -> ErrorIssue {
+		ErrorIssue(
+			errorLabel: type,
+			exceptionMessage: message,
+			exceptionType: type,
+			fingerprintHash: id,
+			firstSeenAt: stamp(firstSeen),
+			hasOpenIncident: incident,
+			id: id,
+			kind: .error,
+			lastSeenAt: stamp(lastSeen),
+			object: .errorIssue,
+			occurrenceCount: count,
+			priority: 1,
+			serviceName: service,
+			severity: severity,
+			severitySource: .manual,
+			topFrame: frame,
+			workflowState: state
+		)
+	}
+
+	func issues(query: IssueQuery, window: ResolvedTimeWindow?, limit: Int, cursor: String?) async throws
+		-> Page<ErrorIssue>
+	{
+		try await pause()
+		var items = issues
+		if let service = query.serviceName { items = items.filter { $0.serviceName == service } }
+		if let window {
+			items = items.filter { issue in
+				guard let last = ResolvedTimeWindow.parse(issue.lastSeenAt) else { return false }
+				return last >= window.start
+			}
+		}
+		return Page(items: Array(items.prefix(limit)), hasMore: false, nextCursor: nil)
+	}
+
+	func issue(id: String) async throws -> ErrorIssueDetail {
+		try await pause()
+		guard let issue = issues.first(where: { $0.id == id }) else {
+			throw MapleAPIError.decoding(NSError(domain: "fixtures", code: 404))
+		}
+		let buckets = (0..<24).map { index -> ErrorIssueTimeseriesPoint in
+			let hoursAgo = TimeInterval(23 - index) * 3600
+			let share: Double = index > 20 ? 3.2 : 0.7
+			let count = (issue.occurrenceCount / 24 * share).rounded()
+			return ErrorIssueTimeseriesPoint(bucket: stamp(-hoursAgo), count: count)
+		}
+		return ErrorIssueDetail(
+			errorLabel: issue.errorLabel,
+			exceptionMessage: issue.exceptionMessage,
+			exceptionType: issue.exceptionType,
+			fingerprintHash: issue.fingerprintHash,
+			firstSeenAt: issue.firstSeenAt,
+			hasOpenIncident: issue.hasOpenIncident,
+			id: issue.id,
+			incidents: [],
+			kind: issue.kind,
+			lastSeenAt: issue.lastSeenAt,
+			object: .errorIssue,
+			occurrenceCount: issue.occurrenceCount,
+			priority: issue.priority,
+			sampleTraces: [],
+			serviceName: issue.serviceName,
+			severity: issue.severity,
+			severitySource: issue.severitySource,
+			timeseries: buckets,
+			topFrame: issue.topFrame,
+			workflowState: issue.workflowState
+		)
+	}
+
+	func issueCountsByService() async throws -> [ErrorIssueServiceCount] {
+		try await pause()
+		return [
+			ErrorIssueServiceCount(openCount: 2, serviceName: "checkout-api"),
+			ErrorIssueServiceCount(openCount: 1, serviceName: "search"),
+			ErrorIssueServiceCount(openCount: 1, serviceName: "payments"),
+		]
+	}
+
+	// MARK: Alerts
+
+	private var rules: [AlertRule] {
+		[
+			rule(
+				id: "alrt_checkout_errors", name: "Checkout error rate", severity: .critical, services: ["checkout-api"],
+				signal: .errorRate, threshold: 0.05, window: 5, breaches: 2, healthy: 3
+			),
+			rule(
+				id: "alrt_search_p95", name: "Search latency", severity: .warning, services: ["search"],
+				signal: .p95Latency, threshold: 1_000, window: 10, breaches: 3, healthy: 3
+			),
+			rule(
+				id: "alrt_global_errors", name: "Any service error rate", severity: .warning, services: [],
+				signal: .errorRate, threshold: 0.2, window: 5, breaches: 2, healthy: 3
+			),
+		]
+	}
+
+	private func rule(
+		id: String, name: String, severity: AlertSeverity, services: [String], signal: AlertSignalType,
+		threshold: Double, window: Int, breaches: Int, healthy: Int
+	) -> AlertRule {
+		AlertRule(
+			comparator: .gt,
+			consecutiveBreachesRequired: breaches,
+			consecutiveHealthyRequired: healthy,
+			createdAt: stamp(-30 * 86_400),
+			createdBy: "user_fixture",
+			destinationIds: ["dest_slack_oncall"],
+			enabled: true,
+			environments: ["production"],
+			excludeServiceNames: [],
+			id: id,
+			lastEvaluatedAt: stamp(-30),
+			minimumSampleCount: 50,
+			name: name,
+			noDataBehavior: .skip,
+			object: .alertRule,
+			renotifyIntervalMinutes: 60,
+			serviceNames: services,
+			severity: severity,
+			signalType: signal,
+			tags: [],
+			threshold: threshold,
+			updatedAt: stamp(-2 * 86_400),
+			updatedBy: "user_fixture",
+			windowMinutes: window
+		)
+	}
+
+	private var incidents: [AlertIncident] {
+		[
+			AlertIncident(
+				comparator: .gt,
+				dedupeKey: "alrt_checkout_errors:__total__",
+				errorIssueId: "iss_checkout_timeout",
+				firstTriggeredAt: stamp(-32 * 60),
+				id: "inc_checkout_now",
+				lastDeliveredEventType: .trigger,
+				lastNotifiedAt: stamp(-32 * 60 + 5),
+				lastObservedValue: 0.091,
+				lastSampleCount: 1_260,
+				lastTriggeredAt: stamp(-60),
+				object: .alertIncident,
+				ruleId: "alrt_checkout_errors",
+				ruleName: "Checkout error rate",
+				severity: .critical,
+				signalType: .errorRate,
+				status: .open,
+				threshold: 0.05
+			),
+			AlertIncident(
+				comparator: .gt,
+				dedupeKey: "alrt_search_p95:__total__",
+				firstTriggeredAt: stamp(-2 * 3600 - 14 * 60),
+				id: "inc_search_now",
+				lastDeliveredEventType: .renotify,
+				lastNotifiedAt: stamp(-74 * 60),
+				lastObservedValue: 1_340,
+				lastSampleCount: 7_100,
+				lastTriggeredAt: stamp(-120),
+				object: .alertIncident,
+				ruleId: "alrt_search_p95",
+				ruleName: "Search latency",
+				severity: .warning,
+				signalType: .p95Latency,
+				status: .open,
+				threshold: 1_000
+			),
+			AlertIncident(
+				comparator: .gt,
+				dedupeKey: "alrt_checkout_errors:__total__",
+				firstTriggeredAt: stamp(-2 * 86_400 - 3_000),
+				id: "inc_checkout_yesterday",
+				lastDeliveredEventType: .resolve,
+				lastNotifiedAt: stamp(-2 * 86_400),
+				lastObservedValue: 0.03,
+				lastSampleCount: 900,
+				lastTriggeredAt: stamp(-2 * 86_400 - 600),
+				object: .alertIncident,
+				resolvedAt: stamp(-2 * 86_400),
+				ruleId: "alrt_checkout_errors",
+				ruleName: "Checkout error rate",
+				severity: .critical,
+				signalType: .errorRate,
+				status: .resolved,
+				threshold: 0.05
+			),
+		]
+	}
+
+	func alertIncidents(status: AlertIncidentStatus?, ruleId: String?, limit: Int, cursor: String?) async throws
+		-> Page<AlertIncident>
+	{
+		try await pause()
+		var items = incidents
+		if let status { items = items.filter { $0.status == status } }
+		if let ruleId { items = items.filter { $0.ruleId == ruleId } }
+		return Page(items: items, hasMore: false, nextCursor: nil)
+	}
+
+	func alertIncident(id: String) async throws -> AlertIncident {
+		try await pause()
+		guard let incident = incidents.first(where: { $0.id == id }) else {
+			throw MapleAPIError.decoding(NSError(domain: "fixtures", code: 404))
+		}
+		return incident
+	}
+
+	func alertRules(limit: Int, cursor: String?) async throws -> Page<AlertRule> {
+		try await pause()
+		return Page(items: rules, hasMore: false, nextCursor: nil)
+	}
+
+	func alertRule(id: String) async throws -> AlertRule {
+		try await pause()
+		guard let rule = rules.first(where: { $0.id == id }) else {
+			throw MapleAPIError.decoding(NSError(domain: "fixtures", code: 404))
+		}
+		return rule
+	}
+
+	func alertRuleChecks(ruleId: String, groupKey: String?, since: Date?, limit: Int) async throws -> [AlertCheck] {
+		try await pause()
+		guard let rule = rules.first(where: { $0.id == ruleId }) else { return [] }
+		let incident = incidents.first { $0.ruleId == ruleId && $0.status == .open }
+		let start = since ?? now.addingTimeInterval(-3600)
+		let count = min(limit, max(2, Int(now.timeIntervalSince(start) / 60)))
+		return (0..<count).map { index in
+			let at = start.addingTimeInterval(TimeInterval(index) * 60)
+			let progress = Double(index) / Double(max(1, count - 1))
+			// Calm, then a ramp that crosses the threshold about 60% of the
+			// way through, then a plateau — the shape most incidents have.
+			let ramp = max(0, (progress - 0.45) / 0.3)
+			let value: Double
+			switch rule.signalType {
+			case .errorRate:
+				value = incident == nil ? 0.004 + 0.002 * sin(Double(index)) : min(0.11, 0.006 + 0.1 * min(1, ramp))
+			case .p95Latency, .p99Latency:
+				value = incident == nil ? 620 + 40 * sin(Double(index) / 3) : 640 + 780 * min(1, ramp)
+			default:
+				value = rule.threshold * (0.5 + 0.7 * min(1, ramp))
+			}
+			let breached = value > rule.threshold
+			return AlertCheck(
+				comparator: rule.comparator,
+				consecutiveBreaches: breached ? 1 : 0,
+				consecutiveHealthy: breached ? 0 : 1,
+				evaluationDurationMs: 320,
+				groupKey: "__total__",
+				incidentId: breached ? incident?.id : nil,
+				incidentTransition: .none,
+				object: .alertCheck,
+				observedValue: value,
+				sampleCount: 1_000,
+				signalType: rule.signalType,
+				status: breached ? .breached : .healthy,
+				threshold: rule.threshold,
+				timestamp: ResolvedTimeWindow.format(at),
+				windowEnd: ResolvedTimeWindow.format(at),
+				windowMinutes: Double(rule.windowMinutes),
+				windowStart: ResolvedTimeWindow.format(at.addingTimeInterval(-Double(rule.windowMinutes) * 60))
+			)
+		}
+	}
+
+	func alertDeliveries(incidentId: String, limit: Int) async throws -> [AlertDelivery] {
+		try await pause()
+		guard let incident = incidents.first(where: { $0.id == incidentId }) else { return [] }
+		var deliveries = [
+			AlertDelivery(
+				attemptNumber: 1,
+				attemptedAt: incident.lastNotifiedAt ?? incident.firstTriggeredAt,
+				deliveryKey: "\(incident.id):trigger",
+				destinationId: "dest_slack_oncall",
+				destinationName: "#oncall",
+				destinationType: .slackBot,
+				eventType: .trigger,
+				id: "evt_\(incident.id)_1",
+				incidentId: incident.id,
+				object: .alertDelivery,
+				responseCode: 200,
+				ruleId: incident.ruleId,
+				scheduledAt: incident.firstTriggeredAt,
+				status: .success
+			)
+		]
+		if incident.severity == .critical {
+			deliveries.append(
+				AlertDelivery(
+					attemptNumber: 2,
+					attemptedAt: incident.firstTriggeredAt,
+					deliveryKey: "\(incident.id):trigger:pd",
+					destinationId: "dest_pagerduty",
+					destinationName: "Payments on-call",
+					destinationType: .pagerduty,
+					errorMessage: incident.status == .open ? "429 Too Many Requests" : nil,
+					eventType: .trigger,
+					id: "evt_\(incident.id)_2",
+					incidentId: incident.id,
+					object: .alertDelivery,
+					responseCode: incident.status == .open ? 429 : 202,
+					ruleId: incident.ruleId,
+					scheduledAt: incident.firstTriggeredAt,
+					status: incident.status == .open ? .failed : .success
+				)
+			)
+		}
+		if let resolved = incident.resolvedAt {
+			deliveries.append(
+				AlertDelivery(
+					attemptNumber: 1,
+					attemptedAt: resolved,
+					deliveryKey: "\(incident.id):resolve",
+					destinationId: "dest_slack_oncall",
+					destinationName: "#oncall",
+					destinationType: .slackBot,
+					eventType: .resolve,
+					id: "evt_\(incident.id)_3",
+					incidentId: incident.id,
+					object: .alertDelivery,
+					responseCode: 200,
+					ruleId: incident.ruleId,
+					scheduledAt: resolved,
+					status: .success
+				)
+			)
+		}
+		return deliveries
+	}
+
+	// MARK: Anomalies
+
+	private var anomalies: [AnomalyIncident] {
+		[
+			AnomalyIncident(
+				baselineMedian: 27.4,
+				baselineSigma: 3.1,
+				deploymentEnv: "production",
+				detectorKey: "throughput:catalog:production",
+				fingerprints: [],
+				firstTriggeredAt: stamp(-48 * 60),
+				id: "anom_catalog_throughput",
+				lastObservedValue: 9.8,
+				lastSampleCount: 2_300,
+				lastTriggeredAt: stamp(-120),
+				object: .anomalyIncident,
+				openedValue: 11.2,
+				reopenCount: 0,
+				serviceName: "catalog",
+				severity: .warning,
+				signalType: .throughput,
+				status: .open,
+				thresholdValue: 18.1,
+				triageStatus: .completed
+			)
+		]
+	}
+
+	func anomalyIncidents(
+		status: AnomalyIncidentStatus?, serviceName: String?, window: ResolvedTimeWindow?, limit: Int, cursor: String?
+	) async throws -> Page<AnomalyIncident> {
+		try await pause()
+		var items = anomalies
+		if let status { items = items.filter { $0.status == status } }
+		if let serviceName { items = items.filter { $0.serviceName == serviceName } }
+		return Page(items: items, hasMore: false, nextCursor: nil)
+	}
+
+	func anomalyIncident(id: String) async throws -> AnomalyIncident {
+		try await pause()
+		guard let anomaly = anomalies.first(where: { $0.id == id }) else {
+			throw MapleAPIError.decoding(NSError(domain: "fixtures", code: 404))
+		}
+		return anomaly
+	}
+
+	func anomalyIncidentTimeseries(id: String) async throws -> AnomalyIncidentTimeseries {
+		try await pause()
+		let anomaly = try await anomalyIncident(id: id)
+		let buckets = (0..<36).map { index -> AnomalyTimeseriesBucket in
+			let progress = Double(index) / 35
+			let drop = max(0, (progress - 0.6) / 0.15)
+			let value = anomaly.baselineMedian * (1 - 0.65 * min(1, drop)) + 1.5 * sin(Double(index))
+			return AnomalyTimeseriesBucket(
+				bucket: stamp(TimeInterval(-(35 - index) * 300)),
+				sampleCount: 100,
+				value: max(0, value)
+			)
+		}
+		return AnomalyIncidentTimeseries(
+			baselineMedian: anomaly.baselineMedian,
+			bucketSeconds: 300,
+			buckets: buckets,
+			object: .anomalyIncident_timeseries,
+			signalType: anomaly.signalType,
+			thresholdValue: anomaly.thresholdValue,
+			unit: .perMinute
+		)
+	}
+
+	// MARK: Telemetry
+
+	func traceTimeseries(_ request: TraceTimeseriesRequest) async throws -> TraceTimeseriesResult {
+		try await pause()
+		let seed = Self.seeds.first { $0.name == request.serviceName } ?? Self.seeds[3]
+		let bucket = TimeInterval(request.resolvedBucketSeconds)
+		let count = max(2, Int(request.window.end.timeIntervalSince(request.window.start) / bucket))
+		let incident = request.serviceName == "checkout-api" || request.serviceName == "search"
+		let points = (0..<count).map { index -> TimeseriesValuePoint in
+			let progress = Double(index) / Double(max(1, count - 1))
+			let ramp = incident ? max(0, (progress - 0.55) / 0.3) : 0
+			let wobble = sin(Double(index) * 0.9) * 0.08 + 1
+			let value: Double
+			switch request.aggregation {
+			case .errorRate: value = incident ? min(0.11, 0.004 + 0.1 * min(1, ramp)) : seed.errorRate * wobble
+			case .p95Duration: value = seed.p95 * (incident ? 0.55 + 0.6 * min(1, ramp) : wobble)
+			case .p99Duration: value = seed.p99 * wobble
+			case .p50Duration, .avgDuration: value = seed.p50 * wobble
+			case .count: value = seed.throughput * bucket * (incident ? 1 - 0.3 * min(1, ramp) : wobble)
+			case .apdex: value = 0.94 * wobble
+			}
+			return TimeseriesValuePoint(
+				timestamp: ResolvedTimeWindow.format(request.window.start.addingTimeInterval(bucket * Double(index))),
+				value: value
+			)
+		}
+		return TraceTimeseriesResult(
+			aggregation: .init(rawValue: request.aggregation.rawValue) ?? .count,
+			bucketSeconds: request.resolvedBucketSeconds,
+			endTime: request.window.endTime,
+			object: .traceTimeseries,
+			series: [TimeseriesSeries(group: nil, points: points)],
+			startTime: request.window.startTime
+		)
+	}
+
+	func traceBreakdown(_ request: TraceBreakdownRequest) async throws -> TraceBreakdownResult {
+		try await pause()
+		let service = request.serviceName ?? "web"
+		let items: [BreakdownItem]
+		switch request.aggregation {
+		case .count where request.hasError == true:
+			items = [
+				BreakdownItem(name: "POST /checkout/authorize", value: 812),
+				BreakdownItem(name: "payments.authorize", value: 790),
+				BreakdownItem(name: "GET /cart", value: 61),
+				BreakdownItem(name: "db.query SELECT carts", value: 12),
+			]
+		default:
+			items = [
+				BreakdownItem(name: "POST /checkout/authorize", value: 1_420),
+				BreakdownItem(name: "\(service).render", value: 610),
+				BreakdownItem(name: "GET /cart", value: 240),
+				BreakdownItem(name: "db.query SELECT carts", value: 44),
+				BreakdownItem(name: "cache.get", value: 3),
+			]
+		}
+		return TraceBreakdownResult(
+			aggregation: .init(rawValue: request.aggregation.rawValue) ?? .count,
+			data: Array(items.prefix(request.limit)),
+			endTime: request.window.endTime,
+			groupBy: request.groupBy.rawValue,
+			object: .traceBreakdown,
+			startTime: request.window.startTime
+		)
+	}
+
+	// MARK: Helpers
+
+	private func stamp(_ offset: TimeInterval) -> String {
+		ResolvedTimeWindow.format(now.addingTimeInterval(offset))
+	}
+
+	private func pause() async throws {
+		try await Task.sleep(for: latency)
+	}
+}

--- a/apps/ios/Maple/Fixtures/FixtureSession.swift
+++ b/apps/ios/Maple/Fixtures/FixtureSession.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum FixtureSession {
+	static let organizationId = "org_fixture"
+
+	/// A syntactically valid Clerk publishable key whose frontend API host does
+	/// not exist. `Clerk.configure` decodes the host from the base64 tail, so
+	/// the SDK initialises and then simply fails to reach anything — which is
+	/// what fixture mode wants.
+	static let publishableKey: String = {
+		let host = Data("fixtures.clerk.invalid$".utf8).base64EncodedString()
+		return "pk_test_\(host)"
+	}()
+}

--- a/apps/ios/PRODUCT.md
+++ b/apps/ios/PRODUCT.md
@@ -1,0 +1,191 @@
+# Maple for iOS — what the app is for
+
+The phone is not a smaller dashboard. It answers three questions, in this
+order, and nothing else earns a tab:
+
+1. **Is anything wrong right now?** — one glance, no scrolling.
+2. **Why is it going off?** — enough context to decide "page someone / wait /
+   it's known" without opening a laptop.
+3. **Tell me when it happens.** — push, with the same context, deep-linked.
+
+Everything the web app does that isn't in service of those (dashboards, query
+building, replay, settings) stays on the web.
+
+## Information architecture
+
+Three tabs + a profile sheet. The current Services/Issues split goes away.
+
+```
+Home        Services        Alerts                 (profile sheet: org switch,
+                                                    notifications, sign out)
+```
+
+### Home — "the pulse"
+
+Everything above the fold answers question 1.
+
+- **Status headline.** Derived on-device, no new endpoint:
+  `All 14 services healthy` · `2 degraded, 1 critical alert` · `No data in
+  the last hour` (liveness — an org that stopped sending is *not* healthy).
+  Colour follows the worst thing on screen; amber primary used here and only
+  here.
+- **Open incidents**, critical first, each a card: rule name · service(s) ·
+  `observed vs threshold` in the rule's unit · how long open · a 1h sparkline
+  of the signal. Tap → Incident detail. Empty state is a real sentence, not
+  a placeholder.
+- **Services needing attention**: services whose health isn't `healthy`,
+  sorted worst-first (health-dot · name · error rate · p95). "All healthy"
+  collapses this to a single line. Tap → Service detail. "See all" → Services
+  tab.
+- **New in the last 24h**: count of new/regressed error issues and anomalies,
+  each a row that opens the Alerts tab pre-filtered.
+- Pull-to-refresh; auto-refresh every 60s while foregrounded.
+
+Time window is fixed to *now* (1h for rates, 24h for "new"). Home has no time
+picker — a time picker is a question-2 tool.
+
+### Services
+
+The existing list, kept: health-dot, name, throughput, error rate, p95,
+sorted worst-first. Time window picker (1h · 6h · 24h · 7d) lives here.
+
+**Service detail** gets: health headline, four stat tiles (throughput, error
+rate, p95, p99) each with a sparkline (`POST /v2/traces/timeseries`), open
+incidents scoped to this service, top error issues for this service, top
+operations by errors and by latency (`POST /v2/traces/breakdown` grouped by
+span name). No trace waterfall on the phone — link out to the web for that.
+
+### Alerts
+
+The triage hub. Segmented control at the top: **Incidents · Errors ·
+Anomalies**. Default segment is whichever has open items, incidents first.
+
+- Incidents: open then resolved, grouped by rule; severity badge, service,
+  duration, observed/threshold. Filter chips: open · critical · mine
+  (rules for services I follow — later).
+- Errors: the current Issues list, unchanged in content, restyled as rows
+  (title · service · count · last seen · sparkline).
+- Anomalies: `GET /v2/anomalies/incidents`, same row shape.
+
+**Incident detail** — the "why" screen. Top to bottom:
+
+1. Headline: `Checkout error rate · 9.0% > 5.0% · open 32 min · critical`.
+2. **What the rule saw**: the check history for this rule/group
+   (`GET /v2/alerts/rules/{id}/checks`) rendered as a bar/line of observed
+   values with the threshold line. This works for *every* signal type
+   including builder/raw queries, because it's the rule's own observations,
+   not a re-query.
+3. **What changed on the service** (only for the five service signals): the
+   affected service's error-rate / p95 / throughput timeseries around the
+   incident window, from `/v2/traces/timeseries`. This is where a latency
+   alert shows "throughput also spiked" or "errors did too".
+4. **Likely cause**: linked error issue if `error_issue_id` is set; otherwise
+   top error issues for the service in the window (`GET /v2/error_issues`
+   filtered by service, sorted by first-seen desc). Top failing operations
+   from a breakdown by span name.
+5. **Timeline**: trigger / renotify / resolve events and where they went
+   (`GET /v2/alerts/deliveries?incident_id=`).
+6. Actions: **Open on web** (deep link into the same incident), **Share**
+   (link + headline). Incidents can't be closed via the API — no fake
+   "acknowledge" button. Mute-rule is a later addition once we decide it
+   belongs on the phone.
+
+**Error issue detail** stays roughly as-is: title, message, service, first/
+last seen, occurrence sparkline, stack, linked incidents. Actions: open on
+web, share.
+
+### Profile sheet
+
+Org switcher (existing), **Notifications** (per-org toggles: critical
+incidents · warning incidents · resolved · new error issues · anomalies), sign
+out. Nothing else.
+
+## Health model
+
+Reuse the thresholds already ported into `Primitives.swift` from
+`service-health.ts` / `latency-tone.ts` — the phone must agree with the
+browser about what "degraded" means. Home's headline is `max` over per-service
+health, then bumped to critical if any open incident is critical, then to
+"no data" if `throughput == 0` across the org for the last hour.
+
+## API surface
+
+Reads needed, all in v2 already:
+
+| Screen | Operations |
+| --- | --- |
+| Home | `listServices` (1h), `listAlertIncidents?status=open`, `listErrorIssues` (24h, sort first_seen), `listAnomalyIncidents`, `queryTraceTimeseries` for sparklines |
+| Services | `listServices`, `getService`, `queryTraceTimeseries`, `queryTraceBreakdown`, `listAlertIncidents`, `listErrorIssues` |
+| Alerts | `listAlertIncidents`, `getAlertIncident`, `getAlertRule`, `listAlertRuleChecks`, `listAlertDeliveries`, `listErrorIssues`, `getErrorIssue`, `listAnomalyIncidents`, `getAnomalyIncident`, `getAnomalyIncidentTimeseries` |
+
+Add these `operationId`s to `IOS_OPERATIONS` in `scripts/generate-ios-openapi.ts`.
+Sparkline queries: batch per screen, 1h/24 buckets, `p95_duration` and
+`error_rate` aggregations — cheap, and the API is already cost-profiled.
+
+Gaps to fill on the API side (small):
+
+- `listAlertIncidents` filtered by service name — today filter is `rule_id`/
+  `status`. Either add `service_name` or the app joins client-side via the
+  rule's `service_names` (fine for the first version; org rule counts are
+  small).
+- Error issue **occurrence timeseries** isn't in v2 (`events` is deferred).
+  Sparklines on issue rows can wait, or use `/v2/traces/timeseries` filtered
+  by `status = Error` + service as a proxy.
+
+## Push notifications
+
+### Product
+
+Notify on: incident **triggered** (critical → time-sensitive interruption
+level; warning → active), incident **resolved** (quiet), **new** error issue,
+**regressed** error issue, anomaly opened. Per-org, per-user toggles in the
+profile sheet. Ask for permission the first time the user opens an incident
+or flips a toggle — never at launch.
+
+Payload = the Home card: `Checkout error rate — 9.0% > 5.0% on checkout-api`,
+subtitle with severity + duration, thread by `dedupe_key` so renotifies
+collapse, deep link `maple://incidents/{id}` (universal link
+`https://app.maple.dev/…` so it also works with the app absent). Later:
+a Live Activity on the Lock Screen while a critical incident is open.
+
+### Backend shape
+
+Alert destinations are **org-scoped** (Slack channel, PagerDuty…); push is
+**user-scoped**. Don't model a phone as a destination. Instead:
+
+- `mobile_devices` table: `user_id`, `org_id`, `platform`, `token`,
+  `environment` (sandbox/prod), `preferences` (the toggles), `last_seen_at`.
+  Register/refresh via `PUT /v2/me/devices/{token}`, delete on sign-out /
+  APNs feedback.
+- A `pushFanOut` step in `NotificationDispatcher` (the same shared path error
+  issues and incidents already use), keyed off the event type — independent
+  of which rule destinations exist, so a rule with zero destinations still
+  reaches phones. Filter by device preferences, dedupe by
+  `(dedupe_key, event_type)`.
+- Transport: **APNs requires HTTP/2**, which the Workers `fetch` API doesn't
+  guarantee to origins. Verify before committing to direct APNs from
+  `apps/alerting`; if it fails, relay through FCM (HTTP v1 works over
+  HTTP/1.1, and covers Android later) or run the sender where HTTP/2 egress
+  is available (the ingest gateway's host). Decide this first — it's the only
+  real unknown in the plan.
+- Deliveries table already records attempts per destination; record push
+  sends there too (destination type `mobile`) so the incident timeline shows
+  "notified 3 devices".
+
+## Sequencing
+
+1. Home + Alerts (incidents) + incident detail. Requires only new
+   `IOS_OPERATIONS`. This is the app.
+2. Service detail expansion, anomalies segment.
+3. Push: transport spike → devices endpoint → fan-out → iOS registration
+   and settings sheet.
+4. Live Activity, follow-a-service, mute-rule — only after 1–3 are in
+   people's hands.
+
+## Design
+
+`DESIGN.md` conventions hold (Geist Mono body, hairlines, tonal depth, one
+amber per screen, skeletons not spinners). Home is the screen that has to be
+beautiful; the rest can be dense. Sparklines are 1px lines with no axes; the
+threshold on incident charts is a dashed hairline. Health colours come from
+`Tokens.swift`, never ad hoc.

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+Alerts.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+Alerts.swift
@@ -1,0 +1,109 @@
+import Foundation
+import OpenAPIRuntime
+
+extension MapleClient {
+	public func alertIncidents(
+		status: AlertIncidentStatus? = nil,
+		ruleId: String? = nil,
+		limit: Int = 20,
+		cursor: String? = nil
+	) async throws -> Page<AlertIncident> {
+		try await mapping {
+			let output = try await client.listAlertIncidents(
+				.init(query: .init(limit: String(limit), cursor: cursor, status: status, ruleId: ruleId))
+			)
+			let list = try output.ok.body.json
+			return Page(items: list.data, hasMore: list.hasMore, nextCursor: list.nextCursor)
+		}
+	}
+
+	public func alertIncident(id: String) async throws -> AlertIncident {
+		try await mapping {
+			try await client.getAlertIncident(.init(path: .init(id: id))).ok.body.json
+		}
+	}
+
+	public func alertRules(limit: Int = 100, cursor: String? = nil) async throws -> Page<AlertRule> {
+		try await mapping {
+			let output = try await client.listAlertRules(.init(query: .init(limit: String(limit), cursor: cursor)))
+			let list = try output.ok.body.json
+			return Page(items: list.data, hasMore: list.hasMore, nextCursor: list.nextCursor)
+		}
+	}
+
+	public func alertRule(id: String) async throws -> AlertRule {
+		try await mapping {
+			try await client.getAlertRule(.init(path: .init(id: id))).ok.body.json
+		}
+	}
+
+	/// The rule's recent evaluations, **oldest first** — the order a chart wants.
+	/// The server returns newest first; one page is enough for a screen.
+	public func alertRuleChecks(
+		ruleId: String,
+		groupKey: String? = nil,
+		since: Date? = nil,
+		limit: Int = 100
+	) async throws -> [AlertCheck] {
+		try await mapping {
+			let output = try await client.listAlertRuleChecks(
+				.init(
+					path: .init(id: ruleId),
+					query: .init(
+						limit: String(limit),
+						groupKey: groupKey,
+						since: since.map(ResolvedTimeWindow.format)
+					)
+				)
+			)
+			return try output.ok.body.json.data.sorted { $0.timestamp < $1.timestamp }
+		}
+	}
+
+	public func alertDeliveries(incidentId: String, limit: Int = 50) async throws -> [AlertDelivery] {
+		try await mapping {
+			let output = try await client.listAlertDeliveries(
+				.init(query: .init(limit: String(limit), incidentId: incidentId))
+			)
+			return try output.ok.body.json.data
+		}
+	}
+
+	public func anomalyIncidents(
+		status: AnomalyIncidentStatus? = nil,
+		serviceName: String? = nil,
+		window: ResolvedTimeWindow? = nil,
+		limit: Int = 20,
+		cursor: String? = nil
+	) async throws -> Page<AnomalyIncident> {
+		try await mapping {
+			let output = try await client.listAnomalyIncidents(
+				.init(
+					query: .init(
+						limit: String(limit),
+						cursor: cursor,
+						status: status,
+						serviceName: serviceName,
+						startTime: window?.startTime,
+						endTime: window?.endTime
+					)
+				)
+			)
+			let list = try output.ok.body.json
+			return Page(items: list.data, hasMore: list.hasMore, nextCursor: list.nextCursor)
+		}
+	}
+
+	public func anomalyIncident(id: String) async throws -> AnomalyIncident {
+		try await mapping {
+			try await client.getAnomalyIncident(.init(path: .init(id: id))).ok.body.json
+		}
+	}
+
+	/// Defaults to the incident's own window server-side.
+	public func anomalyIncidentTimeseries(id: String) async throws -> AnomalyIncidentTimeseries {
+		try await mapping {
+			try await client.getAnomalyIncidentTimeseries(.init(path: .init(id: id))).ok.body.json
+		}
+	}
+}

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+Telemetry.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+Telemetry.swift
@@ -1,0 +1,117 @@
+import Foundation
+import OpenAPIRuntime
+
+/// A trace timeseries query, narrowed to the shape the app needs: one service,
+/// one aggregation, one window. `bucketSeconds` defaults to whatever gives the
+/// window roughly `TraceTimeseriesRequest.targetPoints` points, so a sparkline
+/// on a 1h window and one on a 7d window carry the same visual density.
+public struct TraceTimeseriesRequest: Hashable, Sendable {
+	public var aggregation: TraceAggregation
+	public var window: ResolvedTimeWindow
+	public var serviceName: String?
+	public var hasError: Bool?
+	public var bucketSeconds: Int?
+
+	public static let targetPoints = 40
+
+	public init(
+		aggregation: TraceAggregation,
+		window: ResolvedTimeWindow,
+		serviceName: String? = nil,
+		hasError: Bool? = nil,
+		bucketSeconds: Int? = nil
+	) {
+		self.aggregation = aggregation
+		self.window = window
+		self.serviceName = serviceName
+		self.hasError = hasError
+		self.bucketSeconds = bucketSeconds
+	}
+
+	/// Snapped to a minute multiple: the server rounds anyway, and a whole
+	/// number of minutes keeps bucket boundaries aligned with the window's
+	/// minute-snapped end.
+	public var resolvedBucketSeconds: Int {
+		if let bucketSeconds { return bucketSeconds }
+		let raw = window.end.timeIntervalSince(window.start) / Double(Self.targetPoints)
+		return max(60, Int((raw / 60).rounded(.up)) * 60)
+	}
+}
+
+public struct TraceBreakdownRequest: Hashable, Sendable {
+	public var aggregation: TraceBreakdownAggregation
+	public var groupBy: TraceBreakdownGroup
+	public var window: ResolvedTimeWindow
+	public var serviceName: String?
+	public var hasError: Bool?
+	public var limit: Int
+
+	public init(
+		aggregation: TraceBreakdownAggregation,
+		groupBy: TraceBreakdownGroup,
+		window: ResolvedTimeWindow,
+		serviceName: String? = nil,
+		hasError: Bool? = nil,
+		limit: Int = 5
+	) {
+		self.aggregation = aggregation
+		self.groupBy = groupBy
+		self.window = window
+		self.serviceName = serviceName
+		self.hasError = hasError
+		self.limit = limit
+	}
+}
+
+extension MapleClient {
+	public func traceTimeseries(_ request: TraceTimeseriesRequest) async throws -> TraceTimeseriesResult {
+		try await mapping {
+			let output = try await client.queryTraceTimeseries(
+				.init(
+					body: .json(
+						.init(
+							aggregation: request.aggregation,
+							bucketSeconds: request.resolvedBucketSeconds,
+							endTime: request.window.endTime,
+							filters: filters(serviceName: request.serviceName, hasError: request.hasError),
+							startTime: request.window.startTime
+						)
+					)
+				)
+			)
+			return try output.ok.body.json
+		}
+	}
+
+	public func traceBreakdown(_ request: TraceBreakdownRequest) async throws -> TraceBreakdownResult {
+		try await mapping {
+			let output = try await client.queryTraceBreakdown(
+				.init(
+					body: .json(
+						.init(
+							aggregation: request.aggregation,
+							endTime: request.window.endTime,
+							filters: filters(serviceName: request.serviceName, hasError: request.hasError),
+							groupBy: request.groupBy,
+							limit: request.limit,
+							startTime: request.window.startTime
+						)
+					)
+				)
+			)
+			return try output.ok.body.json
+		}
+	}
+
+	private func filters(serviceName: String?, hasError: Bool?) -> Components.Schemas.TraceFilters? {
+		guard serviceName != nil || hasError != nil else { return nil }
+		return .init(hasError: hasError, serviceName: serviceName)
+	}
+}
+
+extension TraceTimeseriesResult {
+	/// The values of the first (only, when ungrouped) series, in order.
+	public var values: [Double] {
+		series.first?.points.map(\.value) ?? []
+	}
+}

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient.swift
@@ -9,9 +9,39 @@ public typealias ErrorIssueActor = Components.Schemas.ErrorIssueActor
 public typealias ErrorIncident = Components.Schemas.ErrorIncident
 public typealias ErrorIssueSampleTrace = Components.Schemas.ErrorIssueSampleTrace
 public typealias ErrorIssueServiceCount = Components.Schemas.ErrorIssueServiceCount
+public typealias ErrorIssueTimeseriesPoint = Components.Schemas.ErrorIssueTimeseriesPoint
 public typealias IssueSeverity = Components.Schemas._MapleIssueSeverity
 public typealias WorkflowState = Components.Schemas._MapleWorkflowState
 public typealias IssueKind = Components.Schemas._MapleIssueKind
+
+public typealias AlertIncident = Components.Schemas.AlertIncident
+public typealias AlertRule = Components.Schemas.AlertRule
+public typealias AlertCheck = Components.Schemas.AlertCheck
+public typealias AlertDelivery = Components.Schemas.AlertDelivery
+public typealias AlertSeverity = Components.Schemas._MapleAlertSeverity
+public typealias AlertSignalType = Components.Schemas._MapleAlertSignalType
+public typealias AlertComparator = Components.Schemas._MapleAlertComparator
+public typealias AlertIncidentStatus = Components.Schemas._MapleAlertIncidentStatus
+public typealias AlertCheckStatus = Components.Schemas._MapleAlertCheckStatus
+public typealias AlertEventType = Components.Schemas._MapleAlertEventType
+public typealias AlertDeliveryStatus = Components.Schemas._MapleAlertDeliveryStatus
+public typealias AlertDestinationType = Components.Schemas._MapleAlertDestinationType
+
+public typealias AnomalyIncident = Components.Schemas.AnomalyIncident
+public typealias AnomalyIncidentTimeseries = Components.Schemas.AnomalyIncidentTimeseries
+public typealias AnomalyTimeseriesBucket = Components.Schemas.AnomalyTimeseriesBucket
+public typealias AnomalyIncidentStatus = Components.Schemas._MapleAnomalyIncidentStatus
+public typealias AnomalyIncidentSeverity = Components.Schemas._MapleAnomalyIncidentSeverity
+public typealias AnomalySignalType = Components.Schemas._MapleAnomalySignalType
+
+public typealias TraceTimeseriesResult = Components.Schemas.TraceTimeseriesResult
+public typealias TraceBreakdownResult = Components.Schemas.TraceBreakdownResult
+public typealias TraceAggregation = Components.Schemas.TraceTimeseriesParams.AggregationPayload
+public typealias TraceBreakdownAggregation = Components.Schemas.TraceBreakdownParams.AggregationPayload
+public typealias TraceBreakdownGroup = Components.Schemas.TraceBreakdownParams.GroupByPayload
+public typealias TimeseriesSeries = Components.Schemas.TimeseriesSeries
+public typealias TimeseriesValuePoint = Components.Schemas.TimeseriesValuePoint
+public typealias BreakdownItem = Components.Schemas.BreakdownItem
 
 /// `IssueSeverity` widened with the `unset` sentinel the list filter accepts.
 /// The pruned spec merges the contract's `IssueSeverity | "unset"` union into
@@ -80,12 +110,31 @@ public protocol MapleAPI: Sendable {
 		-> Page<ErrorIssue>
 	func issue(id: String) async throws -> ErrorIssueDetail
 	func issueCountsByService() async throws -> [ErrorIssueServiceCount]
+
+	// Alerts — see MapleClient+Alerts.swift
+	func alertIncidents(status: AlertIncidentStatus?, ruleId: String?, limit: Int, cursor: String?) async throws
+		-> Page<AlertIncident>
+	func alertIncident(id: String) async throws -> AlertIncident
+	func alertRules(limit: Int, cursor: String?) async throws -> Page<AlertRule>
+	func alertRule(id: String) async throws -> AlertRule
+	func alertRuleChecks(ruleId: String, groupKey: String?, since: Date?, limit: Int) async throws -> [AlertCheck]
+	func alertDeliveries(incidentId: String, limit: Int) async throws -> [AlertDelivery]
+
+	// Anomalies — see MapleClient+Alerts.swift
+	func anomalyIncidents(status: AnomalyIncidentStatus?, serviceName: String?, window: ResolvedTimeWindow?, limit: Int, cursor: String?)
+		async throws -> Page<AnomalyIncident>
+	func anomalyIncident(id: String) async throws -> AnomalyIncident
+	func anomalyIncidentTimeseries(id: String) async throws -> AnomalyIncidentTimeseries
+
+	// Telemetry — see MapleClient+Telemetry.swift
+	func traceTimeseries(_ request: TraceTimeseriesRequest) async throws -> TraceTimeseriesResult
+	func traceBreakdown(_ request: TraceBreakdownRequest) async throws -> TraceBreakdownResult
 }
 
 /// The live client: generated operations, wrapped so call sites see plain
 /// values and one error type.
 public struct MapleClient: MapleAPI {
-	private let client: Client
+	let client: Client
 
 	/// - Parameters:
 	///   - tokens: supplies the Clerk session JWT.
@@ -178,7 +227,7 @@ public struct MapleClient: MapleAPI {
 	///
 	/// `ErrorMappingMiddleware` already converts non-2xx responses, so what
 	/// reaches here is a transport failure or a 2xx body that failed to decode.
-	private func mapping<T>(_ work: () async throws -> T) async throws -> T {
+	func mapping<T>(_ work: () async throws -> T) async throws -> T {
 		do {
 			return try await work()
 		} catch let error as MapleAPIError {

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/openapi.json
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/openapi.json
@@ -1,6 +1,1238 @@
 {
   "components": {
     "schemas": {
+      "AlertCheck": {
+        "additionalProperties": false,
+        "description": "One recorded evaluation of an alert rule: the observed value, the verdict, and how it moved the incident state machine. Checks form the rule's audit trail.",
+        "examples": [
+          {
+            "comparator": "gt",
+            "consecutive_breaches": 2,
+            "consecutive_healthy": 0,
+            "error_category": null,
+            "error_message": null,
+            "evaluation_duration_ms": 412,
+            "group_key": "__total__",
+            "incident_id": "inc_tC4d9V79DCDzgbGKhAnff9",
+            "incident_transition": "opened",
+            "object": "alert_check",
+            "observed_value": 0.09,
+            "sample_count": 132,
+            "signal_type": "error_rate",
+            "status": "breached",
+            "threshold": 0.05,
+            "threshold_upper": null,
+            "timestamp": "2026-07-15T09:10:00.000Z",
+            "window_end": "2026-07-15T09:10:00.000Z",
+            "window_minutes": 5,
+            "window_start": "2026-07-15T09:05:00.000Z"
+          }
+        ],
+        "properties": {
+          "comparator": {
+            "$ref": "#/components/schemas/_maple_AlertComparator"
+          },
+          "consecutive_breaches": {
+            "type": "number"
+          },
+          "consecutive_healthy": {
+            "type": "number"
+          },
+          "error_category": {
+            "description": "Failure category (e.g. `\"validation\"`) — populated only on `error` checks.",
+            "type": "string"
+          },
+          "error_message": {
+            "description": "Why the evaluation failed — populated only on `error` checks.",
+            "type": "string"
+          },
+          "evaluation_duration_ms": {
+            "type": "number"
+          },
+          "group_key": {
+            "description": "The evaluated group, or `\"__total__\"` for ungrouped rules.",
+            "examples": [
+              "__total__"
+            ],
+            "type": "string"
+          },
+          "incident_id": {
+            "$ref": "#/components/schemas/_maple_AlertIncidentId",
+            "description": "The incident (`inc_…`) this check opened or continued, or `null`."
+          },
+          "incident_transition": {
+            "$ref": "#/components/schemas/_maple_AlertIncidentTransition"
+          },
+          "object": {
+            "description": "The object type — always `\"alert_check\"`.",
+            "enum": [
+              "alert_check"
+            ],
+            "type": "string"
+          },
+          "observed_value": {
+            "type": "number"
+          },
+          "sample_count": {
+            "type": "number"
+          },
+          "signal_type": {
+            "$ref": "#/components/schemas/_maple_AlertSignalType"
+          },
+          "status": {
+            "$ref": "#/components/schemas/_maple_AlertCheckStatus"
+          },
+          "threshold": {
+            "type": "number"
+          },
+          "threshold_upper": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "window_end": {
+            "type": "string"
+          },
+          "window_minutes": {
+            "type": "number"
+          },
+          "window_start": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "timestamp",
+          "group_key",
+          "status",
+          "signal_type",
+          "comparator",
+          "threshold",
+          "sample_count",
+          "window_minutes",
+          "window_start",
+          "window_end",
+          "consecutive_breaches",
+          "consecutive_healthy",
+          "incident_transition",
+          "evaluation_duration_ms"
+        ],
+        "title": "Alert Check",
+        "type": "object"
+      },
+      "AlertCheckList": {
+        "additionalProperties": false,
+        "description": "A cursor-paginated page of alert checks, newest first.",
+        "properties": {
+          "data": {
+            "description": "The page of objects, in the ordering documented by the endpoint.",
+            "items": {
+              "$ref": "#/components/schemas/AlertCheck"
+            },
+            "type": "array"
+          },
+          "has_more": {
+            "description": "Whether more objects exist after this page. When `true`, use `next_cursor` to fetch them.",
+            "examples": [
+              true
+            ],
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "description": "Cursor for the next page, or `null` on the last page. Pass it back as the `cursor` query param.",
+            "examples": [
+              "off_1k"
+            ],
+            "type": "string"
+          },
+          "object": {
+            "description": "Always `\"list\"` for a list response.",
+            "enum": [
+              "list"
+            ],
+            "examples": [
+              "list"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
+        "title": "Alert check list",
+        "type": "object"
+      },
+      "AlertDelivery": {
+        "additionalProperties": false,
+        "description": "One notification delivery attempt produced by an alert rule. This is the canonical delivery-history resource used by both the dashboard and API clients.",
+        "properties": {
+          "attempt_number": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "attempted_at": {
+            "type": "string"
+          },
+          "delivery_key": {
+            "type": "string"
+          },
+          "destination_id": {
+            "$ref": "#/components/schemas/_maple_AlertDestinationId"
+          },
+          "destination_name": {
+            "type": "string"
+          },
+          "destination_type": {
+            "$ref": "#/components/schemas/_maple_AlertDestinationType"
+          },
+          "error_message": {
+            "type": "string"
+          },
+          "event_type": {
+            "$ref": "#/components/schemas/_maple_AlertEventType"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_maple_AlertDeliveryEventId"
+          },
+          "incident_id": {
+            "$ref": "#/components/schemas/_maple_AlertIncidentId"
+          },
+          "object": {
+            "enum": [
+              "alert_delivery"
+            ],
+            "type": "string"
+          },
+          "provider_message": {
+            "type": "string"
+          },
+          "provider_reference": {
+            "type": "string"
+          },
+          "response_code": {
+            "type": "number"
+          },
+          "rule_id": {
+            "$ref": "#/components/schemas/_maple_AlertRuleId"
+          },
+          "scheduled_at": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/_maple_AlertDeliveryStatus"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "rule_id",
+          "destination_id",
+          "destination_name",
+          "destination_type",
+          "delivery_key",
+          "event_type",
+          "attempt_number",
+          "status",
+          "scheduled_at"
+        ],
+        "title": "Alert Delivery",
+        "type": "object"
+      },
+      "AlertDeliveryList": {
+        "additionalProperties": false,
+        "description": "Cursor-paginated list envelope wrapping a page of objects.",
+        "properties": {
+          "data": {
+            "description": "The page of objects, in the ordering documented by the endpoint.",
+            "items": {
+              "$ref": "#/components/schemas/AlertDelivery"
+            },
+            "type": "array"
+          },
+          "has_more": {
+            "description": "Whether more objects exist after this page. When `true`, use `next_cursor` to fetch them.",
+            "examples": [
+              true
+            ],
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "description": "Cursor for the next page, or `null` on the last page. Pass it back as the `cursor` query param.",
+            "examples": [
+              "off_1k"
+            ],
+            "type": "string"
+          },
+          "object": {
+            "description": "Always `\"list\"` for a list response.",
+            "enum": [
+              "list"
+            ],
+            "examples": [
+              "list"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
+        "title": "Alert delivery list",
+        "type": "object"
+      },
+      "AlertIncident": {
+        "additionalProperties": false,
+        "description": "A period during which an alert rule's condition held: opened after enough consecutive breaches, resolved by the scheduler after enough consecutive healthy checks. Read-only via the API.",
+        "examples": [
+          {
+            "comparator": "gt",
+            "dedupe_key": "alrt_gU26thvJECdQvu54Ad9jiz:__total__",
+            "error_issue_id": null,
+            "first_triggered_at": "2026-07-15T09:10:00.000Z",
+            "group_key": null,
+            "id": "inc_tC4d9V79DCDzgbGKhAnff9",
+            "last_delivered_event_type": "trigger",
+            "last_notified_at": "2026-07-15T09:10:05.000Z",
+            "last_observed_value": 0.09,
+            "last_sample_count": 132,
+            "last_triggered_at": "2026-07-15T09:40:00.000Z",
+            "object": "alert_incident",
+            "resolved_at": null,
+            "rule_id": "alrt_gU26thvJECdQvu54Ad9jiz",
+            "rule_name": "Checkout error rate",
+            "severity": "critical",
+            "signal_type": "error_rate",
+            "status": "open",
+            "threshold": 0.05,
+            "threshold_upper": null
+          }
+        ],
+        "properties": {
+          "comparator": {
+            "$ref": "#/components/schemas/_maple_AlertComparator"
+          },
+          "dedupe_key": {
+            "description": "Stable identity of the (rule, group) incident stream, used to deduplicate notifications.",
+            "type": "string"
+          },
+          "error_issue_id": {
+            "$ref": "#/components/schemas/_maple_ErrorIssueId",
+            "description": "The linked error issue (`iss_…`) when the incident was correlated to one, or `null`."
+          },
+          "first_triggered_at": {
+            "type": "string"
+          },
+          "group_key": {
+            "description": "The breaching group for grouped rules, or `null` for ungrouped rules.",
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_maple_AlertIncidentId"
+          },
+          "last_delivered_event_type": {
+            "$ref": "#/components/schemas/_maple_AlertEventType",
+            "description": "The most recent notification event delivered for this incident (`trigger`, `resolve`, `renotify`, `test`), or `null`."
+          },
+          "last_notified_at": {
+            "description": "When a notification was last delivered for this incident, or `null`.",
+            "type": "string"
+          },
+          "last_observed_value": {
+            "type": "number"
+          },
+          "last_sample_count": {
+            "type": "number"
+          },
+          "last_triggered_at": {
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type — always `\"alert_incident\"`.",
+            "enum": [
+              "alert_incident"
+            ],
+            "examples": [
+              "alert_incident"
+            ],
+            "type": "string"
+          },
+          "resolved_at": {
+            "description": "When the incident resolved, or `null` while it is still open.",
+            "type": "string"
+          },
+          "rule_id": {
+            "$ref": "#/components/schemas/_maple_AlertRuleId"
+          },
+          "rule_name": {
+            "description": "Name of the rule at the time the incident was recorded.",
+            "examples": [
+              "Checkout error rate"
+            ],
+            "type": "string"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/_maple_AlertSeverity"
+          },
+          "signal_type": {
+            "$ref": "#/components/schemas/_maple_AlertSignalType"
+          },
+          "status": {
+            "$ref": "#/components/schemas/_maple_AlertIncidentStatus"
+          },
+          "threshold": {
+            "type": "number"
+          },
+          "threshold_upper": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "rule_id",
+          "rule_name",
+          "signal_type",
+          "severity",
+          "status",
+          "comparator",
+          "threshold",
+          "first_triggered_at",
+          "last_triggered_at",
+          "dedupe_key"
+        ],
+        "title": "Alert Incident",
+        "type": "object"
+      },
+      "AlertIncidentList": {
+        "additionalProperties": false,
+        "description": "A cursor-paginated page of alert incidents.",
+        "properties": {
+          "data": {
+            "description": "The page of objects, in the ordering documented by the endpoint.",
+            "items": {
+              "$ref": "#/components/schemas/AlertIncident"
+            },
+            "type": "array"
+          },
+          "has_more": {
+            "description": "Whether more objects exist after this page. When `true`, use `next_cursor` to fetch them.",
+            "examples": [
+              true
+            ],
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "description": "Cursor for the next page, or `null` on the last page. Pass it back as the `cursor` query param.",
+            "examples": [
+              "off_1k"
+            ],
+            "type": "string"
+          },
+          "object": {
+            "description": "Always `\"list\"` for a list response.",
+            "enum": [
+              "list"
+            ],
+            "examples": [
+              "list"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
+        "title": "Alert incident list",
+        "type": "object"
+      },
+      "AlertQueryBuilderDraft": {
+        "description": "The query-builder draft document for `builder_query` rules, exactly as produced by the Maple dashboard. Treat it as an opaque document: keys are passed through verbatim (no case conversion) and the server validates the structure on write.",
+        "title": "Query-builder draft",
+        "type": "object"
+      },
+      "AlertRule": {
+        "additionalProperties": false,
+        "description": "A monitor that evaluates a built-in signal, query-builder query, or raw SQL over a rolling window and opens incidents when the threshold condition holds for enough consecutive checks. Metrics use the same query-builder path as metric charts. Notifications are delivered to the referenced alert destinations.",
+        "examples": [
+          {
+            "apdex_threshold_ms": null,
+            "comparator": "gt",
+            "consecutive_breaches_required": 2,
+            "consecutive_healthy_required": 3,
+            "created_at": "2026-07-01T12:00:00.000Z",
+            "created_by": "user_2Nk8mXqPfR3yZ1aB4cD5eF6g",
+            "destination_ids": [
+              "dest_oybbpTBhtSFGShMjjLiCrh"
+            ],
+            "enabled": true,
+            "environments": [
+              "production"
+            ],
+            "exclude_service_names": [],
+            "group_by": null,
+            "id": "alrt_gU26thvJECdQvu54Ad9jiz",
+            "last_evaluated_at": "2026-07-15T09:10:00.000Z",
+            "last_evaluation_error": null,
+            "last_scheduled_at": "2026-07-15T09:10:00.000Z",
+            "minimum_sample_count": 50,
+            "name": "Checkout error rate",
+            "no_data_behavior": "skip",
+            "notes": null,
+            "notification_template": null,
+            "object": "alert_rule",
+            "query_builder_draft": null,
+            "raw_query_reducer": null,
+            "raw_query_sql": null,
+            "renotify_interval_minutes": 60,
+            "service_names": [
+              "checkout"
+            ],
+            "severity": "critical",
+            "signal_type": "error_rate",
+            "tags": [
+              "payments"
+            ],
+            "threshold": 0.05,
+            "threshold_upper": null,
+            "updated_at": "2026-07-14T08:30:00.000Z",
+            "updated_by": "user_2Nk8mXqPfR3yZ1aB4cD5eF6g",
+            "window_minutes": 5
+          }
+        ],
+        "properties": {
+          "apdex_threshold_ms": {
+            "description": "For `apdex` rules: the satisfied-latency threshold in milliseconds.",
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "comparator": {
+            "$ref": "#/components/schemas/_maple_AlertComparator"
+          },
+          "consecutive_breaches_required": {
+            "description": "Consecutive breached checks required before an incident opens.",
+            "examples": [
+              2
+            ],
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "consecutive_healthy_required": {
+            "description": "Consecutive healthy checks required before an open incident resolves.",
+            "examples": [
+              3
+            ],
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "created_by": {
+            "description": "Maple user ID of the rule's creator.",
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "title": "User ID",
+            "type": "string"
+          },
+          "destination_ids": {
+            "$ref": "#/components/schemas/Arrays_9"
+          },
+          "enabled": {
+            "description": "Whether the scheduler evaluates this rule.",
+            "examples": [
+              true
+            ],
+            "type": "boolean"
+          },
+          "environments": {
+            "$ref": "#/components/schemas/Arrays_6"
+          },
+          "exclude_service_names": {
+            "$ref": "#/components/schemas/Arrays_5"
+          },
+          "group_by": {
+            "items": {
+              "minLength": 1,
+              "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_maple_AlertRuleId"
+          },
+          "last_evaluated_at": {
+            "description": "When the rule was last evaluated, or `null` if never.",
+            "type": "string"
+          },
+          "last_evaluation_error": {
+            "description": "The most recent evaluation error for this rule, or `null` if the last evaluation succeeded.",
+            "type": "string"
+          },
+          "last_scheduled_at": {
+            "description": "When the scheduler last picked the rule up, or `null` if never.",
+            "type": "string"
+          },
+          "minimum_sample_count": {
+            "description": "Minimum samples required in the window before the rule can breach; below it the check is skipped.",
+            "examples": [
+              50
+            ],
+            "minimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "description": "Human-readable name of the rule.",
+            "examples": [
+              "Checkout error rate"
+            ],
+            "type": "string"
+          },
+          "no_data_behavior": {
+            "$ref": "#/components/schemas/_maple_QueryEngineNoDataBehavior"
+          },
+          "notes": {
+            "description": "Free-form operator notes shown alongside the rule, or `null`.",
+            "type": "string"
+          },
+          "notification_template": {
+            "$ref": "#/components/schemas/_maple_AlertNotificationTemplate",
+            "description": "Custom notification message (`title` + Markdown `body` with `{{ variable }}` substitution, plus per-channel `overrides`), or `null` for Maple's built-in format."
+          },
+          "object": {
+            "description": "The object type — always `\"alert_rule\"`.",
+            "enum": [
+              "alert_rule"
+            ],
+            "examples": [
+              "alert_rule"
+            ],
+            "type": "string"
+          },
+          "query_builder_draft": {
+            "$ref": "#/components/schemas/AlertQueryBuilderDraft"
+          },
+          "raw_query_reducer": {
+            "$ref": "#/components/schemas/_maple_QueryEngineAlertReducer",
+            "description": "For `raw_query` rules: how multi-row results reduce to one value (`identity`, `sum`, `avg`, `min`, `max`)."
+          },
+          "raw_query_sql": {
+            "description": "For `raw_query` rules: the SQL evaluated each window. `null` for other signal types.",
+            "type": "string"
+          },
+          "renotify_interval_minutes": {
+            "description": "How often an open incident re-notifies its destinations, in minutes.",
+            "examples": [
+              60
+            ],
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "service_names": {
+            "$ref": "#/components/schemas/Arrays_4"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/_maple_AlertSeverity"
+          },
+          "signal_type": {
+            "$ref": "#/components/schemas/_maple_AlertSignalType"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Arrays_7"
+          },
+          "threshold": {
+            "type": "number"
+          },
+          "threshold_upper": {
+            "type": "number"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "updated_by": {
+            "description": "Maple user ID of the last editor.",
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "title": "User ID",
+            "type": "string"
+          },
+          "window_minutes": {
+            "description": "Length of the evaluation window in minutes.",
+            "examples": [
+              5
+            ],
+            "exclusiveMinimum": 0,
+            "maximum": 1440,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "name",
+          "enabled",
+          "severity",
+          "service_names",
+          "exclude_service_names",
+          "environments",
+          "tags",
+          "signal_type",
+          "comparator",
+          "threshold",
+          "window_minutes",
+          "minimum_sample_count",
+          "consecutive_breaches_required",
+          "consecutive_healthy_required",
+          "renotify_interval_minutes",
+          "destination_ids",
+          "no_data_behavior",
+          "created_at",
+          "updated_at",
+          "created_by",
+          "updated_by"
+        ],
+        "title": "Alert Rule",
+        "type": "object"
+      },
+      "AlertRuleList": {
+        "additionalProperties": false,
+        "description": "A cursor-paginated page of alert rules.",
+        "properties": {
+          "data": {
+            "description": "The page of objects, in the ordering documented by the endpoint.",
+            "items": {
+              "$ref": "#/components/schemas/AlertRule"
+            },
+            "type": "array"
+          },
+          "has_more": {
+            "description": "Whether more objects exist after this page. When `true`, use `next_cursor` to fetch them.",
+            "examples": [
+              true
+            ],
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "description": "Cursor for the next page, or `null` on the last page. Pass it back as the `cursor` query param.",
+            "examples": [
+              "off_1k"
+            ],
+            "type": "string"
+          },
+          "object": {
+            "description": "Always `\"list\"` for a list response.",
+            "enum": [
+              "list"
+            ],
+            "examples": [
+              "list"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
+        "title": "Alert rule list",
+        "type": "object"
+      },
+      "AnomalyIncident": {
+        "additionalProperties": false,
+        "description": "A detected anomaly on a monitored signal (error rate, latency, throughput, error spike, or log volume) for a service and environment, opened by Maple's baseline detector.",
+        "examples": [
+          {
+            "baseline_median": 0.01,
+            "baseline_sigma": 0.004,
+            "deployment_env": "production",
+            "detector_key": "error_rate:payments:production",
+            "error_issue_id": null,
+            "fingerprint_hash": null,
+            "fingerprints": [],
+            "first_triggered_at": "2026-07-15T09:12:00.000Z",
+            "id": "anom_YofPTrK9782DWwcnXhpcCw",
+            "last_observed_value": 0.14,
+            "last_reopened_at": null,
+            "last_sample_count": 4200,
+            "last_triggered_at": "2026-07-15T09:18:00.000Z",
+            "object": "anomaly_incident",
+            "opened_value": 0.12,
+            "reopen_count": 0,
+            "resolve_reason": null,
+            "resolved_at": null,
+            "service_name": "payments",
+            "severity": "critical",
+            "signal_type": "error_rate",
+            "status": "open",
+            "threshold_value": 0.05,
+            "triage_status": "completed"
+          }
+        ],
+        "properties": {
+          "baseline_median": {
+            "type": "number"
+          },
+          "baseline_sigma": {
+            "type": "number"
+          },
+          "deployment_env": {
+            "description": "The deployment environment (e.g. `production`).",
+            "type": "string"
+          },
+          "detector_key": {
+            "description": "Stable key identifying the detector (signal + service + env) that opened the incident.",
+            "type": "string"
+          },
+          "error_issue_id": {
+            "$ref": "#/components/schemas/_maple_ErrorIssueId",
+            "description": "The `iss_…` error issue linked to the incident, or `null`."
+          },
+          "fingerprint_hash": {
+            "description": "The error fingerprint for `error_spike` incidents, or `null` for golden-signal incidents.",
+            "type": "string"
+          },
+          "fingerprints": {
+            "description": "Fingerprints sharing this incident; empty for golden-signal incidents.",
+            "items": {
+              "$ref": "#/components/schemas/AnomalyIncidentFingerprint"
+            },
+            "type": "array"
+          },
+          "first_triggered_at": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_maple_AnomalyIncidentId"
+          },
+          "last_observed_value": {
+            "type": "number"
+          },
+          "last_reopened_at": {
+            "description": "When the incident last reopened, or `null`.",
+            "type": "string"
+          },
+          "last_sample_count": {
+            "type": "number"
+          },
+          "last_triggered_at": {
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type — always `\"anomaly_incident\"`.",
+            "enum": [
+              "anomaly_incident"
+            ],
+            "examples": [
+              "anomaly_incident"
+            ],
+            "type": "string"
+          },
+          "opened_value": {
+            "type": "number"
+          },
+          "reopen_count": {
+            "type": "number"
+          },
+          "resolve_reason": {
+            "$ref": "#/components/schemas/_maple_AnomalyResolveReason",
+            "description": "Why the incident resolved (`returned_to_baseline`, `no_data`, `manual`), or `null`."
+          },
+          "resolved_at": {
+            "description": "When the incident resolved, or `null`.",
+            "type": "string"
+          },
+          "service_name": {
+            "description": "The service the anomaly was detected on.",
+            "type": "string"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/_maple_AnomalyIncidentSeverity"
+          },
+          "signal_type": {
+            "$ref": "#/components/schemas/_maple_AnomalySignalType"
+          },
+          "status": {
+            "$ref": "#/components/schemas/_maple_AnomalyIncidentStatus"
+          },
+          "threshold_value": {
+            "type": "number"
+          },
+          "triage_status": {
+            "$ref": "#/components/schemas/_maple_AnomalyTriageStatus"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "detector_key",
+          "signal_type",
+          "service_name",
+          "deployment_env",
+          "status",
+          "severity",
+          "opened_value",
+          "baseline_median",
+          "baseline_sigma",
+          "threshold_value",
+          "last_observed_value",
+          "last_sample_count",
+          "first_triggered_at",
+          "last_triggered_at",
+          "triage_status",
+          "fingerprints",
+          "reopen_count"
+        ],
+        "title": "Anomaly incident",
+        "type": "object"
+      },
+      "AnomalyIncidentFingerprint": {
+        "additionalProperties": false,
+        "description": "One error fingerprint participating in a consolidated error-spike incident.",
+        "properties": {
+          "attached_at": {
+            "type": "string"
+          },
+          "error_issue_id": {
+            "$ref": "#/components/schemas/_maple_ErrorIssueId",
+            "description": "The `iss_…` error issue for this fingerprint, or `null`."
+          },
+          "fingerprint_hash": {
+            "description": "The error fingerprint hash.",
+            "type": "string"
+          },
+          "last_value": {
+            "type": "number"
+          },
+          "opened_value": {
+            "type": "number"
+          },
+          "resolved_at": {
+            "description": "When this fingerprint returned to baseline, or `null`.",
+            "type": "string"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/_maple_AnomalyIncidentSeverity"
+          }
+        },
+        "required": [
+          "fingerprint_hash",
+          "opened_value",
+          "last_value",
+          "severity",
+          "attached_at"
+        ],
+        "title": "Anomaly incident fingerprint",
+        "type": "object"
+      },
+      "AnomalyIncidentList": {
+        "additionalProperties": false,
+        "description": "A cursor-paginated page of anomaly incidents, newest first.",
+        "properties": {
+          "data": {
+            "description": "The page of objects, in the ordering documented by the endpoint.",
+            "items": {
+              "$ref": "#/components/schemas/AnomalyIncident"
+            },
+            "type": "array"
+          },
+          "has_more": {
+            "description": "Whether more objects exist after this page. When `true`, use `next_cursor` to fetch them.",
+            "examples": [
+              true
+            ],
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "description": "Cursor for the next page, or `null` on the last page. Pass it back as the `cursor` query param.",
+            "examples": [
+              "off_1k"
+            ],
+            "type": "string"
+          },
+          "object": {
+            "description": "Always `\"list\"` for a list response.",
+            "enum": [
+              "list"
+            ],
+            "examples": [
+              "list"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
+        "title": "Anomaly incident list",
+        "type": "object"
+      },
+      "AnomalyIncidentTimeseries": {
+        "additionalProperties": false,
+        "description": "The monitored signal's timeseries around an incident, with the baseline and threshold.",
+        "examples": [
+          {
+            "baseline_median": 0.01,
+            "bucket_seconds": 300,
+            "buckets": [
+              {
+                "bucket": "2026-07-15T09:10:00.000Z",
+                "sample_count": 4200,
+                "value": 0.12
+              }
+            ],
+            "object": "anomaly_incident.timeseries",
+            "signal_type": "error_rate",
+            "threshold_value": 0.05,
+            "unit": "ratio"
+          }
+        ],
+        "properties": {
+          "baseline_median": {
+            "type": "number"
+          },
+          "bucket_seconds": {
+            "type": "number"
+          },
+          "buckets": {
+            "description": "The signal timeseries around the incident window.",
+            "items": {
+              "$ref": "#/components/schemas/AnomalyTimeseriesBucket"
+            },
+            "type": "array"
+          },
+          "object": {
+            "description": "The object type — always `\"anomaly_incident.timeseries\"`.",
+            "enum": [
+              "anomaly_incident.timeseries"
+            ],
+            "type": "string"
+          },
+          "signal_type": {
+            "$ref": "#/components/schemas/_maple_AnomalySignalType"
+          },
+          "threshold_value": {
+            "type": "number"
+          },
+          "unit": {
+            "$ref": "#/components/schemas/_maple_AnomalyTimeseriesUnit"
+          }
+        },
+        "required": [
+          "object",
+          "signal_type",
+          "unit",
+          "bucket_seconds",
+          "buckets",
+          "baseline_median",
+          "threshold_value"
+        ],
+        "title": "Anomaly incident timeseries",
+        "type": "object"
+      },
+      "AnomalyTimeseriesBucket": {
+        "additionalProperties": false,
+        "properties": {
+          "bucket": {
+            "type": "string"
+          },
+          "sample_count": {
+            "type": "number"
+          },
+          "value": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "bucket",
+          "value",
+          "sample_count"
+        ],
+        "title": "Anomaly timeseries bucket",
+        "type": "object"
+      },
+      "Arrays_18": {
+        "items": {
+          "$ref": "#/components/schemas/TimeseriesSeries"
+        },
+        "type": "array"
+      },
+      "Arrays_19": {
+        "items": {
+          "$ref": "#/components/schemas/BreakdownItem"
+        },
+        "type": "array"
+      },
+      "Arrays_4": {
+        "description": "Services the rule is scoped to. Empty for all services.",
+        "examples": [
+          [
+            "checkout"
+          ]
+        ],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "Arrays_5": {
+        "description": "Services excluded from evaluation.",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "Arrays_6": {
+        "description": "Deployment environments the rule is scoped to. Empty for all environments. Always empty for `builder_query` / `raw_query`, whose queries carry their own filters.",
+        "examples": [
+          [
+            "production"
+          ]
+        ],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "Arrays_7": {
+        "description": "Free-form tags used to group and filter rules.",
+        "examples": [
+          [
+            "payments"
+          ]
+        ],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "Arrays_9": {
+        "description": "The alert destinations (`dest_…`) this rule notifies.",
+        "items": {
+          "$ref": "#/components/schemas/_maple_AlertDestinationId"
+        },
+        "type": "array"
+      },
+      "AttributeFilter": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "key": {
+                "minLength": 1,
+                "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+                "type": "string"
+              },
+              "negated": {
+                "type": "boolean"
+              },
+              "operator": {
+                "enum": [
+                  "exists"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "not": {}
+              }
+            },
+            "required": [
+              "key",
+              "operator"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "key": {
+                "minLength": 1,
+                "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+                "type": "string"
+              },
+              "negated": {
+                "type": "boolean"
+              },
+              "operator": {
+                "enum": [
+                  "equals",
+                  "contains"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "operator",
+              "value"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "key": {
+                "minLength": 1,
+                "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+                "type": "string"
+              },
+              "negated": {
+                "type": "boolean"
+              },
+              "operator": {
+                "enum": [
+                  "gt",
+                  "gte",
+                  "lt",
+                  "lte"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "key",
+              "operator",
+              "value"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "Matches an attribute by key. `exists` has no value, string operators require a string value, and numeric operators require a finite number.",
+        "title": "Attribute filter"
+      },
+      "BreakdownItem": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ],
+        "title": "Breakdown item",
+        "type": "object"
+      },
       "ErrorIncident": {
         "additionalProperties": false,
         "properties": {
@@ -675,6 +1907,368 @@
         "title": "Service list",
         "type": "object"
       },
+      "TimeseriesSeries": {
+        "additionalProperties": false,
+        "properties": {
+          "group": {
+            "type": "string"
+          },
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/TimeseriesValuePoint"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "points"
+        ],
+        "title": "Timeseries series",
+        "type": "object"
+      },
+      "TimeseriesValuePoint": {
+        "additionalProperties": false,
+        "properties": {
+          "timestamp": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "timestamp",
+          "value"
+        ],
+        "title": "Timeseries value point",
+        "type": "object"
+      },
+      "TraceBreakdownParams": {
+        "additionalProperties": false,
+        "properties": {
+          "aggregation": {
+            "enum": [
+              "count",
+              "avg_duration",
+              "p50_duration",
+              "p95_duration",
+              "p99_duration",
+              "error_rate",
+              "apdex"
+            ],
+            "type": "string"
+          },
+          "apdex_threshold_ms": {
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "end_time": {
+            "type": "string"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/TraceFilters"
+          },
+          "group_by": {
+            "enum": [
+              "service",
+              "span_name",
+              "status_code",
+              "http_method",
+              "attribute"
+            ],
+            "type": "string"
+          },
+          "group_by_attribute_key": {
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "type": "string"
+          },
+          "limit": {
+            "exclusiveMinimum": 0,
+            "maximum": 100,
+            "type": "integer"
+          },
+          "start_time": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "start_time",
+          "end_time",
+          "aggregation",
+          "group_by"
+        ],
+        "type": "object"
+      },
+      "TraceBreakdownResult": {
+        "additionalProperties": false,
+        "examples": [
+          {
+            "aggregation": "error_rate",
+            "data": [
+              {
+                "name": "api",
+                "value": 0.05
+              }
+            ],
+            "end_time": "2026-07-15T13:00:00.000Z",
+            "group_by": "service",
+            "object": "trace_breakdown",
+            "start_time": "2026-07-15T12:00:00.000Z"
+          }
+        ],
+        "properties": {
+          "aggregation": {
+            "enum": [
+              "count",
+              "avg_duration",
+              "p50_duration",
+              "p95_duration",
+              "p99_duration",
+              "error_rate",
+              "apdex"
+            ],
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/components/schemas/Arrays_19"
+          },
+          "end_time": {
+            "type": "string"
+          },
+          "group_by": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "trace_breakdown"
+            ],
+            "type": "string"
+          },
+          "start_time": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "aggregation",
+          "start_time",
+          "end_time",
+          "group_by",
+          "data"
+        ],
+        "title": "Trace breakdown result",
+        "type": "object"
+      },
+      "TraceFilters": {
+        "additionalProperties": false,
+        "properties": {
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/AttributeFilter"
+            },
+            "maxItems": 20,
+            "type": "array"
+          },
+          "deployment_environment": {
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "type": "string"
+          },
+          "has_error": {
+            "type": "boolean"
+          },
+          "http_method": {
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "type": "string"
+          },
+          "http_route": {
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "type": "string"
+          },
+          "http_status_code": {
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "type": "string"
+          },
+          "max_duration_ms": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "min_duration_ms": {
+            "minimum": 0,
+            "type": "number"
+          },
+          "resource_attributes": {
+            "items": {
+              "$ref": "#/components/schemas/AttributeFilter"
+            },
+            "maxItems": 20,
+            "type": "array"
+          },
+          "service_name": {
+            "$ref": "#/components/schemas/_maple_ServiceName"
+          },
+          "service_namespace": {
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "type": "string"
+          },
+          "span_name": {
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "type": "string"
+          },
+          "span_scope": {
+            "enum": [
+              "root"
+            ],
+            "type": "string"
+          },
+          "status_code": {
+            "enum": [
+              "Ok",
+              "Error",
+              "Unset"
+            ],
+            "type": "string"
+          }
+        },
+        "title": "Trace filters",
+        "type": "object"
+      },
+      "TraceTimeseriesParams": {
+        "additionalProperties": false,
+        "properties": {
+          "aggregation": {
+            "enum": [
+              "count",
+              "avg_duration",
+              "p50_duration",
+              "p95_duration",
+              "p99_duration",
+              "error_rate",
+              "apdex"
+            ],
+            "type": "string"
+          },
+          "apdex_threshold_ms": {
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "bucket_seconds": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "end_time": {
+            "type": "string"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/TraceFilters"
+          },
+          "group_by": {
+            "enum": [
+              "service",
+              "span_name",
+              "status_code",
+              "http_method",
+              "attribute"
+            ],
+            "type": "string"
+          },
+          "group_by_attribute_key": {
+            "minLength": 1,
+            "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+            "type": "string"
+          },
+          "series_limit": {
+            "exclusiveMinimum": 0,
+            "maximum": 100,
+            "type": "integer"
+          },
+          "start_time": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "start_time",
+          "end_time",
+          "aggregation"
+        ],
+        "type": "object"
+      },
+      "TraceTimeseriesResult": {
+        "additionalProperties": false,
+        "examples": [
+          {
+            "aggregation": "count",
+            "bucket_seconds": 60,
+            "end_time": "2026-07-15T13:00:00.000Z",
+            "group_by": "service",
+            "object": "trace_timeseries",
+            "series": [
+              {
+                "group": "api",
+                "points": [
+                  {
+                    "timestamp": "2026-07-15T12:00:00.000Z",
+                    "value": 42
+                  }
+                ]
+              }
+            ],
+            "start_time": "2026-07-15T12:00:00.000Z"
+          }
+        ],
+        "properties": {
+          "aggregation": {
+            "enum": [
+              "count",
+              "avg_duration",
+              "p50_duration",
+              "p95_duration",
+              "p99_duration",
+              "error_rate",
+              "apdex"
+            ],
+            "type": "string"
+          },
+          "bucket_seconds": {
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "end_time": {
+            "type": "string"
+          },
+          "group_by": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "trace_timeseries"
+            ],
+            "type": "string"
+          },
+          "series": {
+            "$ref": "#/components/schemas/Arrays_18"
+          },
+          "start_time": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "aggregation",
+          "start_time",
+          "end_time",
+          "bucket_seconds",
+          "series"
+        ],
+        "title": "Trace timeseries result",
+        "type": "object"
+      },
       "_maple_ActorId": {
         "description": "Opaque, prefixed public object ID (e.g. `actor_YofPTrK9782DWwcnXhpcCw`). A reversible base58 encoding of the internal ID — treat it as an opaque string.",
         "examples": [
@@ -690,6 +2284,265 @@
           "agent"
         ],
         "title": "Actor Type",
+        "type": "string"
+      },
+      "_maple_AlertCheckStatus": {
+        "description": "Only return checks with this evaluation status.",
+        "enum": [
+          "breached",
+          "healthy",
+          "skipped",
+          "error"
+        ],
+        "title": "Alert Check Status",
+        "type": "string"
+      },
+      "_maple_AlertComparator": {
+        "description": "Comparison operator: `gt`, `gte`, `lt`, `lte`, `eq`, `neq`, or the range forms `between` / `not_between` (which also require `threshold_upper`).",
+        "enum": [
+          "gt",
+          "gte",
+          "lt",
+          "lte",
+          "eq",
+          "neq",
+          "between",
+          "not_between"
+        ],
+        "examples": [
+          "gt"
+        ],
+        "title": "Alert Comparator",
+        "type": "string"
+      },
+      "_maple_AlertDeliveryEventId": {
+        "description": "Opaque, prefixed public object ID (e.g. `evt_YofPTrK9782DWwcnXhpcCw`). A reversible base58 encoding of the internal ID — treat it as an opaque string.",
+        "examples": [
+          "evt_YofPTrK9782DWwcnXhpcCw"
+        ],
+        "format": "maple.public_id",
+        "title": "Public ID",
+        "type": "string"
+      },
+      "_maple_AlertDeliveryStatus": {
+        "enum": [
+          "queued",
+          "processing",
+          "success",
+          "failed"
+        ],
+        "title": "Alert Delivery Status",
+        "type": "string"
+      },
+      "_maple_AlertDestinationId": {
+        "description": "Opaque, prefixed public object ID (e.g. `dest_YofPTrK9782DWwcnXhpcCw`). A reversible base58 encoding of the internal ID — treat it as an opaque string.",
+        "examples": [
+          "dest_YofPTrK9782DWwcnXhpcCw"
+        ],
+        "format": "maple.public_id",
+        "title": "Public ID",
+        "type": "string"
+      },
+      "_maple_AlertDestinationType": {
+        "enum": [
+          "slack-bot",
+          "pagerduty",
+          "webhook",
+          "hazel-oauth",
+          "discord",
+          "email"
+        ],
+        "title": "Alert Destination Type",
+        "type": "string"
+      },
+      "_maple_AlertEventType": {
+        "enum": [
+          "trigger",
+          "resolve",
+          "renotify",
+          "test"
+        ],
+        "title": "Alert Event Type",
+        "type": "string"
+      },
+      "_maple_AlertIncidentId": {
+        "description": "Opaque, prefixed public object ID (e.g. `inc_YofPTrK9782DWwcnXhpcCw`). A reversible base58 encoding of the internal ID — treat it as an opaque string.",
+        "examples": [
+          "inc_YofPTrK9782DWwcnXhpcCw"
+        ],
+        "format": "maple.public_id",
+        "title": "Public ID",
+        "type": "string"
+      },
+      "_maple_AlertIncidentStatus": {
+        "description": "Only return incidents with this status (`open` or `resolved`).",
+        "enum": [
+          "open",
+          "resolved"
+        ],
+        "examples": [
+          "open"
+        ],
+        "title": "Alert Incident Status",
+        "type": "string"
+      },
+      "_maple_AlertIncidentTransition": {
+        "description": "How this check moved the incident state machine: `none`, `opened`, `continued`, or `resolved`.",
+        "enum": [
+          "none",
+          "opened",
+          "continued",
+          "resolved"
+        ],
+        "examples": [
+          "opened"
+        ],
+        "title": "Alert Incident Transition",
+        "type": "string"
+      },
+      "_maple_AlertNotificationTemplate": {
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "maxLength": 4000,
+            "type": "string"
+          },
+          "overrides": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/_maple_AlertNotificationTemplateOverride"
+            },
+            "type": "object"
+          },
+          "title": {
+            "maxLength": 4000,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "_maple_AlertNotificationTemplateOverride": {
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "maxLength": 4000,
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 4000,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "_maple_AlertRuleId": {
+        "description": "Opaque, prefixed public object ID (e.g. `alrt_YofPTrK9782DWwcnXhpcCw`). A reversible base58 encoding of the internal ID — treat it as an opaque string.",
+        "examples": [
+          "alrt_YofPTrK9782DWwcnXhpcCw"
+        ],
+        "format": "maple.public_id",
+        "title": "Public ID",
+        "type": "string"
+      },
+      "_maple_AlertSeverity": {
+        "description": "Severity attached to incidents this rule opens: `warning` or `critical`.",
+        "enum": [
+          "warning",
+          "critical"
+        ],
+        "examples": [
+          "critical"
+        ],
+        "title": "Alert Severity",
+        "type": "string"
+      },
+      "_maple_AlertSignalType": {
+        "description": "What the rule measures: `error_rate`, `p95_latency`, `p99_latency`, `apdex`, `throughput`, `builder_query`, or `raw_query`. Metrics use `builder_query` with a metrics draft.",
+        "enum": [
+          "error_rate",
+          "p95_latency",
+          "p99_latency",
+          "apdex",
+          "throughput",
+          "builder_query",
+          "raw_query"
+        ],
+        "examples": [
+          "error_rate"
+        ],
+        "title": "Alert Signal Type",
+        "type": "string"
+      },
+      "_maple_AnomalyIncidentId": {
+        "description": "Opaque, prefixed public object ID (e.g. `anom_YofPTrK9782DWwcnXhpcCw`). A reversible base58 encoding of the internal ID — treat it as an opaque string.",
+        "examples": [
+          "anom_YofPTrK9782DWwcnXhpcCw"
+        ],
+        "format": "maple.public_id",
+        "title": "Public ID",
+        "type": "string"
+      },
+      "_maple_AnomalyIncidentSeverity": {
+        "description": "Incident severity: `warning` or `critical`.",
+        "enum": [
+          "warning",
+          "critical"
+        ],
+        "examples": [
+          "critical"
+        ],
+        "title": "Anomaly Incident Severity",
+        "type": "string"
+      },
+      "_maple_AnomalyIncidentStatus": {
+        "description": "Filter by incident status.",
+        "enum": [
+          "open",
+          "resolved"
+        ],
+        "title": "Anomaly Incident Status",
+        "type": "string"
+      },
+      "_maple_AnomalyResolveReason": {
+        "enum": [
+          "returned_to_baseline",
+          "no_data",
+          "manual"
+        ],
+        "title": "Anomaly Resolve Reason",
+        "type": "string"
+      },
+      "_maple_AnomalySignalType": {
+        "description": "Filter by signal type.",
+        "enum": [
+          "error_rate",
+          "latency_p95",
+          "throughput",
+          "error_spike",
+          "log_volume"
+        ],
+        "title": "Anomaly Signal Type",
+        "type": "string"
+      },
+      "_maple_AnomalyTimeseriesUnit": {
+        "description": "The unit of the bucketed values (`ratio`, `milliseconds`, `per_minute`, `count_per_30m`).",
+        "enum": [
+          "ratio",
+          "milliseconds",
+          "per_minute",
+          "count_per_30m"
+        ],
+        "title": "Anomaly Timeseries Unit",
+        "type": "string"
+      },
+      "_maple_AnomalyTriageStatus": {
+        "description": "AI-triage state for the incident (`none`, `pending`, `completed`, `skipped`).",
+        "enum": [
+          "none",
+          "pending",
+          "completed",
+          "skipped"
+        ],
+        "title": "Anomaly Triage Status",
         "type": "string"
       },
       "_maple_ErrorIncidentId": {
@@ -738,6 +2591,27 @@
         "title": "Issue Severity Source",
         "type": "string"
       },
+      "_maple_QueryEngineAlertReducer": {
+        "enum": [
+          "identity",
+          "sum",
+          "avg",
+          "max",
+          "min"
+        ],
+        "type": "string"
+      },
+      "_maple_QueryEngineNoDataBehavior": {
+        "description": "What the evaluator does when the window has no data: `skip` the check or treat the value as `zero`.",
+        "enum": [
+          "skip",
+          "zero"
+        ],
+        "examples": [
+          "skip"
+        ],
+        "type": "string"
+      },
       "_maple_ServiceName": {
         "title": "Service Name",
         "type": "string"
@@ -782,6 +2656,1407 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/v2/alerts/deliveries": {
+      "get": {
+        "description": "Returns the organization's most recent alert notification attempts, newest first, optionally filtered by `incident_id` or `rule_id`. Requires the `alerts:read` scope.",
+        "operationId": "listAlertDeliveries",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Opaque pagination cursor. Pass the `next_cursor` from a previous response to fetch the following page. Omit for the first page.",
+              "examples": [
+                "off_1k"
+              ],
+              "title": "Cursor",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "incident_id",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AlertIncidentId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rule_id",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AlertRuleId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertDeliveryList"
+                }
+              }
+            },
+            "description": "Cursor-paginated list envelope wrapping a page of objects."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ParameterInvalidError failure. HTTP 400. | The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List alert deliveries",
+        "tags": [
+          "Alert Deliveries"
+        ]
+      }
+    },
+    "/v2/alerts/incidents": {
+      "get": {
+        "description": "Returns your organization's alert incidents, most recently triggered first, optionally filtered by `status` or `rule_id`. Cursor-paginated. Requires the `alerts:read` scope.",
+        "operationId": "listAlertIncidents",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Opaque pagination cursor. Pass the `next_cursor` from a previous response to fetch the following page. Omit for the first page.",
+              "examples": [
+                "off_1k"
+              ],
+              "title": "Cursor",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AlertIncidentStatus"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rule_id",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AlertRuleId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertIncidentList"
+                }
+              }
+            },
+            "description": "A cursor-paginated page of alert incidents."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ParameterInvalidError failure. HTTP 400. | The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List alert incidents",
+        "tags": [
+          "Alert Incidents"
+        ]
+      }
+    },
+    "/v2/alerts/incidents/{id}": {
+      "get": {
+        "description": "Returns a single alert incident by its `inc_…` ID. Requires the `alerts:read` scope.",
+        "operationId": "getAlertIncident",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AlertIncidentId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertIncident"
+                }
+              }
+            },
+            "description": "A period during which an alert rule's condition held: opened after enough consecutive breaches, resolved by the scheduler after enough consecutive healthy checks. Read-only via the API."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertIncidentNotFoundError failure. HTTP 404."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Retrieve an alert incident",
+        "tags": [
+          "Alert Incidents"
+        ]
+      }
+    },
+    "/v2/alerts/rules": {
+      "get": {
+        "description": "Returns your organization's alert rules, most recently created first. Cursor-paginated. Requires the `alerts:read` scope.",
+        "operationId": "listAlertRules",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Opaque pagination cursor. Pass the `next_cursor` from a previous response to fetch the following page. Omit for the first page.",
+              "examples": [
+                "off_1k"
+              ],
+              "title": "Cursor",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleList"
+                }
+              }
+            },
+            "description": "A cursor-paginated page of alert rules."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ParameterInvalidError failure. HTTP 400. | The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertRuleStoredConfigInvalidError failure. HTTP 500. | The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List alert rules",
+        "tags": [
+          "Alert Rules"
+        ]
+      }
+    },
+    "/v2/alerts/rules/{id}": {
+      "get": {
+        "description": "Returns a single alert rule by its `alrt_…` ID. Requires the `alerts:read` scope.",
+        "operationId": "getAlertRule",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AlertRuleId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRule"
+                }
+              }
+            },
+            "description": "A monitor that evaluates a built-in signal, query-builder query, or raw SQL over a rolling window and opens incidents when the threshold condition holds for enough consecutive checks. Metrics use the same query-builder path as metric charts. Notifications are delivered to the referenced alert destinations."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertRuleNotFoundError failure. HTTP 404."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertRuleStoredConfigInvalidError failure. HTTP 500. | The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Retrieve an alert rule",
+        "tags": [
+          "Alert Rules"
+        ]
+      }
+    },
+    "/v2/alerts/rules/{id}/checks": {
+      "get": {
+        "description": "Returns the rule's recorded evaluations (its audit trail), newest first, optionally filtered by group key and time range. Requires the `alerts:read` scope.",
+        "operationId": "listAlertRuleChecks",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AlertRuleId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Opaque pagination cursor. Pass the `next_cursor` from a previous response to fetch the following page. Omit for the first page.",
+              "examples": [
+                "off_1k"
+              ],
+              "title": "Cursor",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "group_key",
+            "required": false,
+            "schema": {
+              "description": "Only return checks for this group key.",
+              "examples": [
+                "__total__"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AlertCheckStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertCheckList"
+                }
+              }
+            },
+            "description": "A cursor-paginated page of alert checks, newest first."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ParameterInvalidError failure. HTTP 400. | The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertRuleNotFoundError failure. HTTP 404."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQuotaExceededError failure. HTTP 429. | The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseMalformedQueryError failure. HTTP 500. | The @maple/http/errors/WarehouseScopeError failure. HTTP 500. | The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQueryError failure. HTTP 502. | The @maple/http/errors/WarehouseAuthError failure. HTTP 502. | The @maple/http/errors/WarehouseConfigError failure. HTTP 502. | The @maple/http/errors/WarehouseClientError failure. HTTP 502. | The @maple/http/errors/WarehouseSchemaDriftError failure. HTTP 502. | The @maple/http/errors/WarehouseResultDecodeError failure. HTTP 502."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/AlertPersistenceError failure. HTTP 503. | The @maple/http/errors/WarehouseUpstreamError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List a rule's checks",
+        "tags": [
+          "Alert Rules"
+        ]
+      }
+    },
+    "/v2/anomalies/incidents": {
+      "get": {
+        "description": "Returns your organization's anomaly incidents, newest first, with optional filters. Cursor-paginated. Requires the `anomalies:read` scope.",
+        "operationId": "listAnomalyIncidents",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Opaque pagination cursor. Pass the `next_cursor` from a previous response to fetch the following page. Omit for the first page.",
+              "examples": [
+                "off_1k"
+              ],
+              "title": "Cursor",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AnomalyIncidentStatus"
+            }
+          },
+          {
+            "in": "query",
+            "name": "signal_type",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AnomalySignalType"
+            }
+          },
+          {
+            "in": "query",
+            "name": "service_name",
+            "required": false,
+            "schema": {
+              "description": "Filter by service name.",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "deployment_env",
+            "required": false,
+            "schema": {
+              "description": "Filter by deployment environment.",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "error_issue_id",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_ErrorIssueId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnomalyIncidentList"
+                }
+              }
+            },
+            "description": "A cursor-paginated page of anomaly incidents, newest first."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ParameterInvalidError failure. HTTP 400. | The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/anomalies/AnomalyPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List anomaly incidents",
+        "tags": [
+          "Anomalies"
+        ]
+      }
+    },
+    "/v2/anomalies/incidents/{id}": {
+      "get": {
+        "description": "Returns a single anomaly incident by its `anom_…` ID. Requires the `anomalies:read` scope.",
+        "operationId": "getAnomalyIncident",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AnomalyIncidentId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnomalyIncident"
+                }
+              }
+            },
+            "description": "A detected anomaly on a monitored signal (error rate, latency, throughput, error spike, or log volume) for a service and environment, opened by Maple's baseline detector."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/anomalies/AnomalyIncidentNotFoundError failure. HTTP 404."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/anomalies/AnomalyPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Retrieve an anomaly incident",
+        "tags": [
+          "Anomalies"
+        ]
+      }
+    },
+    "/v2/anomalies/incidents/{id}/timeseries": {
+      "get": {
+        "description": "Returns the monitored signal's timeseries around the incident, with baseline and threshold overlays. Requires the `anomalies:read` scope.",
+        "operationId": "getAnomalyIncidentTimeseries",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/_maple_AnomalyIncidentId"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_time",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnomalyIncidentTimeseries"
+                }
+              }
+            },
+            "description": "The monitored signal's timeseries around an incident, with the baseline and threshold."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/anomalies/AnomalyIncidentNotFoundError failure. HTTP 404."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQuotaExceededError failure. HTTP 429. | The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseMalformedQueryError failure. HTTP 500. | The @maple/http/errors/WarehouseScopeError failure. HTTP 500. | The @maple/http/errors/OrgClickHouseSettingsEncryptionError failure. HTTP 500. | The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQueryError failure. HTTP 502. | The @maple/http/errors/WarehouseAuthError failure. HTTP 502. | The @maple/http/errors/WarehouseConfigError failure. HTTP 502. | The @maple/http/errors/WarehouseClientError failure. HTTP 502. | The @maple/http/errors/WarehouseSchemaDriftError failure. HTTP 502. | The @maple/http/errors/WarehouseResultDecodeError failure. HTTP 502. | The @maple/http/errors/OrgClickHouseSettingsStoredConfigInvalidError failure. HTTP 502."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/anomalies/AnomalyPersistenceError failure. HTTP 503. | The @maple/http/errors/WarehouseUpstreamError failure. HTTP 503. | The @maple/http/errors/OrgClickHouseSettingsPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Retrieve incident timeseries",
+        "tags": [
+          "Anomalies"
+        ]
+      }
+    },
     "/v2/error_issues": {
       "get": {
         "description": "Returns a bounded, cursor-paginated page of your organization's issues. Requires `error_issues:read`.",
@@ -1642,6 +4917,276 @@
         "summary": "Retrieve a service",
         "tags": [
           "Services"
+        ]
+      }
+    },
+    "/v2/traces/breakdown": {
+      "post": {
+        "description": "Aggregates traces by one dimension. Requires `traces:read`.",
+        "operationId": "queryTraceBreakdown",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TraceBreakdownParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceBreakdownResult"
+                }
+              }
+            },
+            "description": "TraceBreakdownResult"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/TimeRangeInvalidError failure. HTTP 400. | The @maple/http/v2/TelemetryRangeTooLargeError failure. HTTP 400. | The @maple/http/v2/TelemetryBreakdownFilterRequiredError failure. HTTP 400. | The @maple/http/v2/TraceQueryInvalidError failure. HTTP 400. | The @maple/http/errors/QueryEngineValidationError failure. HTTP 400. | The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQuotaExceededError failure. HTTP 429. | The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseMalformedQueryError failure. HTTP 500. | The @maple/http/errors/WarehouseScopeError failure. HTTP 500. | The @maple/http/errors/OrgClickHouseSettingsEncryptionError failure. HTTP 500. | The @maple/http/errors/QueryEngineResultMismatchError failure. HTTP 500. | The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQueryError failure. HTTP 502. | The @maple/http/errors/WarehouseAuthError failure. HTTP 502. | The @maple/http/errors/WarehouseConfigError failure. HTTP 502. | The @maple/http/errors/WarehouseClientError failure. HTTP 502. | The @maple/http/errors/WarehouseSchemaDriftError failure. HTTP 502. | The @maple/http/errors/WarehouseResultDecodeError failure. HTTP 502. | The @maple/http/errors/OrgClickHouseSettingsStoredConfigInvalidError failure. HTTP 502."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseUpstreamError failure. HTTP 503. | The @maple/http/errors/OrgClickHouseSettingsPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/QueryEngineTimeoutError failure. HTTP 504. | The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Query trace breakdown",
+        "tags": [
+          "Traces"
+        ]
+      }
+    },
+    "/v2/traces/timeseries": {
+      "post": {
+        "description": "Aggregates traces into chronological series. Requires `traces:read`.",
+        "operationId": "queryTraceTimeseries",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TraceTimeseriesParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceTimeseriesResult"
+                }
+              }
+            },
+            "description": "TraceTimeseriesResult"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/TimeRangeInvalidError failure. HTTP 400. | The @maple/http/v2/TelemetryRangeTooLargeError failure. HTTP 400. | The @maple/http/v2/TelemetryBucketCountTooLargeError failure. HTTP 400. | The @maple/http/v2/TraceQueryInvalidError failure. HTTP 400. | The @maple/http/errors/QueryEngineValidationError failure. HTTP 400. | The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQuotaExceededError failure. HTTP 429. | The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseMalformedQueryError failure. HTTP 500. | The @maple/http/errors/WarehouseScopeError failure. HTTP 500. | The @maple/http/errors/OrgClickHouseSettingsEncryptionError failure. HTTP 500. | The @maple/http/errors/QueryEngineResultMismatchError failure. HTTP 500. | The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQueryError failure. HTTP 502. | The @maple/http/errors/WarehouseAuthError failure. HTTP 502. | The @maple/http/errors/WarehouseConfigError failure. HTTP 502. | The @maple/http/errors/WarehouseClientError failure. HTTP 502. | The @maple/http/errors/WarehouseSchemaDriftError failure. HTTP 502. | The @maple/http/errors/WarehouseResultDecodeError failure. HTTP 502. | The @maple/http/errors/OrgClickHouseSettingsStoredConfigInvalidError failure. HTTP 502."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseUpstreamError failure. HTTP 503. | The @maple/http/errors/OrgClickHouseSettingsPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/QueryEngineTimeoutError failure. HTTP 504. | The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Query trace timeseries",
+        "tags": [
+          "Traces"
         ]
       }
     }

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -1,7 +1,15 @@
 # Maple for iOS
 
-A native SwiftUI client for Maple: Clerk sign-in, services, and error issues,
-reading the **v2 public API**.
+A native SwiftUI client for Maple, reading the **v2 public API**. Three tabs,
+in the order the questions get asked — see [`PRODUCT.md`](PRODUCT.md):
+
+- **Home** — is anything wrong right now? Status headline, open alerts with
+  the rule's own last hour, services needing attention, what's new in 24h.
+- **Services** — the list, and a detail with golden-signal sparklines, scoped
+  alerts, issues, and top failing/slowest operations.
+- **Alerts** — the triage hub: incidents (with a "why" detail: what the rule
+  saw, what changed on the service, likely cause, timeline), error issues,
+  anomalies.
 
 ## Getting started
 
@@ -32,11 +40,12 @@ Xcode will ask once to trust the swift-openapi-generator build-tool plugin.
 ```
 project.yml                  XcodeGen source of truth; Maple.xcodeproj is generated + gitignored
 Config/                      xcconfigs; Secrets.xcconfig is gitignored
-Maple/App                    entry point, auth gate, build-time config
+Maple/App                    entry point, auth gate, build-time config, Route
 Maple/Auth                   token provider, session state machine, org picker
 Maple/DesignSystem           tokens, type scale, service colours, shared primitives
-Maple/Features               services and issues screens
-Maple/Components             LoadableView, formatting
+Maple/Features               Home, Services, Alerts (incidents/anomalies), Issues
+Maple/Components             LoadableView, formatting, Sparkline, alert formatting
+Maple/Fixtures               FixtureAPI — the app without Clerk or a network
 Maple/Resources/Fonts        Geist + Geist Mono (SIL OFL)
 Packages/MapleAPI            the generated API client — builds and tests with plain `swift test`
 ```
@@ -45,6 +54,22 @@ Everything that is worth unit-testing lives in `Packages/MapleAPI`, which has no
 UIKit, no simulator, and no signing requirement. That is why CI runs
 `swift test` there first: it fails in about a minute rather than after a full
 app build.
+
+## Running without a sign-in
+
+Set `MAPLE_FIXTURES=1` in the scheme's environment (Product → Scheme → Edit →
+Run → Arguments), or from the CLI:
+
+```bash
+SIMCTL_CHILD_MAPLE_FIXTURES=1 xcrun simctl launch booted com.maple.mobile
+```
+
+`FixtureAPI` then stands in for the network with one believable organization
+(nine services, a critical incident, a warning, issues, an anomaly), generated
+relative to now so timestamps always read as current, and the session is pinned
+to `.ready` without touching Clerk. This is how screens get built and
+screenshotted; it is not a test double for logic — that stays in
+`Packages/MapleAPI`.
 
 ## The API client is generated
 
@@ -68,8 +93,10 @@ uses three idioms that generate unusable Swift:
 | `anyOf: [number, enum["NaN", …]]` | a struct wrapping a `Double` | `Double` |
 | `allOf: [{minLength}, {pattern}]` | struct with `value1`/`value2` | `String` |
 
-It also prunes to the five operations the app calls and collapses every error
-response to a single `MapleErrorEnvelope`. Result: 21 schemas instead of 480.
+It also prunes to the operations the app calls, merges the per-annotation-site
+copies of a domain enum (`_maple_AlertSignalType_2` → `_maple_AlertSignalType`)
+so one wire enum is one Swift enum, and collapses every error response to a
+single `MapleErrorEnvelope`. Result: ~75 schemas instead of 480.
 
 Adding a screen means adding its `operationId` to `IOS_OPERATIONS` in that
 script and re-running it. A removed or renamed operation makes the script exit

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -63,14 +63,20 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Maple/Resources/Maple.entitlements
         # iPhone only, portrait only, for the first slice.
         TARGETED_DEVICE_FAMILY: "1"
-        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
-        INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        INFOPLIST_KEY_UISupportedInterfaceOrientations: UIInterfaceOrientationPortrait
     info:
       path: Maple/Resources/Info.plist
       properties:
         CFBundleDisplayName: Maple
         CFBundleShortVersionString: "0.1.0"
+        # These must live in the plist itself: `INFOPLIST_KEY_*` build settings
+        # are only honoured when Xcode generates the plist, and this one is
+        # written by XcodeGen. Without `UILaunchScreen` iOS assumes a legacy
+        # app and letterboxes it inside the old 4.7" canvas.
+        UILaunchScreen: {}
+        UIApplicationSceneManifest:
+          UIApplicationSupportsMultipleScenes: false
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
         # Geist Mono is the body voice and proportional Geist the display face —
         # the inversion that defines Maple's look. See Typography.swift.
         # Bare filenames: Xcode flattens resources to the bundle root, so a

--- a/packages/domain/src/http/v2/alert-deliveries.ts
+++ b/packages/domain/src/http/v2/alert-deliveries.ts
@@ -39,6 +39,24 @@ export const V2AlertDelivery = Schema.Struct({
 })
 export type V2AlertDelivery = Schema.Schema.Type<typeof V2AlertDelivery>
 
+const DeliveriesQuery = Schema.Struct({
+	...ListQuery.fields,
+	incident_id: Schema.optional(
+		AlertIncidentPublicId.annotate({
+			description: "Only return deliveries produced for this incident (`inc_…`).",
+		}),
+	),
+	rule_id: Schema.optional(
+		AlertRulePublicId.annotate({
+			description: "Only return deliveries produced by this alert rule (`alrt_…`).",
+		}),
+	),
+}).annotate({
+	identifier: "AlertDeliveryListQuery",
+	title: "Alert delivery list query",
+	description: "Pagination plus optional incident / rule filters.",
+})
+
 const AlertDeliveryList = ListOf(V2AlertDelivery).annotate({
 	identifier: "AlertDeliveryList",
 	title: "Alert delivery list",
@@ -47,7 +65,7 @@ const AlertDeliveryList = ListOf(V2AlertDelivery).annotate({
 export class V2AlertDeliveriesApiGroup extends HttpApiGroup.make("alertDeliveries")
 	.add(
 		HttpApiEndpoint.get("list", "/", {
-			query: ListQuery,
+			query: DeliveriesQuery,
 			success: AlertDeliveryList,
 			error: [V2ParameterInvalid.schema, publicError(AlertPersistenceError)],
 		}).annotateMerge(
@@ -55,7 +73,7 @@ export class V2AlertDeliveriesApiGroup extends HttpApiGroup.make("alertDeliverie
 				identifier: "listAlertDeliveries",
 				summary: "List alert deliveries",
 				description:
-					"Returns the organization's most recent alert notification attempts, newest first. Requires the `alerts:read` scope.",
+					"Returns the organization's most recent alert notification attempts, newest first, optionally filtered by `incident_id` or `rule_id`. Requires the `alerts:read` scope.",
 			}),
 		),
 	)

--- a/packages/domain/src/http/v2/openapi-ios.test.ts
+++ b/packages/domain/src/http/v2/openapi-ios.test.ts
@@ -34,10 +34,29 @@ const schemas = spec.components.schemas as JsonObject
 const IOS_OPERATIONS = [
 	"listServices",
 	"getService",
+	"queryTraceTimeseries",
+	"queryTraceBreakdown",
 	"listErrorIssues",
 	"listErrorIssueServiceCounts",
 	"getErrorIssue",
+	"listAlertIncidents",
+	"getAlertIncident",
+	"listAlertRules",
+	"getAlertRule",
+	"listAlertRuleChecks",
+	"listAlertDeliveries",
+	"listAnomalyIncidents",
+	"getAnomalyIncident",
+	"getAnomalyIncidentTimeseries",
 ] as const
+
+/**
+ * Unions that are *real* — discriminated request shapes, not Effect's
+ * nullability/non-finite/constraint idioms. These generate a Swift enum with
+ * one case per branch, which is the right thing. Anything else carrying an
+ * `anyOf` is a normalization regression.
+ */
+const GENUINE_UNIONS = ["AttributeFilter"] as const
 
 const operations = (): ReadonlyArray<JsonObject> =>
 	Object.values(spec.paths as JsonObject).flatMap((item) =>
@@ -97,9 +116,23 @@ describe("iOS OpenAPI spec", () => {
 	 * `notes` as `.value1: String?`, `error_rate` as a wrapper around a Double.
 	 */
 	it("collapses every synthetic union", () => {
-		expect(specText).not.toContain('"anyOf"')
+		const withoutGenuine = JSON.stringify(
+			Object.fromEntries(
+				Object.entries(schemas).filter(([name]) => !GENUINE_UNIONS.includes(name as never)),
+			),
+		)
+		expect(withoutGenuine).not.toContain('"anyOf"')
+		expect(withoutGenuine).not.toContain('"allOf"')
+		expect(JSON.stringify(spec.paths)).not.toContain('"anyOf"')
 		expect(specText).not.toContain('"type":"null"')
 		expect(Object.keys(schemas).filter((name) => name.startsWith("Union_"))).toEqual([])
+	})
+
+	it("emits one component per domain enum", () => {
+		// `_maple_AlertSignalType_2` next to `_maple_AlertSignalType` would give
+		// the app two unrelated Swift enums for the same wire values.
+		const numbered = Object.keys(schemas).filter((name) => /^_maple_.+_\d+$/.test(name))
+		expect(numbered).toEqual([])
 	})
 
 	it("keeps nullable fields optional and non-nullable fields required", () => {

--- a/scripts/generate-ios-openapi.ts
+++ b/scripts/generate-ios-openapi.ts
@@ -39,11 +39,26 @@ import { MapleApiV2 } from "../packages/domain/src/http/v2/api"
  * re-running the script — the incremental cost of the allowlist is two lines.
  */
 const IOS_OPERATIONS: ReadonlyArray<string> = [
+	// Services
 	"listServices",
 	"getService",
+	"queryTraceTimeseries",
+	"queryTraceBreakdown",
+	// Errors
 	"listErrorIssues",
 	"listErrorIssueServiceCounts",
 	"getErrorIssue",
+	// Alerts
+	"listAlertIncidents",
+	"getAlertIncident",
+	"listAlertRules",
+	"getAlertRule",
+	"listAlertRuleChecks",
+	"listAlertDeliveries",
+	// Anomalies
+	"listAnomalyIncidents",
+	"getAnomalyIncident",
+	"getAnomalyIncidentTimeseries",
 ]
 
 const ERROR_ENVELOPE_SCHEMA_NAME = "MapleErrorEnvelope"
@@ -126,6 +141,7 @@ function render(): { text: string; doc: JsonObject } {
 	prunePaths(doc)
 	collapseNullableUnions(doc)
 	collapseErrorResponses(doc)
+	mergeDuplicateEnums(doc)
 	sweepUnreachableSchemas(doc)
 
 	const sorted = sortKeysDeep(doc)
@@ -292,7 +308,9 @@ function collapseNullableUnions(doc: JsonObject): void {
 				const target = asObject(value)
 				if (target === undefined) continue
 				const { schema, nullable } = resolve(target)
-				properties[key] = schema
+				// Descend as well: a property that is itself an array or object
+				// can carry a union in its `items` (`AlertRule.group_by`).
+				properties[key] = visit(schema)
 				if (nullable) required.delete(key)
 			}
 			if (required.size > 0) object.required = [...required]
@@ -512,6 +530,58 @@ function errorEnvelopeSchema(): JsonObject {
 }
 
 /** Pass 4a — drop components no longer reachable from the pruned paths. */
+/**
+ * Pass 3b — one Swift enum per domain enum.
+ *
+ * Effect registers a component per *annotation site*, so a domain enum such as
+ * `AlertSignalType` that is re-annotated on the incident, the check, and the
+ * rule arrives as `_maple_AlertSignalType`, `_maple_AlertSignalType_2`,
+ * `_maple_AlertSignalType_3` — identical `enum` + `type`, differing only in
+ * `description`/`examples`. Left alone, the generator emits three unrelated
+ * Swift enums and every comparison across them needs a raw-value round trip.
+ * When the numbered copy is the same string enum as its base, point every
+ * `$ref` at the base and drop the copy.
+ */
+function mergeDuplicateEnums(doc: JsonObject): void {
+	const schemas = asObject(asObject(doc.components)?.schemas) ?? {}
+	const aliases = new Map<string, string>()
+
+	for (const name of Object.keys(schemas)) {
+		const match = /^(.+)_(\d+)$/.exec(name)
+		if (match === null) continue
+		const base = match[1]
+		const baseSchema = asObject(schemas[base])
+		const copy = asObject(schemas[name])
+		if (baseSchema === undefined || copy === undefined) continue
+		const baseEnum = asStringArray(baseSchema.enum)
+		const copyEnum = asStringArray(copy.enum)
+		if (baseEnum === undefined || copyEnum === undefined) continue
+		if (baseSchema.type !== "string" || copy.type !== "string") continue
+		if (baseEnum.length !== copyEnum.length || baseEnum.some((value, index) => value !== copyEnum[index]))
+			continue
+		aliases.set(name, base)
+	}
+
+	const rewrite = (node: JsonValue | undefined): void => {
+		if (Array.isArray(node)) {
+			for (const entry of node) rewrite(entry)
+			return
+		}
+		const object = asObject(node)
+		if (object === undefined) return
+		const ref = asString(object.$ref)
+		if (ref !== undefined) {
+			const name = componentNameFromRef(ref)
+			const target = name === undefined ? undefined : aliases.get(name)
+			if (target !== undefined) object.$ref = `#/components/schemas/${target}`
+		}
+		for (const value of Object.values(object)) rewrite(value)
+	}
+
+	rewrite(doc)
+	for (const name of aliases.keys()) delete schemas[name]
+}
+
 function sweepUnreachableSchemas(doc: JsonObject): void {
 	const schemas = asObject(asObject(doc.components)?.schemas) ?? {}
 	const reachable = new Set<string>()


### PR DESCRIPTION
## Summary

Rebuilds the iOS app around three questions, in the order they get asked (see `apps/ios/PRODUCT.md`): **is anything wrong right now** (Home), **which service** (Services), **why** (Alerts).

- **Home** — status headline derived on-device, open alerts with the rule's own last hour as a sparkline against its threshold, services needing attention worst-first, what's new in 24h. Auto-refreshes every 60s while visible.
- **Alerts hub** — Incidents / Errors / Anomalies under one segmented control. **Incident detail** answers "why": what the rule saw (its checks charted with the threshold — works for every signal type incl. builder/raw SQL), what changed on the service (error rate / p95 / requests), likely cause (linked issue, errors in the window, failing operations), delivery timeline, rule facts, share.
- **Service detail** — golden-signal sparklines, scoped alerts, issues, top failing + slowest operations.
- `Route` enum + `mapleDestinations()`, `AppNavigation` for cross-tab jumps, `SessionController.perform` replaces the copied 401-retry blocks.
- **Fixture mode** (`MAPLE_FIXTURES=1`): the app without Clerk or a network, for building screens and screenshots.
- Fixes a pre-existing letterboxing bug: `INFOPLIST_KEY_UILaunchScreen_Generation` is ignored for XcodeGen-written plists, so `UILaunchScreen` now lives in the plist.

### API / generator
- `GET /v2/alerts/deliveries` accepts `incident_id` / `rule_id` (index already existed).
- `generate-ios-openapi`: allowlist grows 5 → 16 operations; per-annotation-site copies of a domain enum are merged (one wire enum = one Swift enum); union collapse descends into property `items`. Both guarded in `openapi-ios.test.ts`.

Push notifications are deliberately not in this PR — design in `PRODUCT.md`, gated on the APNs-from-Workers transport spike.

## Test plan
- [x] `xcodebuild` clean, no warnings in app sources
- [x] `swift test` in `Packages/MapleAPI` (18/18)
- [x] domain v2 tests incl. `openapi-ios.test.ts` (80/80), API alert route + read-model tests
- [x] `tsgo` clean for `apps/api` + `packages/domain`; `bun run ios:openapi:check` up to date
- [x] Verified visually in the simulator via fixture mode: Home, incident detail, Alerts segments, service detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789554263&installation_model_id=427786&pr_number=508&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F508&signature=a6586182f623aae6147252d47029845b03d69d2656991d8bae8b1e7cb70b6ae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->