### PR TITLE
fix(mcp): negotiate down an unsupported Mcp-Protocol-Version header

### DIFF
--- a/apps/api/src/mcp/app.test.ts
+++ b/apps/api/src/mcp/app.test.ts
@@ -187,4 +187,75 @@ describe("MCP HTTP authorization", () => {
 			await dispose()
 		}
 	})
+
+	it("negotiates down when the client declares a newer Mcp-Protocol-Version header on initialize", async () => {
+		// Regression test for the eve/@ai-sdk/mcp client (used by apps/slack-agent), which
+		// defaults to a newer protocol version than this server implements and sends it as
+		// the `Mcp-Protocol-Version` header on the very first `initialize` request — before
+		// any negotiation has happened. `effect`'s McpServer.layerHttp rejects a header that
+		// isn't in its declared `protocols` list outright, even for `initialize`, where the
+		// header is only the client's preference and negotiation should happen via the body.
+		const db = createTestDb(createdDbs)
+		const base = Layer.mergeAll(db.layer, Env.layer.pipe(Layer.provide(testConfig())))
+		const services = Layer.mergeAll(
+			ApiKeysService.layer,
+			AuthService.layer,
+			makeMcpToolExecutorStubLayer(),
+		).pipe(Layer.provideMerge(base))
+		const orgId = Schema.decodeUnknownSync(OrgId)("org_test")
+		const userId = Schema.decodeUnknownSync(UserId)("user_test")
+		const key = await Effect.runPromise(
+			Effect.gen(function* () {
+				const apiKeys = yield* ApiKeysService
+				return yield* apiKeys.create(orgId, userId, {
+					name: "Newer protocol version test",
+					kind: "mcp",
+					scopes: ["mcp:tools"],
+					metadataJson: {
+						source: "maple_mcp_oauth",
+						roles: ["org:member"],
+						clientId: "client_test",
+						resource: "https://api.example.com/mcp",
+					},
+				})
+			}).pipe(Effect.provide(services)),
+		)
+		const routes = McpLive.pipe(Layer.provideMerge(services))
+		const { handler, dispose } = HttpRouter.toWebHandler(routes, { disableLogger: true })
+		try {
+			const response = await handler(
+				new Request("http://internal-worker.invalid/mcp", {
+					method: "POST",
+					headers: {
+						authorization: `Bearer ${key.secret}`,
+						accept: "application/json, text/event-stream",
+						"content-type": "application/json",
+						host: "internal-worker.invalid",
+						"x-forwarded-host": "api.example.com",
+						"x-forwarded-proto": "https",
+						"mcp-protocol-version": "2025-11-25",
+					},
+					body: JSON.stringify({
+						jsonrpc: "2.0",
+						id: 1,
+						method: "initialize",
+						params: {
+							protocolVersion: "2025-11-25",
+							capabilities: {},
+							clientInfo: { name: "test", version: "1.0.0" },
+						},
+					}),
+				}),
+				Context.empty() as never,
+			)
+			const body = await response.clone().json()
+			expect({ status: response.status, protocolVersion: body.result?.protocolVersion }).toEqual({
+				status: 200,
+				protocolVersion: "2025-06-18",
+			})
+			expect(response.headers.get("mcp-session-id")).not.toBeNull()
+		} finally {
+			await dispose()
+		}
+	})
 })

--- a/apps/api/src/mcp/app.ts
+++ b/apps/api/src/mcp/app.ts
@@ -1,6 +1,6 @@
 import { McpProtocol, McpServer } from "effect/unstable/ai"
 import { Cause, Effect, Layer } from "effect"
-import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { Headers, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { McpToolsLive } from "./server"
 import { DebugErrorsPrompt } from "./prompts/debug-errors"
 import { LatencyAnalysisPrompt } from "./prompts/latency-analysis"
@@ -46,6 +46,34 @@ const mcpUnavailable = () =>
 		),
 	)
 
+/**
+ * `effect`'s `McpServer.layerHttp` (as of the pinned rc.108) rejects any request whose
+ * `Mcp-Protocol-Version` header isn't in the server's declared `protocols` list with a
+ * bare 400 — including the `initialize` request, where that header is only the client's
+ * *preferred* version, not yet a negotiated one (negotiation happens via the `initialize`
+ * body/response per the MCP spec). Clients that default to a newer version than we
+ * implement — e.g. the `@ai-sdk/mcp` client vendored in `eve`, which defaults to
+ * `2025-11-25` — get a 400 on the very first request instead of a normal downgrade.
+ * Since this server only ever implements one protocol version, rewriting an
+ * unsupported header to that version is always correct: it fixes the `initialize`
+ * precheck and keeps the post-initialize session-continuity check (which compares the
+ * header against the version recorded on the session) consistent too.
+ */
+const normalizeMcpProtocolVersionHeader = <A, E, R>(
+	httpEffect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R | HttpServerRequest.HttpServerRequest> =>
+	Effect.gen(function* () {
+		const request = yield* HttpServerRequest.HttpServerRequest
+		const protocolVersion = request.headers["mcp-protocol-version"]
+		if (protocolVersion === undefined || protocolVersion === McpProtocol.v2025_06_18.protocolVersion) {
+			return yield* httpEffect
+		}
+		const normalizedRequest = request.modify({
+			headers: Headers.set(request.headers, "mcp-protocol-version", McpProtocol.v2025_06_18.protocolVersion),
+		})
+		return yield* Effect.provideService(httpEffect, HttpServerRequest.HttpServerRequest, normalizedRequest)
+	})
+
 const McpAuthorizationMiddleware = HttpRouter.middleware<{ provides: CurrentMcpTenant }>()(
 	Effect.gen(function* () {
 		const apiKeys = yield* ApiKeysService
@@ -57,7 +85,7 @@ const McpAuthorizationMiddleware = HttpRouter.middleware<{ provides: CurrentMcpT
 				Effect.provideService(AuthService, auth),
 				Effect.provideService(Env, env),
 				Effect.flatMap((tenant) =>
-					Effect.provideService(httpEffect, CurrentMcpTenant, tenant).pipe(
+					Effect.provideService(normalizeMcpProtocolVersionHeader(httpEffect), CurrentMcpTenant, tenant).pipe(
 						Effect.provideService(CurrentMcpRequestTenant, tenant),
 					),
 				),


### PR DESCRIPTION
## Summary
- `apps/slack-agent`'s Railway logs showed the Maple connection failing to load tools: `MCPClientError: MCP SSE Transport Error: 405 Method Not Allowed. This server does not support SSE transport. Try using \`http\` transport instead`.
- Root cause: `effect`'s `McpServer.layerHttp` (pinned `rc.108`) rejects any request whose `Mcp-Protocol-Version` header isn't in the server's declared `protocols` list — even the `initialize` request, where that header is only the client's *preferred* version and negotiation should happen via the request/response body per the MCP spec.
- The `@ai-sdk/mcp` client bundled in `eve` (used by `apps/slack-agent`) defaults to protocol version `2025-11-25` and sends it as a header on the very first request. Our server only implements `2025-06-18`, so it got a bare `400` instead of a normal downgrade. `eve`'s client then fell back to legacy SSE transport (which we don't support either), producing the confusing 405 in the logs.
- Verified directly against production (`api.maple.dev/mcp`) with a real API key: no header or `2025-06-18` → `200`, `2025-11-25` → `400`.
- Fix: in the MCP auth middleware (`apps/api/src/mcp/app.ts`), rewrite an unsupported `Mcp-Protocol-Version` header to the one version this server implements before the request reaches `effect`'s router. Since we only ever support one version, this is always correct — it fixes both the `initialize` precheck and the post-initialize session-continuity check.

## Test plan
- [x] Added a regression test (`apps/api/src/mcp/app.test.ts`) that sends `Mcp-Protocol-Version: 2025-11-25` on `initialize` and asserts `200` with a negotiated `2025-06-18` response; confirmed it fails (400) without the fix.
- [x] `bun run --cwd apps/api test src/mcp` — 329 tests passed.
- [x] `oxlint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789640307&installation_model_id=427786&pr_number=514&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F514&signature=47179af873cc606c34234dbb2a0cd244c85c1704134370278264e8a55f5d96f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->