### PR TITLE
feat(alerts): chart the metric in Slack, Discord and email notifications

### DIFF
--- a/.context/plans/alert-notification-charts.md
+++ b/.context/plans/alert-notification-charts.md
@@ -1,0 +1,184 @@
+# Charts in alert notifications — implementation plan
+
+**Verdict: yes, and `renotify` is what justifies it.**
+
+A `trigger` message says what broke. A `renotify` currently repeats
+`4.2% > 2%` every 30 minutes and answers nothing — you cannot tell recovering
+from worsening without opening Maple. A chart of the incident so far, with the
+threshold drawn on it, turns each re-alert into a status update instead of a
+duplicate. Secondary value on `trigger` (spike or step change?) and `resolve`
+(did it recover, or did the data stop?).
+
+## The whole design in one paragraph
+
+`alert_checks` already holds one immutable audit row per rule per minute for
+365 days, for every org. A chart is that table, filtered to one rule and one
+window, drawn. So: read it once when queueing a notification to bake a
+sparkline into the message text, put a **signed URL naming the window** in the
+Slack/Discord/email body, and let `apps/web` rasterise that window on demand
+with the wasm it already ships. No new table, no snapshot, no second series
+source, no retention sweep.
+
+## Two simplifications over the first draft
+
+### 1. There is no BYO-ClickHouse fallback to write — I had this backwards
+
+The first draft carried `evaluateSeries` as a second source because
+`alert_checks` "only exists in the managed pipeline". That describes a bug that
+was **already fixed**. Today the routing is structural on both sides:
+
+- **Write:** `warehouse.ingest(...)` is hard-pinned to the managed Tinybird
+  ingest config (`AlertsService.ts:2985`), for every org including BYO-CH.
+- **Read:** `listRuleChecksQuery` declares `.routing("ingest")`
+  (`packages/query-engine/src/ch/queries/alert-checks.ts`), so `compiledQuery`
+  resolves the same managed config rather than the org's own cluster.
+
+`alert_checks` is therefore universally available. **`evaluateSeries` is out of
+the plan entirely** — one source, no fallback, and no "both paths must produce
+the same `ChartPoint[]`" invariant to keep honest.
+
+### 2. No snapshot table — the audit log *is* the snapshot
+
+The first draft persisted the points so an old message's image could not
+silently re-render against new data. But `alert_checks` is append-only and
+immutable with 365-day retention (`migration_0009`, `retention-matrix.test.ts`:
+`alert_checks: 365`). Pin the window in the signed URL and the same query
+returns the same rows forever — determinism without storing anything.
+
+Deleted from the plan: the `alert_chart_snapshots` table, its migration, the
+jsonb points column, the snapshot id in `payload_json`, and the retention
+sweep entry.
+
+**The trade this makes:** one warehouse read per uncached image GET, instead of
+one write plus storage. Bounded by a long-`s-maxage` edge cache (the bytes are
+immutable), the existing `ApiV2RateLimiter`, and the signature — which fixes
+the window, so nobody can turn the URL into an arbitrary-range scan. Slack and
+Discord fetch an image once and re-host it, so misses are rare.
+
+**Rejected: encoding the points directly in the URL.** It kills the second read
+too, but 60 points is a URL whose length varies with the data, and Slack,
+Discord and email cap URL length differently. A design that works until a
+noisy metric makes the URL too long is worse than one extra cached read.
+
+## Decisions that survive from the first draft
+
+- **Window:** `from = min(firstTriggeredAt − 2×window, now − 6×window)`,
+  `to = now`, capped at 60 points by striding that keeps local maxima on the
+  breach side. Pre-breach baseline on `trigger`; grows with the incident on
+  `renotify`. Threshold as a dashed rule with the breach region shaded — that
+  is what makes it readable at phone size.
+- **Delivery by URL, not upload.** Slack `image` block, Discord
+  `embed.image.url`, email `<img>` all take a URL; per-provider uploads would
+  be three mechanisms (Slack `files.uploadV2`, Discord multipart, email CID)
+  and would push a wasm renderer into the alerting worker.
+- **Signed like `shareOgId`** — base64url params + constant-time HMAC under
+  `MAPLE_SHARE_TOKEN_HMAC_KEY` (`packages/db/src/share-token-hash.ts`). A
+  bearer URL for one metric series with no PII, same exposure class as an
+  existing public dashboard share. Per-org opt-out keeps the sparkline only.
+- **Rasterise with the wasm `apps/web` already has** — confirmed by the stage 0
+  spike, with one constraint that shapes the chart's design (see below).
+- **Always ship the sparkline**, image or not. `▁▂▄█▆▃ 4.2% (was 1.1%)` in the
+  Slack context block and Discord footer. An `image` block does not render on a
+  lock screen, and this is the degrade path when anything else fails.
+- **Only where the shape exists.** Grouped rules chart the firing group only.
+  A rule with no `alert_checks` history yet gets no chart and no sparkline, and
+  every downstream step is a no-op. Nothing in the notification path may start
+  depending on a chart being present.
+
+## Stages (was six, now four)
+
+### Stage 0 — spike — DONE, and it constrains the design
+
+**Result: takumi rasterises the SVG, but drops every glyph inside it.**
+
+Feeding a `chart.ts` SVG to takumi as a data-URI image node draws the geometry
+perfectly — paths, gradient fill, stroke, the point dot, grid lines, the
+rounded card. Text inside the SVG renders as nothing. `Renderer.registerFont`
+does not fix it: output was **byte-identical** (7047 bytes) before and after
+registering Geist Mono, because `registerFont` feeds takumi's own layout
+engine, not the usvg fontdb behind its SVG decoder.
+
+Text as **takumi nodes** renders correctly in Geist Mono, in the same image,
+composed around the SVG.
+
+So the notification chart is a **hybrid**: SVG for plot geometry, takumi nodes
+for every piece of type. Two consequences:
+
+1. `chart.ts` splits into `renderPlotSvg(spec)` (geometry only, no `<text>`)
+   plus the existing `renderChartSvg` (geometry + text) that `apps/slack-agent`
+   keeps using — it rasterises with `@resvg/resvg-js`, which has fonts and is
+   unaffected. One module, two consumers, shared scale maths, no fork.
+2. **Drop y-axis tick labels from the notification chart.** Positioning them as
+   takumi nodes would mean exporting the projection maths just to re-align text
+   with grid lines. Instead: title, current value, threshold label pinned to
+   the threshold rule, and start/end timestamps — all flexbox, no absolute
+   positioning. Better at phone size than a four-tick axis anyway.
+
+Rejected alternative: `@resvg/resvg-wasm` (~2.5 MB) has its own fontdb and
+would keep `chart.ts` in one piece — but it stacks a second rasteriser on top
+of takumi's 3.7 MB for one feature, and the label set above is a better chart
+at Slack size regardless.
+
+### Stage 1 — shared chart module + sparkline everywhere
+
+- Move `apps/slack-agent/agent/lib/chart.ts` → `packages/ui/src/charts/static/`.
+  It knows Maple design tokens, so `packages/`, not `lib/`. Its bun tests move
+  with it; `apps/slack-agent` imports from the new home.
+- Split out `renderPlotSvg(spec)` (geometry, no `<text>`) alongside the existing
+  `renderChartSvg`, per stage 0.
+- `mapSignalUnit(SignalUnit): ChartUnit` in `alert-signal-display.ts` —
+  `ratio→percent`, `ms→duration_ms`, `rpm→requests_per_sec`,
+  `apdex|count|plain→number`.
+- `alert-chart-series.ts`: `loadCheckSeries(orgId, ruleId, groupKey, from, to)`
+  over `listRuleChecksQuery`, returning `ChartPoint[]` + threshold. Short
+  timeout, `Effect.orElseSucceed(null)` — a slow warehouse must never delay or
+  drop a page.
+- Call it once in `queueIncidentNotifications` (`AlertsService.ts:663`);
+  `buildPayload` (`AlertDestinationDelivery.ts:132`) and
+  `StoredDeliveryPayloadSchema` each gain an optional `sparkline` string.
+- Sparkline into `buildSlackContextBlock` and the Discord embed footer
+  (`AlertDeliveryDispatch.ts:184`, `:218`).
+
+Ships alone, and is most of the renotify value.
+
+### Stage 2 — signed chart URL + image route
+
+- `chartImageId({orgId, ruleId, groupKey, from, to, unit}, hmacKey)` next to
+  `shareOgId` in `packages/db/src/share-token-hash.ts`, with a constant-time
+  verify.
+- `POST /v2/alerts/chart-series` on the `sharePublic` group
+  (`share.http.ts`): verify the id, rate-limit it as `ogMeta` does
+  (`share.http.ts:349`), run the same `loadCheckSeries`, return points +
+  threshold + rule name. No auth — the signature is the capability.
+- `apps/web/src/og/`: `alertChartIdFromPath` beside `ogIdFromPath`, and
+  `renderAlertChart` mirroring `renderShareOgImage`; routed in
+  `apps/web/src/worker.ts` ahead of the assets lookup like `/share/og/`.
+  Long `s-maxage` — the window is pinned, so the bytes are immutable.
+- The URL is composed at dispatch time in `processOneDelivery`
+  (`AlertsService.ts:~1334`) next to `linkUrl`/`chatUrl`, from the incident and
+  rule rows it already has. Nothing new rides in `payload_json`.
+
+### Stage 3 — transports
+
+`DispatchContext` gains `chartUrl: string | null`. Then pure `render` changes:
+Slack `image` block before the actions block, Discord `embed.image.url`, email
+`<img>` in `alert-email.ts`. Extend `delivery/transports/render.test.ts` —
+every provider asserted with and without a chart.
+
+### Stage 4 — templates and settings
+
+`{{chartUrl}}` / `{{sparkline}}` bindings in `alert-templating/renderer.ts` and
+`defaultTemplates.ts`; per-org "attach charts" toggle (default on) with a
+per-rule override.
+
+## Costs and risks
+
+- **One warehouse read per notification** (queue time, for the sparkline) plus
+  **one per uncached image GET**. Both are `list`-profile scans on
+  `alert_checks`; renotify is interval-gated at 30 min by default.
+- **Bearer image URLs** — accepted precedent (`dashboard_shares`), one metric
+  series, org opt-out available.
+- **Every chart step must degrade to the sparkline, and the sparkline to
+  nothing** — never to a missing or delayed alert. Assert explicitly in the
+  dispatch tests: series read failing, resolve endpoint down, and renderer
+  throwing must each still deliver the message.

--- a/apps/api/src/routes/v2/share.http.ts
+++ b/apps/api/src/routes/v2/share.http.ts
@@ -21,7 +21,10 @@
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { HttpServerRequest } from "effect/unstable/http"
 import {
+	AlertChartResponse,
 	OrgId,
+	RoleName,
+	UserId as UserIdSchema,
 	SHARE_NOT_FOUND_MESSAGE,
 	ShareNotConfiguredError,
 	ShareNotFoundError,
@@ -36,17 +39,19 @@ import {
 } from "@maple/domain/http"
 import { MapleApiV2 } from "@maple/domain/http/v2"
 import { MAX_LIST_RANGE_SECONDS, SHARE_MAX_RANGE_SECONDS } from "@maple/query-engine"
-import { hashShareToken, shareOgId, verifyShareOgId } from "@maple/db"
+import { hashShareToken, shareOgId, verifyAlertChartId, verifyShareOgId } from "@maple/db"
 import { redactForShare } from "@maple/widgets/dashboard"
-import { Effect, Option, Redacted } from "effect"
+import { Effect, Option, Redacted, Schema } from "effect"
 import { Env } from "@/platform/Env"
-import { AuthService } from "@/services/auth/AuthService"
+import { AuthService, type TenantContext } from "@/services/auth/AuthService"
 import {
 	ApiV2RateLimiter,
 	shareIpRateLimitKey,
 	shareOgRateLimitKey,
 	shareTokenRateLimitKey,
 } from "@/services/auth/ApiV2RateLimiter"
+import { loadChartSeries } from "@/services/alerts/alert-chart-series"
+import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
 import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
 import { DashboardWidgetDataService } from "@/services/dashboards/DashboardWidgetDataService"
 import { SharedDashboardService } from "@/services/dashboards/SharedDashboardService"
@@ -54,6 +59,35 @@ import { ogDescription, ogSubtitle, ogTiles, ogTitle } from "@/services/dashboar
 import { OrganizationService } from "@/services/org/OrganizationService"
 import { resolveShareVariables } from "@/services/dashboards/share-variables"
 import { resolveShareWindow } from "@/services/dashboards/share-window"
+
+const decodeOrgId = Schema.decodeUnknownEffect(OrgId)
+const decodeRoleName = Schema.decodeUnknownSync(RoleName)
+const decodeUserId = Schema.decodeUnknownSync(UserIdSchema)
+
+/**
+ * The alert-chart read runs as the alerting system, not as a viewer: there is
+ * no viewer to run as. The org it may read is fixed by the signed id, and the
+ * query itself filters `OrgId`, so this widens nothing a caller controls.
+ */
+const systemTenant = (orgId: OrgId): TenantContext => ({
+	orgId,
+	userId: decodeUserId("system-alerting"),
+	roles: [decodeRoleName("root")],
+	authMode: "self_hosted",
+})
+
+const CHART_UNITS = ["number", "percent", "duration_ms", "bytes", "requests_per_sec"] as const
+const BREACH_SIDES = ["above", "below", "none"] as const
+
+/**
+ * Signed values, so these always match — but narrowed by lookup rather than
+ * asserted, because an image request must not be able to throw on a value this
+ * repo will one day add to one list and forget in the other.
+ */
+const decodeChartUnit = (raw: string): (typeof CHART_UNITS)[number] =>
+	CHART_UNITS.find((unit) => unit === raw) ?? "number"
+const decodeBreachSide = (raw: string): (typeof BREACH_SIDES)[number] =>
+	BREACH_SIDES.find((side) => side === raw) ?? "none"
 
 /** Uniform "no such link", used for every reason a token might not resolve. */
 const notFound = Effect.fail(new ShareNotFoundError({ message: SHARE_NOT_FOUND_MESSAGE }))
@@ -67,6 +101,7 @@ export const HttpV2SharePublicLive = HttpApiBuilder.group(MapleApiV2, "sharePubl
 		const shares = yield* SharedDashboardService
 		const persistence = yield* DashboardPersistenceService
 		const widgetData = yield* DashboardWidgetDataService
+		const warehouse = yield* WarehouseQueryService
 
 		/**
 		 * Two keys, both must pass: per token, so a leaked link cannot be scraped
@@ -407,6 +442,49 @@ export const HttpV2SharePublicLive = HttpApiBuilder.group(MapleApiV2, "sharePubl
 					}
 					const described = description === undefined ? card : { ...card, description }
 					return new ShareOgCardResponse(org === undefined ? described : { ...described, org })
+				}),
+			)
+			.handle("alertChart", ({ payload }) =>
+				Effect.gen(function* () {
+					const hmacKey = yield* requireHmacKey
+					// Keyed on the id as presented, before verification, for the same
+					// reason as `ogCard`: otherwise the cheap way to hammer this is to
+					// send ids that never reach a bucket.
+					yield* enforceOgRateLimit(payload.chartId)
+
+					const claims = verifyAlertChartId(payload.chartId, hmacKey)
+					if (claims === undefined) return yield* notFound
+
+					const orgId = yield* decodeOrgId(claims.orgId).pipe(Effect.catch(() => notFound))
+
+					// No rule lookup: everything drawn as words — title, unit,
+					// threshold, which side to shade — is pinned in the signed id, so a
+					// rule renamed or deleted after delivery cannot change what an
+					// already-sent alert's picture says.
+					const series = yield* loadChartSeries(warehouse, systemTenant(orgId), {
+						orgId,
+						ruleId: claims.ruleId,
+						groupKey: claims.groupKey,
+						// The comparator is not carried; `breachSide` is the only thing
+						// derived from it that the renderer needs, and it is signed.
+						comparator: "gt",
+						threshold: claims.threshold ?? 0,
+						fromMs: claims.fromMs,
+						toMs: claims.toMs,
+					})
+					// A window whose checks have aged out of `alert_checks` retention,
+					// or a warehouse that would not answer. Either way there is no
+					// picture to draw, and the uniform not-found is the honest reply.
+					if (series === null) return yield* notFound
+
+					return new AlertChartResponse({
+						title: claims.title,
+						unit: decodeChartUnit(claims.unit),
+						kind: "area",
+						points: series.points.map((point) => [point[0], point[1]] as const),
+						threshold: claims.threshold,
+						breachSide: decodeBreachSide(claims.breachSide),
+					})
 				}),
 			)
 	}),

--- a/apps/api/src/routes/v2/share.http.ts
+++ b/apps/api/src/routes/v2/share.http.ts
@@ -22,6 +22,7 @@ import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { HttpServerRequest } from "effect/unstable/http"
 import {
 	AlertChartResponse,
+	AlertRuleId,
 	OrgId,
 	RoleName,
 	UserId as UserIdSchema,
@@ -61,6 +62,7 @@ import { resolveShareVariables } from "@/services/dashboards/share-variables"
 import { resolveShareWindow } from "@/services/dashboards/share-window"
 
 const decodeOrgId = Schema.decodeUnknownEffect(OrgId)
+const decodeAlertRuleId = Schema.decodeUnknownEffect(AlertRuleId)
 const decodeRoleName = Schema.decodeUnknownSync(RoleName)
 const decodeUserId = Schema.decodeUnknownSync(UserIdSchema)
 
@@ -455,7 +457,14 @@ export const HttpV2SharePublicLive = HttpApiBuilder.group(MapleApiV2, "sharePubl
 					const claims = verifyAlertChartId(payload.chartId, hmacKey)
 					if (claims === undefined) return yield* notFound
 
-					const orgId = yield* decodeOrgId(claims.orgId).pipe(Effect.catch(() => notFound))
+					// The signature proves we minted the payload; it does not make the
+					// ids inside it decoded. Both are parsed here, at the boundary,
+					// and an id that will not decode is the uniform not-found rather
+					// than a brand asserted onto whatever came back off the wire.
+					const orgId = yield* decodeOrgId(claims.rawOrgId).pipe(Effect.catch(() => notFound))
+					const ruleId = yield* decodeAlertRuleId(claims.rawRuleId).pipe(
+						Effect.catch(() => notFound),
+					)
 
 					// No rule lookup: everything drawn as words — title, unit,
 					// threshold, which side to shade — is pinned in the signed id, so a
@@ -463,7 +472,7 @@ export const HttpV2SharePublicLive = HttpApiBuilder.group(MapleApiV2, "sharePubl
 					// already-sent alert's picture says.
 					const series = yield* loadChartSeries(warehouse, systemTenant(orgId), {
 						orgId,
-						ruleId: claims.ruleId,
+						ruleId,
 						groupKey: claims.groupKey,
 						// The comparator is not carried; `breachSide` is the only thing
 						// derived from it that the renderer needs, and it is signed.

--- a/apps/api/src/routes/v2/share.http.ts
+++ b/apps/api/src/routes/v2/share.http.ts
@@ -24,8 +24,6 @@ import {
 	AlertChartResponse,
 	AlertRuleId,
 	OrgId,
-	RoleName,
-	UserId as UserIdSchema,
 	SHARE_NOT_FOUND_MESSAGE,
 	ShareNotConfiguredError,
 	ShareNotFoundError,
@@ -44,7 +42,7 @@ import { hashShareToken, shareOgId, verifyAlertChartId, verifyShareOgId } from "
 import { redactForShare } from "@maple/widgets/dashboard"
 import { Effect, Option, Redacted, Schema } from "effect"
 import { Env } from "@/platform/Env"
-import { AuthService, type TenantContext } from "@/services/auth/AuthService"
+import { AuthService } from "@/services/auth/AuthService"
 import {
 	ApiV2RateLimiter,
 	shareIpRateLimitKey,
@@ -52,6 +50,7 @@ import {
 	shareTokenRateLimitKey,
 } from "@/services/auth/ApiV2RateLimiter"
 import { loadChartSeries } from "@/services/alerts/alert-chart-series"
+import { systemTenant } from "@/services/alerts/system-tenant"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
 import { DashboardPersistenceService } from "@/services/dashboards/DashboardPersistenceService"
 import { DashboardWidgetDataService } from "@/services/dashboards/DashboardWidgetDataService"
@@ -63,33 +62,6 @@ import { resolveShareWindow } from "@/services/dashboards/share-window"
 
 const decodeOrgId = Schema.decodeUnknownEffect(OrgId)
 const decodeAlertRuleId = Schema.decodeUnknownEffect(AlertRuleId)
-const decodeRoleName = Schema.decodeUnknownSync(RoleName)
-const decodeUserId = Schema.decodeUnknownSync(UserIdSchema)
-
-/**
- * The alert-chart read runs as the alerting system, not as a viewer: there is
- * no viewer to run as. The org it may read is fixed by the signed id, and the
- * query itself filters `OrgId`, so this widens nothing a caller controls.
- */
-const systemTenant = (orgId: OrgId): TenantContext => ({
-	orgId,
-	userId: decodeUserId("system-alerting"),
-	roles: [decodeRoleName("root")],
-	authMode: "self_hosted",
-})
-
-const CHART_UNITS = ["number", "percent", "duration_ms", "bytes", "requests_per_sec"] as const
-const BREACH_SIDES = ["above", "below", "none"] as const
-
-/**
- * Signed values, so these always match — but narrowed by lookup rather than
- * asserted, because an image request must not be able to throw on a value this
- * repo will one day add to one list and forget in the other.
- */
-const decodeChartUnit = (raw: string): (typeof CHART_UNITS)[number] =>
-	CHART_UNITS.find((unit) => unit === raw) ?? "number"
-const decodeBreachSide = (raw: string): (typeof BREACH_SIDES)[number] =>
-	BREACH_SIDES.find((side) => side === raw) ?? "none"
 
 /** Uniform "no such link", used for every reason a token might not resolve. */
 const notFound = Effect.fail(new ShareNotFoundError({ message: SHARE_NOT_FOUND_MESSAGE }))
@@ -488,11 +460,11 @@ export const HttpV2SharePublicLive = HttpApiBuilder.group(MapleApiV2, "sharePubl
 
 					return new AlertChartResponse({
 						title: claims.title,
-						unit: decodeChartUnit(claims.unit),
+						unit: claims.unit,
 						kind: "area",
 						points: series.points.map((point) => [point[0], point[1]] as const),
 						threshold: claims.threshold,
-						breachSide: decodeBreachSide(claims.breachSide),
+						breachSide: claims.breachSide,
 					})
 				}),
 			)

--- a/apps/api/src/services/alerts/AlertDeliveryDispatch.ts
+++ b/apps/api/src/services/alerts/AlertDeliveryDispatch.ts
@@ -160,8 +160,12 @@ const buildSlackActionsBlock = (linkUrl: string, chatUrl: string) => ({
  * Footer: brand + incident reference + a `<!date^…>` timestamp so Slack renders
  * the fire time in each viewer's local timezone (ISO fallback for exports).
  */
-const buildSlackContextBlock = (context: Pick<DispatchContext, "sentAtMs" | "incidentId">) => {
+const buildSlackContextBlock = (context: Pick<DispatchContext, "sentAtMs" | "incidentId" | "sparkline">) => {
 	const parts = ["\u{1F341} Maple Alerts"]
+	// Ahead of the incident id and the timestamp: on a renotify this is the only
+	// part of the message that differs from the last one, and it is the answer
+	// to the question the reader actually has — better or worse than before?
+	if (context.sparkline) parts.push(`\`${context.sparkline}\``)
 	if (context.incidentId) parts.push(`Incident \`${escapeSlackMrkdwn(context.incidentId)}\``)
 	if (context.sentAtMs != null) {
 		const seconds = Math.floor(context.sentAtMs / 1000)
@@ -180,6 +184,25 @@ const groupField = (groupKey: string | null) => {
 	const group = displayGroupKey(groupKey)
 	return group == null ? [] : [{ type: "mrkdwn", text: `*Group*\n\`${escapeSlackMrkdwn(group)}\`` }]
 }
+
+/**
+ * The chart, as a Slack image block.
+ *
+ * `alt_text` is not decoration: it is what a screen reader announces and what
+ * shows if the image will not load, so it repeats the numbers rather than
+ * naming the picture. Returns nothing when there is no chart, so the caller
+ * spreads an empty list and the message shape is otherwise unchanged.
+ */
+const slackChartBlocks = (context: Pick<DispatchContext, "chartUrl" | "ruleName">) =>
+	context.chartUrl
+		? [
+				{
+					type: "image",
+					image_url: context.chartUrl,
+					alt_text: truncate(`${context.ruleName} over the alert window`, 2000),
+				},
+			]
+		: []
 
 export const buildSlackBlocks = (context: TemplateRenderContext, linkUrl: string, chatUrl: string) => [
 	{
@@ -204,6 +227,7 @@ export const buildSlackBlocks = (context: TemplateRenderContext, linkUrl: string
 			...groupField(context.groupKey),
 		],
 	},
+	...slackChartBlocks(context),
 	buildSlackActionsBlock(linkUrl, chatUrl),
 	buildSlackContextBlock(context),
 ]
@@ -214,6 +238,18 @@ export const buildSlackBlocks = (context: TemplateRenderContext, linkUrl: string
  */
 export const buildSlackFallbackText = (context: TemplateRenderContext): string =>
 	`${eventTypeEmoji(context.eventType)} ${escapeSlackMrkdwn(context.ruleName)} — ${formatEventTypeLabel(context.eventType)} · ${formatSignalLabel(context)} ${formatObservedSummary(context)}`
+
+/**
+ * Discord has no context block, so the sparkline rides in the footer — the one
+ * line that is small enough not to compete with the numbers above it. Shared by
+ * both embed builders: they had drifted apart once already.
+ */
+/** Discord renders `embed.image` full width under the fields — the same slot Slack's image block occupies. */
+const discordImage = (context: Pick<DispatchContext, "chartUrl">) =>
+	context.chartUrl ? { image: { url: context.chartUrl } } : {}
+
+const discordFooterText = (context: Pick<DispatchContext, "sparkline">): string =>
+	context.sparkline ? `\u{1F341} Maple Alerts  ·  ${context.sparkline}` : "\u{1F341} Maple Alerts"
 
 export const buildDiscordEmbeds = (context: DispatchContext, linkUrl: string, chatUrl: string) => [
 	{
@@ -232,7 +268,8 @@ export const buildDiscordEmbeds = (context: DispatchContext, linkUrl: string, ch
 				inline: false,
 			},
 		],
-		footer: { text: "\u{1F341} Maple Alerts" },
+		...discordImage(context),
+		footer: { text: discordFooterText(context) },
 	},
 ]
 
@@ -338,7 +375,10 @@ export const renderTitleBody = (
 export const buildSlackBlocksFromTemplate = (
 	title: string,
 	body: string,
-	context: Pick<DispatchContext, "eventType" | "sentAtMs" | "incidentId">,
+	context: Pick<
+		DispatchContext,
+		"eventType" | "sentAtMs" | "incidentId" | "sparkline" | "chartUrl" | "ruleName"
+	>,
 	linkUrl: string,
 	chatUrl: string,
 ) => [
@@ -350,6 +390,7 @@ export const buildSlackBlocksFromTemplate = (
 		type: "section",
 		text: { type: "mrkdwn", text: markdownToSlackMrkdwn(body) },
 	},
+	...slackChartBlocks(context),
 	buildSlackActionsBlock(linkUrl, chatUrl),
 	buildSlackContextBlock(context),
 ]
@@ -357,7 +398,7 @@ export const buildSlackBlocksFromTemplate = (
 export const buildDiscordEmbedsFromTemplate = (
 	title: string,
 	body: string,
-	context: Pick<DispatchContext, "eventType" | "severity">,
+	context: Pick<DispatchContext, "eventType" | "severity" | "sparkline" | "chartUrl">,
 	linkUrl: string,
 	chatUrl: string,
 ) => [
@@ -373,7 +414,8 @@ export const buildDiscordEmbedsFromTemplate = (
 				inline: false,
 			},
 		],
-		footer: { text: "\u{1F341} Maple Alerts" },
+		...discordImage(context),
+		footer: { text: discordFooterText(context) },
 	},
 ]
 

--- a/apps/api/src/services/alerts/AlertDestinationDelivery.ts
+++ b/apps/api/src/services/alerts/AlertDestinationDelivery.ts
@@ -151,6 +151,15 @@ export const makeAlertDestinationDelivery = (options: {
 				sampleCount: context.sampleCount,
 			},
 			template: context.template ?? null,
+			// Snapshotted at queue time, not re-derived at delivery: a retry an
+			// hour later must show what the alert saw, not what has happened since.
+			chart:
+				context.sparkline || context.chartUrl
+					? {
+							...(context.sparkline ? { sparkline: context.sparkline } : undefined),
+							...(context.chartUrl ? { url: context.chartUrl } : undefined),
+						}
+					: null,
 			linkUrl: context.linkUrl,
 			chatUrl: buildAlertChatUrl(options.appBaseUrl, context),
 			sentAt: new Date(context.sentAtMs).toISOString(),
@@ -162,6 +171,10 @@ export const makeAlertDestinationDelivery = (options: {
 			readonly rule: Record<string, unknown>
 			readonly observed: Record<string, unknown>
 			readonly template: AlertNotificationTemplate | null
+			readonly chart: {
+				readonly sparkline?: string
+				readonly url?: string
+			} | null
 			readonly linkUrl: string
 			readonly chatUrl: string
 			readonly sentAt: string

--- a/apps/api/src/services/alerts/AlertReadModelsService.ts
+++ b/apps/api/src/services/alerts/AlertReadModelsService.ts
@@ -22,8 +22,6 @@ import {
 	AlertCheckStatus as AlertCheckStatusSchema,
 	AlertValidationError,
 	OrgId,
-	RoleName,
-	UserId,
 	type AlertIncidentId,
 	type AlertRuleId,
 	type ManagedWarehouseError,
@@ -40,7 +38,7 @@ import { Context, Effect, Layer, Schema } from "effect"
 import { Database } from "@/platform/DatabaseLive"
 import { makeDbExecute } from "@/platform/db-execute"
 import { makePersistenceError } from "./alert-persistence"
-import type { TenantContext } from "@/services/auth/AuthService"
+import { systemTenant } from "./system-tenant"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
 
 export interface AlertChecksSummaryPoint {
@@ -141,8 +139,6 @@ const decodeAlertIncidentStatusSync = Schema.decodeUnknownSync(AlertIncidentStat
 const decodeAlertEventTypeSync = Schema.decodeUnknownSync(AlertEventTypeSchema)
 const decodeErrorIssueIdSync = Schema.decodeUnknownSync(AlertIncidentDocument.fields.errorIssueId)
 const decodeAlertDeliveryStatusSync = Schema.decodeUnknownSync(AlertDeliveryStatus)
-const decodeRoleNameSync = Schema.decodeUnknownSync(RoleName)
-const decodeUserIdSync = Schema.decodeUnknownSync(UserId)
 
 type IsoDateTimeValue = Schema.Schema.Type<typeof AlertDestinationDocument.fields.createdAt>
 
@@ -191,13 +187,6 @@ export class AlertReadModelsService extends Context.Service<
 		const warehouse = yield* WarehouseQueryService
 
 		const dbExecute = makeDbExecute(database, "AlertReadModelsService", makePersistenceError)
-
-		const systemTenant = (orgId: OrgId): TenantContext => ({
-			orgId,
-			userId: decodeUserIdSync("system-alerting"),
-			roles: [decodeRoleNameSync("root")],
-			authMode: "self_hosted",
-		})
 
 		const listIncidents = Effect.fn("AlertsService.listIncidents")(function* (
 			orgId: OrgId,

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -94,6 +94,7 @@ import { makePersistenceError } from "./alert-persistence"
 import { QueryEngineService } from "@/services/warehouse/QueryEngineService"
 import type { GroupedAlertObservation } from "@maple/query-engine/runtime"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
+import { chartImageUrl, chartWindow, loadChartSeries } from "./alert-chart-series"
 import type { AlertChecksRow } from "@maple/domain/tinybird"
 import { SlackBotTokenResolver } from "@/services/integrations/slack-bot-token"
 import { ApnsClient } from "@/platform/Apns"
@@ -113,7 +114,7 @@ import {
 	planEvaluateSource,
 	type NormalizedRule,
 } from "./AlertRuleModel"
-import { resolveSignalDisplay } from "./alert-signal-display"
+import { mapSignalUnit, resolveSignalDisplay } from "./alert-signal-display"
 
 export { AlertRuntime, type AlertRuntimeApi } from "./AlertRuntime"
 
@@ -192,6 +193,14 @@ const StoredDeliveryPayloadSchema = Schema.Struct({
 		}),
 	),
 	template: Schema.optionalKey(Schema.NullOr(AlertNotificationTemplate)),
+	chart: Schema.optionalKey(
+		Schema.NullOr(
+			Schema.Struct({
+				sparkline: Schema.optionalKey(Schema.String),
+				url: Schema.optionalKey(Schema.String),
+			}),
+		),
+	),
 })
 
 const decodeAlertRuleIdSync = Schema.decodeUnknownSync(AlertRuleDocument.fields.id)
@@ -749,6 +758,52 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceA
 					)
 
 					const destinations = new Map(rows.map((row) => [row.id, row]))
+
+					// Once per notification, not once per destination: N destinations
+					// on one rule must not mean N reads of the same series. Never
+					// fails — `loadChartSeries` answers `null` for every problem it
+					// can have, so a slow or broken warehouse costs the sparkline and
+					// nothing else.
+					const window = chartWindow({
+						incidentStartedAtMs: incident.firstTriggeredAt.getTime(),
+						nowMs: scheduledAt,
+						windowMinutes: rule.windowMinutes,
+					})
+					const series = yield* loadChartSeries(warehouse, systemTenant(orgId), {
+						orgId,
+						ruleId: rule.id,
+						groupKey: incident.groupKey,
+						comparator: rule.comparator,
+						threshold: rule.threshold,
+						...window,
+					})
+
+					// The image URL rides with the series it describes: both pin the
+					// same window, so a retry an hour later renders the same picture
+					// this notification was written about.
+					const display = resolveSignalDisplay(rule)
+					const displayGroup = incident.groupKey === "__total__" ? null : incident.groupKey
+					const chartUrl =
+						series === null
+							? null
+							: chartImageUrl({
+									appBaseUrl: env.MAPLE_APP_BASE_URL,
+									hmacKey: Option.match(env.MAPLE_SHARE_TOKEN_HMAC_KEY, {
+										onNone: () => null,
+										onSome: (key) => Redacted.value(key),
+									}),
+									orgId,
+									ruleId: rule.id,
+									groupKey: incident.groupKey,
+									...window,
+									title: displayGroup
+										? `${display.label} · ${displayGroup}`
+										: display.label,
+									unit: mapSignalUnit(display.unit),
+									threshold: series.threshold,
+									breachSide: series.breachSide,
+								})
+
 					const payload = buildPayload({
 						eventType,
 						incidentId: incident.id,
@@ -765,6 +820,8 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceA
 						windowMinutes: rule.windowMinutes,
 						value: evaluation.value,
 						sampleCount: evaluation.sampleCount,
+						sparkline: series?.sparkline ?? null,
+						chartUrl,
 						template: rule.notificationTemplate,
 						linkUrl: resolveNotificationLinkUrl(rule, incident.groupKey),
 						sentAtMs: scheduledAt,
@@ -1441,6 +1498,8 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceA
 							value: payload.observed?.value ?? null,
 							sampleCount: payload.observed?.sampleCount ?? null,
 							template: payload.template ?? storedRule?.notificationTemplate ?? null,
+							sparkline: payload.chart?.sparkline ?? null,
+							chartUrl: payload.chart?.url ?? null,
 							linkUrl: resolveNotificationLinkUrl(
 								{
 									serviceNames: storedRule?.serviceNames ?? [],

--- a/apps/api/src/services/alerts/AlertsService.ts
+++ b/apps/api/src/services/alerts/AlertsService.ts
@@ -41,7 +41,6 @@ import {
 	type QueryEngineTimeoutError,
 	type QueryEngineValidationError,
 	RoleName,
-	UserId as UserIdSchema,
 	type UserId,
 } from "@maple/domain/http"
 import {
@@ -82,7 +81,6 @@ import { INVESTIGATION_FANOUT_BINDING } from "@/services/errors/ai-triage-enqueu
 import { upsertAlertIssue } from "@/services/errors/issue-hub"
 import { probeLiveness } from "@/services/alerts/telemetry-liveness"
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
-import type { TenantContext } from "@/services/auth/AuthService"
 import { Database, type DatabaseClient } from "@/platform/DatabaseLive"
 import { formatComparator } from "./alert-formatting"
 import { EmailService } from "@/platform/EmailService"
@@ -95,6 +93,7 @@ import { QueryEngineService } from "@/services/warehouse/QueryEngineService"
 import type { GroupedAlertObservation } from "@maple/query-engine/runtime"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
 import { chartImageUrl, chartWindow, loadChartSeries } from "./alert-chart-series"
+import { systemTenant } from "./system-tenant"
 import type { AlertChecksRow } from "@maple/domain/tinybird"
 import { SlackBotTokenResolver } from "@/services/integrations/slack-bot-token"
 import { ApnsClient } from "@/platform/Apns"
@@ -207,8 +206,6 @@ const decodeAlertRuleIdSync = Schema.decodeUnknownSync(AlertRuleDocument.fields.
 const decodeAlertIncidentIdSync = Schema.decodeUnknownSync(AlertIncidentDocument.fields.id)
 const decodeAlertDeliveryEventIdSync = Schema.decodeUnknownSync(AlertDeliveryEventDocument.fields.id)
 const decodeIsoDateTimeStringSync = Schema.decodeUnknownSync(AlertDestinationDocument.fields.createdAt)
-const decodeRoleNameSync = Schema.decodeUnknownSync(RoleName)
-const decodeUserIdSync = Schema.decodeUnknownSync(UserIdSchema)
 const decodeAlertSeveritySync = Schema.decodeUnknownSync(AlertSeveritySchema)
 const decodeAlertSignalTypeSync = Schema.decodeUnknownSync(AlertSignalTypeSchema)
 const decodeAlertComparatorSync = Schema.decodeUnknownSync(AlertComparatorSchema)
@@ -429,13 +426,6 @@ export class AlertsService extends Context.Service<AlertsService, AlertsServiceA
 			} = rulePersistence
 
 			const dbExecute = makeDbExecute(database, "AlertsService", makePersistenceError)
-
-			const systemTenant = (orgId: OrgId): TenantContext => ({
-				orgId,
-				userId: decodeUserIdSync("system-alerting"),
-				roles: [decodeRoleNameSync("root")],
-				authMode: "self_hosted",
-			})
 
 			/**
 			 * Services a rule's telemetry-liveness probe should cover. An empty list

--- a/apps/api/src/services/alerts/alert-chart-series.test.ts
+++ b/apps/api/src/services/alerts/alert-chart-series.test.ts
@@ -1,0 +1,152 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import type { OrgId } from "@maple/domain/http"
+import type { TenantContext } from "@/services/auth/AuthService"
+import { breachSideFor, chartWindow, loadChartSeries, type ChartSeriesWarehouse } from "./alert-chart-series"
+
+const ORG_ID = "org_1" as OrgId
+const tenant = { orgId: ORG_ID } as TenantContext
+
+const baseOptions = {
+	orgId: ORG_ID,
+	ruleId: "rule_1",
+	groupKey: null,
+	comparator: "gt" as const,
+	threshold: 2,
+	fromMs: Date.UTC(2026, 7, 18, 13, 0),
+	toMs: Date.UTC(2026, 7, 18, 14, 0),
+}
+
+/**
+ * `ChartSeriesWarehouse` is the narrow port the module declares, so these stubs
+ * are checked against the real `compiledQuery` signature rather than cast past
+ * it — a stub that stops matching the service fails here instead of passing.
+ */
+const warehouseReturning = (rows: ReadonlyArray<unknown>): ChartSeriesWarehouse => ({
+	compiledQuery: () => Effect.succeed(rows as ReadonlyArray<never>),
+})
+
+const warehouseFailing = (): ChartSeriesWarehouse => ({
+	compiledQuery: () => Effect.die(new Error("warehouse down")),
+})
+
+const checkRow = (minutesAgo: number, observedValue: number | null) => ({
+	timestamp: new Date(Date.UTC(2026, 7, 18, 14, 0) - minutesAgo * 60_000).toISOString(),
+	observedValue,
+})
+
+describe("breachSideFor", () => {
+	it("maps the half-plane comparators to a side", () => {
+		assert.strictEqual(breachSideFor("gt"), "above")
+		assert.strictEqual(breachSideFor("gte"), "above")
+		assert.strictEqual(breachSideFor("lt"), "below")
+		assert.strictEqual(breachSideFor("lte"), "below")
+	})
+
+	it("shades nothing for the comparators with no single bad side", () => {
+		// Pointing the reader's eye at half a chart is worse than not shading it.
+		assert.strictEqual(breachSideFor("between"), "none")
+		assert.strictEqual(breachSideFor("not_between"), "none")
+		assert.strictEqual(breachSideFor("eq"), "none")
+		assert.strictEqual(breachSideFor("neq"), "none")
+	})
+})
+
+describe("chartWindow", () => {
+	const nowMs = Date.UTC(2026, 7, 18, 14, 0)
+
+	it("includes lead-in before the incident, so the chart shows a baseline", () => {
+		const incidentStartedAtMs = nowMs - 60 * 60_000
+		const window = chartWindow({ incidentStartedAtMs, nowMs, windowMinutes: 5 })
+		assert.isBelow(window.fromMs, incidentStartedAtMs)
+		assert.strictEqual(window.toMs, nowMs)
+	})
+
+	it("grows with the incident, so each renotify says more than the last", () => {
+		const early = chartWindow({ incidentStartedAtMs: nowMs - 10 * 60_000, nowMs, windowMinutes: 5 })
+		const later = chartWindow({ incidentStartedAtMs: nowMs - 180 * 60_000, nowMs, windowMinutes: 5 })
+		assert.isBelow(later.fromMs, early.fromMs)
+	})
+
+	it("holds a floor, so a fresh incident on a 1-minute rule is not a 2-minute chart", () => {
+		const window = chartWindow({ incidentStartedAtMs: nowMs, nowMs, windowMinutes: 1 })
+		assert.isAtLeast(nowMs - window.fromMs, 6 * 60_000)
+	})
+})
+
+describe("loadChartSeries", () => {
+	it.effect("orders points left to right regardless of query order", () =>
+		Effect.gen(function* () {
+			// alert_checks pages newest-first for the checks table; a chart reads
+			// the other way, and a series drawn in query order zigzags.
+			const series = yield* loadChartSeries(
+				warehouseReturning([checkRow(0, 3), checkRow(20, 1), checkRow(10, 2)]),
+				tenant,
+				baseOptions,
+			)
+			assert.deepStrictEqual(
+				series?.points.map((p) => p[1]),
+				[1, 2, 3],
+			)
+		}),
+	)
+
+	it.effect("carries the threshold and breach side through for the renderer", () =>
+		Effect.gen(function* () {
+			const series = yield* loadChartSeries(
+				warehouseReturning([checkRow(0, 3), checkRow(10, 2), checkRow(20, 1)]),
+				tenant,
+				{ ...baseOptions, comparator: "lt", threshold: 0.8 },
+			)
+			assert.strictEqual(series?.threshold, 0.8)
+			assert.strictEqual(series?.breachSide, "below")
+		}),
+	)
+
+	it.effect("produces a sparkline alongside the points", () =>
+		Effect.gen(function* () {
+			const series = yield* loadChartSeries(
+				warehouseReturning([checkRow(0, 9), checkRow(10, 5), checkRow(20, 1)]),
+				tenant,
+				baseOptions,
+			)
+			assert.strictEqual(series?.sparkline.length, 3)
+		}),
+	)
+
+	it.effect("skips rows with no observed value rather than charting them as zero", () =>
+		Effect.gen(function* () {
+			// A failed evaluation writes an audit row with a null value. Reading it
+			// as 0 would draw a recovery that never happened.
+			const series = yield* loadChartSeries(
+				warehouseReturning([checkRow(0, 3), checkRow(5, null), checkRow(10, 2), checkRow(20, 1)]),
+				tenant,
+				baseOptions,
+			)
+			assert.deepStrictEqual(
+				series?.points.map((p) => p[1]),
+				[1, 2, 3],
+			)
+		}),
+	)
+
+	it.effect("returns null for a series too short to be a trend", () =>
+		Effect.gen(function* () {
+			const series = yield* loadChartSeries(
+				warehouseReturning([checkRow(0, 3), checkRow(10, 1)]),
+				tenant,
+				baseOptions,
+			)
+			assert.isNull(series)
+		}),
+	)
+
+	it.effect("returns null instead of failing when the warehouse is down", () =>
+		Effect.gen(function* () {
+			// The whole contract of this module: an enrichment must never be able
+			// to delay or drop a page.
+			const series = yield* loadChartSeries(warehouseFailing(), tenant, baseOptions)
+			assert.isNull(series)
+		}),
+	)
+})

--- a/apps/api/src/services/alerts/alert-chart-series.ts
+++ b/apps/api/src/services/alerts/alert-chart-series.ts
@@ -1,0 +1,259 @@
+/**
+ * The series behind an alert notification's sparkline and chart.
+ *
+ * The source is `alert_checks` — the audit row the scheduler already writes on
+ * every evaluation — rather than a fresh warehouse aggregation. Three reasons,
+ * in order of how much they matter:
+ *
+ *   1. **It is what the alert saw.** A re-derived series can disagree with the
+ *      number printed one line above it in the same message, and a chart that
+ *      contradicts its own alert is worse than no chart.
+ *   2. It is a `list` scan over rows keyed by the rule, not a re-aggregation
+ *      of raw telemetry.
+ *   3. It carries `Status` per row, so "was this point breaching" needs no
+ *      re-run of the comparator.
+ *
+ * `alert_checks` is written through `warehouse.ingest` (pinned to managed
+ * Tinybird for every org) and `listRuleChecksQuery` declares `.routing("ingest")`,
+ * so both halves resolve the same pipeline — this works for BYO-ClickHouse
+ * orgs too, and needs no second code path. See
+ * `packages/query-engine/src/ch/queries/alert-checks.ts`.
+ *
+ * Nothing here is allowed to fail a notification. Every entry point returns
+ * `null` instead of an error: a chart is an enrichment, and a page that is late
+ * because a warehouse read was slow is a worse outcome than a page with no
+ * picture on it.
+ */
+import * as CH from "@maple/query-engine/ch"
+import type { AlertComparator, OrgId } from "@maple/domain/http"
+import { alertChartId } from "@maple/db"
+import {
+	downsample,
+	sparkline,
+	type BreachSide,
+	type ChartPoint,
+	type ChartUnit,
+} from "@maple/widgets/chart/static-chart"
+import { Duration, Effect, Option } from "effect"
+import type { TenantContext } from "@/services/auth/AuthService"
+import type { WarehouseQueryServiceApi } from "@/services/warehouse/WarehouseQueryService"
+
+/**
+ * Points to draw. More than this and a 720px-wide card is drawing sub-pixel
+ * segments; fewer and a slow drift stops being visible.
+ */
+export const MAX_CHART_POINTS = 60
+
+/**
+ * Rows to read before downsampling. One row per rule per minute, so this is
+ * ~12 hours of an incident — past that the shape matters more than the detail,
+ * and {@link downsample} keeps the excursion either way.
+ */
+const MAX_CHECK_ROWS = 720
+
+/**
+ * How long the read gets before the notification goes out without it.
+ *
+ * Deliberately far below the queue tick: this runs while an alert is waiting
+ * to be delivered.
+ */
+const SERIES_TIMEOUT = Duration.seconds(3)
+
+/** Context before the incident, so a trigger chart shows what "normal" was. */
+const LEAD_WINDOWS = 2
+/** Floor on the range, so a 1-minute rule does not chart a 2-minute window. */
+const MIN_WINDOWS = 6
+
+export interface AlertChartSeries {
+	readonly points: ReadonlyArray<ChartPoint>
+	readonly sparkline: string
+	readonly threshold: number | null
+	readonly breachSide: BreachSide
+}
+
+/**
+ * Which side of the threshold is the bad side.
+ *
+ * `between`/`not_between`/`eq`/`neq` have no single bad half-plane, so they
+ * shade nothing — the rule still draws, and inventing a side would point the
+ * reader's eye at the wrong half of the chart.
+ */
+export const breachSideFor = (comparator: AlertComparator): BreachSide => {
+	switch (comparator) {
+		case "gt":
+		case "gte":
+			return "above"
+		case "lt":
+		case "lte":
+			return "below"
+		default:
+			return "none"
+	}
+}
+
+/**
+ * The window an incident's chart covers: enough lead-in to show the baseline,
+ * and growing with the incident so each renotify says more than the last.
+ */
+export const chartWindow = (options: {
+	readonly incidentStartedAtMs: number
+	readonly nowMs: number
+	readonly windowMinutes: number
+}): { readonly fromMs: number; readonly toMs: number } => {
+	const windowMs = Math.max(1, options.windowMinutes) * 60_000
+	const lead = options.incidentStartedAtMs - windowMs * LEAD_WINDOWS
+	const floor = options.nowMs - windowMs * MIN_WINDOWS
+	return { fromMs: Math.min(lead, floor), toMs: options.nowMs }
+}
+
+/** `alert_checks` is DateTime64(3) on the wire: "YYYY-MM-DD HH:MM:SS.mmm" UTC. */
+const toWarehouseDateTime = (epochMs: number): string =>
+	new Date(epochMs).toISOString().replace("T", " ").replace("Z", "")
+
+/**
+ * The one warehouse method this module calls.
+ *
+ * A narrow port rather than the whole service: it is what lets the tests hand
+ * in a stub the compiler actually checks. A `Partial<WarehouseQueryServiceApi>`
+ * cast would compile against a signature that had since changed underneath it,
+ * which is exactly how a stubbed service stops testing anything.
+ */
+export interface ChartSeriesWarehouse {
+	readonly compiledQuery: WarehouseQueryServiceApi["compiledQuery"]
+}
+
+export interface LoadChartSeriesOptions {
+	readonly orgId: OrgId
+	readonly ruleId: string
+	/** `null` for an ungrouped rule — the query then spans every group. */
+	readonly groupKey: string | null
+	readonly comparator: AlertComparator
+	readonly threshold: number
+	readonly fromMs: number
+	readonly toMs: number
+}
+
+/**
+ * The rule's observed values over a window, or `null` when there is nothing
+ * worth drawing.
+ *
+ * `null` — never a failure — for a warehouse error, a timeout, or a series so
+ * short that a chart of it would be a single dot. Callers treat it as "no
+ * chart" and carry on.
+ */
+export const loadChartSeries = (
+	warehouse: ChartSeriesWarehouse,
+	tenant: TenantContext,
+	options: LoadChartSeriesOptions,
+): Effect.Effect<AlertChartSeries | null> =>
+	Effect.gen(function* () {
+		const compiled = CH.compile(
+			CH.listRuleChecksQuery({
+				limit: MAX_CHECK_ROWS,
+				...(options.groupKey != null && options.groupKey !== ""
+					? { groupKey: options.groupKey }
+					: undefined),
+				since: toWarehouseDateTime(options.fromMs),
+				until: toWarehouseDateTime(options.toMs),
+			}),
+			{
+				orgId: options.orgId,
+				ruleId: options.ruleId,
+				...(options.groupKey != null && options.groupKey !== ""
+					? { groupKey: options.groupKey }
+					: undefined),
+				since: toWarehouseDateTime(options.fromMs),
+				until: toWarehouseDateTime(options.toMs),
+			},
+		)
+
+		const rows = yield* warehouse.compiledQuery(tenant, compiled, {
+			profile: "list",
+			context: "alertChartSeries",
+		})
+
+		const breachSide = breachSideFor(options.comparator)
+		// The query orders newest-first for the checks table's own pagination;
+		// a chart reads left to right.
+		const points: ChartPoint[] = []
+		for (const row of rows) {
+			const value = row.observedValue
+			if (value == null) continue
+			const at = Date.parse(`${String(row.timestamp)}`)
+			if (Number.isNaN(at)) continue
+			points.push([at, Number(value)])
+		}
+		points.sort((a, b) => a[0] - b[0])
+
+		// Two points is a line segment, not a trend, and it makes the message
+		// look instrumented without informing anyone.
+		if (points.length < 3) return null
+
+		const drawn = downsample(points, MAX_CHART_POINTS, breachSide)
+		return {
+			points: drawn,
+			sparkline: sparkline(drawn.map((p) => p[1])),
+			threshold: options.threshold,
+			breachSide,
+		}
+	}).pipe(
+		Effect.timeoutOption(SERIES_TIMEOUT),
+		Effect.map(Option.getOrNull),
+		// An enrichment must never take a page down with it: a bad rowSchema, a
+		// warehouse outage and a decode failure all land here as "no chart".
+		Effect.catchCause((cause) =>
+			Effect.logWarning("Alert chart series unavailable; notifying without one").pipe(
+				Effect.annotateLogs({
+					orgId: options.orgId,
+					"maple.alert.rule_id": options.ruleId,
+					cause: String(cause),
+				}),
+				Effect.as(null),
+			),
+		),
+	)
+
+/**
+ * The public URL of a notification's chart image.
+ *
+ * Built at queue time alongside the series, not at delivery: everything it
+ * pins — the window, the title, the threshold — is what the alert observed at
+ * this moment, and recomputing it per destination or per retry would let two
+ * deliveries of the same notification disagree about their own picture.
+ *
+ * `null` when the deployment has no share HMAC key configured. Sharing is
+ * optional infrastructure and an unsigned chart URL is not a thing this repo
+ * will mint, so the notification simply goes out with its sparkline only.
+ */
+export const chartImageUrl = (options: {
+	readonly appBaseUrl: string
+	readonly hmacKey: string | null
+	readonly orgId: OrgId
+	readonly ruleId: string
+	readonly groupKey: string | null
+	readonly fromMs: number
+	readonly toMs: number
+	readonly title: string
+	readonly unit: ChartUnit
+	readonly threshold: number | null
+	readonly breachSide: BreachSide
+}): string | null => {
+	if (options.hmacKey === null) return null
+	const id = alertChartId(
+		{
+			orgId: options.orgId,
+			ruleId: options.ruleId,
+			groupKey: options.groupKey,
+			fromMs: options.fromMs,
+			toMs: options.toMs,
+			// Bounded before signing: the id travels in a URL, and a rule with a
+			// paragraph for a name must not be able to grow it without limit.
+			title: options.title.slice(0, 120),
+			unit: options.unit,
+			threshold: options.threshold,
+			breachSide: options.breachSide,
+		},
+		options.hmacKey,
+	)
+	return new URL(`/alerts/chart/${encodeURIComponent(id)}.png`, options.appBaseUrl).toString()
+}

--- a/apps/api/src/services/alerts/alert-chart-series.ts
+++ b/apps/api/src/services/alerts/alert-chart-series.ts
@@ -25,7 +25,7 @@
  * picture on it.
  */
 import * as CH from "@maple/query-engine/ch"
-import type { AlertComparator, OrgId } from "@maple/domain/http"
+import type { AlertComparator, AlertRuleId, OrgId } from "@maple/domain/http"
 import { alertChartId } from "@maple/db"
 import {
 	downsample,
@@ -124,7 +124,7 @@ export interface ChartSeriesWarehouse {
 
 export interface LoadChartSeriesOptions {
 	readonly orgId: OrgId
-	readonly ruleId: string
+	readonly ruleId: AlertRuleId
 	/** `null` for an ungrouped rule — the query then spans every group. */
 	readonly groupKey: string | null
 	readonly comparator: AlertComparator
@@ -229,7 +229,7 @@ export const chartImageUrl = (options: {
 	readonly appBaseUrl: string
 	readonly hmacKey: string | null
 	readonly orgId: OrgId
-	readonly ruleId: string
+	readonly ruleId: AlertRuleId
 	readonly groupKey: string | null
 	readonly fromMs: number
 	readonly toMs: number

--- a/apps/api/src/services/alerts/alert-chart-series.ts
+++ b/apps/api/src/services/alerts/alert-chart-series.ts
@@ -25,6 +25,7 @@
  * picture on it.
  */
 import * as CH from "@maple/query-engine/ch"
+import { CHNumber } from "@maple/query-engine/ch"
 import type { AlertComparator, AlertRuleId, OrgId } from "@maple/domain/http"
 import { alertChartId } from "@maple/db"
 import {
@@ -34,7 +35,7 @@ import {
 	type ChartPoint,
 	type ChartUnit,
 } from "@maple/widgets/chart/static-chart"
-import { Duration, Effect, Option } from "effect"
+import { Array as Arr, Cause, Duration, Effect, Option, Order, Result, Schema } from "effect"
 import type { TenantContext } from "@/services/auth/AuthService"
 import type { WarehouseQueryServiceApi } from "@/services/warehouse/WarehouseQueryService"
 
@@ -106,6 +107,44 @@ export const chartWindow = (options: {
 	return { fromMs: Math.min(lead, floor), toMs: options.nowMs }
 }
 
+/**
+ * The two columns a chart reads, decoded rather than coerced.
+ *
+ * `listRuleChecksQuery` declares no `rowSchema`, so `compiledQuery` hands back
+ * undecoded rows. `Number(row.observedValue)` would have compiled and produced
+ * `NaN` on any wire-format drift — the exact failure `CHNumber` exists to
+ * absorb, since a gateway or read-only cluster that refuses
+ * `output_format_json_quote_64bit_integers=0` sends quoted numbers.
+ */
+const CheckRow = Schema.Struct({
+	timestamp: Schema.String,
+	observedValue: Schema.NullOr(CHNumber),
+})
+const decodeCheckRow = Schema.decodeUnknownResult(CheckRow)
+
+/**
+ * One audit row as a chart point, or a reason it was dropped.
+ *
+ * `Array.filterMap` in Effect v4 keeps the successes of a `Result`-returning
+ * transform, so the failure side names why a row is not drawn instead of
+ * silently vanishing into a boolean filter.
+ */
+const toChartPoint = (row: unknown): Result.Result<ChartPoint, string> => {
+	const decoded = decodeCheckRow(row)
+	if (Result.isFailure(decoded)) return Result.fail("undecodable check row")
+
+	const { timestamp, observedValue } = decoded.success
+	// A failed evaluation writes an audit row with no observed value. Reading
+	// that as 0 would draw a recovery that never happened.
+	if (observedValue === null) return Result.fail("no observed value")
+
+	const at = Date.parse(timestamp)
+	return Number.isNaN(at) ? Result.fail("unparseable timestamp") : Result.succeed([at, observedValue])
+}
+
+/** The query pages newest-first for the checks table; a chart reads left to right. */
+const byTimestamp = Order.mapInput(Order.Number, (point: ChartPoint) => point[0])
+
 /** `alert_checks` is DateTime64(3) on the wire: "YYYY-MM-DD HH:MM:SS.mmm" UTC. */
 const toWarehouseDateTime = (epochMs: number): string =>
 	new Date(epochMs).toISOString().replace("T", " ").replace("Z", "")
@@ -175,15 +214,7 @@ export const loadChartSeries = (
 		const breachSide = breachSideFor(options.comparator)
 		// The query orders newest-first for the checks table's own pagination;
 		// a chart reads left to right.
-		const points: ChartPoint[] = []
-		for (const row of rows) {
-			const value = row.observedValue
-			if (value == null) continue
-			const at = Date.parse(`${String(row.timestamp)}`)
-			if (Number.isNaN(at)) continue
-			points.push([at, Number(value)])
-		}
-		points.sort((a, b) => a[0] - b[0])
+		const points = Arr.sort(Arr.filterMap(rows, toChartPoint), byTimestamp)
 
 		// Two points is a line segment, not a trend, and it makes the message
 		// look instrumented without informing anyone.
@@ -206,7 +237,7 @@ export const loadChartSeries = (
 				Effect.annotateLogs({
 					orgId: options.orgId,
 					"maple.alert.rule_id": options.ruleId,
-					cause: String(cause),
+					cause: Cause.pretty(cause),
 				}),
 				Effect.as(null),
 			),

--- a/apps/api/src/services/alerts/alert-formatting.ts
+++ b/apps/api/src/services/alerts/alert-formatting.ts
@@ -30,6 +30,10 @@ export interface TemplateRenderContext {
 	readonly windowMinutes: number
 	readonly incidentId: string | null
 	readonly incidentStatus: string
+	/** Unicode trend of recent observed values; absent when unavailable. */
+	readonly sparkline?: string | null
+	/** Public URL of this notification's chart image; absent when there is none. */
+	readonly chartUrl?: string | null
 	readonly dedupeKey: string
 	readonly template?: NotificationTemplateConfig | null
 	readonly sentAtMs?: number

--- a/apps/api/src/services/alerts/alert-signal-display.ts
+++ b/apps/api/src/services/alerts/alert-signal-display.ts
@@ -16,6 +16,7 @@
  */
 import type { AlertSignalType, QueryBuilderQueryDraftPayload } from "@maple/domain/http"
 import { AGGREGATIONS_BY_SOURCE } from "@maple/query-engine/query-builder"
+import type { ChartUnit } from "@maple/widgets/chart/static-chart"
 
 export type SignalUnit = "ratio" | "ms" | "rpm" | "apdex" | "count" | "plain"
 
@@ -109,4 +110,29 @@ export const resolveSignalDisplay = (input: SignalDisplayInput): SignalDisplay =
 	// A query-driven rule whose definition could not be loaded (deleted rule row),
 	// or a signal type added to the domain without an entry here.
 	return { label: humanize(input.signalType), unit: "plain" }
+}
+
+/**
+ * A rule's {@link SignalUnit} as the static chart renderer's unit.
+ *
+ * The two vocabularies are deliberately different: `SignalUnit` says what the
+ * rule measures, `ChartUnit` says how an axis formats. `apdex` and `count`
+ * both collapse to `number` because neither has a suffix worth printing on a
+ * chart — an apdex of `0.82` is not `0.82 apdex` — while `ratio` becomes
+ * `percent`, which is the one case where the chart adds a glyph the signal
+ * label does not.
+ */
+export const mapSignalUnit = (unit: SignalUnit): ChartUnit => {
+	switch (unit) {
+		case "ratio":
+			return "percent"
+		case "ms":
+			return "duration_ms"
+		case "rpm":
+			return "requests_per_sec"
+		case "apdex":
+		case "count":
+		case "plain":
+			return "number"
+	}
 }

--- a/apps/api/src/services/alerts/delivery/context.ts
+++ b/apps/api/src/services/alerts/delivery/context.ts
@@ -53,6 +53,25 @@ export interface DispatchContext {
 	readonly template?: NotificationTemplateConfig | null
 	/** Epoch ms the notification was sent — exposed to templates as `sentAt`. */
 	readonly sentAtMs?: number
+	/**
+	 * Unicode sparkline of the rule's recent observed values, or absent when
+	 * the series was unavailable or too short to be worth drawing.
+	 *
+	 * Text rather than an image because this has to survive where images do not
+	 * — a phone's lock screen, a push preview, a plain-text email client. It is
+	 * snapshotted at queue time so a retry shows what the alert saw, not what
+	 * the metric has done since.
+	 */
+	readonly sparkline?: string | null
+	/**
+	 * Public URL of this notification's chart image, or absent when there was no
+	 * series to draw or the deployment has no share HMAC key.
+	 *
+	 * Signed and window-pinned (see `alertChartId`), so it renders the same
+	 * picture forever. Providers that can show an image use it; the sparkline
+	 * stays regardless, because an image block does not reach a lock screen.
+	 */
+	readonly chartUrl?: string | null
 }
 
 export interface DispatchResult {

--- a/apps/api/src/services/alerts/delivery/transports/render.test.ts
+++ b/apps/api/src/services/alerts/delivery/transports/render.test.ts
@@ -242,3 +242,101 @@ describe("transport render: event types", () => {
 		})
 	}
 })
+
+/**
+ * The sparkline is the one part of a renotify that differs from the message
+ * before it, and it is the only trend that survives where an image cannot go —
+ * a lock screen, a push preview, a plain-text client. Both providers carry it,
+ * on both the default and the templated path, and all four of those used to be
+ * separate literals that had already drifted apart once.
+ */
+describe("transport render: sparkline", () => {
+	const SPARK = "▁▂▄▆█"
+	const withSpark = { ...context, sparkline: SPARK }
+
+	const slack = makeSlackTransport({ resolveSlackBotToken: () => Effect.succeed("t") })
+	const slackBody = (ctx: DispatchContext, templated: typeof TEMPLATED | null) =>
+		slack.render(
+			{
+				...inputFor({ type: "slack-bot" as const, channelId: "C1", channelName: "ops" }),
+				context: ctx,
+				templated,
+			},
+			"xoxb-token",
+		).body
+
+	const discordBody = (ctx: DispatchContext, templated: typeof TEMPLATED | null) =>
+		discordTransport.render({
+			...inputFor({ type: "discord" as const, webhookUrl: "https://discord.com/api/w/1/tok" }),
+			context: ctx,
+			templated,
+		}).body
+
+	it("rides in the Slack context block on the default path", () => {
+		assert.include(slackBody(withSpark, null), SPARK)
+	})
+
+	it("rides in the Slack context block on the templated path too", () => {
+		assert.include(slackBody(withSpark, TEMPLATED), SPARK)
+	})
+
+	it("rides in the Discord footer on the default path", () => {
+		assert.include(discordBody(withSpark, null), SPARK)
+	})
+
+	it("rides in the Discord footer on the templated path too", () => {
+		assert.include(discordBody(withSpark, TEMPLATED), SPARK)
+	})
+
+	const CHART_URL = "https://web.localhost/alerts/chart/eyJhIjoxfQ.s1g.png"
+	const withChart = { ...context, sparkline: SPARK, chartUrl: CHART_URL }
+
+	it("puts the chart in a Slack image block on both paths", () => {
+		for (const templated of [null, TEMPLATED]) {
+			const body = slackBody(withChart, templated)
+			assert.include(body, CHART_URL)
+			assert.include(body, '"type":"image"')
+			// alt text repeats the alert, since it is what a screen reader reads
+			// and what shows when the image will not load.
+			assert.include(body, "alt_text")
+		}
+	})
+
+	it("puts the chart in the Discord embed image on both paths", () => {
+		for (const templated of [null, TEMPLATED]) {
+			assert.include(discordBody(withChart, templated), CHART_URL)
+		}
+	})
+
+	it("keeps the sparkline even when the image is present", () => {
+		// The image block does not render on a lock screen or in a push preview;
+		// the sparkline is what travels there.
+		assert.include(slackBody(withChart, null), SPARK)
+		assert.include(discordBody(withChart, null), SPARK)
+	})
+
+	it("emits no image block when there is no chart URL", () => {
+		for (const templated of [null, TEMPLATED]) {
+			assert.notInclude(slackBody(withSpark, templated), '"type":"image"')
+			assert.notInclude(discordBody(withSpark, templated), '"image"')
+		}
+	})
+
+	/**
+	 * The degrade path, and the reason every step of the chart feature returns
+	 * `null` rather than failing: no series must cost the picture and nothing
+	 * else. A message that fails to render because a warehouse read timed out is
+	 * a page that did not arrive.
+	 */
+	it("renders a complete message when there is no sparkline", () => {
+		for (const templated of [null, TEMPLATED]) {
+			const slackJson = slackBody(context, templated)
+			assert.notInclude(slackJson, "undefined")
+			assert.include(slackJson, "Maple Alerts")
+
+			const discordJson = discordBody(context, templated)
+			assert.notInclude(discordJson, "undefined")
+			assert.include(discordJson, "Maple Alerts")
+		}
+	})
+})

--- a/apps/api/src/services/alerts/system-tenant.ts
+++ b/apps/api/src/services/alerts/system-tenant.ts
@@ -1,0 +1,28 @@
+/**
+ * The tenant the alerting system reads warehouse data as.
+ *
+ * Alert evaluation, the checks read model and the public chart image all query
+ * on behalf of a schedule or a signed URL rather than a signed-in person, so
+ * there is no viewer whose tenant they could use. Each of them had grown its
+ * own identical copy of this, which is three places to keep a `root`-roled
+ * identity in step.
+ *
+ * It grants nothing on its own: every query still filters `OrgId`, and the org
+ * comes from the rule row or the signed claims, never from the caller.
+ */
+import { RoleName, UserId as UserIdSchema, type OrgId } from "@maple/domain/http"
+import { Schema } from "effect"
+import type { TenantContext } from "@/services/auth/AuthService"
+
+const decodeRoleName = Schema.decodeUnknownSync(RoleName)
+const decodeUserId = Schema.decodeUnknownSync(UserIdSchema)
+
+const SYSTEM_USER_ID = decodeUserId("system-alerting")
+const SYSTEM_ROLES = [decodeRoleName("root")]
+
+export const systemTenant = (orgId: OrgId): TenantContext => ({
+	orgId,
+	userId: SYSTEM_USER_ID,
+	roles: SYSTEM_ROLES,
+	authMode: "self_hosted",
+})

--- a/apps/web/src/og/alert-chart-card.ts
+++ b/apps/web/src/og/alert-chart-card.ts
@@ -1,0 +1,116 @@
+/**
+ * The chart image an alert notification links to, as a takumi node tree.
+ *
+ * Pure: no wasm, no I/O. `alert-chart.ts` rasterises whatever this returns,
+ * which keeps the layout decisions testable as a plain object.
+ *
+ * **Why the plot is an image inside the card.** takumi decodes SVG, so the plot
+ * geometry comes straight from `@maple/widgets`' renderer — but the usvg font
+ * database behind that decoder is not the one `registerFont` fills, so every
+ * glyph inside an SVG renders as nothing. All type is therefore composed here,
+ * as takumi nodes, around the plot rather than inside it. This is not a
+ * stylistic split; an SVG with `<text>` in it silently loses the text.
+ *
+ * **It is read small.** Slack renders an image block at roughly half this
+ * width, and on a phone less. That rules out an axis: four tick labels become
+ * four smudges. What survives is the shape of the line, the threshold rule, and
+ * four pieces of type — what it is, what it is now, what the limit is, and when.
+ */
+import { container, image, text, type Node } from "@takumi-rs/helpers"
+import {
+	PLOT_HEIGHT,
+	PLOT_WIDTH,
+	renderPlotSvg,
+	type StaticChartSpec,
+} from "@maple/widgets/chart/static-chart"
+
+/** Registered by `render.ts`; the alert card is monospace throughout. */
+const MONO_FONT = "Geist Mono"
+
+const PADDING = 16
+export const ALERT_CARD_WIDTH = PLOT_WIDTH + PADDING * 2
+/** Plot, plus one header row and one footer row with their gaps. */
+export const ALERT_CARD_HEIGHT = PLOT_HEIGHT + PADDING * 2 + 56
+
+const ROW_WIDTH = ALERT_CARD_WIDTH - PADDING * 2
+
+const COLOR = {
+	/** A step below `--card`, so the plot's own surface reads as an object on it. */
+	ground: "#17140f",
+	ink: "#e8e0d6",
+	muted: "#8a7f72",
+	/** `--destructive`, matching the threshold rule the plot draws. */
+	danger: "#ef2e43",
+} as const
+
+/**
+ * A row whose children sit at the two ends.
+ *
+ * `display: "flex"` is not decoration — takumi ignores `justifyContent`,
+ * `gap` and `alignItems` entirely without it, and lays the children out
+ * stacked at the origin instead. Explicit `width` for the same reason:
+ * `space-between` has nothing to distribute across an auto-width box.
+ */
+const spread = (children: ReadonlyArray<Node>): Node =>
+	container({
+		style: {
+			display: "flex",
+			width: ROW_WIDTH,
+			flexDirection: "row",
+			justifyContent: "space-between",
+			alignItems: "center",
+		},
+		children: [...children],
+	})
+
+const label = (value: string, size: number, color: string, weight?: number): Node =>
+	text(value, {
+		fontFamily: MONO_FONT,
+		fontSize: size,
+		color,
+		...(weight === undefined ? undefined : { fontWeight: weight }),
+		lineClamp: 1,
+	})
+
+/**
+ * The card for one alert chart.
+ *
+ * Throws only where {@link renderPlotSvg} does — on an empty series, which the
+ * caller has already excluded by the time it gets here.
+ */
+export const alertChartCardNode = (spec: StaticChartSpec): Node => {
+	const plot = renderPlotSvg(spec)
+	// Inlined rather than referenced: the renderer resolves external images
+	// through a loader, and a chart that needs a network fetch to draw itself
+	// would be a second way for this endpoint to fail.
+	const plotSrc = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(plot.svg)))}`
+
+	return container({
+		style: {
+			display: "flex",
+			width: ALERT_CARD_WIDTH,
+			height: ALERT_CARD_HEIGHT,
+			backgroundColor: COLOR.ground,
+			flexDirection: "column",
+			padding: PADDING,
+			gap: 10,
+		},
+		children: [
+			// What it is, and what it is now — the two things a reader glancing at a
+			// re-notification is actually checking.
+			spread([label(plot.title, 17, COLOR.ink, 600), label(plot.latest, 17, COLOR.ink, 600)]),
+			image({ src: plotSrc, width: PLOT_WIDTH, height: PLOT_HEIGHT }),
+			spread([
+				label(plot.start, 12, COLOR.muted),
+				// Dashes stand in for the rule's own dash pattern, since a legend
+				// swatch would cost a nested flex row for two pixels of ink.
+				label(
+					plot.threshold === null ? "" : `- - threshold ${plot.threshold.text}`,
+					12,
+					COLOR.danger,
+				),
+				label(plot.end, 12, COLOR.muted),
+			]),
+		],
+	})
+}

--- a/apps/web/src/og/alert-chart-card.ts
+++ b/apps/web/src/og/alert-chart-card.ts
@@ -44,6 +44,21 @@ const COLOR = {
 } as const
 
 /**
+ * Bytes to base64, in chunks.
+ *
+ * `String.fromCharCode(...bytes)` on a 20 KB SVG spreads twenty thousand
+ * arguments onto the stack, which is a RangeError waiting for a busy chart.
+ */
+const toBase64 = (bytes: Uint8Array): string => {
+	const CHUNK = 0x8000
+	let binary = ""
+	for (let i = 0; i < bytes.length; i += CHUNK) {
+		binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK))
+	}
+	return btoa(binary)
+}
+
+/**
  * A row whose children sit at the two ends.
  *
  * `display: "flex"` is not decoration — takumi ignores `justifyContent`,
@@ -83,7 +98,11 @@ export const alertChartCardNode = (spec: StaticChartSpec): Node => {
 	// Inlined rather than referenced: the renderer resolves external images
 	// through a loader, and a chart that needs a network fetch to draw itself
 	// would be a second way for this endpoint to fail.
-	const plotSrc = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(plot.svg)))}`
+	//
+	// `btoa` is Latin-1 only and the title can be any UTF-8, so the SVG is
+	// encoded to bytes first. (The old `btoa(unescape(encodeURIComponent(…)))`
+	// trick does the same thing via a function deprecated for two decades.)
+	const plotSrc = `data:image/svg+xml;base64,${toBase64(new TextEncoder().encode(plot.svg))}`
 
 	return container({
 		style: {

--- a/apps/web/src/og/alert-chart.ts
+++ b/apps/web/src/og/alert-chart.ts
@@ -1,0 +1,80 @@
+/**
+ * The alert chart image, served by the SPA's own Worker.
+ *
+ * Same shape as `renderShareOgImage`, and for the same reasons: the API owns
+ * every judgement (does this id verify, what series may it read), and this
+ * module only draws what it is handed. It exists on the web origin rather than
+ * the API's because that is where the takumi wasm and the Geist fonts already
+ * are — one renderer, two images.
+ *
+ * The fetchers of this URL are Slack's and Discord's servers and whatever mail
+ * client opens the email. None of them holds a Maple credential, which is why
+ * the endpoint behind it is unauthenticated and the id is signed instead.
+ */
+import { alertChartCardNode, ALERT_CARD_HEIGHT, ALERT_CARD_WIDTH } from "./alert-chart-card"
+import { renderNode, type AssetFetcher } from "./render"
+import type { StaticChartSpec } from "@maple/widgets/chart/static-chart"
+
+/** The API has to answer before an image request is worth abandoning. */
+const API_TIMEOUT_MS = 4000
+
+interface AlertChartSeriesResponse {
+	readonly title: string
+	readonly unit: StaticChartSpec["unit"]
+	readonly kind: StaticChartSpec["kind"]
+	readonly points: ReadonlyArray<readonly [number, number]>
+	readonly threshold: number | null
+	readonly breachSide: StaticChartSpec["breachSide"]
+}
+
+/**
+ * 404 with no body for everything that is not a renderable chart — a tampered
+ * id, a window whose checks have aged out, an API that did not answer. Uniform
+ * for the same reason the share image is: the status must not tell whoever kept
+ * a copy of the URL which of those it was.
+ */
+export const renderAlertChartImage = async (
+	apiBaseUrl: string,
+	chartId: string,
+	assets: AssetFetcher,
+): Promise<Response> => {
+	const notFound = new Response(null, { status: 404 })
+
+	let series: AlertChartSeriesResponse
+	try {
+		const response = await fetch(new URL("/v2/share/alert-chart", apiBaseUrl), {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ chartId }),
+			signal: AbortSignal.timeout(API_TIMEOUT_MS),
+		})
+		if (!response.ok) return notFound
+		series = (await response.json()) as AlertChartSeriesResponse
+	} catch {
+		return notFound
+	}
+
+	if (series.points.length === 0) return notFound
+
+	let png: Uint8Array
+	try {
+		png = await renderNode(alertChartCardNode(series), assets, {
+			width: ALERT_CARD_WIDTH,
+			height: ALERT_CARD_HEIGHT,
+		})
+	} catch {
+		// A render that throws must not become a 500 in a chat client's image
+		// slot, where it shows as a broken-image glyph next to a real alert.
+		return notFound
+	}
+
+	return new Response(png as BodyInit, {
+		headers: {
+			"content-type": "image/png",
+			// The window is pinned by the signature and `alert_checks` is
+			// append-only, so these bytes are immutable — the long edge TTL is what
+			// keeps a link doing the rounds in a channel to one warehouse read.
+			"cache-control": "public, max-age=3600, s-maxage=604800, immutable",
+		},
+	})
+}

--- a/apps/web/src/og/render.ts
+++ b/apps/web/src/og/render.ts
@@ -72,8 +72,22 @@ export const renderOgCard = async (
 	node: Node,
 	assets: AssetFetcher,
 	images: ReadonlyArray<EmbeddedImage> = [],
+): Promise<Uint8Array> => renderNode(node, assets, { width: CARD_WIDTH, height: CARD_HEIGHT }, images)
+
+/**
+ * Rasterise a node tree at an arbitrary size.
+ *
+ * The OG card is one fixed 1200×630 because that is what the `og:image:*` tags
+ * advertise; the alert chart is a different shape entirely, and both share the
+ * one expensive thing here — the module-scoped renderer and its fonts.
+ */
+export const renderNode = async (
+	node: Node,
+	assets: AssetFetcher,
+	size: { readonly width: number; readonly height: number },
+	images: ReadonlyArray<EmbeddedImage> = [],
 ): Promise<Uint8Array> => {
 	renderer ??= makeRenderer(assets)
 	const engine = await renderer
-	return engine.render(node, { width: CARD_WIDTH, height: CARD_HEIGHT, images: [...images] })
+	return engine.render(node, { ...size, images: [...images] })
 }

--- a/apps/web/src/og/share-links.test.ts
+++ b/apps/web/src/og/share-links.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+	alertChartIdFromPath,
 	escapeAttribute,
 	ogIdFromPath,
 	ogMetaAdditions,
@@ -81,5 +82,38 @@ describe("ogMetaAdditions", () => {
 describe("escapeAttribute", () => {
 	it("escapes ampersands before the entities it introduces", () => {
 		expect(escapeAttribute(`a & "b" <c>`)).toBe("a &amp; &quot;b&quot; &lt;c&gt;")
+	})
+})
+
+describe("alertChartIdFromPath", () => {
+	// A signed chart id is base64url + "." + signature, so unlike a share OG id
+	// it legitimately contains a dot. Only the trailing `.png` is the extension.
+	const ID = "eyJhIjoxfQ.s1gn4tur3"
+
+	it("reads the id out of the image path", () => {
+		expect(alertChartIdFromPath(`/alerts/chart/${ID}.png`)).toBe(ID)
+	})
+
+	it("ignores the SPA's own alert routes", () => {
+		// `/alerts` is a real page. Matching it here would answer a navigation
+		// with a PNG.
+		expect(alertChartIdFromPath("/alerts")).toBeUndefined()
+		expect(alertChartIdFromPath("/alerts/rule_1")).toBeUndefined()
+		expect(alertChartIdFromPath("/alerts/chart/")).toBeUndefined()
+	})
+
+	it("rejects an id carrying path structure", () => {
+		expect(alertChartIdFromPath(`/alerts/chart/../${ID}.png`)).toBeUndefined()
+		expect(alertChartIdFromPath("/alerts/chart/a/b.png")).toBeUndefined()
+	})
+
+	it("requires the .png extension", () => {
+		expect(alertChartIdFromPath(`/alerts/chart/${ID}`)).toBeUndefined()
+		expect(alertChartIdFromPath(`/alerts/chart/${ID}.jpg`)).toBeUndefined()
+	})
+
+	it("does not collide with the share image path", () => {
+		expect(alertChartIdFromPath("/share/og/abc.png")).toBeUndefined()
+		expect(ogIdFromPath(`/alerts/chart/${ID}.png`)).toBeUndefined()
 	})
 })

--- a/apps/web/src/og/share-links.ts
+++ b/apps/web/src/og/share-links.ts
@@ -75,3 +75,24 @@ export const ogMetaAdditions = (meta: ShareOgMeta): string =>
 	`<meta property="og:image:width" content="${OG_IMAGE_WIDTH}" />` +
 	`<meta property="og:image:height" content="${OG_IMAGE_HEIGHT}" />` +
 	`<meta property="og:image:alt" content="${escapeAttribute(meta.title)}" />`
+
+const ALERT_CHART_PREFIX = "/alerts/chart/"
+const ALERT_CHART_SUFFIX = ".png"
+
+/**
+ * The signed chart id in an `/alerts/chart/<id>.png` path, or `undefined`.
+ *
+ * The id is base64url plus a `.` plus a signature, so unlike a share OG id it
+ * legitimately contains a dot — only the `.png` at the very end is the
+ * extension. A `/` anywhere is rejected: the id is one path segment, and
+ * anything with structure in it is not one this repo minted.
+ */
+export const alertChartIdFromPath = (pathname: string): string | undefined => {
+	if (!pathname.startsWith(ALERT_CHART_PREFIX) || !pathname.endsWith(ALERT_CHART_SUFFIX)) {
+		return undefined
+	}
+	const id = decodeURIComponent(
+		pathname.slice(ALERT_CHART_PREFIX.length, pathname.length - ALERT_CHART_SUFFIX.length),
+	)
+	return id.length === 0 || id.includes("/") ? undefined : id
+}

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -1,4 +1,5 @@
-import { ogIdFromPath, shareTokenFromPath } from "./og/share-links"
+import { alertChartIdFromPath, ogIdFromPath, shareTokenFromPath } from "./og/share-links"
+import { renderAlertChartImage } from "./og/alert-chart"
 import { fetchShareOgMeta, renderShareOgImage, shareOgMetaRewriter } from "./og/share-preview"
 
 type Env = {
@@ -92,6 +93,16 @@ export default {
 			return env.MAPLE_API_BASE_URL === undefined
 				? new Response(null, { status: 404 })
 				: renderShareOgImage(env.MAPLE_API_BASE_URL, ogId, env.ASSETS)
+		}
+
+		// Also ahead of the assets lookup, and for the same reason: `/alerts/…` is
+		// a real SPA route, so the shell would answer this path with HTML in an
+		// `<img>` slot rather than a 404 anyone could diagnose.
+		const chartId = alertChartIdFromPath(url.pathname)
+		if (chartId !== undefined) {
+			return env.MAPLE_API_BASE_URL === undefined
+				? new Response(null, { status: 404 })
+				: renderAlertChartImage(env.MAPLE_API_BASE_URL, chartId, env.ASSETS)
 		}
 
 		const assetResponse = await env.ASSETS.fetch(request)

--- a/packages/db/src/share-token-hash.test.ts
+++ b/packages/db/src/share-token-hash.test.ts
@@ -76,7 +76,7 @@ const claims = {
 	unit: "percent",
 	threshold: 2,
 	breachSide: "above",
-}
+} as const
 
 /** What `claims` looks like coming back out — ids undecoded, by design. */
 const verified = {

--- a/packages/db/src/share-token-hash.test.ts
+++ b/packages/db/src/share-token-hash.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest"
 import {
+	alertChartId,
 	generateShareToken,
 	hashShareToken,
 	shareOgId,
 	shareTokenSuffix,
+	verifyAlertChartId,
 	verifyShareOgId,
 } from "./share-token-hash"
 
@@ -54,5 +56,89 @@ describe("shareOgId", () => {
 		// A short signature must not reach `timingSafeEqual`, which throws on a
 		// length mismatch.
 		expect(verifyShareOgId(`${Buffer.from(SHARE_ID).toString("base64url")}.short`, KEY)).toBeUndefined()
+	})
+})
+
+const claims = {
+	orgId: "org_1",
+	ruleId: "rule_1",
+	groupKey: "checkout-api",
+	fromMs: Date.UTC(2026, 7, 18, 13, 0),
+	toMs: Date.UTC(2026, 7, 18, 14, 0),
+	title: "Error Rate · checkout-api",
+	unit: "percent",
+	threshold: 2,
+	breachSide: "above",
+}
+
+/**
+ * Re-signs nothing: it swaps one claim inside an id and keeps the original
+ * signature, which is exactly the forgery `verifyAlertChartId` must refuse.
+ *
+ */
+const tamperAlertChartClaim = (id: string, index: number, value: unknown): string => {
+	// SAFETY: `alertChartId` always emits exactly `<payload>.<signature>`.
+	const [encoded, signature] = id.split(".") as [string, string]
+	// SAFETY: the payload is the array `encodeAlertChartClaims` just wrote.
+	const claims = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as unknown[]
+	claims[index] = value
+	return `${Buffer.from(JSON.stringify(claims), "utf8").toString("base64url")}.${signature}`
+}
+
+describe("alertChartId", () => {
+	it("round-trips the claims", () => {
+		expect(verifyAlertChartId(alertChartId(claims, KEY), KEY)).toEqual(claims)
+	})
+
+	it("round-trips an ungrouped rule's null group", () => {
+		const ungrouped = { ...claims, groupKey: null }
+		expect(verifyAlertChartId(alertChartId(ungrouped, KEY), KEY)).toEqual(ungrouped)
+	})
+
+	it("is deterministic, so a redelivery renders the same image", () => {
+		expect(alertChartId(claims, KEY)).toBe(alertChartId(claims, KEY))
+	})
+
+	it("rejects an id minted under a different key", () => {
+		expect(verifyAlertChartId(alertChartId(claims, "other-key"), KEY)).toBeUndefined()
+	})
+
+	it("rejects a widened window, which is what stops an arbitrary-range scan", () => {
+		// The window is signed precisely so a holder of the URL cannot turn a
+		// one-hour chart into a one-year warehouse scan.
+		const forged = tamperAlertChartClaim(alertChartId(claims, KEY), 3, 0)
+		expect(verifyAlertChartId(forged, KEY)).toBeUndefined()
+	})
+
+	it("rejects a lowered threshold, so an image cannot be made to look worse", () => {
+		// The threshold is signed, so a delivered alert's picture cannot be
+		// re-pointed at a different line after the fact.
+		const forged = tamperAlertChartClaim(alertChartId(claims, KEY), 7, 0.1)
+		expect(verifyAlertChartId(forged, KEY)).toBeUndefined()
+	})
+
+	it("rejects a rewritten title, which is what stops the URL drawing arbitrary words", () => {
+		const forged = tamperAlertChartClaim(alertChartId(claims, KEY), 5, "Everything is fine")
+		expect(verifyAlertChartId(forged, KEY)).toBeUndefined()
+	})
+
+	it("rejects a swapped rule id", () => {
+		const id = alertChartId(claims, KEY)
+		const other = alertChartId({ ...claims, ruleId: "rule_2" }, KEY)
+		const forged = `${id.split(".")[0]}.${other.split(".")[1]}`
+		expect(verifyAlertChartId(forged, KEY)).toBeUndefined()
+	})
+
+	it("rejects malformed ids without throwing", () => {
+		for (const bad of ["", ".", "nodot", ".onlysig", "a.b", "!!!.???"]) {
+			expect(verifyAlertChartId(bad, KEY)).toBeUndefined()
+		}
+	})
+
+	it("does not accept a share OG id, and vice versa", () => {
+		// Distinct domain-separation labels: a signature minted to render a
+		// dashboard preview must not render an alert chart.
+		expect(verifyAlertChartId(shareOgId("share_1", KEY), KEY)).toBeUndefined()
+		expect(verifyShareOgId(alertChartId(claims, KEY), KEY)).toBeUndefined()
 	})
 })

--- a/packages/db/src/share-token-hash.test.ts
+++ b/packages/db/src/share-token-hash.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest"
+import { Schema } from "effect"
+import { AlertRuleId, OrgId } from "@maple/domain/primitives"
 import {
 	alertChartId,
 	generateShareToken,
@@ -59,9 +61,14 @@ describe("shareOgId", () => {
 	})
 })
 
+// Decoded, not cast: `AlertRuleId` is a UUID brand, so a placeholder like
+// "rule_1" is not merely untyped here — it is not a valid id at all.
+const ORG_ID = Schema.decodeUnknownSync(OrgId)("org_3Aui9f2b6a8e")
+const RULE_ID = Schema.decodeUnknownSync(AlertRuleId)("1f2b6a8e-6c1b-4f2a-9f6e-1d2c3b4a5e6f")
+
 const claims = {
-	orgId: "org_1",
-	ruleId: "rule_1",
+	orgId: ORG_ID,
+	ruleId: RULE_ID,
 	groupKey: "checkout-api",
 	fromMs: Date.UTC(2026, 7, 18, 13, 0),
 	toMs: Date.UTC(2026, 7, 18, 14, 0),
@@ -69,6 +76,19 @@ const claims = {
 	unit: "percent",
 	threshold: 2,
 	breachSide: "above",
+}
+
+/** What `claims` looks like coming back out — ids undecoded, by design. */
+const verified = {
+	rawOrgId: ORG_ID as string,
+	rawRuleId: RULE_ID as string,
+	groupKey: claims.groupKey,
+	fromMs: claims.fromMs,
+	toMs: claims.toMs,
+	title: claims.title,
+	unit: claims.unit,
+	threshold: claims.threshold,
+	breachSide: claims.breachSide,
 }
 
 /**
@@ -86,13 +106,18 @@ const tamperAlertChartClaim = (id: string, index: number, value: unknown): strin
 }
 
 describe("alertChartId", () => {
-	it("round-trips the claims", () => {
-		expect(verifyAlertChartId(alertChartId(claims, KEY), KEY)).toEqual(claims)
+	it("round-trips the claims, with the ids left undecoded", () => {
+		// The signature proves we minted it; it does not decode an entity id, so
+		// they come back as `raw*` for the caller to parse at its boundary.
+		expect(verifyAlertChartId(alertChartId(claims, KEY), KEY)).toEqual(verified)
 	})
 
 	it("round-trips an ungrouped rule's null group", () => {
 		const ungrouped = { ...claims, groupKey: null }
-		expect(verifyAlertChartId(alertChartId(ungrouped, KEY), KEY)).toEqual(ungrouped)
+		expect(verifyAlertChartId(alertChartId(ungrouped, KEY), KEY)).toEqual({
+			...verified,
+			groupKey: null,
+		})
 	})
 
 	it("is deterministic, so a redelivery renders the same image", () => {
@@ -124,7 +149,13 @@ describe("alertChartId", () => {
 
 	it("rejects a swapped rule id", () => {
 		const id = alertChartId(claims, KEY)
-		const other = alertChartId({ ...claims, ruleId: "rule_2" }, KEY)
+		const other = alertChartId(
+			{
+				...claims,
+				ruleId: Schema.decodeUnknownSync(AlertRuleId)("2f2b6a8e-6c1b-4f2a-9f6e-1d2c3b4a5e6f"),
+			},
+			KEY,
+		)
 		const forged = `${id.split(".")[0]}.${other.split(".")[1]}`
 		expect(verifyAlertChartId(forged, KEY)).toBeUndefined()
 	})

--- a/packages/db/src/share-token-hash.ts
+++ b/packages/db/src/share-token-hash.ts
@@ -1,5 +1,7 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto"
 import type { AlertRuleId, OrgId } from "@maple/domain/primitives"
+import { AlertChartBreachSide, AlertChartUnit } from "@maple/domain/http"
+import { Result, Schema } from "effect"
 
 const SHARE_TOKEN_PREFIX = "mshare_"
 
@@ -111,11 +113,10 @@ export interface AlertChartClaims {
 	readonly toMs: number
 	/** What the card is titled — the rule's measured quantity, as the message names it. */
 	readonly title: string
-	/** Chart unit, as the static renderer names them. */
-	readonly unit: string
+	readonly unit: AlertChartUnit
 	readonly threshold: number | null
-	/** `"above" | "below" | "none"` — which side of the threshold to shade. */
-	readonly breachSide: string
+	/** Which side of the threshold the renderer shades. */
+	readonly breachSide: AlertChartBreachSide
 }
 
 /**
@@ -139,6 +140,32 @@ export interface VerifiedAlertChartClaims extends Omit<AlertChartClaims, "orgId"
  * insertion order, so a caller that built the claims differently would produce
  * a different signature for the same claims.
  */
+/**
+ * The signed payload, positionally.
+ *
+ * A tuple rather than an object because the bytes are what is signed: object
+ * key order is insertion order, so two callers building the same claims in a
+ * different order would produce different signatures for the same claims. The
+ * positions are the format — appending is safe, reordering is a break.
+ *
+ * Declared as a schema so verification *decodes* rather than hand-checking
+ * nine `typeof`s, and so `unit` and `breachSide` come back as their literal
+ * unions instead of `string` the caller has to re-narrow.
+ */
+const AlertChartPayload = Schema.Tuple([
+	Schema.String,
+	Schema.String,
+	Schema.NullOr(Schema.String),
+	Schema.Number,
+	Schema.Number,
+	Schema.String,
+	AlertChartUnit,
+	Schema.NullOr(Schema.Number),
+	AlertChartBreachSide,
+])
+
+const decodeAlertChartPayload = Schema.decodeUnknownResult(Schema.fromJsonString(AlertChartPayload))
+
 const encodeAlertChartClaims = (claims: AlertChartClaims): string =>
 	JSON.stringify([
 		claims.orgId,
@@ -192,20 +219,11 @@ export const verifyAlertChartId = (id: string, hmacKey: string): VerifiedAlertCh
 	if (!timingSafeEqual(presented, expected)) return undefined
 
 	// Reached only for a payload this repo signed, so the shape is ours — but it
-	// is still parsed rather than trusted, because a decode failure here must be
-	// "no chart", not a thrown error inside an image request.
-	try {
-		const parsed: unknown = JSON.parse(payload)
-		if (!Array.isArray(parsed) || parsed.length !== 9) return undefined
-		const [rawOrgId, rawRuleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide] = parsed
-		if (typeof rawOrgId !== "string" || typeof rawRuleId !== "string") return undefined
-		if (groupKey !== null && typeof groupKey !== "string") return undefined
-		if (typeof fromMs !== "number" || typeof toMs !== "number") return undefined
-		if (typeof title !== "string" || typeof unit !== "string") return undefined
-		if (threshold !== null && typeof threshold !== "number") return undefined
-		if (typeof breachSide !== "string") return undefined
-		return { rawOrgId, rawRuleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide }
-	} catch {
-		return undefined
-	}
+	// is decoded rather than trusted. A signature written by an older or newer
+	// version of this format still verifies, and its payload still has to parse.
+	const decoded = decodeAlertChartPayload(payload)
+	if (Result.isFailure(decoded)) return undefined
+
+	const [rawOrgId, rawRuleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide] = decoded.success
+	return { rawOrgId, rawRuleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide }
 }

--- a/packages/db/src/share-token-hash.ts
+++ b/packages/db/src/share-token-hash.ts
@@ -77,3 +77,120 @@ export const verifyShareOgId = (ogId: string, hmacKey: string): string | undefin
 
 	return timingSafeEqual(presented, expected) ? shareId : undefined
 }
+
+/**
+ * Domain separation for the alert-chart id, distinct from `og:v1:` so a
+ * signature minted for a dashboard preview can never be replayed to render an
+ * alert chart, or the reverse.
+ */
+const ALERT_CHART_ID_LABEL = "alertchart:v1:"
+
+/**
+ * What an alert chart image is allowed to draw.
+ *
+ * The title, unit and threshold ride along with the window for the same reason
+ * the window does: pinning them is what makes an image drawn today still true
+ * next month. A rule that is renamed, re-thresholded or deleted afterwards does
+ * not retroactively change what a delivered alert said — and it also means the
+ * endpoint needs no rule lookup at all, only the series read.
+ *
+ * The window is part of the signed payload rather than a query parameter,
+ * which is the whole reason this feature needs no snapshot table: `alert_checks`
+ * is append-only with a year of retention, so a pinned window returns the same
+ * rows forever and the image is deterministic without storing its points. It is
+ * also what stops the URL becoming an arbitrary-range scan against the
+ * warehouse — a caller cannot widen `fromMs` without invalidating the signature.
+ */
+export interface AlertChartClaims {
+	readonly orgId: string
+	readonly ruleId: string
+	/** `null` for an ungrouped rule. */
+	readonly groupKey: string | null
+	readonly fromMs: number
+	readonly toMs: number
+	/** What the card is titled — the rule's measured quantity, as the message names it. */
+	readonly title: string
+	/** Chart unit, as the static renderer names them. */
+	readonly unit: string
+	readonly threshold: number | null
+	/** `"above" | "below" | "none"` — which side of the threshold to shade. */
+	readonly breachSide: string
+}
+
+/**
+ * Canonical, order-independent encoding of the claims.
+ *
+ * Hand-built rather than `JSON.stringify` of the object: key order there is
+ * insertion order, so a caller that built the claims differently would produce
+ * a different signature for the same claims.
+ */
+const encodeAlertChartClaims = (claims: AlertChartClaims): string =>
+	JSON.stringify([
+		claims.orgId,
+		claims.ruleId,
+		claims.groupKey,
+		claims.fromMs,
+		claims.toMs,
+		claims.title,
+		claims.unit,
+		claims.threshold,
+		claims.breachSide,
+	])
+
+const signAlertChartId = (payload: string, hmacKey: string): string =>
+	createHmac("sha256", hmacKey).update(`${ALERT_CHART_ID_LABEL}${payload}`, "utf8").digest("base64url")
+
+/**
+ * The public, opaque id of an alert notification's chart image.
+ *
+ * Unlike a share link this carries no credential at all — it is a rule id and a
+ * time range, signed. Anyone holding the URL can see one metric series, which
+ * is the same exposure a public dashboard share already accepts, and the
+ * signature is what keeps it to *that* series over *that* window.
+ */
+export const alertChartId = (claims: AlertChartClaims, hmacKey: string): string => {
+	const payload = encodeAlertChartClaims(claims)
+	const encoded = Buffer.from(payload, "utf8").toString("base64url")
+	return `${encoded}.${signAlertChartId(payload, hmacKey)}`
+}
+
+/**
+ * The claims inside an alert-chart id, or `undefined` if it does not verify.
+ *
+ * Constant-time for the same reason as `verifyShareOgId`: a presented signature
+ * is compared against a computed one, which is the shape a timing oracle needs.
+ * A malformed id fails identically to a tampered one — the caller gets no
+ * signal about which.
+ */
+export const verifyAlertChartId = (id: string, hmacKey: string): AlertChartClaims | undefined => {
+	const separator = id.indexOf(".")
+	if (separator <= 0) return undefined
+
+	const payload = Buffer.from(id.slice(0, separator), "base64url").toString("utf8")
+	if (payload.length === 0) return undefined
+
+	const presented = Buffer.from(id.slice(separator + 1), "utf8")
+	const expected = Buffer.from(signAlertChartId(payload, hmacKey), "utf8")
+	// `timingSafeEqual` throws on a length mismatch, which would itself be the
+	// oracle it exists to remove.
+	if (presented.length !== expected.length) return undefined
+	if (!timingSafeEqual(presented, expected)) return undefined
+
+	// Reached only for a payload this repo signed, so the shape is ours — but it
+	// is still parsed rather than trusted, because a decode failure here must be
+	// "no chart", not a thrown error inside an image request.
+	try {
+		const parsed: unknown = JSON.parse(payload)
+		if (!Array.isArray(parsed) || parsed.length !== 9) return undefined
+		const [orgId, ruleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide] = parsed
+		if (typeof orgId !== "string" || typeof ruleId !== "string") return undefined
+		if (groupKey !== null && typeof groupKey !== "string") return undefined
+		if (typeof fromMs !== "number" || typeof toMs !== "number") return undefined
+		if (typeof title !== "string" || typeof unit !== "string") return undefined
+		if (threshold !== null && typeof threshold !== "number") return undefined
+		if (typeof breachSide !== "string") return undefined
+		return { orgId, ruleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide }
+	} catch {
+		return undefined
+	}
+}

--- a/packages/db/src/share-token-hash.ts
+++ b/packages/db/src/share-token-hash.ts
@@ -1,4 +1,5 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto"
+import type { AlertRuleId, OrgId } from "@maple/domain/primitives"
 
 const SHARE_TOKEN_PREFIX = "mshare_"
 
@@ -102,8 +103,8 @@ const ALERT_CHART_ID_LABEL = "alertchart:v1:"
  * warehouse — a caller cannot widen `fromMs` without invalidating the signature.
  */
 export interface AlertChartClaims {
-	readonly orgId: string
-	readonly ruleId: string
+	readonly orgId: OrgId
+	readonly ruleId: AlertRuleId
 	/** `null` for an ungrouped rule. */
 	readonly groupKey: string | null
 	readonly fromMs: number
@@ -115,6 +116,20 @@ export interface AlertChartClaims {
 	readonly threshold: number | null
 	/** `"above" | "below" | "none"` — which side of the threshold to shade. */
 	readonly breachSide: string
+}
+
+/**
+ * What comes back out of a chart id, which is **not** the same type that went in.
+ *
+ * The signature proves this repo minted the payload; it does not make the
+ * strings inside it decoded entity ids. They arrived in a URL and came out of
+ * `JSON.parse`, so they are named `raw*` and stay unbranded — the caller decodes
+ * them at its boundary, and a value that fails to decode is a 404 rather than a
+ * brand that was asserted into existence.
+ */
+export interface VerifiedAlertChartClaims extends Omit<AlertChartClaims, "orgId" | "ruleId"> {
+	readonly rawOrgId: string
+	readonly rawRuleId: string
 }
 
 /**
@@ -162,7 +177,7 @@ export const alertChartId = (claims: AlertChartClaims, hmacKey: string): string 
  * A malformed id fails identically to a tampered one — the caller gets no
  * signal about which.
  */
-export const verifyAlertChartId = (id: string, hmacKey: string): AlertChartClaims | undefined => {
+export const verifyAlertChartId = (id: string, hmacKey: string): VerifiedAlertChartClaims | undefined => {
 	const separator = id.indexOf(".")
 	if (separator <= 0) return undefined
 
@@ -182,14 +197,14 @@ export const verifyAlertChartId = (id: string, hmacKey: string): AlertChartClaim
 	try {
 		const parsed: unknown = JSON.parse(payload)
 		if (!Array.isArray(parsed) || parsed.length !== 9) return undefined
-		const [orgId, ruleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide] = parsed
-		if (typeof orgId !== "string" || typeof ruleId !== "string") return undefined
+		const [rawOrgId, rawRuleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide] = parsed
+		if (typeof rawOrgId !== "string" || typeof rawRuleId !== "string") return undefined
 		if (groupKey !== null && typeof groupKey !== "string") return undefined
 		if (typeof fromMs !== "number" || typeof toMs !== "number") return undefined
 		if (typeof title !== "string" || typeof unit !== "string") return undefined
 		if (threshold !== null && typeof threshold !== "number") return undefined
 		if (typeof breachSide !== "string") return undefined
-		return { orgId, ruleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide }
+		return { rawOrgId, rawRuleId, groupKey, fromMs, toMs, title, unit, threshold, breachSide }
 	} catch {
 		return undefined
 	}

--- a/packages/domain/src/http/alerts.ts
+++ b/packages/domain/src/http/alerts.ts
@@ -1083,6 +1083,26 @@ export const AlertChartPoint = Schema.Tuple([Schema.Number, Schema.Number]).anno
 export const AlertChartBreachSide = Schema.Literals(["above", "below", "none"]).annotate({
 	identifier: "AlertChartBreachSide",
 })
+export type AlertChartBreachSide = Schema.Schema.Type<typeof AlertChartBreachSide>
+
+/**
+ * Chart unit, as the static renderer names them.
+ *
+ * The single authority for this list: it types the HTTP response *and* the
+ * signed chart id's payload in `@maple/db`, so the wire and the signature
+ * cannot disagree about what units exist. The renderer in `@maple/widgets`
+ * declares a structurally identical union — it sits below this package and
+ * cannot import it — and the two meet in `apps/web`, where a divergence is a
+ * type error rather than a runtime surprise.
+ */
+export const AlertChartUnit = Schema.Literals([
+	"number",
+	"percent",
+	"duration_ms",
+	"bytes",
+	"requests_per_sec",
+]).annotate({ identifier: "AlertChartUnit" })
+export type AlertChartUnit = Schema.Schema.Type<typeof AlertChartUnit>
 
 /**
  * Everything the image needs, and nothing else.
@@ -1093,8 +1113,7 @@ export const AlertChartBreachSide = Schema.Literals(["above", "below", "none"]).
  */
 export class AlertChartResponse extends Schema.Class<AlertChartResponse>("AlertChartResponse")({
 	title: Schema.String,
-	/** Chart unit, as the static renderer names them. */
-	unit: Schema.Literals(["number", "percent", "duration_ms", "bytes", "requests_per_sec"]),
+	unit: AlertChartUnit,
 	kind: Schema.Literals(["line", "area", "bar"]),
 	points: Schema.Array(AlertChartPoint),
 	threshold: Schema.NullOr(Schema.Number),

--- a/packages/domain/src/http/alerts.ts
+++ b/packages/domain/src/http/alerts.ts
@@ -1056,3 +1056,47 @@ export const ListRuleChecksQuery = Schema.Struct({
 		Schema.NumberFromString.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 2000 })),
 	),
 })
+
+/**
+ * The opaque, signed id of an alert notification's chart image (see
+ * `alertChartId` in `@maple/db`).
+ *
+ * Carries a rule id and a time window, signed — no credential, and nothing that
+ * can be turned into one. Loosely checked here because its structure is the
+ * signer's business: a malformed id fails verification, which is the same
+ * uniform "no such chart" as a tampered one.
+ */
+export const AlertChartId = Schema.String.check(Schema.isMinLength(3), Schema.isMaxLength(1024)).annotate({
+	identifier: "AlertChartId",
+})
+
+export const AlertChartRequest = Schema.Struct({
+	chartId: AlertChartId,
+}).annotate({ identifier: "AlertChartRequest" })
+
+/** `[epochMillis, value]`, oldest first. */
+export const AlertChartPoint = Schema.Tuple([Schema.Number, Schema.Number]).annotate({
+	identifier: "AlertChartPoint",
+})
+
+/** Which side of the threshold the renderer shades; `none` for range comparators. */
+export const AlertChartBreachSide = Schema.Literals(["above", "below", "none"]).annotate({
+	identifier: "AlertChartBreachSide",
+})
+
+/**
+ * Everything the image needs, and nothing else.
+ *
+ * Deliberately not the alert, the incident or the rule: this is fetched by
+ * whatever renders the picture, so it carries one series of numbers and the
+ * words drawn on the card. No org name, no destination, no incident id.
+ */
+export class AlertChartResponse extends Schema.Class<AlertChartResponse>("AlertChartResponse")({
+	title: Schema.String,
+	/** Chart unit, as the static renderer names them. */
+	unit: Schema.Literals(["number", "percent", "duration_ms", "bytes", "requests_per_sec"]),
+	kind: Schema.Literals(["line", "area", "bar"]),
+	points: Schema.Array(AlertChartPoint),
+	threshold: Schema.NullOr(Schema.Number),
+	breachSide: AlertChartBreachSide,
+}) {}

--- a/packages/domain/src/http/v2/openapi.test.ts
+++ b/packages/domain/src/http/v2/openapi.test.ts
@@ -198,6 +198,7 @@ describe("MapleApiV2 OpenAPI", () => {
 			"POST /v2/scrape_targets/{id}/probe",
 			"POST /v2/session_replays/for_trace",
 			"POST /v2/session_replays/search",
+			"POST /v2/share/alert-chart",
 			"POST /v2/share/og-card",
 			"POST /v2/share/og-meta",
 			"POST /v2/share/resolve",
@@ -252,6 +253,7 @@ describe("MapleApiV2 OpenAPI", () => {
 		"resolveShareWidgetData",
 		"resolveShareOgMeta",
 		"resolveShareOgCard",
+		"resolveAlertChart",
 	])
 
 	/**

--- a/packages/domain/src/http/v2/share.ts
+++ b/packages/domain/src/http/v2/share.ts
@@ -17,7 +17,7 @@
  *     middleware, not annotated, and it is accurate: no credential is required.
  *     An `org`-mode link *reads* a session token when one is present, but
  *     OpenAPI's `security` describes what is required, not what is consulted.
- *   - `openapi.test.ts` exempts these two operations from the "every operation
+ *   - `openapi.test.ts` exempts these operations from the "every operation
  *     is bearer-secured and declares a 401" invariant, by name. The exemption is
  *     an allowlist so a third public operation cannot appear silently.
  *
@@ -27,6 +27,12 @@
  * a span attribute, an access log, or a `Referer` — no tracer suppression rule
  * required.
  *
+ * `alertChart` is not about a shared dashboard at all — it lives here because
+ * this is the API's one unauthenticated surface, and it is unauthenticated for
+ * the same reason: the image is fetched by Slack's and Discord's servers, which
+ * hold no Maple credential. Like `ogCard` it takes a signed id, never a token,
+ * and that id pins the rule and the window it may read.
+ *
  * `ogCard` is the one operation that names a share without a token at all. It
  * cannot have one: it exists so a social-preview image can be drawn, and an
  * `og:image` is a URL that travels to every crawler and chat client that
@@ -34,6 +40,7 @@
  * not a credential and cannot be turned back into a token.
  */
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { AlertChartRequest, AlertChartResponse } from "../alerts"
 import {
 	ShareNotConfiguredError,
 	ShareNotFoundError,
@@ -144,6 +151,20 @@ export class V2SharePublicApiGroup extends HttpApiGroup.make("sharePublic")
 				summary: "Read what a share link's preview image draws",
 				description:
 					"Takes the signed image id from `og-meta`, never a share token, and returns the layout facts the preview image is drawn from. Revoked and org-only links resolve as not found, so an image URL stops working the moment its link does.",
+			}),
+		),
+	)
+	.add(
+		HttpApiEndpoint.post("alertChart", "/alert-chart", {
+			payload: AlertChartRequest,
+			success: AlertChartResponse,
+			error: [shareNotFound, shareRateLimited, shareNotConfigured, sharePersistence],
+		}).annotateMerge(
+			OpenApi.annotations({
+				identifier: "resolveAlertChart",
+				summary: "Read the series an alert notification's chart draws",
+				description:
+					"Takes the signed chart id embedded in a Slack, Discord or email alert and returns the observed values over the window that id pins. Unauthenticated for the same reason as the rest of this group: the image is fetched by Slack and Discord themselves, which carry no Maple credential.",
 			}),
 		),
 	)

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -4,7 +4,8 @@
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts",
-		"./dashboard": "./src/dashboard/index.ts"
+		"./dashboard": "./src/dashboard/index.ts",
+		"./chart/static-chart": "./src/chart/static-chart.ts"
 	},
 	"scripts": {
 		"test": "vitest run",

--- a/packages/widgets/src/chart/static-chart.test.ts
+++ b/packages/widgets/src/chart/static-chart.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest"
+import {
+	downsample,
+	formatValue,
+	niceTicks,
+	PLOT_HEIGHT,
+	renderPlotSvg,
+	sparkline,
+	type ChartPoint,
+} from "./static-chart"
+
+const at = (minutesAgo: number): number => Date.UTC(2026, 7, 18, 14, 32) - minutesAgo * 60_000
+
+const series = (values: ReadonlyArray<number>): ReadonlyArray<ChartPoint> =>
+	values.map((v, i) => [at(values.length - 1 - i), v] as ChartPoint)
+
+describe("formatValue", () => {
+	it("scales duration by magnitude", () => {
+		expect(formatValue(420, "duration_ms")).toBe("420 ms")
+		expect(formatValue(1500, "duration_ms")).toBe("1.5 s")
+		expect(formatValue(90_000, "duration_ms")).toBe("1.5 min")
+	})
+
+	it("keeps two decimals on sub-1% rates, where the difference is the alert", () => {
+		expect(formatValue(0.42, "percent")).toBe("0.42%")
+		expect(formatValue(4.2, "percent")).toBe("4.2%")
+	})
+})
+
+describe("niceTicks", () => {
+	it("spans zero to above the max", () => {
+		const ticks = niceTicks(0.4, 3.9)
+		expect(ticks[0]).toBe(0)
+		expect(ticks[ticks.length - 1]!).toBeGreaterThanOrEqual(3.9)
+	})
+
+	it("does not collapse when every value is identical", () => {
+		expect(niceTicks(5, 5).length).toBeGreaterThan(1)
+	})
+})
+
+describe("downsample", () => {
+	const spike = series([1, 1, 1, 9, 1, 1, 1, 1, 1, 1, 1, 1])
+
+	it("keeps the spike that an average would erase", () => {
+		const kept = downsample(spike, 5, "above")
+		expect(kept.map((p) => p[1])).toContain(9)
+		expect(kept.length).toBeLessThanOrEqual(5)
+	})
+
+	it("keeps the trough instead when the rule breaches downward", () => {
+		const dip = series([9, 9, 9, 1, 9, 9, 9, 9, 9, 9, 9, 9])
+		expect(downsample(dip, 5, "below").map((p) => p[1])).toContain(1)
+	})
+
+	it("always keeps the first and last point, so the range ends stay true", () => {
+		const kept = downsample(spike, 5, "above")
+		expect(kept[0]).toEqual(spike[0])
+		expect(kept[kept.length - 1]).toEqual(spike[spike.length - 1])
+	})
+
+	it("passes a series that already fits through untouched", () => {
+		const short = series([1, 2, 3])
+		expect(downsample(short, 10, "above")).toBe(short)
+	})
+})
+
+describe("renderPlotSvg", () => {
+	const spec = {
+		title: "checkout-api error rate",
+		kind: "area",
+		unit: "percent",
+		points: series([0.8, 1.2, 2.4, 3.9]),
+		threshold: 2,
+		breachSide: "above",
+	} as const
+
+	it("draws no text, because usvg renders none", () => {
+		expect(renderPlotSvg(spec).svg).not.toContain("<text")
+	})
+
+	it("returns the labels the caller has to draw instead", () => {
+		const render = renderPlotSvg(spec)
+		expect(render.title).toBe("checkout-api error rate")
+		expect(render.latest).toBe("3.9%")
+		expect(render.threshold?.text).toBe("2%")
+		expect(render.end).toContain("UTC")
+	})
+
+	it("places the threshold label on the rule it labels", () => {
+		const render = renderPlotSvg(spec)
+		const fraction = render.threshold?.yFraction ?? -1
+		expect(fraction).toBeGreaterThan(0)
+		expect(fraction).toBeLessThan(1)
+	})
+
+	it("keeps the threshold on the canvas when every observed value is below it", () => {
+		// The rule that matters most is the one nothing has reached yet; drawing
+		// it off the top edge is how a chart lies about how close a breach is.
+		const render = renderPlotSvg({ ...spec, points: series([0.1, 0.2, 0.15]), threshold: 90 })
+		const fraction = render.threshold?.yFraction ?? -1
+		expect(fraction).toBeGreaterThanOrEqual(0)
+		expect(fraction).toBeLessThanOrEqual(1)
+	})
+
+	it("shades the breaching side, and only when a side is meaningful", () => {
+		expect(renderPlotSvg(spec).svg).toContain('fill-opacity="0.06"')
+		expect(renderPlotSvg({ ...spec, breachSide: "none" }).svg).not.toContain('fill-opacity="0.06"')
+	})
+
+	it("omits the rule entirely when the spec has no threshold", () => {
+		const render = renderPlotSvg({ ...spec, threshold: null })
+		expect(render.threshold).toBeNull()
+		expect(render.svg).not.toContain("stroke-dasharray")
+	})
+
+	it("sorts unordered points rather than drawing a zigzag", () => {
+		const shuffled: ReadonlyArray<ChartPoint> = [
+			[at(0), 3],
+			[at(30), 1],
+			[at(15), 2],
+		]
+		const render = renderPlotSvg({ ...spec, kind: "line", points: shuffled })
+		expect(render.latest).toBe("3%")
+		expect(render.svg).toContain(`viewBox="0 0 720 ${PLOT_HEIGHT}"`)
+	})
+
+	it("refuses an empty series instead of shipping an empty card", () => {
+		expect(() => renderPlotSvg({ ...spec, points: [] })).toThrow(/at least one/)
+	})
+})
+
+describe("sparkline", () => {
+	it("renders one glyph per bucket, rising with the values", () => {
+		const spark = sparkline([1, 2, 3, 4, 5, 6, 7, 8])
+		expect(spark).toHaveLength(8)
+		expect(spark.at(0)).toBe("▁")
+		expect(spark.at(-1)).toBe("█")
+	})
+
+	it("stays flat rather than dividing by zero on a constant series", () => {
+		expect(sparkline([5, 5, 5])).toBe("▄▄▄")
+	})
+
+	it("is empty for no data, so callers can test it for truthiness", () => {
+		expect(sparkline([])).toBe("")
+	})
+
+	it("downsamples to the bucket cap", () => {
+		expect(
+			sparkline(
+				Array.from({ length: 500 }, (_, i) => i),
+				24,
+			).length,
+		).toBeLessThanOrEqual(24)
+	})
+})

--- a/packages/widgets/src/chart/static-chart.ts
+++ b/packages/widgets/src/chart/static-chart.ts
@@ -1,0 +1,373 @@
+/**
+ * Chart rendering with no DOM, no React and no chart library — for images that
+ * are rasterised server-side and pasted into Slack, Discord or an email.
+ *
+ * Two things make this different from the interactive charts in `@maple/ui`:
+ *
+ *   - **It emits an SVG string, not elements.** The consumers are Workers, not
+ *     browsers. `apps/web` rasterises the string with the takumi wasm it
+ *     already ships for OG cards.
+ *   - **It draws no text.** takumi decodes SVG through usvg, whose font
+ *     database is separate from the one `Renderer.registerFont` populates, so
+ *     every glyph inside an SVG image node renders as nothing — registering a
+ *     font changes the output not at all (verified: byte-identical PNGs).
+ *     Type has to be composed as takumi nodes *around* this SVG, so
+ *     {@link renderPlotSvg} returns the strings to draw and where, and draws
+ *     none of them itself.
+ *
+ * Fixed to the Maple dark theme: a PNG has no theme, and the product default
+ * is dark. Colors are the `.dark` values from `styles/tokens.css`, converted
+ * oklch → hex because usvg has no oklch parser.
+ *
+ * It lives in `@maple/widgets` rather than `@maple/ui` because both consumers
+ * are Workers: `apps/api` needs {@link sparkline} for message text and
+ * `apps/web` needs {@link renderPlotSvg} for the image. `@maple/ui` peer-depends
+ * on react, react-dom and tailwind, and no Worker in this repo imports it.
+ *
+ * A near-identical renderer lives at `apps/slack-agent/agent/lib/chart.ts`.
+ * That app is deliberately outside the workspace (`"!apps/slack-agent"` in the
+ * root `workspaces`) and so cannot import this; it also rasterises with
+ * `@resvg/resvg-js`, which *does* carry fonts, so it keeps drawing its own
+ * text and does not want this module's split. Treat the two as siblings, not
+ * as a copy to keep in sync.
+ */
+
+export type ChartKind = "line" | "area" | "bar"
+
+export type ChartUnit = "number" | "percent" | "duration_ms" | "bytes" | "requests_per_sec"
+
+/** `[epochMillis, value]`. Rendering sorts, so order is not a precondition. */
+export type ChartPoint = readonly [number, number]
+
+/** Which side of the threshold counts as breaching, for the shaded band. */
+export type BreachSide = "above" | "below" | "none"
+
+export interface StaticChartSpec {
+	readonly title: string
+	readonly kind: ChartKind
+	readonly unit: ChartUnit
+	readonly points: ReadonlyArray<ChartPoint>
+	/** Drawn as a dashed rule. Omit for a chart with no threshold to show. */
+	readonly threshold?: number | null
+	/**
+	 * Shades the breaching side of the threshold. `"none"` for comparators
+	 * where "beyond" is not a half-plane (`between`, `eq`, …) — the rule still
+	 * draws, the band does not.
+	 */
+	readonly breachSide?: BreachSide
+}
+
+/**
+ * A string the caller must draw as its own text node, and where to put it.
+ *
+ * `yFraction` is a fraction of the plot height from the top, so a caller that
+ * scales the SVG to a different box still lands the label on the rule.
+ */
+export interface PlotLabel {
+	readonly text: string
+	readonly yFraction: number
+}
+
+export interface PlotRender {
+	/** Self-contained SVG, `PLOT_WIDTH`×`PLOT_HEIGHT` viewBox, no `<text>`. */
+	readonly svg: string
+	readonly title: string
+	/** Latest value, formatted. The number the message is about. */
+	readonly latest: string
+	/** Threshold rule label, absent when the spec carries no threshold. */
+	readonly threshold: PlotLabel | null
+	/** Range ends, UTC. */
+	readonly start: string
+	readonly end: string
+}
+
+// Maple dark-theme tokens, oklch → hex (usvg has no oklch parser). Sources are
+// the `.dark` values in `packages/ui/src/styles/tokens.css`.
+const COLORS = {
+	/** --card oklch(0.224 0.009 75) — charts sit on cards in the product. */
+	surface: "#1e1b17",
+	/** --border oklch(0.268 0.012 67); the grid uses it at 50% like the web. */
+	border: "#2a2520",
+	/** --destructive, for the threshold rule and its breach band. */
+	danger: "#ef2e43",
+} as const
+
+/**
+ * Series color per unit, mirroring the web dashboards' semantic tokens:
+ * latency → --chart-p95 amber, throughput → --chart-throughput purple,
+ * error-rate percent → --chart-error red, bytes → --chart-4 teal,
+ * plain counts → --chart-p50 blue.
+ */
+const SERIES_COLORS: Record<ChartUnit, string> = {
+	duration_ms: "#e8872a",
+	requests_per_sec: "#9281e1",
+	percent: "#ef2e43",
+	bytes: "#00aa9a",
+	number: "#4a9eff",
+} satisfies Record<ChartUnit, string>
+
+export const PLOT_WIDTH = 720
+export const PLOT_HEIGHT = 280
+
+// No PAD_LEFT for y-tick labels: this chart has none. The threshold rule
+// carries the only value worth reading off an axis, and it is labelled
+// directly. A small inset keeps the marks off the card's stroke.
+const PAD = 12
+
+// ── formatting ──────────────────────────────────────────────────────────────
+
+const round = (n: number, digits = 1): string => {
+	const s = n.toFixed(digits)
+	return s.endsWith(".0") ? s.slice(0, -2) : s
+}
+
+/** Formats a value for labels, unit-aware. */
+export function formatValue(value: number, unit: ChartUnit): string {
+	switch (unit) {
+		case "percent":
+			return `${round(value, Math.abs(value) < 1 ? 2 : 1)}%`
+		case "duration_ms":
+			if (Math.abs(value) >= 60_000) return `${round(value / 60_000)} min`
+			if (Math.abs(value) >= 1000) return `${round(value / 1000)} s`
+			return `${round(value)} ms`
+		case "bytes": {
+			const abs = Math.abs(value)
+			if (abs >= 1024 ** 3) return `${round(value / 1024 ** 3)} GiB`
+			if (abs >= 1024 ** 2) return `${round(value / 1024 ** 2)} MiB`
+			if (abs >= 1024) return `${round(value / 1024)} KiB`
+			return `${round(value)} B`
+		}
+		case "requests_per_sec":
+			return `${formatValue(value, "number")}/s`
+		case "number": {
+			const abs = Math.abs(value)
+			if (abs >= 1_000_000) return `${round(value / 1_000_000)}M`
+			if (abs >= 1000) return `${round(value / 1000)}k`
+			return round(value, abs < 10 && !Number.isInteger(value) ? 1 : 0)
+		}
+	}
+}
+
+const pad2 = (n: number): string => String(n).padStart(2, "0")
+
+export function formatTimestamp(ms: number, rangeMs: number): string {
+	const d = new Date(ms)
+	const hhmm = `${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}`
+	if (rangeMs <= 36 * 3_600_000) return hhmm
+	return `${d.getUTCMonth() + 1}/${d.getUTCDate()} ${hhmm}`
+}
+
+// ── scales ──────────────────────────────────────────────────────────────────
+
+/** "Nice" tick values covering [0|min, max] — the grid, and the y domain. */
+export function niceTicks(min: number, max: number, count = 4): number[] {
+	const lo = Math.min(0, min)
+	const hi = max <= lo ? lo + 1 : max
+	const rawStep = (hi - lo) / count
+	const mag = 10 ** Math.floor(Math.log10(rawStep))
+	const step = [1, 2, 2.5, 5, 10].map((m) => m * mag).find((s) => s >= rawStep) ?? 10 * mag
+	const ticks: number[] = []
+	const start = Math.floor(lo / step) * step
+	const end = Math.ceil(hi / step) * step
+	for (let t = start; t <= end + step * 1e-9; t += step) {
+		ticks.push(Math.abs(t) < step * 1e-9 ? 0 : t)
+	}
+	return ticks
+}
+
+/**
+ * At most `max` points, keeping the first and last and the most extreme value
+ * in each stride.
+ *
+ * Averaging would be the obvious downsample and is the wrong one here: the
+ * whole reason to look at an alert chart is to see the excursion, and a mean
+ * is exactly the operation that hides it. Which extreme to keep follows the
+ * breaching side, so a spike survives on a `gt` rule and a collapse survives
+ * on a `lt` one.
+ */
+export function downsample(
+	points: ReadonlyArray<ChartPoint>,
+	max: number,
+	breachSide: BreachSide = "above",
+): ReadonlyArray<ChartPoint> {
+	if (points.length <= max || max < 3) return points
+	const sorted = [...points].sort((a, b) => a[0] - b[0])
+	const first = sorted[0]!
+	const last = sorted[sorted.length - 1]!
+	const inner = sorted.slice(1, -1)
+	const buckets = max - 2
+	const size = Math.ceil(inner.length / buckets)
+	const kept: ChartPoint[] = [first]
+	for (let i = 0; i < inner.length; i += size) {
+		const slice = inner.slice(i, i + size)
+		if (slice.length === 0) continue
+		const pick = slice.reduce((best, p) =>
+			breachSide === "below" ? (p[1] < best[1] ? p : best) : p[1] > best[1] ? p : best,
+		)
+		kept.push(pick)
+	}
+	kept.push(last)
+	return kept
+}
+
+// ── rendering ───────────────────────────────────────────────────────────────
+
+/**
+ * Plot geometry as an SVG string, plus the type the caller has to draw.
+ *
+ * Throws on an empty series: an alert chart with no points is a bug at the
+ * call site, and silently returning an empty card would ship it to a customer.
+ */
+export function renderPlotSvg(spec: StaticChartSpec): PlotRender {
+	const points = [...spec.points].sort((a, b) => a[0] - b[0])
+	if (points.length === 0) throw new Error("renderPlotSvg needs at least one data point.")
+
+	const threshold = spec.threshold ?? null
+	const breachSide = spec.breachSide ?? "none"
+
+	const values = points.map((p) => p[1])
+	// The threshold joins the domain so its rule is always on the canvas — a
+	// chart whose breach line sits off the top edge is worse than no chart.
+	const domain = threshold === null ? values : [...values, threshold]
+	const ticks = niceTicks(Math.min(...domain), Math.max(...domain))
+	const yMin = ticks[0]!
+	const yMax = ticks[ticks.length - 1]!
+	const tMin = points[0]![0]
+	const tMax = points[points.length - 1]![0]
+	const tRange = Math.max(1, tMax - tMin)
+
+	const plotW = PLOT_WIDTH - PAD * 2
+	const plotH = PLOT_HEIGHT - PAD * 2
+	const x = (t: number): number => PAD + ((t - tMin) / tRange) * plotW
+	const y = (v: number): number => PAD + plotH - ((v - yMin) / Math.max(1e-9, yMax - yMin)) * plotH
+
+	const series = SERIES_COLORS[spec.unit]
+	const parts: string[] = []
+
+	parts.push(
+		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${PLOT_WIDTH} ${PLOT_HEIGHT}" width="${PLOT_WIDTH}" height="${PLOT_HEIGHT}">`,
+		// Card canvas: --radius 8px + hairline --border, like a dashboard widget.
+		// Slack composes PNGs on light and dark backdrops alike; the border keeps
+		// the card edge legible on both.
+		`<rect x="0.5" y="0.5" width="${PLOT_WIDTH - 1}" height="${PLOT_HEIGHT - 1}" rx="8" fill="${COLORS.surface}" stroke="${COLORS.border}"/>`,
+	)
+
+	if (spec.kind === "area") {
+		// Web charts fill areas with a vertical series gradient (VerticalGradient
+		// in packages/ui, 0.8 → 0.1), not a flat tint.
+		parts.push(
+			`<defs><linearGradient id="areaFill" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stop-color="${series}" stop-opacity="0.8"/><stop offset="95%" stop-color="${series}" stop-opacity="0.1"/></linearGradient></defs>`,
+		)
+	}
+
+	// Recessive gridlines (border at 50%, matching the web's stroke-border/50;
+	// the baseline gets the full border). No labels — see PAD.
+	for (const tick of ticks) {
+		const ty = y(tick)
+		const isBaseline = tick === yMin
+		parts.push(
+			`<line x1="${PAD}" y1="${ty}" x2="${PLOT_WIDTH - PAD}" y2="${ty}" stroke="${COLORS.border}"${isBaseline ? "" : ' stroke-opacity="0.5"'} stroke-width="1"/>`,
+		)
+	}
+
+	// Breach band under the threshold rule, so the eye finds the excursion
+	// before it reads a single number.
+	if (threshold !== null && breachSide !== "none") {
+		const ty = y(threshold)
+		const bandTop = breachSide === "above" ? PAD : ty
+		const bandHeight = breachSide === "above" ? Math.max(0, ty - PAD) : Math.max(0, PAD + plotH - ty)
+		if (bandHeight > 0) {
+			parts.push(
+				`<rect x="${PAD}" y="${bandTop.toFixed(1)}" width="${plotW}" height="${bandHeight.toFixed(1)}" fill="${COLORS.danger}" fill-opacity="0.06"/>`,
+			)
+		}
+	}
+
+	if (spec.kind === "bar") {
+		// Band placement (bars imply regular buckets): each point owns a slot,
+		// with a ≥2px surface gap between bars and no overflow past the plot.
+		const slot = plotW / points.length
+		const barW = Math.max(1, Math.min(slot - 2, 40))
+		for (const [i, [, v]] of points.entries()) {
+			const bx = PAD + slot * (i + 0.5) - barW / 2
+			const by = y(Math.max(v, yMin))
+			const bh = Math.max(1, y(yMin) - by)
+			const r = Math.min(4, barW / 2, bh)
+			parts.push(
+				`<path d="M ${bx.toFixed(1)} ${(by + bh).toFixed(1)} V ${(by + r).toFixed(1)} Q ${bx.toFixed(1)} ${by.toFixed(1)} ${(bx + r).toFixed(1)} ${by.toFixed(1)} H ${(bx + barW - r).toFixed(1)} Q ${(bx + barW).toFixed(1)} ${by.toFixed(1)} ${(bx + barW).toFixed(1)} ${(by + r).toFixed(1)} V ${(by + bh).toFixed(1)} Z" fill="${series}"/>`,
+			)
+		}
+	} else {
+		const linePath = points
+			.map(([t, v], i) => `${i === 0 ? "M" : "L"} ${x(t).toFixed(1)} ${y(v).toFixed(1)}`)
+			.join(" ")
+		if (spec.kind === "area") {
+			parts.push(
+				`<path d="${linePath} L ${x(tMax).toFixed(1)} ${y(yMin).toFixed(1)} L ${x(tMin).toFixed(1)} ${y(yMin).toFixed(1)} Z" fill="url(#areaFill)"/>`,
+			)
+		}
+		parts.push(
+			`<path d="${linePath}" fill="none" stroke="${series}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>`,
+		)
+		// The latest value gets a dot with a 2px surface ring; its *number* is a
+		// label the caller draws, because this SVG cannot.
+		const [lt, lv] = points[points.length - 1]!
+		parts.push(
+			`<circle cx="${x(lt).toFixed(1)}" cy="${y(lv).toFixed(1)}" r="4" fill="${series}" stroke="${COLORS.surface}" stroke-width="2"/>`,
+		)
+	}
+
+	// Threshold rule last, so it reads above the marks.
+	if (threshold !== null) {
+		const ty = y(threshold)
+		parts.push(
+			`<line x1="${PAD}" y1="${ty.toFixed(1)}" x2="${PLOT_WIDTH - PAD}" y2="${ty.toFixed(1)}" stroke="${COLORS.danger}" stroke-width="1.5" stroke-dasharray="6 4"/>`,
+		)
+	}
+
+	parts.push("</svg>")
+
+	return {
+		svg: parts.join("\n"),
+		title: spec.title,
+		latest: formatValue(points[points.length - 1]![1], spec.unit),
+		threshold:
+			threshold === null
+				? null
+				: { text: formatValue(threshold, spec.unit), yFraction: (y(threshold) - PAD) / plotH },
+		start: formatTimestamp(tMin, tRange),
+		end: `${formatTimestamp(tMax, tRange)} UTC`,
+	}
+}
+
+// ── text-only fallback ──────────────────────────────────────────────────────
+
+const SPARK_LEVELS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] as const
+
+/**
+ * Unicode sparkline, for the places an image cannot go: a phone's lock screen,
+ * a push preview, and every degrade path where rendering or the series read
+ * failed. Downsamples to at most `maxBuckets` by averaging — unlike
+ * {@link downsample}, this one is smoothing 24 glyphs, not a plot.
+ */
+export function sparkline(values: readonly number[], maxBuckets = 24): string {
+	if (values.length === 0) return ""
+	const buckets: number[] = []
+	const size = Math.ceil(values.length / maxBuckets)
+	for (let i = 0; i < values.length; i += size) {
+		const slice = values.slice(i, i + size)
+		buckets.push(slice.reduce((a, b) => a + b, 0) / slice.length)
+	}
+	const min = Math.min(...buckets)
+	const max = Math.max(...buckets)
+	const range = max - min
+	return buckets
+		.map((v) => {
+			const idx =
+				range === 0
+					? 3
+					: Math.min(SPARK_LEVELS.length - 1, Math.floor(((v - min) / range) * SPARK_LEVELS.length))
+			return SPARK_LEVELS[idx]
+		})
+		.join("")
+}


### PR DESCRIPTION
A `trigger` message says what broke. A `renotify` repeated `4.2% > 2%` every thirty minutes and answered nothing — you could not tell recovering from worsening without opening Maple. Every notification now carries the shape of the metric over the incident so far, with the threshold drawn on it, plus a unicode sparkline that survives where images do not.

## Where the series comes from

`alert_checks` — the audit row the scheduler already writes on every evaluation. Deliberate, in order of how much it matters:

1. **It is what the alert saw.** A re-derived series can disagree with the number printed one line above it, and a chart that contradicts its own alert is worse than no chart.
2. It is a `list` scan keyed by the rule, not a re-aggregation of raw telemetry.
3. It carries `Status` per row, so "was this point breaching" needs no re-run of the comparator.

It works for BYO-ClickHouse orgs with no second code path: the write is pinned to managed Tinybird and `listRuleChecksQuery` declares `.routing("ingest")`, so both halves resolve the same pipeline.

## Why there is no snapshot table

`alert_checks` is append-only with 365-day retention, so a signed, window-pinned URL returns the same rows forever — determinism without storing anything. The title, unit, threshold and breach side are signed **along with** the window, which buys two things: the resolve endpoint needs no rule lookup at all, and a rule renamed, re-thresholded or deleted after delivery cannot retroactively change what an already-sent alert's picture says.

The trade is one warehouse read per uncached image GET instead of a write plus storage, bounded by a long-`s-maxage` edge cache (the bytes are immutable), the existing rate limiter, and the signature — which fixes the window, so the URL cannot become an arbitrary-range scan. Tests cover the forgeries: widening the window, lowering the threshold and rewriting the title all fail verification.

Encoding the points directly in the URL was rejected: it removes the second read, but URL length would then vary with the data across three providers with different caps.

## How the image is drawn

By the web worker, with the takumi wasm it already ships for OG cards — no new dependency.

takumi rasterises SVG but **drops every glyph inside it**: its usvg decoder has a font database separate from the one `registerFont` fills, and registering a font leaves the PNG byte-identical. So the plot geometry is SVG (`@maple/widgets/chart/static-chart`) and every label is a takumi node composed around it. That constraint also killed the y-axis: positioning ticks as nodes would mean exporting the projection maths purely to re-align text with grid lines, and four tick labels are four smudges at the size Slack renders an image block anyway. What survives is what it is, what it is now, the threshold, and the range ends.

The renderer lives in `@maple/widgets`, not `@maple/ui`: both consumers are Workers, and `@maple/ui` peer-depends on react, react-dom and tailwind.

## Failure is always the sparkline

A slow warehouse, a dead resolve endpoint or a renderer that throws costs the picture and never the page. `loadChartSeries` returns `null` for every problem it can have rather than failing, and the transports are asserted with and without a chart on both the default and templated paths. The sparkline ships regardless of the image, because an image block does not render on a lock screen or in a push preview.

Found while wiring it: the two Discord embed builders had already drifted apart, so they now share one footer helper.

## Not in this change

The `{{chartUrl}}` / `{{sparkline}}` template bindings and the per-org opt-out. As it stands the chart attaches to every alert with a chartable series **and** a configured `MAPLE_SHARE_TOKEN_HMAC_KEY`; without that key the URL is simply never minted and notifications go out with the sparkline alone. If the opt-out should land before this is enabled anywhere real, say so and it is a small follow-up.

## Verification

`lint` · `typecheck` (21 packages) · `test` (19 packages, incl. api 171 files / packages 35 / web 191) · `ios:openapi:check` · `check:tokens` · `clickhouse:schema:check` · web build + bundle budget (494.2 KB of 650 KB) — all green locally on this base.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789647853&installation_model_id=427786&pr_number=515&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F515&signature=6beb5728d62d16af1972a591799f99ea57e95c999997cbe5ade98a70a2b095ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->