### PR TITLE
chore(ingest): take the crate to zero clippy warnings under the new lint set

### DIFF
--- a/apps/ingest/Cargo.toml
+++ b/apps/ingest/Cargo.toml
@@ -80,6 +80,53 @@ default = []
 hotpath = ["hotpath/hotpath"]
 hotpath-alloc = ["hotpath/hotpath-alloc"]
 
+[lints.rust]
+unsafe_code = "deny"
+missing_debug_implementations = "warn"
+unreachable_pub = "warn"
+unused_qualifications = "warn"
+
+[lints.clippy]
+# groups first, negative priority so specific lints below can override
+pedantic = { level = "warn", priority = -1 }
+
+# --- the agent-specific ones ---
+allow_attributes = "deny"                # forces #[expect] instead of #[allow]
+allow_attributes_without_reason = "deny" # every suppression needs a justification
+todo = "deny"                            # no todo!() left behind
+unimplemented = "deny"
+dbg_macro = "deny"
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"
+unwrap_in_result = "warn"
+let_underscore_must_use = "warn"
+mem_forget = "deny"
+
+# --- clone / alloc slop ---
+redundant_clone = "warn"      # nursery
+assigning_clones = "warn"
+clone_on_ref_ptr = "warn"
+str_to_string = "warn"
+implicit_clone = "warn"
+
+# --- structural slop ---
+cognitive_complexity = "warn" # nursery
+excessive_nesting = "warn"
+unused_async = "warn"         # nursery
+unnecessary_wraps = "warn"
+wildcard_imports = "warn"
+use_self = "warn"             # nursery
+
+# --- pedantic noise to allow back ---
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+doc_markdown = "allow"
+similar_names = "allow"
+items_after_statements = "allow"
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
 

--- a/apps/ingest/benches/ingest_bench.rs
+++ b/apps/ingest/benches/ingest_bench.rs
@@ -1,3 +1,10 @@
+//! Throughput benchmarks for the ingest pipeline.
+#![expect(
+    clippy::expect_used,
+    reason = "a benchmark that cannot build its fixtures has nothing to measure, so failing \
+              loudly at setup is the intended behaviour"
+)]
+
 use std::collections::HashMap;
 use std::io::Read;
 use std::path::PathBuf;
@@ -76,7 +83,7 @@ fn bench_ingest_accept(c: &mut Criterion) {
     });
 
     group.finish();
-    let _ = std::fs::remove_dir_all(&fixture.queue_dir);
+    drop(std::fs::remove_dir_all(&fixture.queue_dir));
 }
 
 impl BenchFixture {
@@ -90,14 +97,14 @@ impl BenchFixture {
             .route("/v0/events", post(fake_tinybird_import))
             .with_state(fake_state);
         tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
+            drop(axum::serve(listener, app).await);
         });
 
         let queue_dir = unique_temp_dir("maple-ingest-bench-wal");
         let pipeline = TelemetryPipeline::new(
             TinybirdConfig {
                 endpoint: format!("http://{addr}"),
-                token: "bench-token".to_string(),
+                token: "bench-token".to_owned(),
                 queue_dir: queue_dir.clone(),
                 // Effectively uncapped: this benchmark measures accept latency
                 // (encode + WAL append + ack), not back-pressure. A single org
@@ -118,9 +125,9 @@ impl BenchFixture {
                 clickhouse_export_timeout: Duration::from_secs(5),
                 clickhouse_breaker: ClickHouseBreakerConfig::default(),
                 datasources: DatasourceNames::defaults(),
-                datasource_session_replays: "session_replays".to_string(),
-                datasource_session_replay_events: "session_replay_events".to_string(),
-                datasource_session_events: "session_events".to_string(),
+                datasource_session_replays: "session_replays".to_owned(),
+                datasource_session_replay_events: "session_replay_events".to_owned(),
+                datasource_session_events: "session_events".to_owned(),
             },
             Client::builder()
                 .timeout(Duration::from_secs(5))
@@ -167,7 +174,7 @@ fn build_logs(count: usize) -> ExportLogsServiceRequest {
             time_unix_nano: 1_700_000_000_000_000_000 + index as u64,
             observed_time_unix_nano: 1_700_000_000_000_000_000 + index as u64,
             severity_number: 9,
-            severity_text: "INFO".to_string(),
+            severity_text: "INFO".to_owned(),
             body: Some(AnyValue {
                 value: Some(any_value::Value::StringValue(format!(
                     "benchmark log {index}"
@@ -187,8 +194,8 @@ fn build_logs(count: usize) -> ExportLogsServiceRequest {
             }),
             scope_logs: vec![ScopeLogs {
                 scope: Some(InstrumentationScope {
-                    name: "criterion".to_string(),
-                    version: "1".to_string(),
+                    name: "criterion".to_owned(),
+                    version: "1".to_owned(),
                     attributes: Vec::new(),
                     dropped_attributes_count: 0,
                 }),
@@ -200,11 +207,17 @@ fn build_logs(count: usize) -> ExportLogsServiceRequest {
     }
 }
 
+/// A non-zero id byte for fixture span/trace ids. Wraps rather than truncating
+/// so a bench that builds more than 255 spans keeps producing valid ids.
+fn fixture_id_byte(index: usize) -> u8 {
+    u8::try_from(index % 255).unwrap_or(0) + 1
+}
+
 fn build_traces(count: usize) -> ExportTraceServiceRequest {
     let spans = (0..count)
         .map(|index| Span {
-            trace_id: vec![index as u8 + 1; 16],
-            span_id: vec![index as u8 + 1; 8],
+            trace_id: vec![fixture_id_byte(index); 16],
+            span_id: vec![fixture_id_byte(index); 8],
             name: format!("benchmark span {index}"),
             kind: span::SpanKind::Server as i32,
             start_time_unix_nano: 1_700_000_000_000_000_000 + index as u64,
@@ -223,8 +236,8 @@ fn build_traces(count: usize) -> ExportTraceServiceRequest {
             }),
             scope_spans: vec![ScopeSpans {
                 scope: Some(InstrumentationScope {
-                    name: "criterion".to_string(),
-                    version: "1".to_string(),
+                    name: "criterion".to_owned(),
+                    version: "1".to_owned(),
                     attributes: Vec::new(),
                     dropped_attributes_count: 0,
                 }),
@@ -238,9 +251,9 @@ fn build_traces(count: usize) -> ExportTraceServiceRequest {
 
 fn string_kv(key: &str, value: &str) -> KeyValue {
     KeyValue {
-        key: key.to_string(),
+        key: key.to_owned(),
         value: Some(AnyValue {
-            value: Some(any_value::Value::StringValue(value.to_string())),
+            value: Some(any_value::Value::StringValue(value.to_owned())),
         }),
     }
 }
@@ -248,8 +261,7 @@ fn string_kv(key: &str, value: &str) -> KeyValue {
 fn unique_temp_dir(prefix: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
+        .map_or(0, |duration| duration.as_nanos());
     std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()))
 }
 

--- a/apps/ingest/src/autumn.rs
+++ b/apps/ingest/src/autumn.rs
@@ -14,7 +14,7 @@ const AUTUMN_TRACK_PATH: &str = "/v1/balances.track";
 const AUTUMN_CHECK_PATH: &str = "/v1/balances.check";
 const AUTUMN_FINALIZE_PATH: &str = "/v1/balances.finalize";
 
-pub struct UsageEvent {
+pub(crate) struct UsageEvent {
     pub org_id: String,
     pub feature_id: &'static str,
     /// Quantity to bill for this event. Unit depends on `feature_id`: GB for
@@ -23,7 +23,7 @@ pub struct UsageEvent {
 }
 
 #[derive(Clone)]
-pub struct AutumnTracker {
+pub(crate) struct AutumnTracker {
     tx: mpsc::UnboundedSender<UsageEvent>,
 }
 
@@ -36,9 +36,9 @@ struct TrackRequest<'a> {
 }
 
 impl AutumnTracker {
-    pub fn spawn(secret_key: String, api_url: &str, flush_interval_secs: u64) -> Self {
+    pub(crate) fn spawn(secret_key: String, api_url: &str, flush_interval_secs: u64) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
-        let api_url = api_url.trim_end_matches('/').to_string();
+        let api_url = api_url.trim_end_matches('/').to_owned();
         let flush_interval = Duration::from_secs(flush_interval_secs);
 
         tokio::spawn(flush_loop(rx, secret_key, api_url, flush_interval));
@@ -48,12 +48,12 @@ impl AutumnTracker {
         Self { tx }
     }
 
-    pub fn track(&self, org_id: &str, feature_id: &'static str, value: f64) {
-        let _ = self.tx.send(UsageEvent {
-            org_id: org_id.to_string(),
+    pub(crate) fn track(&self, org_id: &str, feature_id: &'static str, value: f64) {
+        drop(self.tx.send(UsageEvent {
+            org_id: org_id.to_owned(),
             feature_id,
             value,
-        });
+        }));
     }
 }
 
@@ -92,6 +92,12 @@ impl PendingUsage {
     }
 }
 
+#[expect(
+    clippy::cognitive_complexity,
+    clippy::too_many_lines,
+    reason = "a `select!` loop whose arms are the accumulator's whole state machine; splitting an \
+              arm out hides which branch mutates what"
+)]
 async fn flush_loop(
     mut rx: mpsc::UnboundedReceiver<UsageEvent>,
     secret_key: String,
@@ -143,8 +149,8 @@ async fn flush_loop(
                         "peer.service" = "autumn",
                     );
                     let result: Result<reqwest::Response, reqwest::Error> = client
-                        .post(format!("{}{}", api_url, AUTUMN_TRACK_PATH))
-                        .header("Authorization", format!("Bearer {}", secret_key))
+                        .post(format!("{api_url}{AUTUMN_TRACK_PATH}"))
+                        .header("Authorization", format!("Bearer {secret_key}"))
                         .header("x-api-version", AUTUMN_API_VERSION)
                         .json(&body)
                         .send()
@@ -218,28 +224,25 @@ async fn flush_loop(
             }
 
             event = rx.recv() => {
-                match event {
-                    Some(event) => {
-                        let pending = accumulator
-                            .entry((event.org_id, event.feature_id))
-                            .or_insert_with(|| PendingUsage::new(0.0));
-                        if pending.sealed {
-                            pending.queued_value += event.value;
-                        } else {
-                            pending.value += event.value;
-                        }
+                if let Some(event) = event {
+                    let pending = accumulator
+                        .entry((event.org_id, event.feature_id))
+                        .or_insert_with(|| PendingUsage::new(0.0));
+                    if pending.sealed {
+                        pending.queued_value += event.value;
+                    } else {
+                        pending.value += event.value;
                     }
-                    None => {
-                        // Channel closed, do a final flush attempt
-                        if !accumulator.is_empty() {
-                            info!(
-                                pending_entries = accumulator.len(),
-                                "Autumn tracker shutting down, attempting final flush"
-                            );
-                            flush_all(&client, &secret_key, &api_url, &mut accumulator).await;
-                        }
-                        break;
+                } else {
+                    // Channel closed, do a final flush attempt
+                    if !accumulator.is_empty() {
+                        info!(
+                            pending_entries = accumulator.len(),
+                            "Autumn tracker shutting down, attempting final flush"
+                        );
+                        flush_all(&client, &secret_key, &api_url, &mut accumulator).await;
                     }
+                    break;
                 }
             }
         }
@@ -275,8 +278,8 @@ async fn flush_all(
             "peer.service" = "autumn",
         );
         let result: Result<reqwest::Response, reqwest::Error> = client
-            .post(format!("{}{}", api_url, AUTUMN_TRACK_PATH))
-            .header("Authorization", format!("Bearer {}", secret_key))
+            .post(format!("{api_url}{AUTUMN_TRACK_PATH}"))
+            .header("Authorization", format!("Bearer {secret_key}"))
             .header("x-api-version", AUTUMN_API_VERSION)
             .json(&body)
             .send()
@@ -319,7 +322,7 @@ async fn flush_all(
 /// storage; a failed storage write releases the lock. Plain `is_allowed` remains
 /// for replay payloads that belong to an already-metered browser session.
 #[derive(Clone)]
-pub struct AutumnEntitlements {
+pub(crate) struct AutumnEntitlements {
     client: maple_ingest::telemetry::HttpClient,
     secret_key: String,
     api_url: String,
@@ -351,11 +354,11 @@ struct FinalizeRequest<'a> {
 }
 
 #[derive(Debug)]
-pub struct AutumnReservation {
+pub(crate) struct AutumnReservation {
     lock_id: String,
 }
 
-pub enum AutumnReserveOutcome {
+pub(crate) enum AutumnReserveOutcome {
     Reserved(AutumnReservation),
     Denied,
     /// Autumn could not give a confirmed answer. The ingest path fails open and
@@ -364,13 +367,13 @@ pub enum AutumnReserveOutcome {
 }
 
 impl AutumnEntitlements {
-    pub fn new(
+    pub(crate) fn new(
         client: impl Into<maple_ingest::telemetry::HttpClient>,
         secret_key: String,
         api_url: &str,
     ) -> Self {
         let client = client.into();
-        let api_url = api_url.trim_end_matches('/').to_string();
+        let api_url = api_url.trim_end_matches('/').to_owned();
         info!("Autumn native billing enforcement enabled");
 
         Self {
@@ -382,7 +385,7 @@ impl AutumnEntitlements {
 
     /// Check without consuming usage. Decisions are intentionally not cached:
     /// Autumn customer controls can change, or cross a limit, on any event.
-    pub async fn is_allowed(&self, org_id: &str, feature_id: &str) -> bool {
+    pub(crate) async fn is_allowed(&self, org_id: &str, feature_id: &str) -> bool {
         tracing::Span::current().record("maple.ingest.cache_hit", false);
         self.post_check(org_id, feature_id, None, None)
             .await
@@ -391,18 +394,21 @@ impl AutumnEntitlements {
     }
 
     /// Atomically check and reserve an exact usage quantity.
-    pub async fn reserve(
+    pub(crate) async fn reserve(
         &self,
         org_id: &str,
         feature_id: &str,
         value: f64,
     ) -> AutumnReserveOutcome {
         let lock_id = Uuid::new_v4().to_string();
-        let expires_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64
-            + 120_000;
+        let expires_at = u64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis(),
+        )
+        .unwrap_or(u64::MAX)
+        .saturating_add(120_000);
         let lock = CheckLockRequest {
             lock_id: &lock_id,
             enabled: true,
@@ -421,7 +427,11 @@ impl AutumnEntitlements {
 
     /// Confirm a committed WAL write or release a failed one. A short retry
     /// handles transient downstream errors while the two-minute lock is valid.
-    pub async fn finalize(&self, reservation: &AutumnReservation, confirm: bool) -> bool {
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "one HTTP round trip plus the response classification it exists to do"
+    )]
+    pub(crate) async fn finalize(&self, reservation: &AutumnReservation, confirm: bool) -> bool {
         let action = if confirm { "confirm" } else { "release" };
         let body = FinalizeRequest {
             lock_id: &reservation.lock_id,
@@ -472,6 +482,10 @@ impl AutumnEntitlements {
         false
     }
 
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "one HTTP round trip plus the response classification it exists to do"
+    )]
     async fn post_check(
         &self,
         org_id: &str,
@@ -593,7 +607,7 @@ impl AutumnEntitlements {
 fn truncate_for_log(body: &str) -> String {
     const MAX: usize = 512;
     if body.len() <= MAX {
-        return body.to_string();
+        return body.to_owned();
     }
     // Step back to a char boundary so we never slice through a UTF-8 sequence.
     let mut end = MAX;
@@ -617,7 +631,8 @@ fn truncate_for_log(body: &str) -> String {
 /// control denies the next event. Older response shapes without `allowed` fall
 /// back to unlimited/overage/remaining for compatibility.
 fn decide_allowed(value: &serde_json::Value, required_balance: Option<f64>) -> Option<bool> {
-    let as_bool = |v: &serde_json::Value, key: &str| v.get(key).and_then(|x| x.as_bool());
+    let as_bool =
+        |v: &serde_json::Value, key: &str| v.get(key).and_then(serde_json::Value::as_bool);
 
     if let Some(allowed) = as_bool(value, "allowed") {
         return Some(allowed);
@@ -639,16 +654,19 @@ fn decide_allowed(value: &serde_json::Value, required_balance: Option<f64>) -> O
         }
         Some(serde_json::Value::Object(obj)) => {
             understood = true;
-            if obj.get("unlimited").and_then(|x| x.as_bool()) == Some(true) {
+            if obj.get("unlimited").and_then(serde_json::Value::as_bool) == Some(true) {
                 unlimited = true;
             }
-            if obj.get("overage_allowed").and_then(|x| x.as_bool()) == Some(true) {
+            if obj
+                .get("overage_allowed")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+            {
                 overage = true;
             }
-            remaining = obj.get("remaining").and_then(|x| x.as_f64());
+            remaining = obj.get("remaining").and_then(serde_json::Value::as_f64);
         }
-        Some(serde_json::Value::Null) | None => {}
-        Some(_) => {}
+        _ => {}
     }
 
     if !understood {
@@ -808,7 +826,7 @@ mod tests {
     #[test]
     fn unrecognized_shape_returns_none() {
         assert_eq!(decide(r#"{"error": "internal", "code": 500}"#), None);
-        assert_eq!(decide(r#"{}"#), None);
+        assert_eq!(decide(r"{}"), None);
     }
 
     #[tokio::test]
@@ -816,12 +834,12 @@ mod tests {
         // Port 1 is closed => connection refused => we must fail open (allow),
         // never dropping customer data on a billing-provider outage.
         let entitlements =
-            AutumnEntitlements::new(Client::new(), "sk_test".to_string(), "http://127.0.0.1:1");
+            AutumnEntitlements::new(Client::new(), "sk_test".to_owned(), "http://127.0.0.1:1");
         assert!(entitlements.is_allowed("org_123", "logs").await);
     }
 
     async fn record_check(
-        State(tx): State<tokio::sync::mpsc::UnboundedSender<(serde_json::Value, Option<String>)>>,
+        State(tx): State<mpsc::UnboundedSender<(serde_json::Value, Option<String>)>>,
         headers: axum::http::HeaderMap,
         body: String,
     ) -> axum::Json<serde_json::Value> {
@@ -829,7 +847,7 @@ mod tests {
             .get("x-api-version")
             .and_then(|value| value.to_str().ok())
             .map(str::to_owned);
-        let _ = tx.send((serde_json::from_str(&body).unwrap(), api_version));
+        drop(tx.send((serde_json::from_str(&body).unwrap(), api_version)));
         axum::Json(serde_json::json!({
             "allowed": true,
             "balance": {
@@ -842,7 +860,7 @@ mod tests {
 
     #[tokio::test]
     async fn check_uses_v23_canonical_route_and_header() {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::unbounded_channel();
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
             .await
             .unwrap();
@@ -856,7 +874,7 @@ mod tests {
 
         let entitlements = AutumnEntitlements::new(
             Client::new(),
-            "sk_test".to_string(),
+            "sk_test".to_owned(),
             &format!("http://{addr}"),
         );
         assert!(entitlements.is_allowed("org_123", "logs").await);
@@ -868,24 +886,24 @@ mod tests {
     }
 
     async fn record_atomic_check(
-        State(tx): State<tokio::sync::mpsc::UnboundedSender<(String, serde_json::Value)>>,
+        State(tx): State<mpsc::UnboundedSender<(String, serde_json::Value)>>,
         body: String,
     ) -> axum::Json<serde_json::Value> {
-        let _ = tx.send(("check".to_string(), serde_json::from_str(&body).unwrap()));
+        drop(tx.send(("check".to_owned(), serde_json::from_str(&body).unwrap())));
         axum::Json(serde_json::json!({ "allowed": true, "balance": 10 }))
     }
 
     async fn record_finalize(
-        State(tx): State<tokio::sync::mpsc::UnboundedSender<(String, serde_json::Value)>>,
+        State(tx): State<mpsc::UnboundedSender<(String, serde_json::Value)>>,
         body: String,
     ) -> axum::Json<serde_json::Value> {
-        let _ = tx.send(("finalize".to_string(), serde_json::from_str(&body).unwrap()));
+        drop(tx.send(("finalize".to_owned(), serde_json::from_str(&body).unwrap())));
         axum::Json(serde_json::json!({ "success": true }))
     }
 
     #[tokio::test]
     async fn reserve_tracks_exact_usage_under_a_lock_then_confirms() {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::unbounded_channel();
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
             .await
             .unwrap();
@@ -900,12 +918,13 @@ mod tests {
 
         let entitlements = AutumnEntitlements::new(
             Client::new(),
-            "sk_test".to_string(),
+            "sk_test".to_owned(),
             &format!("http://{addr}"),
         );
-        let reservation = match entitlements.reserve("org_123", "logs", 0.125).await {
-            AutumnReserveOutcome::Reserved(reservation) => reservation,
-            _ => panic!("usage should be reserved"),
+        let AutumnReserveOutcome::Reserved(reservation) =
+            entitlements.reserve("org_123", "logs", 0.125).await
+        else {
+            panic!("usage should be reserved")
         };
         assert!(entitlements.finalize(&reservation, true).await);
 
@@ -920,16 +939,18 @@ mod tests {
         assert_eq!(finalize["action"], "confirm");
     }
 
+    /// Every fake Autumn handler reports what it received down the same channel:
+    /// the decoded body, plus the `x-api-version` header if the client sent one.
+    type TrackSender = mpsc::UnboundedSender<(serde_json::Value, Option<String>)>;
+
     // One stable idempotency key per accumulated entry across retries.
 
     /// Stand-in for Autumn's `/v1/balances.track`. Records every body and API
     /// version it receives and answers with `status`, so a test can drive the
     /// flush loop through a failure and inspect what the retry sent.
     async fn record_track(
-        State((tx, status)): State<(
-            tokio::sync::mpsc::UnboundedSender<(serde_json::Value, Option<String>)>,
-            StatusCode,
-        )>,
+        State((tx, status)): State<(TrackSender, StatusCode)>,
+
         headers: axum::http::HeaderMap,
         body: String,
     ) -> StatusCode {
@@ -937,7 +958,7 @@ mod tests {
             .get("x-api-version")
             .and_then(|value| value.to_str().ok())
             .map(str::to_owned);
-        let _ = tx.send((serde_json::from_str(&body).unwrap(), api_version));
+        drop(tx.send((serde_json::from_str(&body).unwrap(), api_version)));
         status
     }
 
@@ -945,9 +966,9 @@ mod tests {
         status: StatusCode,
     ) -> (
         String,
-        tokio::sync::mpsc::UnboundedReceiver<(serde_json::Value, Option<String>)>,
+        mpsc::UnboundedReceiver<(serde_json::Value, Option<String>)>,
     ) {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::unbounded_channel();
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
             .await
             .unwrap();
@@ -962,10 +983,8 @@ mod tests {
     }
 
     async fn record_track_fail_once(
-        State((tx, attempts)): State<(
-            tokio::sync::mpsc::UnboundedSender<(serde_json::Value, Option<String>)>,
-            Arc<AtomicUsize>,
-        )>,
+        State((tx, attempts)): State<(TrackSender, Arc<AtomicUsize>)>,
+
         headers: axum::http::HeaderMap,
         body: String,
     ) -> StatusCode {
@@ -973,7 +992,7 @@ mod tests {
             .get("x-api-version")
             .and_then(|value| value.to_str().ok())
             .map(str::to_owned);
-        let _ = tx.send((serde_json::from_str(&body).unwrap(), api_version));
+        drop(tx.send((serde_json::from_str(&body).unwrap(), api_version)));
         if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
             StatusCode::INTERNAL_SERVER_ERROR
         } else {
@@ -983,9 +1002,9 @@ mod tests {
 
     async fn spawn_fail_once_autumn_stub() -> (
         String,
-        tokio::sync::mpsc::UnboundedReceiver<(serde_json::Value, Option<String>)>,
+        mpsc::UnboundedReceiver<(serde_json::Value, Option<String>)>,
     ) {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::unbounded_channel();
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
             .await
             .unwrap();
@@ -1004,7 +1023,7 @@ mod tests {
         // The bug this pins: a per-attempt key means Autumn cannot recognize the
         // retry of a track it already committed, and bills the usage twice.
         let (api_url, mut rx) = spawn_autumn_stub(StatusCode::INTERNAL_SERVER_ERROR).await;
-        let tracker = AutumnTracker::spawn("sk_test".to_string(), &api_url, 1);
+        let tracker = AutumnTracker::spawn("sk_test".to_owned(), &api_url, 1);
         tracker.track("org_retry", "logs", 1.5);
 
         let (first, first_api_version) = rx.recv().await.expect("first flush attempt");
@@ -1029,7 +1048,7 @@ mod tests {
         // usage for the same (org, feature) must not reuse its key — Autumn
         // would dedupe it away and we'd under-bill.
         let (api_url, mut rx) = spawn_autumn_stub(StatusCode::OK).await;
-        let tracker = AutumnTracker::spawn("sk_test".to_string(), &api_url, 1);
+        let tracker = AutumnTracker::spawn("sk_test".to_owned(), &api_url, 1);
 
         tracker.track("org_fresh", "traces", 2.0);
         let (first, first_api_version) = rx.recv().await.expect("first flush");
@@ -1046,7 +1065,7 @@ mod tests {
     #[tokio::test]
     async fn usage_after_a_failed_flush_waits_for_a_fresh_batch_key() {
         let (api_url, mut rx) = spawn_fail_once_autumn_stub().await;
-        let tracker = AutumnTracker::spawn("sk_test".to_string(), &api_url, 1);
+        let tracker = AutumnTracker::spawn("sk_test".to_owned(), &api_url, 1);
 
         tracker.track("org_queued", "metrics", 1.5);
         let (failed, _) = rx.recv().await.expect("failed first flush");

--- a/apps/ingest/src/bin/load_test.rs
+++ b/apps/ingest/src/bin/load_test.rs
@@ -1,3 +1,16 @@
+//! Load generator for the ingest gateway. Dev tooling, not part of the served
+//! binary.
+#![expect(
+    clippy::cast_precision_loss,
+    reason = "every f64 cast here widens a request/byte counter for rate and percentile math, \
+              where the counters stay many orders of magnitude below 2^53"
+)]
+#![expect(
+    clippy::expect_used,
+    reason = "a load generator that cannot start its own fixtures has nothing to measure, so \
+              failing loudly at setup is the intended behaviour"
+)]
+
 use std::collections::HashMap;
 use std::io::Read;
 use std::path::PathBuf;
@@ -113,7 +126,7 @@ async fn main() -> Result<(), DynError> {
     let monitor_pid = ingest.id();
     let monitor = tokio::spawn(async move { monitor_process(monitor_pid, sample_tx).await });
 
-    let payload = build_logs_payload(cfg.batch_logs)?;
+    let payload = build_logs_payload(cfg.batch_logs);
     let started = Instant::now();
     let (successes, failures, mut latencies) = run_load(&cfg, payload).await?;
     let request_duration = started.elapsed();
@@ -123,8 +136,8 @@ async fn main() -> Result<(), DynError> {
     wait_for_exported_rows(&fake_state, expected_rows).await?;
     let export_catchup = catchup_started.elapsed();
 
-    let _ = ingest.kill();
-    let _ = ingest.wait();
+    drop(ingest.kill());
+    drop(ingest.wait());
     monitor.abort();
 
     let monitor_summary = summarize_samples(sample_rx);
@@ -158,19 +171,20 @@ async fn main() -> Result<(), DynError> {
         }
     }
     enforce_thresholds(&cfg, &summary)?;
-    let _ = std::fs::remove_dir_all(&cfg.queue_dir);
+    drop(std::fs::remove_dir_all(&cfg.queue_dir));
     Ok(())
 }
 
 impl LoadConfig {
     fn from_env() -> Result<Self, DynError> {
-        let ingest_bin = std::env::var("LOAD_TEST_INGEST_BIN")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| {
+        let ingest_bin = std::env::var("LOAD_TEST_INGEST_BIN").map_or_else(
+            |_| {
                 std::env::current_exe()
                     .expect("current executable path")
                     .with_file_name(format!("maple-ingest{}", std::env::consts::EXE_SUFFIX))
-            });
+            },
+            PathBuf::from,
+        );
 
         Ok(Self {
             ingest_mode: IngestMode::from_env()?,
@@ -183,8 +197,7 @@ impl LoadConfig {
             max_rss_mb: env_optional_u64("LOAD_TEST_MAX_RSS_MB")?,
             min_rps: env_optional_f64("LOAD_TEST_MIN_RPS")?,
             queue_dir: std::env::var("LOAD_TEST_QUEUE_DIR")
-                .map(PathBuf::from)
-                .unwrap_or_else(|_| unique_temp_dir("maple-ingest-load-wal")),
+                .map_or_else(|_| unique_temp_dir("maple-ingest-load-wal"), PathBuf::from),
         })
     }
 }
@@ -192,7 +205,7 @@ impl LoadConfig {
 impl IngestMode {
     fn from_env() -> Result<Self, DynError> {
         let raw = std::env::var("LOAD_TEST_INGEST_MODE")
-            .unwrap_or_else(|_| "tinybird".to_string())
+            .unwrap_or_else(|_| "tinybird".to_owned())
             .trim()
             .to_ascii_lowercase();
         match raw.as_str() {
@@ -333,7 +346,9 @@ async fn run_load(cfg: &LoadConfig, payload: Vec<u8>) -> Result<(u64, u64, Vec<u
     let next_request = Arc::new(AtomicU64::new(0));
     let successes = Arc::new(AtomicU64::new(0));
     let failures = Arc::new(AtomicU64::new(0));
-    let latencies = Arc::new(Mutex::new(Vec::with_capacity(cfg.requests as usize)));
+    let latencies = Arc::new(Mutex::new(Vec::with_capacity(
+        usize::try_from(cfg.requests).unwrap_or(usize::MAX),
+    )));
     let started = Instant::now();
 
     let mut tasks = Vec::with_capacity(cfg.concurrency);
@@ -404,8 +419,9 @@ async fn pace_request(started: Instant, request_index: u64, target_rps: u64) {
     }
     let target_elapsed = Duration::from_secs_f64(request_index as f64 / target_rps as f64);
     let elapsed = started.elapsed();
-    if target_elapsed > elapsed {
-        sleep(target_elapsed - elapsed).await;
+    let remaining = target_elapsed.saturating_sub(elapsed);
+    if !remaining.is_zero() {
+        sleep(remaining).await;
     }
 }
 
@@ -428,7 +444,9 @@ async fn wait_for_exported_rows(
 async fn monitor_process(pid: u32, tx: mpsc::UnboundedSender<ProcessSample>) {
     loop {
         if let Some(sample) = sample_process(pid) {
-            let _ = tx.send(sample);
+            if tx.send(sample).is_err() {
+                break;
+            }
         }
         sleep(Duration::from_millis(500)).await;
     }
@@ -467,13 +485,13 @@ fn summarize_samples(mut rx: mpsc::UnboundedReceiver<ProcessSample>) -> MonitorS
     summary
 }
 
-fn build_logs_payload(batch_logs: usize) -> Result<Vec<u8>, DynError> {
+fn build_logs_payload(batch_logs: usize) -> Vec<u8> {
     let records = (0..batch_logs)
         .map(|index| LogRecord {
             time_unix_nano: 1_700_000_000_000_000_000 + index as u64,
             observed_time_unix_nano: 1_700_000_000_000_000_000 + index as u64,
             severity_number: 9,
-            severity_text: "INFO".to_string(),
+            severity_text: "INFO".to_owned(),
             body: Some(AnyValue {
                 value: Some(any_value::Value::StringValue(format!(
                     "load test log {index}"
@@ -493,8 +511,8 @@ fn build_logs_payload(batch_logs: usize) -> Result<Vec<u8>, DynError> {
             }),
             scope_logs: vec![ScopeLogs {
                 scope: Some(InstrumentationScope {
-                    name: "maple-ingest-load-test".to_string(),
-                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    name: "maple-ingest-load-test".to_owned(),
+                    version: env!("CARGO_PKG_VERSION").to_owned(),
                     attributes: Vec::new(),
                     dropped_attributes_count: 0,
                 }),
@@ -504,14 +522,14 @@ fn build_logs_payload(batch_logs: usize) -> Result<Vec<u8>, DynError> {
             schema_url: String::new(),
         }],
     };
-    Ok(request.encode_to_vec())
+    request.encode_to_vec()
 }
 
 fn string_kv(key: &str, value: &str) -> KeyValue {
     KeyValue {
-        key: key.to_string(),
+        key: key.to_owned(),
         value: Some(AnyValue {
-            value: Some(any_value::Value::StringValue(value.to_string())),
+            value: Some(any_value::Value::StringValue(value.to_owned())),
         }),
     }
 }
@@ -520,6 +538,12 @@ fn percentile_ms(latencies_us: &[u128], percentile: f64) -> f64 {
     if latencies_us.is_empty() {
         return 0.0;
     }
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "percentile is a caller-supplied 0.0..=1.0 fraction, so the rounded product is a \
+                  valid index into the slice; the `min` below is the backstop"
+    )]
     let index = ((latencies_us.len() - 1) as f64 * percentile).round() as usize;
     latencies_us[index.min(latencies_us.len() - 1)] as f64 / 1000.0
 }
@@ -587,7 +611,6 @@ fn env_optional_f64(name: &str) -> Result<Option<f64>, DynError> {
 fn unique_temp_dir(prefix: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
+        .map_or(0, |duration| duration.as_nanos());
     std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()))
 }

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -53,8 +53,8 @@ use maple_ingest::session_analytics::{
 };
 use maple_ingest::telemetry::{
     AttributeMappingRule, ClickHouseBreakerConfig, ClickHouseTarget, ClickHouseTargetProvider,
-    DatasourceNames, ExportDestination, MappingOperation, MappingSourceContext, PipelineError,
-    SamplingPolicy, TelemetryPipeline, TelemetrySignal, TinybirdConfig,
+    DatasourceNames, ExportDestination, HttpClient, MappingOperation, MappingSourceContext,
+    PipelineError, SamplingPolicy, TelemetryPipeline, TelemetrySignal, TinybirdConfig,
 };
 use maple_ingest::usage_metrics::{billable_gb, usage_cardinality_view, UsageMetrics};
 use moka::future::Cache;
@@ -167,14 +167,14 @@ enum WriteMode {
 impl WriteMode {
     fn from_env() -> Result<Self, String> {
         let raw = std::env::var("INGEST_WRITE_MODE")
-            .unwrap_or_else(|_| "tinybird".to_string())
+            .unwrap_or_else(|_| "tinybird".to_owned())
             .trim()
             .to_ascii_lowercase();
         match raw.as_str() {
             "tinybird" | "native" => Ok(Self::Tinybird),
             "forward" | "collector" => Ok(Self::Forward),
             "dual" | "dual_write" => Ok(Self::Dual),
-            _ => Err("INGEST_WRITE_MODE must be tinybird, forward, or dual".to_string()),
+            _ => Err("INGEST_WRITE_MODE must be tinybird, forward, or dual".to_owned()),
         }
     }
 
@@ -208,6 +208,11 @@ enum KeyStoreBackend {
 }
 
 impl AppConfig {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one branch per environment variable, read in the order the deployment docs list \
+                  them"
+    )]
     fn from_env() -> Result<Self, String> {
         let port = parse_u16(
             "INGEST_PORT",
@@ -223,13 +228,13 @@ impl AppConfig {
         let write_mode = WriteMode::from_env()?;
 
         let forward_endpoint = std::env::var("INGEST_FORWARD_OTLP_ENDPOINT")
-            .unwrap_or_else(|_| "http://127.0.0.1:4318".to_string())
+            .unwrap_or_else(|_| "http://127.0.0.1:4318".to_owned())
             .trim()
             .trim_end_matches('/')
-            .to_string();
+            .to_owned();
 
         if forward_endpoint.is_empty() {
-            return Err("INGEST_FORWARD_OTLP_ENDPOINT is required".to_string());
+            return Err("INGEST_FORWARD_OTLP_ENDPOINT is required".to_owned());
         }
 
         let forward_timeout_ms = parse_u64(
@@ -243,14 +248,14 @@ impl AppConfig {
                 .unwrap_or_default()
                 .trim()
                 .trim_end_matches('/')
-                .to_string(),
+                .to_owned(),
             token: std::env::var("TINYBIRD_TOKEN")
                 .unwrap_or_default()
                 .trim()
-                .to_string(),
+                .to_owned(),
             queue_dir: PathBuf::from(
                 std::env::var("INGEST_QUEUE_DIR")
-                    .unwrap_or_else(|_| "/var/lib/maple-ingest/wal".to_string()),
+                    .unwrap_or_else(|_| "/var/lib/maple-ingest/wal".to_owned()),
             ),
             queue_max_bytes: parse_u64(
                 "INGEST_QUEUE_MAX_BYTES",
@@ -312,18 +317,18 @@ impl AppConfig {
                 cooldown: Duration::from_millis(parse_u64(
                     "INGEST_CLICKHOUSE_BREAKER_COOLDOWN_MS",
                     std::env::var("INGEST_CLICKHOUSE_BREAKER_COOLDOWN_MS").ok(),
-                    ClickHouseBreakerConfig::default().cooldown.as_millis() as u64,
+                    duration_millis(ClickHouseBreakerConfig::default().cooldown),
                 )?),
             },
             datasources: DatasourceNames::from_env(),
             datasource_session_replays: std::env::var("INGEST_TINYBIRD_DATASOURCE_SESSION_REPLAYS")
-                .unwrap_or_else(|_| "session_replays".to_string()),
+                .unwrap_or_else(|_| "session_replays".to_owned()),
             datasource_session_replay_events: std::env::var(
                 "INGEST_TINYBIRD_DATASOURCE_SESSION_REPLAY_EVENTS",
             )
-            .unwrap_or_else(|_| "session_replay_events".to_string()),
+            .unwrap_or_else(|_| "session_replay_events".to_owned()),
             datasource_session_events: std::env::var("INGEST_TINYBIRD_DATASOURCE_SESSION_EVENTS")
-                .unwrap_or_else(|_| "session_events".to_string()),
+                .unwrap_or_else(|_| "session_events".to_owned()),
         };
         if write_mode.uses_tinybird() {
             tinybird.validate()?;
@@ -340,7 +345,7 @@ impl AppConfig {
             1_000,
         )?;
         if org_max_in_flight == 0 {
-            return Err("INGEST_ORG_MAX_IN_FLIGHT must be greater than 0".to_string());
+            return Err("INGEST_ORG_MAX_IN_FLIGHT must be greater than 0".to_owned());
         }
 
         let require_tls = parse_bool(
@@ -351,8 +356,7 @@ impl AppConfig {
 
         if require_tls && !forward_endpoint.starts_with("https://") {
             return Err(
-                "INGEST_REQUIRE_TLS=true requires an https INGEST_FORWARD_OTLP_ENDPOINT"
-                    .to_string(),
+                "INGEST_REQUIRE_TLS=true requires an https INGEST_FORWARD_OTLP_ENDPOINT".to_owned(),
             );
         }
 
@@ -362,31 +366,31 @@ impl AppConfig {
             // org_clickhouse_settings, so it needs the encryption key.
             KeyStoreBackend::Postgres { .. } => {
                 let raw = std::env::var("MAPLE_INGEST_KEY_ENCRYPTION_KEY")
-                    .map_err(|_| "MAPLE_INGEST_KEY_ENCRYPTION_KEY is required".to_string())?;
+                    .map_err(|_| "MAPLE_INGEST_KEY_ENCRYPTION_KEY is required".to_owned())?;
                 Some(parse_base64_aes256_gcm_key(&raw)?)
             }
             KeyStoreBackend::Static { .. } => None,
         };
 
         let lookup_hmac_key = std::env::var("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY")
-            .map_err(|_| "MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY is required".to_string())?
+            .map_err(|_| "MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY is required".to_owned())?
             .trim()
-            .to_string();
+            .to_owned();
 
         if lookup_hmac_key.is_empty() {
-            return Err("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY is required".to_string());
+            return Err("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY is required".to_owned());
         }
 
         let autumn_secret_key = std::env::var("AUTUMN_SECRET_KEY")
             .ok()
-            .map(|v| v.trim().to_string())
+            .map(|v| v.trim().to_owned())
             .filter(|v| !v.is_empty());
 
         let autumn_api_url = std::env::var("AUTUMN_API_URL")
-            .unwrap_or_else(|_| "https://api.useautumn.com".to_string())
+            .unwrap_or_else(|_| "https://api.useautumn.com".to_owned())
             .trim()
             .trim_end_matches('/')
-            .to_string();
+            .to_owned();
 
         let autumn_flush_interval_secs = parse_u64(
             "AUTUMN_FLUSH_INTERVAL_SECS",
@@ -434,7 +438,7 @@ impl AppConfig {
         let replay_blob_store = {
             let endpoint = std::env::var("INGEST_REPLAY_R2_ENDPOINT")
                 .ok()
-                .map(|v| v.trim().to_string())
+                .map(|v| v.trim().to_owned())
                 .filter(|v| !v.is_empty());
             match endpoint {
                 None => None,
@@ -442,7 +446,7 @@ impl AppConfig {
                     let required = |name: &str| -> Result<String, String> {
                         std::env::var(name)
                             .ok()
-                            .map(|v| v.trim().to_string())
+                            .map(|v| v.trim().to_owned())
                             .filter(|v| !v.is_empty())
                             .ok_or_else(|| {
                                 format!("{name} is required when INGEST_REPLAY_R2_ENDPOINT is set")
@@ -460,9 +464,9 @@ impl AppConfig {
                         secret_access_key: required("INGEST_REPLAY_R2_SECRET_ACCESS_KEY")?,
                         region: std::env::var("INGEST_REPLAY_R2_REGION")
                             .ok()
-                            .map(|v| v.trim().to_string())
+                            .map(|v| v.trim().to_owned())
                             .filter(|v| !v.is_empty())
-                            .unwrap_or_else(|| "auto".to_string()),
+                            .unwrap_or_else(|| "auto".to_owned()),
                         timeout: Duration::from_millis(timeout_ms),
                     })
                 }
@@ -525,7 +529,7 @@ fn resolve_key_store_backend() -> Result<KeyStoreBackend, String> {
 
     let want = match backend_override.as_deref() {
         Some("static") => Want::Static,
-        Some("postgres") | Some("pg") => Want::Postgres,
+        Some("postgres" | "pg") => Want::Postgres,
         Some(other) => {
             return Err(format!(
                 "INGEST_KEY_STORE_BACKEND must be `static` or `postgres`, got `{other}`"
@@ -543,24 +547,24 @@ fn resolve_key_store_backend() -> Result<KeyStoreBackend, String> {
     if want == Want::Static {
         let org_id = std::env::var("MAPLE_ORG_ID_OVERRIDE")
             .map_err(|_| {
-                "MAPLE_ORG_ID_OVERRIDE is required for the static key store backend".to_string()
+                "MAPLE_ORG_ID_OVERRIDE is required for the static key store backend".to_owned()
             })?
             .trim()
-            .to_string();
+            .to_owned();
         if org_id.is_empty() {
             return Err(
-                "MAPLE_ORG_ID_OVERRIDE is required for the static key store backend".to_string(),
+                "MAPLE_ORG_ID_OVERRIDE is required for the static key store backend".to_owned(),
             );
         }
         return Ok(KeyStoreBackend::Static { org_id });
     }
 
     let url = std::env::var("MAPLE_PG_URL")
-        .map_err(|_| "MAPLE_PG_URL is required for the postgres key store backend".to_string())?
+        .map_err(|_| "MAPLE_PG_URL is required for the postgres key store backend".to_owned())?
         .trim()
-        .to_string();
+        .to_owned();
     if url.is_empty() {
-        return Err("MAPLE_PG_URL is required for the postgres key store backend".to_string());
+        return Err("MAPLE_PG_URL is required for the postgres key store backend".to_owned());
     }
 
     Ok(KeyStoreBackend::Postgres { url })
@@ -688,7 +692,7 @@ struct IngestKeyIdentity {
 }
 
 impl IngestKeyIdentity {
-    fn into_resolved(self, routing: OrgRouting) -> ResolvedIngestKey {
+    fn into_resolved(self, routing: &OrgRouting) -> ResolvedIngestKey {
         ResolvedIngestKey {
             org_id: self.org_id,
             key_type: self.key_type,
@@ -710,7 +714,7 @@ struct CloudflareConnectorIdentity {
 }
 
 impl CloudflareConnectorIdentity {
-    fn into_resolved(self, routing: OrgRouting) -> ResolvedCloudflareConnector {
+    fn into_resolved(self, routing: &OrgRouting) -> ResolvedCloudflareConnector {
         ResolvedCloudflareConnector {
             connector_id: self.connector_id,
             org_id: self.org_id,
@@ -834,7 +838,7 @@ struct AppState {
     config: AppConfig,
     /// The raw `reqwest::Client` in normal builds; the hotpath-instrumented
     /// wrapper (same request API) under `--features hotpath`.
-    http_client: hotpath::wrap::reqwest::Client,
+    http_client: HttpClient,
     telemetry_pipeline: Option<TelemetryPipeline>,
     /// Set once the key store has answered a probe. Drives `/ready`; never
     /// `/health` — see the comment on `health()`.
@@ -983,7 +987,7 @@ impl OrgInFlightLimiter {
     fn try_acquire(&self, org_id: &str) -> Option<OrgInFlightPermit> {
         let counter = self
             .counts
-            .entry(org_id.to_string())
+            .entry(org_id.to_owned())
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .clone();
 
@@ -999,7 +1003,7 @@ impl OrgInFlightLimiter {
             {
                 metrics::org_requests_in_flight(org_id, current + 1);
                 return Some(OrgInFlightPermit {
-                    org_id: org_id.to_string(),
+                    org_id: org_id.to_owned(),
                     counter,
                 });
             }
@@ -1208,7 +1212,7 @@ fn resolve_deployment_env() -> String {
     std::env::var("MAPLE_ENVIRONMENT")
         .or_else(|_| std::env::var("RAILWAY_ENVIRONMENT_NAME"))
         .or_else(|_| std::env::var("DEPLOYMENT_ENV"))
-        .unwrap_or_else(|_| "development".to_string())
+        .unwrap_or_else(|_| "development".to_owned())
 }
 
 struct TelemetryProviders {
@@ -1216,6 +1220,10 @@ struct TelemetryProviders {
     logger: SdkLoggerProvider,
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear construction of one OTel pipeline; every step feeds the next"
+)]
 fn init_tracing(
     forward_endpoint: &str,
     bind_port: u16,
@@ -1230,7 +1238,7 @@ fn init_tracing(
 
     let deployment_env = resolve_deployment_env();
     let internal_org_id =
-        std::env::var("MAPLE_INTERNAL_ORG_ID").unwrap_or_else(|_| "internal".to_string());
+        std::env::var("MAPLE_INTERNAL_ORG_ID").unwrap_or_else(|_| "internal".to_owned());
 
     let forward_explicit = std::env::var("INGEST_FORWARD_OTLP_ENDPOINT").is_ok();
     let skip_dev = deployment_env == "development" && !forward_explicit;
@@ -1253,7 +1261,7 @@ fn init_tracing(
         service_name: "ingest",
         service_namespace: "ingest",
         service_version: env!("CARGO_PKG_VERSION"),
-        service_instance_id: service_instance_id.to_string(),
+        service_instance_id: service_instance_id.to_owned(),
         deployment_env,
         internal_org_id,
     });
@@ -1360,7 +1368,7 @@ fn init_metrics(
 ) -> Option<SdkMeterProvider> {
     let deployment_env = resolve_deployment_env();
     let internal_org_id =
-        std::env::var("MAPLE_INTERNAL_ORG_ID").unwrap_or_else(|_| "internal".to_string());
+        std::env::var("MAPLE_INTERNAL_ORG_ID").unwrap_or_else(|_| "internal".to_owned());
 
     let forward_explicit = std::env::var("INGEST_FORWARD_OTLP_ENDPOINT").is_ok();
     let skip_dev = deployment_env == "development" && !forward_explicit;
@@ -1372,7 +1380,7 @@ fn init_metrics(
         service_name: "ingest",
         service_namespace: "ingest",
         service_version: env!("CARGO_PKG_VERSION"),
-        service_instance_id: service_instance_id.to_string(),
+        service_instance_id: service_instance_id.to_owned(),
         deployment_env,
         internal_org_id,
     });
@@ -1424,7 +1432,7 @@ fn init_usage_metrics(
 ) -> Option<UsageMetrics> {
     let deployment_env = resolve_deployment_env();
     let internal_org_id =
-        std::env::var("MAPLE_INTERNAL_ORG_ID").unwrap_or_else(|_| "internal".to_string());
+        std::env::var("MAPLE_INTERNAL_ORG_ID").unwrap_or_else(|_| "internal".to_owned());
 
     let forward_explicit = std::env::var("INGEST_FORWARD_OTLP_ENDPOINT").is_ok();
     let skip_dev = deployment_env == "development" && !forward_explicit;
@@ -1436,7 +1444,7 @@ fn init_usage_metrics(
         service_name: "ingest",
         service_namespace: "ingest",
         service_version: env!("CARGO_PKG_VERSION"),
-        service_instance_id: service_instance_id.to_string(),
+        service_instance_id: service_instance_id.to_owned(),
         deployment_env,
         internal_org_id,
     });
@@ -1458,7 +1466,7 @@ fn init_usage_metrics(
     };
 
     let reader = PeriodicReader::builder(exporter, OtelTokio)
-        .with_interval(Duration::from_secs(60))
+        .with_interval(Duration::from_mins(1))
         .build();
 
     let provider = SdkMeterProvider::builder()
@@ -1482,8 +1490,12 @@ fn endpoint_loopback_to_self(forward_endpoint: &str, bind_port: u16) -> bool {
 
 #[tokio::main]
 #[hotpath::main(allocator = tikv_jemallocator::Jemalloc)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "process wiring, in start-up order: config, telemetry, state, router, serve, shutdown"
+)]
 async fn main() {
-    let _ = dotenvy::dotenv();
+    drop(dotenvy::dotenv());
     // No-op unless `--features hotpath`: exports tokio runtime metrics (workers,
     // park/unpark, queue depth) into the profiler report alongside function timings.
     hotpath::tokio_runtime!();
@@ -1554,7 +1566,7 @@ async fn main() {
                 store: Arc::clone(&store),
                 encryption_key: config.clickhouse_encryption_key,
                 cache: Cache::builder()
-                    .time_to_live(Duration::from_secs(60))
+                    .time_to_live(Duration::from_mins(1))
                     .max_capacity(10_000)
                     .build(),
             }) as Arc<dyn ClickHouseTargetProvider>)
@@ -1660,7 +1672,7 @@ async fn main() {
         replay_blob_store: config.replay_blob_store.as_ref().map(|blob| {
             ReplayBlobStore::new(
                 http_client_for_blobs,
-                blob.endpoint.clone(),
+                &blob.endpoint,
                 blob.bucket.clone(),
                 blob.access_key_id.clone(),
                 blob.secret_access_key.clone(),
@@ -1720,8 +1732,10 @@ async fn main() {
     // to log — operators can diff this against the API's fingerprint to detect
     // env-var drift between the two services without ever printing the secret.
     let hmac_fingerprint = hash_ingest_key(HMAC_FINGERPRINT_SENTINEL, &config.lookup_hmac_key)
-        .map(|h| h.chars().take(8).collect::<String>())
-        .unwrap_or_else(|_| "<error>".to_string());
+        .map_or_else(
+            |_| "<error>".to_owned(),
+            |h| h.chars().take(8).collect::<String>(),
+        );
 
     {
         // Emit a single startup span so the dashboard has an authoritative
@@ -1758,13 +1772,13 @@ async fn main() {
     if let Some(providers) = telemetry_providers {
         // Flush buffered spans on graceful exit. Errors here are non-fatal —
         // the process is shutting down anyway.
-        let _ = providers.tracer.shutdown();
-        let _ = providers.logger.shutdown();
+        drop(providers.tracer.shutdown());
+        drop(providers.logger.shutdown());
     }
 
     if let Some(provider) = meter_provider {
         // Flush the final metric export on graceful exit.
-        let _ = provider.shutdown();
+        drop(provider.shutdown());
     }
 
     if let Some(usage) = usage_metrics {
@@ -1782,7 +1796,7 @@ async fn main() {
 
 async fn shutdown_signal() {
     let ctrl_c = async {
-        let _ = tokio::signal::ctrl_c().await;
+        drop(tokio::signal::ctrl_c().await);
     };
 
     #[cfg(unix)]
@@ -1798,8 +1812,8 @@ async fn shutdown_signal() {
     let terminate = std::future::pending::<()>();
 
     tokio::select! {
-        _ = ctrl_c => {}
-        _ = terminate => {}
+        () = ctrl_c => {}
+        () = terminate => {}
     }
 }
 
@@ -2049,7 +2063,7 @@ async fn resolve_grpc_ingest_key(
         .and_then(|value| value.to_str().ok())
         .and_then(|value| {
             if value.len() > 7 && value[..7].eq_ignore_ascii_case("Bearer ") {
-                Some(value[7..].trim().to_string())
+                Some(value[7..].trim().to_owned())
             } else {
                 None
             }
@@ -2060,15 +2074,15 @@ async fn resolve_grpc_ingest_key(
                 .and_then(|value| value.to_str().ok())
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
-                .map(str::to_string)
+                .map(str::to_owned)
         })
         .ok_or_else(|| tonic::Status::unauthenticated("Missing ingest key"))?;
 
     if is_sentinel_token(&token) {
         return Ok(ResolvedIngestKey {
-            org_id: SENTINEL_ORG_ID.to_string(),
+            org_id: SENTINEL_ORG_ID.to_owned(),
             key_type: IngestKeyType::Public,
-            key_id: "sentinel".to_string(),
+            key_id: "sentinel".to_owned(),
             self_managed: false,
             clickhouse_ready: false,
         });
@@ -2163,7 +2177,7 @@ impl ReplaySessionBudget {
     fn new(limit: u64) -> Self {
         Self {
             totals: Cache::builder()
-                .time_to_idle(Duration::from_secs(2 * 60 * 60))
+                .time_to_idle(Duration::from_hours(2))
                 .max_capacity(100_000)
                 .build(),
             limit,
@@ -2267,20 +2281,20 @@ fn replay_gunzip_rejection(headers: &HeaderMap, body: &[u8], error: &std::io::Er
 const REPLAY_BODY_PREFIX_BYTES: usize = 16;
 
 fn hex_prefix(body: &[u8], n: usize) -> String {
-    use std::fmt::Write as _;
-    body.iter()
-        .take(n)
-        .fold(String::with_capacity(n * 2), |mut acc, b| {
-            let _ = write!(acc, "{b:02x}");
-            acc
-        })
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(n * 2);
+    for byte in body.iter().take(n) {
+        out.push(char::from(HEX[usize::from(byte >> 4)]));
+        out.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    out
 }
 
 fn replay_header(headers: &HeaderMap, name: &str) -> Option<String> {
     headers
         .get(name)
         .and_then(|value| value.to_str().ok())
-        .map(|value| value.trim().to_string())
+        .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
 }
 
@@ -2397,14 +2411,18 @@ async fn handle_replay_meta(
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "one linear request pass with an early return at each rejection; helpers would thread \
+              a dozen locals back and forth"
+)]
 async fn handle_replay_meta_inner(
     state: &AppState,
     headers: &HeaderMap,
     body: Bytes,
 ) -> Result<usize, ApiError> {
-    let resolved_key = match resolve_replay_key(state, headers).await? {
-        Some(resolved_key) => resolved_key,
-        None => return Ok(0),
+    let Some(resolved_key) = resolve_replay_key(state, headers).await? else {
+        return Ok(0);
     };
     let org_id = resolved_key.org_id.clone();
     Span::current().record("maple.org_id", org_id.as_str());
@@ -2444,7 +2462,7 @@ async fn handle_replay_meta_inner(
             .as_object_mut()
             .ok_or_else(|| ApiError::bad_request("session metadata must be a JSON object"))?;
         obj.insert(
-            "org_id".to_string(),
+            "org_id".to_owned(),
             serde_json::Value::String(org_id.clone()),
         );
         // Server-derived fields, forced alongside org_id so the three stay
@@ -2453,29 +2471,29 @@ async fn handle_replay_meta_inner(
         // matters because ReplacingMergeTree replaces the whole row — a country
         // present only on v1 would be erased by the v2 merge.
         obj.insert(
-            "country".to_string(),
+            "country".to_owned(),
             serde_json::Value::String(country.clone()),
         );
         let referrer = obj
             .get("referrer")
             .and_then(|v| v.as_str())
             .unwrap_or_default()
-            .to_string();
+            .to_owned();
         let current_host = obj
             .get("host")
             .and_then(|v| v.as_str())
             .unwrap_or_default()
-            .to_string();
+            .to_owned();
         let referrer_host = derive_referrer_host(&referrer, &current_host);
         obj.insert(
-            "referrer_host".to_string(),
+            "referrer_host".to_owned(),
             serde_json::Value::String(referrer_host),
         );
         // Everything else on this row is client-supplied, including six
         // LowCardinality columns. Clamp before it reaches the warehouse — the
         // SDK's own trimming ships in customer JavaScript.
         sanitize_session_meta(obj);
-        if obj.get("version").and_then(|v| v.as_u64()) == Some(1) {
+        if obj.get("version").and_then(serde_json::Value::as_u64) == Some(1) {
             session_starts += 1;
         }
         rows.push(
@@ -2489,11 +2507,16 @@ async fn handle_replay_meta_inner(
         return Ok(0);
     }
     let count = rows.len();
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "a single request carries far fewer than 2^53 session starts"
+    )]
+    let billable_sessions = session_starts as f64;
     let reservation = reserve_autumn_usage(
         state,
         &org_id,
         BROWSER_SESSIONS_FEATURE_ID,
-        session_starts as f64,
+        billable_sessions,
     )
     .await?;
     let enqueue_result = pipeline
@@ -2529,7 +2552,7 @@ async fn handle_replay_meta_inner(
     // commit through the retrying tracker.
     if reservation.is_none() && org_id != SENTINEL_ORG_ID && session_starts > 0 {
         if let Some(tracker) = &state.autumn_tracker {
-            tracker.track(&org_id, "browser_sessions", session_starts as f64);
+            tracker.track(&org_id, "browser_sessions", billable_sessions);
         }
     }
 
@@ -2594,9 +2617,8 @@ async fn handle_session_events_inner(
     headers: &HeaderMap,
     body: Bytes,
 ) -> Result<usize, ApiError> {
-    let resolved_key = match resolve_replay_key(state, headers).await? {
-        Some(resolved_key) => resolved_key,
-        None => return Ok(0),
+    let Some(resolved_key) = resolve_replay_key(state, headers).await? else {
+        return Ok(0);
     };
     let org_id = resolved_key.org_id.clone();
     Span::current().record("maple.org_id", org_id.as_str());
@@ -2650,7 +2672,7 @@ async fn handle_session_events_inner(
             continue;
         }
         obj.insert(
-            "org_id".to_string(),
+            "org_id".to_owned(),
             serde_json::Value::String(org_id.clone()),
         );
         rows.push(
@@ -2695,17 +2717,8 @@ async fn handle_session_events_inner(
 /// blob-store path, where the decompressed text is never needed but `ByteSize`
 /// and the per-session budget are still denominated in decompressed bytes.
 fn decompressed_len(body: &[u8]) -> Result<u64, std::io::Error> {
-    use std::io::Read as _;
-    let mut decoder = flate2::read::GzDecoder::new(body);
-    let mut buffer = [0u8; 64 * 1024];
-    let mut total: u64 = 0;
-    loop {
-        match decoder.read(&mut buffer) {
-            Ok(0) => return Ok(total),
-            Ok(n) => total += n as u64,
-            Err(e) => return Err(e),
-        }
-    }
+    let mut decoder = GzDecoder::new(body);
+    std::io::copy(&mut decoder, &mut std::io::sink())
 }
 
 async fn handle_replay_blob(
@@ -2766,14 +2779,18 @@ async fn handle_replay_blob(
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "one linear request pass with an early return at each rejection; helpers would thread \
+              a dozen locals back and forth"
+)]
 async fn handle_replay_blob_inner(
     state: &AppState,
     headers: &HeaderMap,
     body: Bytes,
 ) -> Result<(), ApiError> {
-    let resolved_key = match resolve_replay_key(state, headers).await? {
-        Some(resolved_key) => resolved_key,
-        None => return Ok(()),
+    let Some(resolved_key) = resolve_replay_key(state, headers).await? else {
+        return Ok(());
     };
     let org_id = resolved_key.org_id.clone();
     Span::current().record("maple.org_id", org_id.as_str());
@@ -2808,8 +2825,7 @@ async fn handle_replay_blob_inner(
         .and_then(|v| v.parse().ok())
         .ok_or_else(|| ApiError::bad_request("missing or invalid x-maple-chunk-seq header"))?;
     let is_checkpoint: u8 = replay_header(headers, "x-maple-is-checkpoint")
-        .map(|v| u8::from(v == "1" || v.eq_ignore_ascii_case("true")))
-        .unwrap_or(0);
+        .map_or(0, |v| u8::from(v == "1" || v.eq_ignore_ascii_case("true")));
     let event_count: u32 = replay_header(headers, "x-maple-event-count")
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
@@ -2847,7 +2863,7 @@ async fn handle_replay_blob_inner(
         )
     } else {
         use std::io::Read as _;
-        let mut decoder = flate2::read::GzDecoder::new(&body[..]);
+        let mut decoder = GzDecoder::new(&body[..]);
         let mut events_json = String::new();
         decoder
             .read_to_string(&mut events_json)
@@ -2906,7 +2922,7 @@ async fn handle_replay_blob_inner(
                 })?;
             Span::current().record(
                 "maple.replay.blob_put_ms",
-                started.elapsed().as_millis() as i64,
+                i64::try_from(started.elapsed().as_millis()).unwrap_or(i64::MAX),
             );
             // The index row carries the chunk's metadata; the payload lives in
             // R2 under a key derived from (OrgId, SessionId, ChunkSeq). An empty
@@ -3031,7 +3047,7 @@ async fn handle_signal(
         .instrument(span)
         .await;
     let duration = start.elapsed();
-    let duration_ms = duration.as_millis() as u64;
+    let duration_ms = duration_millis(duration);
 
     match result {
         Ok((response, item_count, org_id, decoded_bytes, metered_atomically)) => {
@@ -3126,7 +3142,7 @@ async fn handle_cloudflare_logpush(
             metrics::cloudflare_batch("http_requests", is_validation);
             info!(
                 status = status_code,
-                duration_ms = duration.as_millis() as u64,
+                duration_ms = duration_millis(duration),
                 item_count,
                 org_id = %org_id,
                 "Cloudflare Logpush request processed"
@@ -3152,6 +3168,12 @@ async fn handle_cloudflare_logpush(
 
 /// Returns Ok((response, item_count, org_id, decoded_bytes, metered_atomically))
 /// or Err((ApiError, error_kind_label)).
+#[expect(
+    clippy::cognitive_complexity,
+    clippy::too_many_lines,
+    reason = "one linear request pass with an early return at each rejection; helpers would thread \
+              a dozen locals back and forth"
+)]
 async fn handle_signal_inner(
     state: &AppState,
     headers: &HeaderMap,
@@ -3173,7 +3195,7 @@ async fn handle_signal_inner(
         return Ok((
             StatusCode::OK.into_response(),
             0,
-            SENTINEL_ORG_ID.to_string(),
+            SENTINEL_ORG_ID.to_owned(),
             0,
             false,
         ));
@@ -3215,7 +3237,7 @@ async fn handle_signal_inner(
         resolved_key.clickhouse_ready,
     );
 
-    Span::current().record("maple.org_id", &resolved_key.org_id.as_str());
+    Span::current().record("maple.org_id", resolved_key.org_id.as_str());
     Span::current().record("maple.ingest.key_type", resolved_key.key_type.as_str());
     Span::current().record("maple.ingest.self_managed", resolved_key.self_managed);
     Span::current().record(
@@ -3223,7 +3245,7 @@ async fn handle_signal_inner(
         resolved_key.clickhouse_ready,
     );
     debug!(
-        resolve_ms = key_resolve_start.elapsed().as_millis() as u64,
+        resolve_ms = duration_millis(key_resolve_start.elapsed()),
         "Authenticated"
     );
 
@@ -3380,6 +3402,12 @@ async fn handle_signal_inner(
     ))
 }
 
+#[expect(
+    clippy::cognitive_complexity,
+    clippy::too_many_lines,
+    reason = "one linear request pass with an early return at each rejection; helpers would thread \
+              a dozen locals back and forth"
+)]
 async fn handle_cloudflare_logpush_inner(
     state: &AppState,
     connector_id: &str,
@@ -3417,7 +3445,7 @@ async fn handle_cloudflare_logpush_inner(
             )
         })?;
 
-    Span::current().record("maple.org_id", &resolved.org_id.as_str());
+    Span::current().record("maple.org_id", resolved.org_id.as_str());
     Span::current().record("maple.ingest.self_managed", resolved.self_managed);
     Span::current().record("maple.ingest.clickhouse_ready", resolved.clickhouse_ready);
 
@@ -3449,7 +3477,7 @@ async fn handle_cloudflare_logpush_inner(
             connector_id = %resolved.connector_id,
             "Cloudflare Logpush payload too large"
         );
-        let _ = state
+        state
             .cloudflare_resolver
             .record_failure(&resolved.connector_id, "Request body too large")
             .await;
@@ -3466,7 +3494,7 @@ async fn handle_cloudflare_logpush_inner(
         .to_ascii_lowercase();
 
     if !is_supported_cloudflare_content_type(&content_type) {
-        let _ = state
+        state
             .cloudflare_resolver
             .record_failure(&resolved.connector_id, "Unsupported content type")
             .await;
@@ -3487,7 +3515,7 @@ async fn handle_cloudflare_logpush_inner(
     let decoded_payload = match decode_payload(&body, content_encoding.as_deref()) {
         Ok(decoded) => decoded,
         Err(error) => {
-            let _ = state
+            state
                 .cloudflare_resolver
                 .record_failure(&resolved.connector_id, &error.message)
                 .await;
@@ -3498,7 +3526,7 @@ async fn handle_cloudflare_logpush_inner(
     let parsed = match parse_cloudflare_payload(&decoded_payload) {
         Ok(parsed) => parsed,
         Err(error) => {
-            let _ = state
+            state
                 .cloudflare_resolver
                 .record_failure(&resolved.connector_id, &error.message)
                 .await;
@@ -3509,12 +3537,12 @@ async fn handle_cloudflare_logpush_inner(
     match parsed {
         ParsedCloudflarePayload::Validation => {
             info!(connector_id = %resolved.connector_id, "Cloudflare validation ping accepted");
-            return Ok((
+            Ok((
                 StatusCode::OK.into_response(),
                 0,
                 resolved.org_id.clone(),
                 true,
-            ));
+            ))
         }
         ParsedCloudflarePayload::Records(records) => {
             let request = build_cloudflare_logs_request(&resolved, records);
@@ -3554,7 +3582,7 @@ async fn handle_cloudflare_logpush_inner(
                     {
                         let _ = entitlements.finalize(reservation, false).await;
                     }
-                    let _ = state
+                    state
                         .cloudflare_resolver
                         .record_failure(&resolved.connector_id, &error.message)
                         .await;
@@ -3568,7 +3596,7 @@ async fn handle_cloudflare_logpush_inner(
                 let _ = entitlements.finalize(reservation, true).await;
             }
 
-            let _ = state
+            state
                 .cloudflare_resolver
                 .record_success(&resolved.connector_id)
                 .await;
@@ -3713,7 +3741,7 @@ fn build_cloudflare_logs_request(
 ) -> ExportLogsServiceRequest {
     let log_records = records
         .into_iter()
-        .map(|record| build_cloudflare_log_record(resolved, record))
+        .map(|record| build_cloudflare_log_record(resolved, &record))
         .collect();
 
     ExportLogsServiceRequest {
@@ -3726,8 +3754,8 @@ fn build_cloudflare_logs_request(
             schema_url: String::new(),
             scope_logs: vec![ScopeLogs {
                 scope: Some(InstrumentationScope {
-                    name: "cloudflare.logpush".to_string(),
-                    version: "http_requests".to_string(),
+                    name: "cloudflare.logpush".to_owned(),
+                    version: "http_requests".to_owned(),
                     attributes: Vec::new(),
                     dropped_attributes_count: 0,
                 }),
@@ -3753,7 +3781,7 @@ fn build_cloudflare_resource_attributes(resolved: &ResolvedCloudflareConnector) 
 
 fn build_cloudflare_log_record(
     _resolved: &ResolvedCloudflareConnector,
-    record: JsonMap<String, JsonValue>,
+    record: &JsonMap<String, JsonValue>,
 ) -> LogRecord {
     let timestamp = record
         .get("EdgeStartTimestamp")
@@ -3770,7 +3798,7 @@ fn build_cloudflare_log_record(
         .and_then(parse_status_code)
         .unwrap_or(0);
     let (severity_text, severity_number) = severity_from_status(status_code);
-    let body = build_cloudflare_body(&record, status_code);
+    let body = build_cloudflare_body(record, status_code);
     let attributes = record
         .iter()
         .filter_map(|(key, value)| json_value_to_attribute(key, value))
@@ -3780,7 +3808,7 @@ fn build_cloudflare_log_record(
         time_unix_nano: timestamp,
         observed_time_unix_nano: timestamp,
         severity_number,
-        severity_text: severity_text.to_string(),
+        severity_text: severity_text.to_owned(),
         body: Some(AnyValue {
             value: Some(any_value::Value::StringValue(body)),
         }),
@@ -3859,15 +3887,16 @@ fn normalize_numeric_timestamp(value: u64) -> u64 {
 fn current_time_unix_nano() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos() as u64)
-        .unwrap_or(0)
+        .map_or(0, |duration| {
+            u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
+        })
 }
 
 fn string_attribute(key: &str, value: &str) -> KeyValue {
     KeyValue {
-        key: key.to_string(),
+        key: key.to_owned(),
         value: Some(AnyValue {
-            value: Some(any_value::Value::StringValue(value.to_string())),
+            value: Some(any_value::Value::StringValue(value.to_owned())),
         }),
     }
 }
@@ -3892,7 +3921,7 @@ fn extract_ingest_key(headers: &HeaderMap) -> Option<String> {
         if value.len() > 7 && value[..7].eq_ignore_ascii_case("Bearer ") {
             let token = value[7..].trim();
             if !token.is_empty() {
-                return Some(token.to_string());
+                return Some(token.to_owned());
             }
         }
     }
@@ -3902,7 +3931,7 @@ fn extract_ingest_key(headers: &HeaderMap) -> Option<String> {
         .and_then(|value| value.to_str().ok())
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(str::to_string)
+        .map(str::to_owned)
 }
 
 #[derive(Clone, Copy)]
@@ -4134,15 +4163,15 @@ fn enrich_resource_attributes(attributes: &mut Vec<KeyValue>, resolved_key: &Res
 fn upsert_string_attribute(attributes: &mut Vec<KeyValue>, key: &str, value: &str) {
     if let Some(attribute) = attributes.iter_mut().find(|attribute| attribute.key == key) {
         attribute.value = Some(AnyValue {
-            value: Some(any_value::Value::StringValue(value.to_string())),
+            value: Some(any_value::Value::StringValue(value.to_owned())),
         });
         return;
     }
 
     attributes.push(KeyValue {
-        key: key.to_string(),
+        key: key.to_owned(),
         value: Some(AnyValue {
-            value: Some(any_value::Value::StringValue(value.to_string())),
+            value: Some(any_value::Value::StringValue(value.to_owned())),
         }),
     });
 }
@@ -4170,6 +4199,10 @@ fn native_rows_pipeline_for<'a>(
 }
 
 #[hotpath::measure]
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "a retry loop whose branches are the retry policy"
+)]
 async fn forward_to_collector(
     state: &AppState,
     signal: Signal,
@@ -4245,7 +4278,7 @@ async fn forward_to_collector(
 
     debug!(
         upstream_status = upstream_status_code,
-        forward_ms = forward_duration.as_millis() as u64,
+        forward_ms = duration_millis(forward_duration),
         "Collector response"
     );
 
@@ -4444,8 +4477,8 @@ impl OrgRoutingResolver {
     }
 
     async fn remember_org_routing(&self, org_id: &str, routing: OrgRouting) {
-        self.last_known.insert(org_id.to_string(), routing.clone());
-        self.cache.insert(org_id.to_string(), routing).await;
+        self.last_known.insert(org_id.to_owned(), routing.clone());
+        self.cache.insert(org_id.to_owned(), routing).await;
     }
 }
 
@@ -4457,7 +4490,7 @@ impl IngestKeyResolver {
         if let Some(identity) = self.cache.get(raw_key).await {
             Span::current().record("maple.ingest.cache_hit", true);
             let routing = self.routing.resolve_org_routing(&identity.org_id).await?;
-            return Ok(Some(identity.into_resolved(routing)));
+            return Ok(Some(identity.into_resolved(&routing)));
         }
         Span::current().record("maple.ingest.cache_hit", false);
 
@@ -4489,13 +4522,13 @@ impl IngestKeyResolver {
         };
 
         self.cache
-            .insert(raw_key.to_string(), identity.clone())
+            .insert(raw_key.to_owned(), identity.clone())
             .await;
         self.routing
             .remember_org_routing(&identity.org_id, routing.clone())
             .await;
 
-        Ok(Some(identity.into_resolved(routing)))
+        Ok(Some(identity.into_resolved(&routing)))
     }
 }
 
@@ -4508,7 +4541,7 @@ impl CloudflareConnectorResolver {
         let cache_key = format!("{connector_id}:{raw_secret}");
         if let Some(identity) = self.cache.get(&cache_key).await {
             let routing = self.routing.resolve_org_routing(&identity.org_id).await?;
-            return Ok(Some(identity.into_resolved(routing)));
+            return Ok(Some(identity.into_resolved(&routing)));
         }
 
         let secret_hash = hash_ingest_key(raw_secret, &self.lookup_hmac_key)?;
@@ -4522,7 +4555,7 @@ impl CloudflareConnectorResolver {
 
         let routing = OrgRouting::from_connector_row(&row);
         let identity = CloudflareConnectorIdentity {
-            connector_id: connector_id.to_string(),
+            connector_id: connector_id.to_owned(),
             org_id: row.org_id.clone(),
             service_name: row.service_name,
             zone_name: row.zone_name,
@@ -4535,19 +4568,30 @@ impl CloudflareConnectorResolver {
             .remember_org_routing(&identity.org_id, routing.clone())
             .await;
 
-        Ok(Some(identity.into_resolved(routing)))
+        Ok(Some(identity.into_resolved(&routing)))
     }
 
-    async fn record_success(&self, connector_id: &str) -> Result<(), String> {
-        self.store
-            .record_connector_success(connector_id, current_time_millis() as i64)
+    /// Connector health bookkeeping is best-effort: every caller is on a path
+    /// that has already decided the request's outcome, so a failed write is
+    /// logged here rather than propagated.
+    async fn record_success(&self, connector_id: &str) {
+        if let Err(error) = self
+            .store
+            .record_connector_success(connector_id, current_time_millis())
             .await
+        {
+            debug!(connector_id, error, "Failed to record connector success");
+        }
     }
 
-    async fn record_failure(&self, connector_id: &str, error_message: &str) -> Result<(), String> {
-        self.store
-            .record_connector_failure(connector_id, error_message, current_time_millis() as i64)
+    async fn record_failure(&self, connector_id: &str, error_message: &str) {
+        if let Err(error) = self
+            .store
+            .record_connector_failure(connector_id, error_message, current_time_millis())
             .await
+        {
+            debug!(connector_id, error, "Failed to record connector failure");
+        }
     }
 }
 
@@ -4574,7 +4618,7 @@ impl SamplingPolicyResolver {
                 SamplingPolicy::default()
             }
         };
-        self.cache.insert(org_id.to_string(), policy.clone()).await;
+        self.cache.insert(org_id.to_owned(), policy.clone()).await;
         policy
     }
 }
@@ -4635,7 +4679,7 @@ impl AttributeMappingResolver {
             }
         };
         self.cache
-            .insert(org_id.to_string(), Arc::clone(&rules))
+            .insert(org_id.to_owned(), Arc::clone(&rules))
             .await;
         rules
     }
@@ -4708,8 +4752,7 @@ impl ClickHouseTargetProvider for ClickHouseTargetResolver {
         ) {
             (Some(ciphertext), Some(iv), Some(tag)) => {
                 let key = self.encryption_key.as_ref().ok_or_else(|| {
-                    "MAPLE_INGEST_KEY_ENCRYPTION_KEY is required to decrypt ClickHouse credentials"
-                        .to_string()
+                    "MAPLE_INGEST_KEY_ENCRYPTION_KEY is required to decrypt ClickHouse credentials".to_owned()
                 })?;
                 decrypt_aes256_gcm(ciphertext, iv, tag, key)?
             }
@@ -4717,29 +4760,29 @@ impl ClickHouseTargetProvider for ClickHouseTargetResolver {
             _ => {
                 return Err(
                     "ClickHouse password encryption fields must be all present or all null"
-                        .to_string(),
+                        .to_owned(),
                 )
             }
         };
 
         let target = ClickHouseTarget {
-            endpoint: row.ch_url.trim().trim_end_matches('/').to_string(),
+            endpoint: row.ch_url.trim().trim_end_matches('/').to_owned(),
             user: row.ch_user,
             password,
             database: row.ch_database,
         };
         if target.endpoint.is_empty() || target.user.is_empty() || target.database.is_empty() {
-            return Err("ClickHouse target is missing url, user, or database".to_string());
+            return Err("ClickHouse target is missing url, user, or database".to_owned());
         }
         let endpoint_url = url::Url::parse(&target.endpoint)
             .map_err(|error| format!("ClickHouse target endpoint URL is invalid: {error}"))?;
         if !target.password.is_empty() && endpoint_url.scheme() != "https" {
             return Err(
                 "ClickHouse target endpoint must use https when a password is configured"
-                    .to_string(),
+                    .to_owned(),
             );
         }
-        self.cache.insert(org_id.to_string(), target.clone()).await;
+        self.cache.insert(org_id.to_owned(), target.clone()).await;
         Ok(Some(target))
     }
 }
@@ -4776,7 +4819,7 @@ impl PostgresTarget {
             None => String::new(),
         };
         Self {
-            namespace: config.get_dbname().unwrap_or_default().to_string(),
+            namespace: config.get_dbname().unwrap_or_default().to_owned(),
             address,
             port: config.get_ports().first().copied().unwrap_or_default(),
         }
@@ -4836,7 +4879,7 @@ impl PostgresKeyStore {
 
         let mut roots = rustls::RootCertStore::empty();
         roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-        let provider = std::sync::Arc::new(rustls::crypto::ring::default_provider());
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
         let tls_config = rustls::ClientConfig::builder_with_provider(provider)
             .with_safe_default_protocol_versions()
             .map_err(|error| format!("rustls config failed: {error}"))?
@@ -5246,7 +5289,7 @@ fn hash_ingest_key(raw_key: &str, lookup_hmac_key: &str) -> Result<String, Strin
 fn parse_base64_aes256_gcm_key(raw: &str) -> Result<[u8; 32], String> {
     let decoded = STANDARD
         .decode(raw.trim())
-        .map_err(|_| "MAPLE_INGEST_KEY_ENCRYPTION_KEY must be base64".to_string())?;
+        .map_err(|_| "MAPLE_INGEST_KEY_ENCRYPTION_KEY must be base64".to_owned())?;
     decoded.try_into().map_err(|bytes: Vec<u8>| {
         format!(
             "MAPLE_INGEST_KEY_ENCRYPTION_KEY must be base64 for exactly 32 bytes, got {} bytes",
@@ -5263,13 +5306,13 @@ fn decrypt_aes256_gcm(
 ) -> Result<String, String> {
     let ciphertext = STANDARD
         .decode(ciphertext)
-        .map_err(|_| "ClickHouse password ciphertext is not base64".to_string())?;
+        .map_err(|_| "ClickHouse password ciphertext is not base64".to_owned())?;
     let iv = STANDARD
         .decode(iv)
-        .map_err(|_| "ClickHouse password iv is not base64".to_string())?;
+        .map_err(|_| "ClickHouse password iv is not base64".to_owned())?;
     let tag = STANDARD
         .decode(tag)
-        .map_err(|_| "ClickHouse password tag is not base64".to_string())?;
+        .map_err(|_| "ClickHouse password tag is not base64".to_owned())?;
     if iv.len() != 12 {
         return Err(format!(
             "ClickHouse password iv must be 12 bytes for AES-GCM, got {} bytes",
@@ -5289,15 +5332,23 @@ fn decrypt_aes256_gcm(
     sealed.extend_from_slice(&tag);
     let plaintext = cipher
         .decrypt(Nonce::from_slice(&iv), sealed.as_ref())
-        .map_err(|_| "Decryption failed".to_string())?;
-    String::from_utf8(plaintext).map_err(|_| "Decrypted password was not UTF-8".to_string())
+        .map_err(|_| "Decryption failed".to_owned())?;
+    String::from_utf8(plaintext).map_err(|_| "Decrypted password was not UTF-8".to_owned())
 }
 
-fn current_time_millis() -> u128 {
+fn current_time_millis() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_millis())
-        .unwrap_or(0)
+        .map_or(0, |duration| {
+            i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
+        })
+}
+
+/// Milliseconds of a measured duration. Every caller is timing an in-process
+/// operation, so the saturating conversion only has to be total — the ceiling
+/// it saturates at is half a billion years.
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 /// Build the KeyStore for this process. The `Static` variant resolves any
@@ -5307,6 +5358,10 @@ fn current_time_millis() -> u128 {
 /// PSBouncer (the API service writes to the same database); a probe query runs at
 /// startup so any auth/schema/network issue surfaces here instead of 503'ing
 /// every request.
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "one arm per key-store backend, each fully configured in place"
+)]
 async fn build_key_store(
     config: &AppConfig,
     ready: Arc<AtomicBool>,
@@ -5370,8 +5425,7 @@ fn spawn_key_store_reprobe(store: Arc<PostgresKeyStore>, ready: Arc<AtomicBool>)
             // each pass so replicas that booted together drift apart.
             let jitter_ms = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|elapsed| u64::from(elapsed.subsec_nanos()) % 1_000)
-                .unwrap_or(0);
+                .map_or(0, |elapsed| u64::from(elapsed.subsec_nanos()) % 1_000);
             tokio::time::sleep(Duration::from_millis(delay_ms + jitter_ms)).await;
 
             match store.probe().await {
@@ -5505,8 +5559,8 @@ mod tests {
         // an absent `db.namespace` drops the span into the generic per-system
         // node on the service map instead of naming the database.
         let target = PostgresTarget {
-            namespace: "maple_prod".to_string(),
-            address: "psbouncer.example.com".to_string(),
+            namespace: "maple_prod".to_owned(),
+            address: "psbouncer.example.com".to_owned(),
             port: 6432,
         };
         let span = postgres_client_span("fetch_ingest_key", "SELECT", "org_ingest_keys", &target);
@@ -5660,23 +5714,23 @@ mod tests {
     fn enrichment_overwrites_tenant_fields() {
         let mut attributes = vec![
             KeyValue {
-                key: "org_id".to_string(),
+                key: "org_id".to_owned(),
                 value: Some(AnyValue {
-                    value: Some(any_value::Value::StringValue("spoofed".to_string())),
+                    value: Some(any_value::Value::StringValue("spoofed".to_owned())),
                 }),
             },
             KeyValue {
-                key: "maple_org_id".to_string(),
+                key: "maple_org_id".to_owned(),
                 value: Some(AnyValue {
-                    value: Some(any_value::Value::StringValue("spoofed".to_string())),
+                    value: Some(any_value::Value::StringValue("spoofed".to_owned())),
                 }),
             },
         ];
 
         let resolved = ResolvedIngestKey {
-            org_id: "org_real".to_string(),
+            org_id: "org_real".to_owned(),
             key_type: IngestKeyType::Private,
-            key_id: "abc".to_string(),
+            key_id: "abc".to_owned(),
             self_managed: false,
             clickhouse_ready: false,
         };
@@ -5693,23 +5747,23 @@ mod tests {
             }
         }
 
-        assert_eq!(values.get("maple_org_id"), Some(&"org_real".to_string()));
+        assert_eq!(values.get("maple_org_id"), Some(&"org_real".to_owned()));
         assert_eq!(
             values.get("maple_ingest_key_type"),
-            Some(&"private".to_string())
+            Some(&"private".to_owned())
         );
         assert_eq!(
             values.get("maple_ingest_source"),
-            Some(&INGEST_SOURCE.to_string())
+            Some(&INGEST_SOURCE.to_owned())
         );
         assert!(!values.contains_key("org_id"));
     }
 
     fn test_key() -> ResolvedIngestKey {
         ResolvedIngestKey {
-            org_id: "org_real".to_string(),
+            org_id: "org_real".to_owned(),
             key_type: IngestKeyType::Private,
-            key_id: "abc".to_string(),
+            key_id: "abc".to_owned(),
             self_managed: false,
             clickhouse_ready: false,
         }
@@ -5736,7 +5790,7 @@ mod tests {
         };
         assert_eq!(count_log_items(&request), 1);
         let record = &request.resource_logs[0].scope_logs[0].log_records[0];
-        assert_eq!(record.time_unix_nano, 1753660000000000000);
+        assert_eq!(record.time_unix_nano, 1_753_660_000_000_000_000);
         assert_eq!(record.severity_number, 9);
         assert!(record.body.is_none());
         // The empty attribute survives as a key with no value; the real one is intact.
@@ -5780,7 +5834,7 @@ mod tests {
         let span = &request.resource_spans[0].scope_spans[0].spans[0];
         assert_eq!(span.name, "GET /");
         assert_eq!(span.kind, 2);
-        assert_eq!(span.end_time_unix_nano, 1753660000000000001);
+        assert_eq!(span.end_time_unix_nano, 1_753_660_000_000_000_001);
     }
 
     /// Enrichment still has to reach a request whose resource we normalized away.
@@ -5810,7 +5864,7 @@ mod tests {
     /// An export request with nothing to export is a no-op, not a rejection.
     #[test]
     fn empty_export_request_is_accepted() {
-        let decoded = decode_json(Signal::Logs, r#"{}"#).expect("payload accepted");
+        let decoded = decode_json(Signal::Logs, r"{}").expect("payload accepted");
         assert_eq!(decoded.item_count(), 0);
     }
 
@@ -5876,7 +5930,7 @@ mod tests {
 
     #[test]
     fn cloudflare_timestamps_support_rfc3339_unix_and_unix_nano() {
-        let rfc3339 = JsonValue::String("2025-03-07T12:34:56Z".to_string());
+        let rfc3339 = JsonValue::String("2025-03-07T12:34:56Z".to_owned());
         let unix = JsonValue::Number(serde_json::Number::from(1_741_351_296u64));
         let unix_nano = JsonValue::Number(serde_json::Number::from(1_741_351_296_123_456_789u64));
 
@@ -5897,12 +5951,12 @@ mod tests {
     #[test]
     fn cloudflare_log_record_maps_body_severity_and_attributes() {
         let resolved = ResolvedCloudflareConnector {
-            connector_id: "connector_1".to_string(),
-            org_id: "org_1".to_string(),
-            service_name: "cloudflare/example.com".to_string(),
-            zone_name: "example.com".to_string(),
-            dataset: "http_requests".to_string(),
-            secret_key_id: "secret".to_string(),
+            connector_id: "connector_1".to_owned(),
+            org_id: "org_1".to_owned(),
+            service_name: "cloudflare/example.com".to_owned(),
+            zone_name: "example.com".to_owned(),
+            dataset: "http_requests".to_owned(),
+            secret_key_id: "secret".to_owned(),
             self_managed: false,
             clickhouse_ready: false,
         };
@@ -5935,7 +5989,7 @@ mod tests {
         );
 
         let mut resource_values = std::collections::HashMap::new();
-        for attribute in resource_log.resource.as_ref().unwrap().attributes.iter() {
+        for attribute in &resource_log.resource.as_ref().unwrap().attributes {
             if let Some(AnyValue {
                 value: Some(any_value::Value::StringValue(value)),
             }) = &attribute.value
@@ -5953,7 +6007,7 @@ mod tests {
         );
 
         let mut log_values = std::collections::HashMap::new();
-        for attribute in log_record.attributes.iter() {
+        for attribute in &log_record.attributes {
             if let Some(AnyValue {
                 value: Some(any_value::Value::StringValue(value)),
             }) = &attribute.value
@@ -6075,18 +6129,18 @@ mod tests {
             self.connectors
                 .lock()
                 .unwrap()
-                .insert((connector_id.to_string(), hash), row);
+                .insert((connector_id.to_owned(), hash), row);
         }
 
         fn set_org_routing(&self, org_id: &str, routing: OrgRouting) {
             self.routings
                 .lock()
                 .unwrap()
-                .insert(org_id.to_string(), routing);
+                .insert(org_id.to_owned(), routing);
         }
 
         fn insert_clickhouse_target(&self, org_id: &str, row: ClickHouseTargetRow) {
-            self.targets.lock().unwrap().insert(org_id.to_string(), row);
+            self.targets.lock().unwrap().insert(org_id.to_owned(), row);
         }
     }
 
@@ -6102,7 +6156,7 @@ mod tests {
                 .keys
                 .lock()
                 .unwrap()
-                .get(&(key_hash.to_string(), hash_column))
+                .get(&(key_hash.to_owned(), hash_column))
                 .cloned())
         }
         async fn fetch_connector(
@@ -6115,7 +6169,7 @@ mod tests {
                 .connectors
                 .lock()
                 .unwrap()
-                .get(&(connector_id.to_string(), secret_hash.to_string()))
+                .get(&(connector_id.to_owned(), secret_hash.to_owned()))
                 .cloned())
         }
         async fn fetch_sampling_policy(
@@ -6139,7 +6193,7 @@ mod tests {
         async fn fetch_org_routing(&self, org_id: &str) -> Result<Option<OrgRouting>, String> {
             self.routing_fetches.fetch_add(1, Ordering::Relaxed);
             if self.routing_errors.load(Ordering::Relaxed) {
-                return Err("simulated routing store outage".to_string());
+                return Err("simulated routing store outage".to_owned());
             }
             Ok(self.routings.lock().unwrap().get(org_id).cloned())
         }
@@ -6170,7 +6224,7 @@ mod tests {
     }
 
     fn make_resolver(store: Arc<FakeKeyStore>) -> IngestKeyResolver {
-        make_resolver_with_routing_ttl(store, Duration::from_secs(60))
+        make_resolver_with_routing_ttl(store, Duration::from_mins(1))
     }
 
     fn make_resolver_with_routing_ttl(
@@ -6181,9 +6235,9 @@ mod tests {
         let store: Arc<dyn KeyStore> = store;
         IngestKeyResolver {
             store,
-            lookup_hmac_key: "test-hmac-key".to_string(),
+            lookup_hmac_key: "test-hmac-key".to_owned(),
             cache: Cache::builder()
-                .time_to_live(Duration::from_secs(60))
+                .time_to_live(Duration::from_mins(1))
                 .max_capacity(16)
                 .build(),
             routing,
@@ -6217,21 +6271,23 @@ mod tests {
             .read_to_string(&mut decoded)
             .expect("fake ClickHouse should receive gzip NDJSON");
 
-        let _ = tx.send(FakeClickHouseImport {
-            query: query.get("query").cloned().unwrap_or_default(),
-            database: query.get("database").cloned().unwrap_or_default(),
-            user: headers
-                .get("x-clickhouse-user")
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            content_encoding: headers
-                .get(CONTENT_ENCODING)
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            body: decoded,
-        });
+        drop(
+            tx.send(FakeClickHouseImport {
+                query: query.get("query").cloned().unwrap_or_default(),
+                database: query.get("database").cloned().unwrap_or_default(),
+                user: headers
+                    .get("x-clickhouse-user")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                content_encoding: headers
+                    .get(CONTENT_ENCODING)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                body: decoded,
+            }),
+        );
 
         StatusCode::OK
     }
@@ -6241,19 +6297,21 @@ mod tests {
         headers: HeaderMap,
         body: Bytes,
     ) -> StatusCode {
-        let _ = tx.send(FakeForwardImport {
-            content_type: headers
-                .get(CONTENT_TYPE)
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            content_encoding: headers
-                .get(CONTENT_ENCODING)
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            body_len: body.len(),
-        });
+        drop(
+            tx.send(FakeForwardImport {
+                content_type: headers
+                    .get(CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                content_encoding: headers
+                    .get(CONTENT_ENCODING)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                body_len: body.len(),
+            }),
+        );
         StatusCode::OK
     }
 
@@ -6282,9 +6340,9 @@ mod tests {
             clickhouse_export_timeout: Duration::from_secs(5),
             clickhouse_breaker: ClickHouseBreakerConfig::default(),
             datasources: DatasourceNames::defaults(),
-            datasource_session_replays: "session_replays".to_string(),
-            datasource_session_replay_events: "session_replay_events".to_string(),
-            datasource_session_events: "session_events".to_string(),
+            datasource_session_replays: "session_replays".to_owned(),
+            datasource_session_replay_events: "session_replay_events".to_owned(),
+            datasource_session_events: "session_events".to_owned(),
         }
     }
 
@@ -6293,9 +6351,9 @@ mod tests {
             resource_logs: vec![ResourceLogs {
                 resource: Some(Resource {
                     attributes: vec![KeyValue {
-                        key: "service.name".to_string(),
+                        key: "service.name".to_owned(),
                         value: Some(AnyValue {
-                            value: Some(any_value::Value::StringValue("routing-test".to_string())),
+                            value: Some(any_value::Value::StringValue("routing-test".to_owned())),
                         }),
                     }],
                     dropped_attributes_count: 0,
@@ -6303,8 +6361,8 @@ mod tests {
                 }),
                 scope_logs: vec![ScopeLogs {
                     scope: Some(InstrumentationScope {
-                        name: "routing-logger".to_string(),
-                        version: "1.0.0".to_string(),
+                        name: "routing-logger".to_owned(),
+                        version: "1.0.0".to_owned(),
                         attributes: Vec::new(),
                         dropped_attributes_count: 0,
                     }),
@@ -6312,9 +6370,9 @@ mod tests {
                         time_unix_nano: 1_700_000_002_000_000_000,
                         observed_time_unix_nano: 1_700_000_002_000_000_000,
                         severity_number: 9,
-                        severity_text: "INFO".to_string(),
+                        severity_text: "INFO".to_owned(),
                         body: Some(AnyValue {
-                            value: Some(any_value::Value::StringValue(message.to_string())),
+                            value: Some(any_value::Value::StringValue(message.to_owned())),
                         }),
                         ..Default::default()
                     }],
@@ -6344,13 +6402,13 @@ mod tests {
         routing_ttl: Duration,
     ) -> AppState {
         let tinybird = test_tinybird_config(queue_dir);
-        let key_store: Arc<dyn KeyStore> = store.clone();
+        let key_store: Arc<dyn KeyStore> = Arc::<FakeKeyStore>::clone(&store);
         let routing = make_routing_resolver(Arc::clone(&store), routing_ttl);
         let clickhouse_targets = Arc::new(ClickHouseTargetResolver {
             store: Arc::clone(&key_store),
             encryption_key: None,
             cache: Cache::builder()
-                .time_to_live(Duration::from_secs(60))
+                .time_to_live(Duration::from_mins(1))
                 .max_capacity(16)
                 .build(),
         });
@@ -6380,12 +6438,12 @@ mod tests {
                 org_max_in_flight: 100,
                 require_tls: false,
                 key_store_backend: KeyStoreBackend::Static {
-                    org_id: "org_test".to_string(),
+                    org_id: "org_test".to_owned(),
                 },
                 clickhouse_encryption_key: None,
-                lookup_hmac_key: "test-hmac-key".to_string(),
+                lookup_hmac_key: "test-hmac-key".to_owned(),
                 autumn_secret_key: None,
-                autumn_api_url: "https://api.useautumn.com".to_string(),
+                autumn_api_url: "https://api.useautumn.com".to_owned(),
                 autumn_flush_interval_secs: 1,
                 ingest_key_cache_ttl_secs: 60,
                 org_routing_cache_ttl_secs: 5,
@@ -6393,13 +6451,18 @@ mod tests {
                 replay_blob_store: None,
                 trust_proxy_geo: false,
             },
+            #[expect(
+                clippy::useless_conversion,
+                reason = "identity in normal builds; under `--features hotpath` this wraps the \
+                          client in the instrumented type"
+            )]
             http_client: http_client.into(),
             telemetry_pipeline: Some(telemetry_pipeline),
             resolver: IngestKeyResolver {
                 store: Arc::clone(&key_store),
-                lookup_hmac_key: "test-hmac-key".to_string(),
+                lookup_hmac_key: "test-hmac-key".to_owned(),
                 cache: Cache::builder()
-                    .time_to_live(Duration::from_secs(60))
+                    .time_to_live(Duration::from_mins(1))
                     .max_capacity(16)
                     .build(),
                 routing: Arc::clone(&routing),
@@ -6421,9 +6484,9 @@ mod tests {
             },
             cloudflare_resolver: CloudflareConnectorResolver {
                 store: key_store,
-                lookup_hmac_key: "test-hmac-key".to_string(),
+                lookup_hmac_key: "test-hmac-key".to_owned(),
                 cache: Cache::builder()
-                    .time_to_live(Duration::from_secs(60))
+                    .time_to_live(Duration::from_mins(1))
                     .max_capacity(16)
                     .build(),
                 routing,
@@ -6441,15 +6504,15 @@ mod tests {
     fn with_replay_blob_store(mut state: AppState, endpoint: String) -> AppState {
         let config = ReplayBlobStoreConfig {
             endpoint,
-            bucket: "replays".to_string(),
-            access_key_id: "test-access-key".to_string(),
-            secret_access_key: "test-secret-key".to_string(),
-            region: "auto".to_string(),
+            bucket: "replays".to_owned(),
+            access_key_id: "test-access-key".to_owned(),
+            secret_access_key: "test-secret-key".to_owned(),
+            region: "auto".to_owned(),
             timeout: Duration::from_secs(5),
         };
         state.replay_blob_store = Some(ReplayBlobStore::new(
             state.http_client.clone(),
-            config.endpoint.clone(),
+            &config.endpoint,
             config.bucket.clone(),
             config.access_key_id.clone(),
             config.secret_access_key.clone(),
@@ -6507,9 +6570,7 @@ mod tests {
     }
 
     async fn fake_r2_put(
-        axum::extract::State(tx): axum::extract::State<
-            tokio::sync::mpsc::UnboundedSender<CapturedPut>,
-        >,
+        State(tx): State<tokio::sync::mpsc::UnboundedSender<CapturedPut>>,
         Path(path): Path<String>,
         headers: HeaderMap,
         body: Bytes,
@@ -6519,15 +6580,15 @@ mod tests {
                 .get(name)
                 .and_then(|v| v.to_str().ok())
                 .unwrap_or_default()
-                .to_string()
+                .to_owned()
         };
-        let _ = tx.send(CapturedPut {
+        drop(tx.send(CapturedPut {
             path,
             authorization: header("authorization"),
             content_type: header("content-type"),
             content_encoding: header("content-encoding"),
             body: body.to_vec(),
-        });
+        }));
         StatusCode::OK
     }
 
@@ -6557,7 +6618,7 @@ mod tests {
     /// Total bytes the pipeline has committed to disk. The WAL is appended
     /// before a frame reaches the export channel, so this growing is the
     /// observable "a row was enqueued".
-    fn queue_dir_bytes(dir: &PathBuf) -> u64 {
+    fn queue_dir_bytes(dir: &std::path::Path) -> u64 {
         fn walk(dir: &std::path::Path) -> u64 {
             let Ok(entries) = std::fs::read_dir(dir) else {
                 return 0;
@@ -6579,7 +6640,7 @@ mod tests {
         store.insert_private(
             raw_key,
             KeyRow {
-                org_id: org_id.to_string(),
+                org_id: org_id.to_owned(),
                 // Routes to ClickHouse. The fixture's `WriteMode::Forward` has no
                 // Tinybird pipeline, so a Tinybird-destined chunk would 503 in
                 // `native_rows_pipeline_for` before reaching the blob path.
@@ -6590,7 +6651,7 @@ mod tests {
         test_app_state(
             store,
             queue_dir,
-            "http://127.0.0.1:1".to_string(),
+            "http://127.0.0.1:1".to_owned(),
             Duration::from_secs(30),
         )
         .await
@@ -6652,7 +6713,7 @@ mod tests {
         );
         assert!(captured.authorization.contains("/auto/s3/aws4_request"));
 
-        let _ = std::fs::remove_dir_all(&queue_dir);
+        drop(std::fs::remove_dir_all(&queue_dir));
     }
 
     #[tokio::test]
@@ -6694,7 +6755,7 @@ mod tests {
             "no index row may be committed when the payload was not stored"
         );
 
-        let _ = std::fs::remove_dir_all(&queue_dir);
+        drop(std::fs::remove_dir_all(&queue_dir));
     }
 
     #[tokio::test]
@@ -6724,7 +6785,7 @@ mod tests {
             "the inline path must still enqueue a row carrying the payload"
         );
 
-        let _ = std::fs::remove_dir_all(&queue_dir);
+        drop(std::fs::remove_dir_all(&queue_dir));
     }
 
     #[test]
@@ -6785,7 +6846,7 @@ mod tests {
         store.insert_private(
             "maple_sk_test_shared",
             KeyRow {
-                org_id: "org_shared".to_string(),
+                org_id: "org_shared".to_owned(),
                 self_managed: false,
                 clickhouse_ready: false,
             },
@@ -6808,7 +6869,7 @@ mod tests {
         store.insert_private(
             "maple_sk_test_byo",
             KeyRow {
-                org_id: "org_byo".to_string(),
+                org_id: "org_byo".to_owned(),
                 self_managed: true,
                 clickhouse_ready: true,
             },
@@ -6831,7 +6892,7 @@ mod tests {
         store.insert_private(
             "maple_sk_test_stale_schema",
             KeyRow {
-                org_id: "org_stale".to_string(),
+                org_id: "org_stale".to_owned(),
                 self_managed: true,
                 clickhouse_ready: false,
             },
@@ -6857,7 +6918,7 @@ mod tests {
         store.insert_private(
             "maple_sk_test_becomes_ready",
             KeyRow {
-                org_id: "org_transition".to_string(),
+                org_id: "org_transition".to_owned(),
                 self_managed: false,
                 clickhouse_ready: false,
             },
@@ -6906,7 +6967,7 @@ mod tests {
         store.insert_private(
             "maple_sk_test_d1_blip",
             KeyRow {
-                org_id: "org_d1_blip".to_string(),
+                org_id: "org_d1_blip".to_owned(),
                 self_managed: false,
                 clickhouse_ready: false,
             },
@@ -6966,21 +7027,21 @@ mod tests {
             "connector_ready_later",
             "secret-before-ready",
             ConnectorRow {
-                org_id: "org_logpush_transition".to_string(),
-                service_name: "cloudflare/example.com".to_string(),
-                zone_name: "example.com".to_string(),
-                dataset: "http_requests".to_string(),
+                org_id: "org_logpush_transition".to_owned(),
+                service_name: "cloudflare/example.com".to_owned(),
+                zone_name: "example.com".to_owned(),
+                dataset: "http_requests".to_owned(),
                 self_managed: false,
                 clickhouse_ready: false,
             },
         );
         let routing = make_routing_resolver(Arc::clone(&store), Duration::from_millis(5));
-        let key_store: Arc<dyn KeyStore> = store.clone();
+        let key_store: Arc<dyn KeyStore> = Arc::<FakeKeyStore>::clone(&store);
         let resolver = CloudflareConnectorResolver {
             store: key_store,
-            lookup_hmac_key: "test-hmac-key".to_string(),
+            lookup_hmac_key: "test-hmac-key".to_owned(),
             cache: Cache::builder()
-                .time_to_live(Duration::from_secs(60))
+                .time_to_live(Duration::from_mins(1))
                 .max_capacity(16)
                 .build(),
             routing,
@@ -7055,6 +7116,11 @@ mod tests {
         /// Scoped to the calling thread. `#[tokio::test]` uses a current-thread
         /// runtime, so the handler and the export worker it spawns both run here,
         /// while other tests' spans are filtered out.
+        #[expect(
+            clippy::option_option,
+            reason = "the two levels are distinct answers: the outer is whether the span was \
+                      recorded at all, the inner is whether it had a parent"
+        )]
         fn parent_of(&self, name: &str) -> Option<Option<String>> {
             let this_thread = std::thread::current().id();
             self.spans
@@ -7090,10 +7156,10 @@ mod tests {
             let Some(span) = ctx.span(id) else {
                 return;
             };
-            let parent = span.parent().map(|parent| parent.name().to_string());
+            let parent = span.parent().map(|parent| parent.name().to_owned());
             self.spans.lock().unwrap().push((
                 std::thread::current().id(),
-                span.name().to_string(),
+                span.name().to_owned(),
                 parent,
             ));
         }
@@ -7112,8 +7178,8 @@ mod tests {
         for error in [
             PipelineError::Backpressure("lane full"),
             PipelineError::Throttled("org cap"),
-            PipelineError::QueueUnavailable("wal io".to_string()),
-            PipelineError::Encode("bad row".to_string()),
+            PipelineError::QueueUnavailable("wal io".to_owned()),
+            PipelineError::Encode("bad row".to_owned()),
         ] {
             let status = api_error_from_pipeline(&error).status.as_u16();
             assert_eq!(
@@ -7156,7 +7222,7 @@ mod tests {
         store.insert_private(
             raw_key,
             KeyRow {
-                org_id: "org_span_tree".to_string(),
+                org_id: "org_span_tree".to_owned(),
                 self_managed: true,
                 clickhouse_ready: true,
             },
@@ -7165,18 +7231,18 @@ mod tests {
             "org_span_tree",
             ClickHouseTargetRow {
                 ch_url: format!("http://{ch_addr}"),
-                ch_user: "ingest".to_string(),
+                ch_user: "ingest".to_owned(),
                 ch_password_ciphertext: None,
                 ch_password_iv: None,
                 ch_password_tag: None,
-                ch_database: "maple".to_string(),
-                schema_version: CLICKHOUSE_SCHEMA_VERSION.to_string(),
+                ch_database: "maple".to_owned(),
+                schema_version: CLICKHOUSE_SCHEMA_VERSION.to_owned(),
             },
         );
         let state = test_app_state(
             Arc::clone(&store),
             queue_dir.clone(),
-            "http://127.0.0.1:1".to_string(),
+            "http://127.0.0.1:1".to_owned(),
             Duration::from_millis(5),
         )
         .await;
@@ -7219,6 +7285,10 @@ mod tests {
     }
 
     #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "an end-to-end scenario test; the setup is the test"
+    )]
     async fn forward_mode_switches_ready_org_to_clickhouse_without_forwarding_again() {
         let (ch_tx, mut ch_rx) = tokio::sync::mpsc::unbounded_channel();
         let ch_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
@@ -7250,7 +7320,7 @@ mod tests {
         store.insert_private(
             raw_key,
             KeyRow {
-                org_id: "org_forward_ready".to_string(),
+                org_id: "org_forward_ready".to_owned(),
                 self_managed: false,
                 clickhouse_ready: false,
             },
@@ -7299,12 +7369,12 @@ mod tests {
             "org_forward_ready",
             ClickHouseTargetRow {
                 ch_url: format!("http://{ch_addr}"),
-                ch_user: "ingest".to_string(),
+                ch_user: "ingest".to_owned(),
                 ch_password_ciphertext: None,
                 ch_password_iv: None,
                 ch_password_tag: None,
-                ch_database: "maple".to_string(),
-                schema_version: CLICKHOUSE_SCHEMA_VERSION.to_string(),
+                ch_database: "maple".to_owned(),
+                schema_version: CLICKHOUSE_SCHEMA_VERSION.to_owned(),
             },
         );
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -7352,7 +7422,7 @@ mod tests {
             "routing cache should refresh independently from auth cache"
         );
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[test]
@@ -7406,13 +7476,13 @@ mod tests {
         store.insert_clickhouse_target(
             "org_old",
             ClickHouseTargetRow {
-                ch_url: "https://clickhouse.example".to_string(),
-                ch_user: "ingest".to_string(),
+                ch_url: "https://clickhouse.example".to_owned(),
+                ch_user: "ingest".to_owned(),
                 ch_password_ciphertext: None,
                 ch_password_iv: None,
                 ch_password_tag: None,
-                ch_database: "maple".to_string(),
-                schema_version: "old-revision".to_string(),
+                ch_database: "maple".to_owned(),
+                schema_version: "old-revision".to_owned(),
             },
         );
 
@@ -7420,7 +7490,7 @@ mod tests {
             store,
             encryption_key: None,
             cache: Cache::builder()
-                .time_to_live(Duration::from_secs(60))
+                .time_to_live(Duration::from_mins(1))
                 .max_capacity(16)
                 .build(),
         };
@@ -7438,13 +7508,13 @@ mod tests {
         store.insert_clickhouse_target(
             "org_ready",
             ClickHouseTargetRow {
-                ch_url: "https://clickhouse.example/".to_string(),
-                ch_user: "ingest".to_string(),
-                ch_password_ciphertext: Some("vDjK0A+Vv5bHlJ2a3A==".to_string()),
-                ch_password_iv: Some("AQIDBAUGBwgJCgsM".to_string()),
-                ch_password_tag: Some("b7D1umrvI8557NFvR9nJ/A==".to_string()),
-                ch_database: "maple".to_string(),
-                schema_version: CLICKHOUSE_SCHEMA_VERSION.to_string(),
+                ch_url: "https://clickhouse.example/".to_owned(),
+                ch_user: "ingest".to_owned(),
+                ch_password_ciphertext: Some("vDjK0A+Vv5bHlJ2a3A==".to_owned()),
+                ch_password_iv: Some("AQIDBAUGBwgJCgsM".to_owned()),
+                ch_password_tag: Some("b7D1umrvI8557NFvR9nJ/A==".to_owned()),
+                ch_database: "maple".to_owned(),
+                schema_version: CLICKHOUSE_SCHEMA_VERSION.to_owned(),
             },
         );
 
@@ -7455,7 +7525,7 @@ mod tests {
                     .unwrap(),
             ),
             cache: Cache::builder()
-                .time_to_live(Duration::from_secs(60))
+                .time_to_live(Duration::from_mins(1))
                 .max_capacity(16)
                 .build(),
         };
@@ -7477,13 +7547,13 @@ mod tests {
         store.insert_clickhouse_target(
             "org_insecure",
             ClickHouseTargetRow {
-                ch_url: "http://clickhouse.example/".to_string(),
-                ch_user: "ingest".to_string(),
-                ch_password_ciphertext: Some("vDjK0A+Vv5bHlJ2a3A==".to_string()),
-                ch_password_iv: Some("AQIDBAUGBwgJCgsM".to_string()),
-                ch_password_tag: Some("b7D1umrvI8557NFvR9nJ/A==".to_string()),
-                ch_database: "maple".to_string(),
-                schema_version: CLICKHOUSE_SCHEMA_VERSION.to_string(),
+                ch_url: "http://clickhouse.example/".to_owned(),
+                ch_user: "ingest".to_owned(),
+                ch_password_ciphertext: Some("vDjK0A+Vv5bHlJ2a3A==".to_owned()),
+                ch_password_iv: Some("AQIDBAUGBwgJCgsM".to_owned()),
+                ch_password_tag: Some("b7D1umrvI8557NFvR9nJ/A==".to_owned()),
+                ch_database: "maple".to_owned(),
+                schema_version: CLICKHOUSE_SCHEMA_VERSION.to_owned(),
             },
         );
 
@@ -7494,7 +7564,7 @@ mod tests {
                     .unwrap(),
             ),
             cache: Cache::builder()
-                .time_to_live(Duration::from_secs(60))
+                .time_to_live(Duration::from_mins(1))
                 .max_capacity(16)
                 .build(),
         };

--- a/apps/ingest/src/metrics.rs
+++ b/apps/ingest/src/metrics.rs
@@ -355,23 +355,23 @@ pub fn request_completed(signal: &str, status: &str, error_kind: &str, duration_
     REQUEST_DURATION_SECONDS.record(
         duration_secs,
         &[
-            KeyValue::new("signal", signal.to_string()),
-            KeyValue::new("status", status.to_string()),
+            KeyValue::new("signal", signal.to_owned()),
+            KeyValue::new("status", status.to_owned()),
         ],
     );
     REQUESTS_TOTAL.add(
         1,
         &[
-            KeyValue::new("signal", signal.to_string()),
-            KeyValue::new("status", status.to_string()),
-            KeyValue::new("error_kind", error_kind.to_string()),
+            KeyValue::new("signal", signal.to_owned()),
+            KeyValue::new("status", status.to_owned()),
+            KeyValue::new("error_kind", error_kind.to_owned()),
         ],
     );
 }
 
 /// Telemetry items accepted from a request payload.
 pub fn items_accepted(signal: &str, count: u64) {
-    ITEMS_TOTAL.add(count, &[KeyValue::new("signal", signal.to_string())]);
+    ITEMS_TOTAL.add(count, &[KeyValue::new("signal", signal.to_owned())]);
 }
 
 /// A request was rejected by a per-org limit (`reason` is `in_flight` or `queue_bytes`).
@@ -379,7 +379,7 @@ pub fn org_throttled(org_id: &str, reason: &'static str) {
     ORG_THROTTLED_TOTAL.add(
         1,
         &[
-            KeyValue::new("org_id", org_id.to_string()),
+            KeyValue::new("org_id", org_id.to_owned()),
             KeyValue::new("reason", reason),
         ],
     );
@@ -398,9 +398,9 @@ pub fn org_data_loss(org_id: &str, signal: &str, error_kind: &str) {
     ORG_DATA_LOSS_TOTAL.add(
         1,
         &[
-            KeyValue::new("org_id", org_id.to_string()),
-            KeyValue::new("signal", signal.to_string()),
-            KeyValue::new("error_kind", error_kind.to_string()),
+            KeyValue::new("org_id", org_id.to_owned()),
+            KeyValue::new("signal", signal.to_owned()),
+            KeyValue::new("error_kind", error_kind.to_owned()),
         ],
     );
 }
@@ -412,9 +412,9 @@ pub fn backpressure_shed(org_id: &str, destination: &str, signal: &str) {
     BACKPRESSURE_SHED_TOTAL.add(
         1,
         &[
-            KeyValue::new("org_id", org_id.to_string()),
-            KeyValue::new("destination", destination.to_string()),
-            KeyValue::new("signal", signal.to_string()),
+            KeyValue::new("org_id", org_id.to_owned()),
+            KeyValue::new("destination", destination.to_owned()),
+            KeyValue::new("signal", signal.to_owned()),
         ],
     );
 }
@@ -423,14 +423,14 @@ pub fn backpressure_shed(org_id: &str, destination: &str, signal: &str) {
 /// crossed it. Recording stops here; every later chunk lands in
 /// `replay_session_chunk_dropped`.
 pub fn replay_session_truncated(org_id: &str) {
-    REPLAY_SESSION_TRUNCATED_TOTAL.add(1, &[KeyValue::new("org_id", org_id.to_string())]);
+    REPLAY_SESSION_TRUNCATED_TOTAL.add(1, &[KeyValue::new("org_id", org_id.to_owned())]);
 }
 
 /// A chunk was rejected because its session had already been truncated. A high
 /// ratio against `replay_session_truncated` means one org keeps recording long
 /// after it stopped being stored — worth an SDK-side sampling conversation.
 pub fn replay_session_chunk_dropped(org_id: &str) {
-    REPLAY_SESSION_CHUNK_DROPPED_TOTAL.add(1, &[KeyValue::new("org_id", org_id.to_string())]);
+    REPLAY_SESSION_CHUNK_DROPPED_TOTAL.add(1, &[KeyValue::new("org_id", org_id.to_owned())]);
 }
 
 /// A replay chunk's payload could not be written to the blob store, so the
@@ -438,17 +438,17 @@ pub fn replay_session_chunk_dropped(org_id: &str) {
 /// every increment here is a permanent gap in a recording — this should sit at
 /// zero, and it is the signal to watch during the R2 cutover.
 pub fn replay_blob_put_failed(org_id: &str) {
-    REPLAY_BLOB_PUT_FAILED_TOTAL.add(1, &[KeyValue::new("org_id", org_id.to_string())]);
+    REPLAY_BLOB_PUT_FAILED_TOTAL.add(1, &[KeyValue::new("org_id", org_id.to_owned())]);
 }
 
 /// Current in-flight request count for an org.
 pub fn org_requests_in_flight(org_id: &str, value: u64) {
-    ORG_REQUESTS_IN_FLIGHT.record(value, &[KeyValue::new("org_id", org_id.to_string())]);
+    ORG_REQUESTS_IN_FLIGHT.record(value, &[KeyValue::new("org_id", org_id.to_owned())]);
 }
 
 /// A request used the sentinel test token.
 pub fn sentinel(signal: &str) {
-    SENTINEL_TOTAL.add(1, &[KeyValue::new("signal", signal.to_string())]);
+    SENTINEL_TOTAL.add(1, &[KeyValue::new("signal", signal.to_owned())]);
 }
 
 /// Ingest key resolution latency.
@@ -458,12 +458,12 @@ pub fn key_resolution_duration(duration_secs: f64) {
 
 /// Raw request body size.
 pub fn request_body_bytes(signal: &str, bytes: u64) {
-    REQUEST_BODY_BYTES.record(bytes, &[KeyValue::new("signal", signal.to_string())]);
+    REQUEST_BODY_BYTES.record(bytes, &[KeyValue::new("signal", signal.to_owned())]);
 }
 
 /// Decompressed request payload size.
 pub fn decoded_body_bytes(signal: &str, bytes: u64) {
-    DECODED_BODY_BYTES.record(bytes, &[KeyValue::new("signal", signal.to_string())]);
+    DECODED_BODY_BYTES.record(bytes, &[KeyValue::new("signal", signal.to_owned())]);
 }
 
 /// A Cloudflare Logpush batch was received.
@@ -471,28 +471,28 @@ pub fn cloudflare_batch(dataset: &str, is_validation: bool) {
     CLOUDFLARE_BATCHES_TOTAL.add(
         1,
         &[
-            KeyValue::new("dataset", dataset.to_string()),
+            KeyValue::new("dataset", dataset.to_owned()),
             KeyValue::new("validation", if is_validation { "true" } else { "false" }),
         ],
     );
     if is_validation {
-        CLOUDFLARE_VALIDATION_TOTAL.add(1, &[KeyValue::new("dataset", dataset.to_string())]);
+        CLOUDFLARE_VALIDATION_TOTAL.add(1, &[KeyValue::new("dataset", dataset.to_owned())]);
     }
 }
 
 /// A Cloudflare Logpush request failed authentication.
 pub fn cloudflare_auth_failure(dataset: &str) {
-    CLOUDFLARE_AUTH_FAILURES_TOTAL.add(1, &[KeyValue::new("dataset", dataset.to_string())]);
+    CLOUDFLARE_AUTH_FAILURES_TOTAL.add(1, &[KeyValue::new("dataset", dataset.to_owned())]);
 }
 
 /// A Cloudflare Logpush request failed parsing.
 pub fn cloudflare_parse_failure(dataset: &str) {
-    CLOUDFLARE_PARSE_FAILURES_TOTAL.add(1, &[KeyValue::new("dataset", dataset.to_string())]);
+    CLOUDFLARE_PARSE_FAILURES_TOTAL.add(1, &[KeyValue::new("dataset", dataset.to_owned())]);
 }
 
 /// Log records parsed from a Cloudflare Logpush batch.
 pub fn cloudflare_records(dataset: &str, count: u64) {
-    CLOUDFLARE_RECORDS_TOTAL.add(count, &[KeyValue::new("dataset", dataset.to_string())]);
+    CLOUDFLARE_RECORDS_TOTAL.add(count, &[KeyValue::new("dataset", dataset.to_owned())]);
 }
 
 /// A WAL append was rejected because the lane file is full. `shard` is the real
@@ -502,7 +502,7 @@ pub fn wal_shard_full(shard: usize, destination: &str) {
         1,
         &[
             KeyValue::new("shard", shard.to_string()),
-            KeyValue::new("destination", destination.to_string()),
+            KeyValue::new("destination", destination.to_owned()),
         ],
     );
 }
@@ -513,7 +513,7 @@ pub fn wal_commit_bytes(shard: usize, destination: &str, bytes: u64) {
         bytes,
         &[
             KeyValue::new("shard", shard.to_string()),
-            KeyValue::new("destination", destination.to_string()),
+            KeyValue::new("destination", destination.to_owned()),
         ],
     );
 }
@@ -524,14 +524,14 @@ pub fn wal_shard_bytes(shard: usize, destination: &str, bytes: u64) {
         bytes,
         &[
             KeyValue::new("shard", shard.to_string()),
-            KeyValue::new("destination", destination.to_string()),
+            KeyValue::new("destination", destination.to_owned()),
         ],
     );
 }
 
 /// Current bytes queued for export for an org.
 pub fn org_queue_bytes(org_id: &str, bytes: u64) {
-    ORG_QUEUE_BYTES.record(bytes, &[KeyValue::new("org_id", org_id.to_string())]);
+    ORG_QUEUE_BYTES.record(bytes, &[KeyValue::new("org_id", org_id.to_owned())]);
 }
 
 /// Latency and exported-byte size of a completed WAL export batch.
@@ -541,7 +541,7 @@ pub fn export_batch_completed(shard: usize, signal: &str, duration_secs: f64, ex
     WAL_EXPORTED_BYTES.record(
         exported_bytes,
         &[
-            KeyValue::new("signal", signal.to_string()),
+            KeyValue::new("signal", signal.to_owned()),
             KeyValue::new("shard", shard.to_string()),
         ],
     );
@@ -552,9 +552,9 @@ pub fn forward_response(signal: &str, upstream_status: &'static str, upstream_po
     FORWARD_RESPONSES_TOTAL.add(
         1,
         &[
-            KeyValue::new("signal", signal.to_string()),
+            KeyValue::new("signal", signal.to_owned()),
             KeyValue::new("upstream_status", upstream_status),
-            KeyValue::new("upstream_pool", upstream_pool.to_string()),
+            KeyValue::new("upstream_pool", upstream_pool.to_owned()),
         ],
     );
 }
@@ -564,28 +564,26 @@ pub fn forward_duration(signal: &str, upstream_pool: &str, duration_secs: f64) {
     FORWARD_DURATION_SECONDS.record(
         duration_secs,
         &[
-            KeyValue::new("signal", signal.to_string()),
-            KeyValue::new("upstream_pool", upstream_pool.to_string()),
+            KeyValue::new("signal", signal.to_owned()),
+            KeyValue::new("upstream_pool", upstream_pool.to_owned()),
         ],
     );
 }
 
 /// Native warehouse pipeline accept latency.
 pub fn native_accept_duration(signal: &str, duration_secs: f64) {
-    NATIVE_ACCEPT_DURATION_SECONDS.record(
-        duration_secs,
-        &[KeyValue::new("signal", signal.to_string())],
-    );
+    NATIVE_ACCEPT_DURATION_SECONDS
+        .record(duration_secs, &[KeyValue::new("signal", signal.to_owned())]);
 }
 
 /// Rows accepted by the native warehouse pipeline.
 pub fn native_rows(signal: &str, count: u64) {
-    NATIVE_ROWS_TOTAL.add(count, &[KeyValue::new("signal", signal.to_string())]);
+    NATIVE_ROWS_TOTAL.add(count, &[KeyValue::new("signal", signal.to_owned())]);
 }
 
 /// Rows dropped by sampling in the native pipeline.
 pub fn native_sampled_dropped(signal: &str, count: u64) {
-    NATIVE_SAMPLED_DROPPED_TOTAL.add(count, &[KeyValue::new("signal", signal.to_string())]);
+    NATIVE_SAMPLED_DROPPED_TOTAL.add(count, &[KeyValue::new("signal", signal.to_owned())]);
 }
 
 /// A successful Tinybird export: latency and exported row count.
@@ -593,11 +591,11 @@ pub fn tinybird_export_succeeded(datasource: &str, duration_secs: f64, rows: u64
     TINYBIRD_EXPORT_DURATION_SECONDS.record(
         duration_secs,
         &[
-            KeyValue::new("datasource", datasource.to_string()),
+            KeyValue::new("datasource", datasource.to_owned()),
             KeyValue::new("status", "2xx"),
         ],
     );
-    TINYBIRD_EXPORT_ROWS_TOTAL.add(rows, &[KeyValue::new("datasource", datasource.to_string())]);
+    TINYBIRD_EXPORT_ROWS_TOTAL.add(rows, &[KeyValue::new("datasource", datasource.to_owned())]);
 }
 
 /// Rows dropped while exporting to Tinybird (`status` is an HTTP code or `retries_exhausted`).
@@ -605,8 +603,8 @@ pub fn tinybird_export_dropped(datasource: &str, status: &str, rows: u64) {
     TINYBIRD_EXPORT_DROPPED_TOTAL.add(
         rows,
         &[
-            KeyValue::new("datasource", datasource.to_string()),
-            KeyValue::new("status", status.to_string()),
+            KeyValue::new("datasource", datasource.to_owned()),
+            KeyValue::new("status", status.to_owned()),
         ],
     );
 }
@@ -616,8 +614,8 @@ pub fn tinybird_export_retry(datasource: &str, status: &str) {
     TINYBIRD_EXPORT_RETRIES_TOTAL.add(
         1,
         &[
-            KeyValue::new("datasource", datasource.to_string()),
-            KeyValue::new("status", status.to_string()),
+            KeyValue::new("datasource", datasource.to_owned()),
+            KeyValue::new("status", status.to_owned()),
         ],
     );
 }
@@ -625,8 +623,8 @@ pub fn tinybird_export_retry(datasource: &str, status: &str) {
 /// A successful ClickHouse export: latency and exported row count.
 pub fn clickhouse_export_succeeded(datasource: &str, status: &str, duration_secs: f64, rows: u64) {
     let attrs = [
-        KeyValue::new("datasource", datasource.to_string()),
-        KeyValue::new("status", status.to_string()),
+        KeyValue::new("datasource", datasource.to_owned()),
+        KeyValue::new("status", status.to_owned()),
     ];
     CLICKHOUSE_EXPORT_DURATION_SECONDS.record(duration_secs, &attrs);
     CLICKHOUSE_EXPORT_ROWS_TOTAL.add(rows, &attrs);
@@ -637,8 +635,8 @@ pub fn clickhouse_export_dropped(datasource: &str, status: &str, rows: u64) {
     CLICKHOUSE_EXPORT_DROPPED_TOTAL.add(
         rows,
         &[
-            KeyValue::new("datasource", datasource.to_string()),
-            KeyValue::new("status", status.to_string()),
+            KeyValue::new("datasource", datasource.to_owned()),
+            KeyValue::new("status", status.to_owned()),
         ],
     );
 }
@@ -648,8 +646,8 @@ pub fn clickhouse_export_retry(datasource: &str, status: &str) {
     CLICKHOUSE_EXPORT_RETRIES_TOTAL.add(
         1,
         &[
-            KeyValue::new("datasource", datasource.to_string()),
-            KeyValue::new("status", status.to_string()),
+            KeyValue::new("datasource", datasource.to_owned()),
+            KeyValue::new("status", status.to_owned()),
         ],
     );
 }

--- a/apps/ingest/src/otel.rs
+++ b/apps/ingest/src/otel.rs
@@ -4,6 +4,7 @@ use std::env;
 use tracing::field::Empty;
 use tracing::{info_span, Span};
 
+#[derive(Debug)]
 pub struct ResourceConfig {
     pub service_name: &'static str,
     pub service_namespace: &'static str,
@@ -39,7 +40,7 @@ pub fn build_resource(cfg: ResourceConfig) -> Resource {
     attrs.push(KeyValue::new(
         "vcs.repository.url.full",
         env::var("VCS_REPOSITORY_URL")
-            .unwrap_or_else(|_| "https://github.com/Makisuo/maple".to_string()),
+            .unwrap_or_else(|_| "https://github.com/Makisuo/maple".to_owned()),
     ));
     if let Some(revision) = detect_head_revision() {
         attrs.push(KeyValue::new("vcs.ref.head.revision", revision));
@@ -64,6 +65,10 @@ fn detect_head_revision() -> Option<String> {
 /// Mirrors packages/effect-sdk/src/server/platform.ts platform detection — first
 /// match wins. Returns the cloud.{provider,platform,region} (and faas.* / k8s.*
 /// where applicable) attribute set for the runtime environment.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one branch per hosting platform, each a self-contained set of resource attributes"
+)]
 fn detect_platform() -> Vec<KeyValue> {
     if env::var("CF_VERSION_METADATA").is_ok() || env::var("WORKERS_CI").is_ok() {
         return vec![
@@ -169,7 +174,7 @@ fn detect_platform() -> Vec<KeyValue> {
 }
 
 fn os_type() -> &'static str {
-    match std::env::consts::OS {
+    match env::consts::OS {
         "macos" => "darwin",
         "windows" => "windows",
         other => other,
@@ -177,7 +182,7 @@ fn os_type() -> &'static str {
 }
 
 fn host_arch() -> &'static str {
-    match std::env::consts::ARCH {
+    match env::consts::ARCH {
         "x86_64" => "amd64",
         "x86" => "x86",
         "aarch64" => "arm64",
@@ -496,7 +501,7 @@ pub fn resolve_config_internal_span() -> Span {
 mod tests {
     use super::*;
 
-    fn find_attr<'a>(resource: &'a Resource, key: &str) -> Option<String> {
+    fn find_attr(resource: &Resource, key: &str) -> Option<String> {
         resource
             .iter()
             .find(|(k, _)| k.as_str() == key)
@@ -705,9 +710,9 @@ mod tests {
             service_name: "ingest",
             service_namespace: "ingest",
             service_version: "0.0.0",
-            service_instance_id: "test-instance".to_string(),
-            deployment_env: "test".to_string(),
-            internal_org_id: "internal".to_string(),
+            service_instance_id: "test-instance".to_owned(),
+            deployment_env: "test".to_owned(),
+            internal_org_id: "internal".to_owned(),
         });
         assert_eq!(
             find_attr(&resource, "process.runtime.name").as_deref(),

--- a/apps/ingest/src/otlp_json.rs
+++ b/apps/ingest/src/otlp_json.rs
@@ -51,6 +51,11 @@ const U32_NUMBER_FIELDS: &[&str] = &[
 /// Enum fields sent as their protobuf enum *name*. The OTLP/JSON profile tells
 /// senders to use numbers, but standard protobuf JSON permits names and some
 /// clients emit them, so decode both.
+#[expect(
+    clippy::match_same_arms,
+    reason = "arms are grouped by protobuf field; three enums happening to share the value 0, 1 or \
+              2 is not a reason to interleave them"
+)]
 fn enum_value(field: &str, name: &str) -> Option<i64> {
     let n = match (field, name) {
         ("severityNumber", n) => return severity_number(n),
@@ -77,14 +82,8 @@ fn severity_number(name: &str) -> Option<i64> {
     if rest == "UNSPECIFIED" {
         return Some(0);
     }
-    let (base, offset) = rest.split_at(
-        rest.len()
-            - rest
-                .chars()
-                .rev()
-                .take_while(|c| c.is_ascii_digit())
-                .count(),
-    );
+    let (base, offset) =
+        rest.split_at(rest.len() - rest.chars().rev().take_while(char::is_ascii_digit).count());
     let step = match base {
         "TRACE" => 1,
         "DEBUG" => 5,
@@ -117,7 +116,7 @@ pub fn normalize(value: &mut Value, root_field: &str) {
         // replacing it with an empty list would discard the payload and answer
         // 200, which is the failure mode this module exists to remove.
         if !map.contains_key(root_field) {
-            map.insert(root_field.to_string(), Value::Array(Vec::new()));
+            map.insert(root_field.to_owned(), Value::Array(Vec::new()));
         }
     }
 }
@@ -313,7 +312,7 @@ mod tests {
 
     #[test]
     fn empty_request_gets_its_root_list() {
-        assert_eq!(norm(r#"{}"#), serde_json::json!({"resourceLogs": []}));
+        assert_eq!(norm(r"{}"), serde_json::json!({"resourceLogs": []}));
         assert_eq!(
             norm(r#"{"resourceLogs":null}"#),
             serde_json::json!({"resourceLogs": []})

--- a/apps/ingest/src/r2.rs
+++ b/apps/ingest/src/r2.rs
@@ -39,8 +39,8 @@ pub enum R2Error {
 impl std::fmt::Display for R2Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            R2Error::Transport(message) => write!(f, "r2 transport error: {message}"),
-            R2Error::Status { status, body } => {
+            Self::Transport(message) => write!(f, "r2 transport error: {message}"),
+            Self::Status { status, body } => {
                 write!(f, "r2 responded {status}: {body}")
             }
         }
@@ -76,18 +76,30 @@ pub struct ReplayBlobStore {
     region: String,
     timeout: Duration,
 }
+/// Hand-written: a derived `Debug` would put the signing credentials one
+/// `{:?}` away from a log line.
+impl std::fmt::Debug for ReplayBlobStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReplayBlobStore")
+            .field("endpoint", &self.endpoint)
+            .field("bucket", &self.bucket)
+            .field("region", &self.region)
+            .field("timeout", &self.timeout)
+            .finish_non_exhaustive()
+    }
+}
 
 impl ReplayBlobStore {
     pub fn new(
         client: impl Into<crate::telemetry::HttpClient>,
-        endpoint: String,
+        endpoint: &str,
         bucket: String,
         access_key_id: String,
         secret_access_key: String,
         region: String,
         timeout: Duration,
     ) -> Self {
-        let endpoint = endpoint.trim_end_matches('/').to_string();
+        let endpoint = endpoint.trim_end_matches('/').to_owned();
         let host = host_from_endpoint(&endpoint);
         Self {
             client: client.into(),
@@ -125,13 +137,13 @@ impl ReplayBlobStore {
         let payload_sha256 = hex(&Sha256::digest(&body));
 
         let mut headers: Vec<(String, String)> = vec![
-            ("content-type".to_string(), content_type.to_string()),
-            ("host".to_string(), self.host.clone()),
-            ("x-amz-content-sha256".to_string(), payload_sha256.clone()),
-            ("x-amz-date".to_string(), amz_date(now)),
+            ("content-type".to_owned(), content_type.to_owned()),
+            ("host".to_owned(), self.host.clone()),
+            ("x-amz-content-sha256".to_owned(), payload_sha256.clone()),
+            ("x-amz-date".to_owned(), amz_date(now)),
         ];
         if let Some(encoding) = content_encoding {
-            headers.push(("content-encoding".to_string(), encoding.to_string()));
+            headers.push(("content-encoding".to_owned(), encoding.to_owned()));
         }
 
         let authorization = authorization_header(&SigningParams {
@@ -197,7 +209,7 @@ fn authorization_header(params: &SigningParams) -> String {
     let mut headers: Vec<(String, String)> = params
         .headers
         .iter()
-        .map(|(name, value)| (name.to_ascii_lowercase(), value.trim().to_string()))
+        .map(|(name, value)| (name.to_ascii_lowercase(), value.trim().to_owned()))
         .collect();
     headers.sort_by(|a, b| a.0.cmp(&b.0));
 
@@ -208,8 +220,13 @@ fn authorization_header(params: &SigningParams) -> String {
         .join(";");
     let canonical_headers = headers
         .iter()
-        .map(|(name, value)| format!("{name}:{value}\n"))
-        .collect::<String>();
+        .fold(String::new(), |mut out, (name, value)| {
+            out.push_str(name);
+            out.push(':');
+            out.push_str(value);
+            out.push('\n');
+            out
+        });
 
     let canonical_request = format!(
         "{}\n{}\n{}\n{}\n{}\n{}",
@@ -258,6 +275,10 @@ fn signing_key(secret_access_key: &str, datestamp: &str, region: &str, service: 
     hmac(&key, b"aws4_request")
 }
 
+#[expect(
+    clippy::expect_used,
+    reason = "HMAC accepts keys of any length, so `new_from_slice` cannot fail here"
+)]
 fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
     let mut mac = HmacSha256::new_from_slice(key).expect("hmac accepts any key length");
     mac.update(data);
@@ -265,8 +286,16 @@ fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
 }
 
 fn hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(char::from(HEX_LOWER[usize::from(byte >> 4)]));
+        out.push(char::from(HEX_LOWER[usize::from(byte & 0x0f)]));
+    }
+    out
 }
+
+const HEX_LOWER: &[u8; 16] = b"0123456789abcdef";
+const HEX_UPPER: &[u8; 16] = b"0123456789ABCDEF";
 
 fn amz_date(now: DateTime<Utc>) -> String {
     now.format("%Y%m%dT%H%M%SZ").to_string()
@@ -282,9 +311,13 @@ fn uri_encode_path(path: &str) -> String {
     for byte in path.as_bytes() {
         match byte {
             b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
-                out.push(*byte as char)
+                out.push(*byte as char);
             }
-            _ => out.push_str(&format!("%{byte:02X}")),
+            _ => {
+                out.push('%');
+                out.push(char::from(HEX_UPPER[usize::from(byte >> 4)]));
+                out.push(char::from(HEX_UPPER[usize::from(byte & 0x0f)]));
+            }
         }
     }
     out
@@ -293,12 +326,11 @@ fn uri_encode_path(path: &str) -> String {
 fn host_from_endpoint(endpoint: &str) -> String {
     endpoint
         .split_once("://")
-        .map(|(_, rest)| rest)
-        .unwrap_or(endpoint)
+        .map_or(endpoint, |(_, rest)| rest)
         .split('/')
         .next()
         .unwrap_or("")
-        .to_string()
+        .to_owned()
 }
 
 #[cfg(test)]
@@ -376,18 +408,21 @@ mod tests {
     fn matches_the_aws_put_object_vector() {
         let now = Utc.with_ymd_and_hms(2013, 5, 24, 0, 0, 0).unwrap();
         let payload_sha256 =
-            "44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072".to_string();
+            "44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072".to_owned();
         let headers = vec![
             (
-                "date".to_string(),
-                "Fri, 24 May 2013 00:00:00 GMT".to_string(),
+                "date".to_owned(),
+                "Fri, 24 May 2013 00:00:00 GMT".to_owned(),
             ),
-            ("host".to_string(), "examplebucket.s3.amazonaws.com".to_string()),
-            ("x-amz-content-sha256".to_string(), payload_sha256.clone()),
-            ("x-amz-date".to_string(), "20130524T000000Z".to_string()),
             (
-                "x-amz-storage-class".to_string(),
-                "REDUCED_REDUNDANCY".to_string(),
+                "host".to_owned(),
+                "examplebucket.s3.amazonaws.com".to_owned(),
+            ),
+            ("x-amz-content-sha256".to_owned(), payload_sha256.clone()),
+            ("x-amz-date".to_owned(), "20130524T000000Z".to_owned()),
+            (
+                "x-amz-storage-class".to_owned(),
+                "REDUCED_REDUNDANCY".to_owned(),
             ),
         ];
 
@@ -416,7 +451,7 @@ mod tests {
     #[test]
     fn sorts_headers_regardless_of_call_order() {
         let now = Utc.with_ymd_and_hms(2013, 5, 24, 0, 0, 0).unwrap();
-        let sha = "44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072".to_string();
+        let sha = "44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072".to_owned();
         let build = |headers: Vec<(String, String)>| {
             authorization_header(&SigningParams {
                 method: "PUT",
@@ -432,12 +467,12 @@ mod tests {
             })
         };
         let forward = build(vec![
-            ("host".to_string(), "h".to_string()),
-            ("x-amz-date".to_string(), "20130524T000000Z".to_string()),
+            ("host".to_owned(), "h".to_owned()),
+            ("x-amz-date".to_owned(), "20130524T000000Z".to_owned()),
         ]);
         let reversed = build(vec![
-            ("x-amz-date".to_string(), "20130524T000000Z".to_string()),
-            ("HOST".to_string(), "h".to_string()),
+            ("x-amz-date".to_owned(), "20130524T000000Z".to_owned()),
+            ("HOST".to_owned(), "h".to_owned()),
         ]);
         assert_eq!(forward, reversed);
     }

--- a/apps/ingest/src/session_analytics.rs
+++ b/apps/ingest/src/session_analytics.rs
@@ -23,7 +23,7 @@ fn canonical_host(url: &str) -> String {
         return String::new();
     };
     let host = host.trim_end_matches('.').to_ascii_lowercase();
-    host.strip_prefix("www.").unwrap_or(&host).to_string()
+    host.strip_prefix("www.").unwrap_or(&host).to_owned()
 }
 
 /// A bare host (no scheme) as sent by the SDK.
@@ -69,7 +69,7 @@ const SESSION_EVENT_MAX_ATTRIBUTE_VALUE_BYTES: usize = 1024;
 /// Truncate to a byte budget without splitting a UTF-8 character.
 fn truncate_str(value: &str, max_bytes: usize) -> String {
     if value.len() <= max_bytes {
-        return value.to_string();
+        return value.to_owned();
     }
     let mut end = max_bytes;
     while end > 0 && !value.is_char_boundary(end) {
@@ -137,7 +137,7 @@ fn clamp_string_field(
         Some(text) => {
             if text.len() > max_bytes {
                 let truncated = truncate_str(text, max_bytes);
-                obj.insert(field.to_string(), serde_json::Value::String(truncated));
+                obj.insert(field.to_owned(), serde_json::Value::String(truncated));
             }
         }
         None => {
@@ -222,7 +222,7 @@ pub fn sanitize_session_event(obj: &mut serde_json::Map<String, serde_json::Valu
     if let Some(message) = obj.get("message").and_then(|v| v.as_str()) {
         if message.len() > SESSION_EVENT_MAX_MESSAGE_BYTES {
             let truncated = truncate_str(message, SESSION_EVENT_MAX_MESSAGE_BYTES);
-            obj.insert("message".to_string(), serde_json::Value::String(truncated));
+            obj.insert("message".to_owned(), serde_json::Value::String(truncated));
         }
     }
 
@@ -274,10 +274,13 @@ mod tests {
     #[test]
     fn session_meta_dimensions_are_clamped() {
         let mut obj = serde_json::Map::new();
-        obj.insert("utm_campaign".to_string(), serde_json::json!("c".repeat(512)));
-        obj.insert("host".to_string(), serde_json::json!("app.example.com"));
-        obj.insert("referrer".to_string(), serde_json::json!("r".repeat(4096)));
-        obj.insert("entry_path".to_string(), serde_json::json!("/pricing"));
+        obj.insert(
+            "utm_campaign".to_owned(),
+            serde_json::json!("c".repeat(512)),
+        );
+        obj.insert("host".to_owned(), serde_json::json!("app.example.com"));
+        obj.insert("referrer".to_owned(), serde_json::json!("r".repeat(4096)));
+        obj.insert("entry_path".to_owned(), serde_json::json!("/pricing"));
 
         sanitize_session_meta(&mut obj);
 
@@ -298,8 +301,8 @@ mod tests {
     #[test]
     fn session_meta_off_type_fields_fall_back_to_the_column_default() {
         let mut obj = serde_json::Map::new();
-        obj.insert("utm_source".to_string(), serde_json::json!(42));
-        obj.insert("user_traits".to_string(), serde_json::json!("not-a-map"));
+        obj.insert("utm_source".to_owned(), serde_json::json!(42));
+        obj.insert("user_traits".to_owned(), serde_json::json!("not-a-map"));
 
         sanitize_session_meta(&mut obj);
 
@@ -315,11 +318,11 @@ mod tests {
         for i in 0..100 {
             traits.insert(format!("trait{i}"), serde_json::json!("v"));
         }
-        traits.insert("long".to_string(), serde_json::json!("x".repeat(4096)));
-        traits.insert("numeric".to_string(), serde_json::json!(7));
+        traits.insert("long".to_owned(), serde_json::json!("x".repeat(4096)));
+        traits.insert("numeric".to_owned(), serde_json::json!(7));
 
         let mut obj = serde_json::Map::new();
-        obj.insert("user_traits".to_string(), serde_json::Value::Object(traits));
+        obj.insert("user_traits".to_owned(), serde_json::Value::Object(traits));
         sanitize_session_meta(&mut obj);
 
         let traits = obj["user_traits"].as_object().unwrap();
@@ -335,11 +338,11 @@ mod tests {
     #[test]
     fn session_meta_trait_values_are_stringified_and_truncated() {
         let mut traits = serde_json::Map::new();
-        traits.insert("big".to_string(), serde_json::json!("y".repeat(4096)));
-        traits.insert("flag".to_string(), serde_json::json!(false));
+        traits.insert("big".to_owned(), serde_json::json!("y".repeat(4096)));
+        traits.insert("flag".to_owned(), serde_json::json!(false));
 
         let mut obj = serde_json::Map::new();
-        obj.insert("user_traits".to_string(), serde_json::Value::Object(traits));
+        obj.insert("user_traits".to_owned(), serde_json::Value::Object(traits));
         sanitize_session_meta(&mut obj);
 
         let traits = obj["user_traits"].as_object().unwrap();
@@ -354,12 +357,12 @@ mod tests {
     fn session_event_types_outside_the_allowlist_are_dropped() {
         for accepted in SESSION_EVENT_TYPES {
             let mut obj = serde_json::Map::new();
-            obj.insert("type".to_string(), serde_json::json!(accepted));
+            obj.insert("type".to_owned(), serde_json::json!(accepted));
             assert!(sanitize_session_event(&mut obj), "{accepted} should be kept");
         }
 
         let mut unknown = serde_json::Map::new();
-        unknown.insert("type".to_string(), serde_json::json!("uniqueish-per-event"));
+        unknown.insert("type".to_owned(), serde_json::json!("uniqueish-per-event"));
         assert!(!sanitize_session_event(&mut unknown));
 
         let mut missing = serde_json::Map::new();
@@ -372,13 +375,16 @@ mod tests {
         for i in 0..100 {
             attributes.insert(format!("k{i}"), serde_json::json!("v"));
         }
-        attributes.insert("long".to_string(), serde_json::json!("x".repeat(4096)));
-        attributes.insert("numeric".to_string(), serde_json::json!(42));
+        attributes.insert("long".to_owned(), serde_json::json!("x".repeat(4096)));
+        attributes.insert("numeric".to_owned(), serde_json::json!(42));
 
         let mut obj = serde_json::Map::new();
-        obj.insert("type".to_string(), serde_json::json!("custom"));
-        obj.insert("message".to_string(), serde_json::json!("n".repeat(4096)));
-        obj.insert("attributes".to_string(), serde_json::Value::Object(attributes));
+        obj.insert("type".to_owned(), serde_json::json!("custom"));
+        obj.insert("message".to_owned(), serde_json::json!("n".repeat(4096)));
+        obj.insert(
+            "attributes".to_owned(),
+            serde_json::Value::Object(attributes),
+        );
 
         assert!(sanitize_session_event(&mut obj));
 
@@ -395,12 +401,15 @@ mod tests {
     #[test]
     fn session_event_attribute_values_are_stringified_and_truncated() {
         let mut attributes = serde_json::Map::new();
-        attributes.insert("big".to_string(), serde_json::json!("y".repeat(4096)));
-        attributes.insert("flag".to_string(), serde_json::json!(true));
+        attributes.insert("big".to_owned(), serde_json::json!("y".repeat(4096)));
+        attributes.insert("flag".to_owned(), serde_json::json!(true));
 
         let mut obj = serde_json::Map::new();
-        obj.insert("type".to_string(), serde_json::json!("custom"));
-        obj.insert("attributes".to_string(), serde_json::Value::Object(attributes));
+        obj.insert("type".to_owned(), serde_json::json!("custom"));
+        obj.insert(
+            "attributes".to_owned(),
+            serde_json::Value::Object(attributes),
+        );
 
         assert!(sanitize_session_event(&mut obj));
         let attributes = obj["attributes"].as_object().unwrap();

--- a/apps/ingest/src/telemetry.rs
+++ b/apps/ingest/src/telemetry.rs
@@ -32,7 +32,7 @@ use reqwest::Client;
 /// The shared outbound HTTP client type: plain `reqwest::Client` in normal
 /// builds, hotpath's instrumented wrapper (same request API) under
 /// `--features hotpath`.
-pub type HttpClient = hotpath::wrap::reqwest::Client;
+pub use hotpath::wrap::reqwest::Client as HttpClient;
 use serde::Serialize;
 use serde_json::{json, Map, Value};
 use tokio::sync::mpsc;
@@ -55,7 +55,7 @@ impl ExportDestination {
     /// Every export destination, in lane order. A frame's lane within its WAL
     /// shard is `shard * LANES_PER_SHARD + destination.lane_ordinal()`, so the
     /// position in this slice is load-bearing — do not reorder.
-    pub const ALL: [ExportDestination; 2] = [Self::Tinybird, Self::ClickHouse];
+    pub const ALL: [Self; 2] = [Self::Tinybird, Self::ClickHouse];
 
     pub fn as_str(self) -> &'static str {
         match self {
@@ -117,8 +117,8 @@ fn collect_source_links(frames: &[QueuedFrame]) -> (Vec<SpanContext>, usize) {
 fn host_of(url: &str) -> String {
     url::Url::parse(url)
         .ok()
-        .and_then(|parsed| parsed.host_str().map(|host| host.to_string()))
-        .unwrap_or_else(|| "unknown".to_string())
+        .and_then(|parsed| parsed.host_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| "unknown".to_owned())
 }
 
 /// One `clickhouse.export` attempt span. Built in several places in the retry
@@ -279,7 +279,7 @@ impl ClickHouseBreakerRegistry {
 
     fn state_for(&self, org_id: &str) -> Arc<Mutex<BreakerState>> {
         self.states
-            .entry(org_id.to_string())
+            .entry(org_id.to_owned())
             .or_insert_with(|| Arc::new(Mutex::new(BreakerState::default())))
             .clone()
     }
@@ -293,7 +293,9 @@ impl ClickHouseBreakerRegistry {
         let Some(state) = self.states.get(org_id) else {
             return BreakerDecision::Allow;
         };
-        let guard = state.lock().unwrap_or_else(|poison| poison.into_inner());
+        let guard = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         breaker_decision(&guard, self.cfg, now)
     }
 
@@ -302,7 +304,9 @@ impl ClickHouseBreakerRegistry {
             return;
         }
         if let Some(state) = self.states.get(org_id) {
-            let mut guard = state.lock().unwrap_or_else(|poison| poison.into_inner());
+            let mut guard = state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             guard.consecutive_failures = 0;
             guard.opened_at = None;
         }
@@ -313,7 +317,9 @@ impl ClickHouseBreakerRegistry {
             return;
         }
         let state = self.state_for(org_id);
-        let mut guard = state.lock().unwrap_or_else(|poison| poison.into_inner());
+        let mut guard = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         guard.consecutive_failures = guard.consecutive_failures.saturating_add(1);
         if guard.consecutive_failures >= self.cfg.failure_threshold {
             // Re-stamped on every failure on purpose: `on_failure` only runs for
@@ -438,40 +444,36 @@ impl TinybirdConfig {
     }
 
     pub fn validate_for_pipeline(&self, require_tinybird_credentials: bool) -> Result<(), String> {
-        if self.endpoint.is_empty() {
-            if require_tinybird_credentials {
-                return Err(
-                    "TINYBIRD_HOST is required when INGEST_WRITE_MODE uses tinybird".to_string(),
-                );
-            }
+        if self.endpoint.is_empty() && require_tinybird_credentials {
+            return Err(
+                "TINYBIRD_HOST is required when INGEST_WRITE_MODE uses tinybird".to_owned(),
+            );
         }
-        if self.token.is_empty() {
-            if require_tinybird_credentials {
-                return Err(
-                    "TINYBIRD_TOKEN is required when INGEST_WRITE_MODE uses tinybird".to_string(),
-                );
-            }
+        if self.token.is_empty() && require_tinybird_credentials {
+            return Err(
+                "TINYBIRD_TOKEN is required when INGEST_WRITE_MODE uses tinybird".to_owned(),
+            );
         }
         if self.wal_shards == 0 {
-            return Err("INGEST_WAL_SHARDS must be greater than 0".to_string());
+            return Err("INGEST_WAL_SHARDS must be greater than 0".to_owned());
         }
         if self.batch_max_rows == 0 || self.batch_max_bytes == 0 {
             return Err(
                 "INGEST_BATCH_MAX_ROWS and INGEST_BATCH_MAX_BYTES must be greater than 0"
-                    .to_string(),
+                    .to_owned(),
             );
         }
         if self.queue_max_bytes == 0 {
-            return Err("INGEST_QUEUE_MAX_BYTES must be greater than 0".to_string());
+            return Err("INGEST_QUEUE_MAX_BYTES must be greater than 0".to_owned());
         }
         if self.org_queue_max_bytes == 0 {
-            return Err("INGEST_ORG_QUEUE_MAX_BYTES must be greater than 0".to_string());
+            return Err("INGEST_ORG_QUEUE_MAX_BYTES must be greater than 0".to_owned());
         }
         if self.export_concurrency_per_shard == 0 {
-            return Err("INGEST_TINYBIRD_CONCURRENCY_PER_SHARD must be greater than 0".to_string());
+            return Err("INGEST_TINYBIRD_CONCURRENCY_PER_SHARD must be greater than 0".to_owned());
         }
         if self.export_max_attempts == 0 {
-            return Err("INGEST_EXPORT_MAX_ATTEMPTS must be greater than 0".to_string());
+            return Err("INGEST_EXPORT_MAX_ATTEMPTS must be greater than 0".to_owned());
         }
         Ok(())
     }
@@ -499,7 +501,7 @@ impl SamplingPolicy {
         if !self.trace_sample_ratio.is_finite() {
             return 1.0;
         }
-        self.trace_sample_ratio.clamp(0.000001, 1.0)
+        self.trace_sample_ratio.clamp(0.000_001, 1.0)
     }
 }
 
@@ -570,10 +572,8 @@ pub enum PipelineError {
 impl std::fmt::Display for PipelineError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Backpressure(message) => f.write_str(message),
-            Self::Throttled(message) => f.write_str(message),
-            Self::QueueUnavailable(message) => f.write_str(message),
-            Self::Encode(message) => f.write_str(message),
+            Self::Backpressure(message) | Self::Throttled(message) => f.write_str(message),
+            Self::QueueUnavailable(message) | Self::Encode(message) => f.write_str(message),
         }
     }
 }
@@ -613,6 +613,13 @@ pub struct AcceptStats {
 #[derive(Clone)]
 pub struct TelemetryPipeline {
     inner: Arc<PipelineInner>,
+}
+/// The pipeline is a handle around channels, files and an export task, none of
+/// which say anything useful in a `{:?}`.
+impl std::fmt::Debug for TelemetryPipeline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TelemetryPipeline").finish_non_exhaustive()
+    }
 }
 
 struct PipelineInner {
@@ -859,7 +866,10 @@ impl TelemetryPipeline {
             rows: rows.len(),
             dropped: 0,
         };
-        let frames = rows_to_frames(org_id, hash64(org_id), signal, datasource, rows);
+        let frames = rows_to_frames(org_id, hash64(org_id), signal, datasource, &rows);
+        // The rows are copied into the frame payload above; free them before the
+        // WAL append rather than holding both across the await.
+        drop(rows);
         self.commit_frames(frames, destination).await?;
         Ok(stats)
     }
@@ -892,25 +902,26 @@ impl TelemetryPipeline {
         let result = async {
             for mut frame in frames {
                 frame.destination = destination;
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "routing_key is a hash; a truncated hash still spreads uniformly across shards"
+                )]
                 let shard = (frame.routing_key as usize) % self.inner.cfg.wal_shards;
                 // Route to the destination's own lane so a stalled ClickHouse export
                 // cannot fill the Tinybird channel for the same shard (and vice versa).
                 let lane = lane_index(shard, destination);
                 let sender = self.inner.lane_senders[lane].clone();
-                let permit = match sender.try_reserve_owned() {
-                    Ok(permit) => permit,
-                    Err(_) => {
-                        metrics::backpressure_shed(
-                            &frame.org_id,
-                            frame.destination.as_str(),
-                            frame.signal.as_str(),
-                        );
-                        // Which lane is full is the whole question when debugging
-                        // a 429: a stalled BYO-ClickHouse target backs up only its
-                        // own lane, and this is what shows that.
-                        record_failing_frame(shard, lane, &frame.datasource);
-                        return Err(PipelineError::Backpressure("Telemetry queue is full"));
-                    }
+                let Ok(permit) = sender.try_reserve_owned() else {
+                    metrics::backpressure_shed(
+                        &frame.org_id,
+                        frame.destination.as_str(),
+                        frame.signal.as_str(),
+                    );
+                    // Which lane is full is the whole question when debugging
+                    // a 429: a stalled BYO-ClickHouse target backs up only its
+                    // own lane, and this is what shows that.
+                    record_failing_frame(shard, lane, &frame.datasource);
+                    return Err(PipelineError::Backpressure("Telemetry queue is full"));
                 };
                 let queued_bytes = frame.payload.len() as u64;
                 self.reserve_org_queue_bytes(&frame.org_id, queued_bytes)
@@ -964,7 +975,7 @@ impl TelemetryPipeline {
         let counter = self
             .inner
             .org_queue_bytes
-            .entry(org_id.to_string())
+            .entry(org_id.to_owned())
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .clone();
         loop {
@@ -1004,6 +1015,11 @@ impl TelemetryPipeline {
     }
 
     #[hotpath::measure]
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "WAL recovery: the branches are the recovery cases, and each needs the others' \
+                  context to be readable"
+    )]
     async fn replay_committed_frames(&self) {
         for lane in 0..self.inner.lane_senders.len() {
             let frames = match self.inner.wal.replay(lane).await {
@@ -1070,7 +1086,7 @@ impl ShardedWal {
                     .read(true)
                     .append(true)
                     .open(&path)
-                    .map_err(|error| format!("open ingest WAL {path:?}: {error}"))?;
+                    .map_err(|error| format!("open ingest WAL {}: {error}", path.display()))?;
                 debug_assert_eq!(lanes.len(), lane_index(shard, destination));
                 lanes.push(Arc::new(WalShard {
                     shard,
@@ -1090,6 +1106,11 @@ impl ShardedWal {
     /// durably re-appended to its destination's lane, then the legacy file + cursor
     /// are removed. Best-effort: a failed shard is logged and left in place so the
     /// next boot retries it — startup never wedges and no frame is dropped.
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "WAL recovery: the branches are the recovery cases, and each needs the others' \
+                  context to be readable"
+    )]
     async fn migrate_legacy_shards(&self, cfg: &TinybirdConfig) {
         for shard in 0..cfg.wal_shards {
             let legacy_path = cfg.queue_dir.join(format!("shard-{shard:03}.wal"));
@@ -1136,8 +1157,8 @@ impl ShardedWal {
                 }
             }
             if migrated {
-                let _ = std::fs::remove_file(&legacy_path);
-                let _ = std::fs::remove_file(&legacy_cursor);
+                drop(std::fs::remove_file(&legacy_path));
+                drop(std::fs::remove_file(&legacy_cursor));
                 if count > 0 {
                     info!(
                         shard,
@@ -1170,13 +1191,13 @@ impl ShardedWal {
             let mut file = lane_ref
                 .file
                 .lock()
-                .map_err(|_| "WAL lane mutex poisoned".to_string())?;
+                .map_err(|_| "WAL lane mutex poisoned".to_owned())?;
             let start = file
                 .seek(SeekFrom::End(0))
                 .map_err(|error| format!("seek WAL: {error}"))?;
             if enforce_cap && start.saturating_add(encoded.len() as u64) > lane_ref.max_bytes {
                 metrics::wal_shard_full(lane_ref.shard, lane_ref.destination.as_str());
-                return Err("Telemetry WAL lane is full".to_string());
+                return Err("Telemetry WAL lane is full".to_owned());
             }
             file.write_all(&encoded)
                 .map_err(|error| format!("write WAL: {error}"))?;
@@ -1222,7 +1243,7 @@ impl ShardedWal {
                 let mut file = shard_ref
                     .file
                     .lock()
-                    .map_err(|_| "WAL shard mutex poisoned".to_string())?;
+                    .map_err(|_| "WAL shard mutex poisoned".to_owned())?;
                 let size = file
                     .seek(SeekFrom::End(0))
                     .map_err(|error| format!("seek WAL: {error}"))?;
@@ -1324,15 +1345,15 @@ fn read_legacy_frames(path: &Path, cursor_path: &Path) -> Result<Vec<DecodedWalF
 fn encode_wal_frame(frame: &EncodedFrame) -> Result<Vec<u8>, String> {
     let datasource = frame.datasource.as_bytes();
     let org_id = frame.org_id.as_bytes();
-    if datasource.len() > u16::MAX as usize {
-        return Err("datasource name too long".to_string());
-    }
-    if org_id.len() > u16::MAX as usize {
-        return Err("org id too long".to_string());
-    }
-    if frame.payload.len() > u32::MAX as usize {
-        return Err("WAL payload too large".to_string());
-    }
+    // Every length below is written into a fixed-width header field, so the
+    // conversion is the bounds check.
+    let datasource_len =
+        u16::try_from(datasource.len()).map_err(|_| "datasource name too long".to_owned())?;
+    let org_id_len = u16::try_from(org_id.len()).map_err(|_| "org id too long".to_owned())?;
+    let payload_len =
+        u32::try_from(frame.payload.len()).map_err(|_| "WAL payload too large".to_owned())?;
+    let row_count =
+        u32::try_from(frame.row_count).map_err(|_| "WAL row count too large".to_owned())?;
     let mut crc = Crc32::new();
     crc.update(&[signal_tag(frame.signal)]);
     crc.update(&[destination_tag(frame.destination)]);
@@ -1348,10 +1369,10 @@ fn encode_wal_frame(frame: &EncodedFrame) -> Result<Vec<u8>, String> {
     out.push(3);
     out.push(signal_tag(frame.signal));
     out.push(destination_tag(frame.destination));
-    out.extend_from_slice(&(datasource.len() as u16).to_le_bytes());
-    out.extend_from_slice(&(org_id.len() as u16).to_le_bytes());
-    out.extend_from_slice(&(frame.payload.len() as u32).to_le_bytes());
-    out.extend_from_slice(&(frame.row_count as u32).to_le_bytes());
+    out.extend_from_slice(&datasource_len.to_le_bytes());
+    out.extend_from_slice(&org_id_len.to_le_bytes());
+    out.extend_from_slice(&payload_len.to_le_bytes());
+    out.extend_from_slice(&row_count.to_le_bytes());
     out.extend_from_slice(&checksum.to_le_bytes());
     out.extend_from_slice(org_id);
     out.extend_from_slice(datasource);
@@ -1369,6 +1390,10 @@ struct DecodedWalFrame {
     payload: Vec<u8>,
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "a binary header parsed field by field, each with its own bounds check"
+)]
 fn read_wal_frame(file: &mut File, start: u64) -> Result<Option<DecodedWalFrame>, String> {
     let mut prefix = [0u8; 6];
     let read = file
@@ -1527,7 +1552,7 @@ fn add_org_queue_bytes(counters: &Arc<DashMap<String, Arc<AtomicU64>>>, org_id: 
         return;
     }
     let counter = counters
-        .entry(org_id.to_string())
+        .entry(org_id.to_owned())
         .or_insert_with(|| Arc::new(AtomicU64::new(0)))
         .clone();
     let current = counter.fetch_add(bytes, Ordering::AcqRel) + bytes;
@@ -1588,7 +1613,7 @@ impl ExportWorker {
                             None => break,
                         }
                     }
-                    _ = &mut deadline => break,
+                    () = &mut deadline => break,
                 }
             }
 
@@ -1615,7 +1640,8 @@ impl ExportWorker {
                 // How long the batch sat in the lane before the worker picked it
                 // up — the difference between "export is slow" and "the queue is
                 // backed up", which the duration alone cannot tell you.
-                "maple.ingest.batch_wait_ms" = batch_wait.as_millis() as u64,
+                "maple.ingest.batch_wait_ms" =
+                    u64::try_from(batch_wait.as_millis()).unwrap_or(u64::MAX),
                 "maple.ingest.linked_traces" = links.len(),
                 "maple.ingest.source_trace_count" = source_trace_count,
             );
@@ -1705,6 +1731,10 @@ impl ExportWorker {
     }
 
     #[hotpath::measure]
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "one export attempt plus the retry and error classification around it"
+    )]
     async fn post_tinybird(
         &self,
         datasource: &str,
@@ -1716,7 +1746,12 @@ impl ExportWorker {
             self.cfg.endpoint.trim_end_matches('/'),
             datasource
         );
-        let compressed = bytes::Bytes::from(gzip(body)?);
+        let compressed = bytes::Bytes::from(gzip(&body)?);
+        // `gzip` only borrows now, so nothing else frees this. The uncompressed
+        // batch is up to INGEST_BATCH_MAX_BYTES and is never read again — during
+        // an upstream outage the retry loop below runs for minutes, and holding
+        // it that long, once per in-flight lane, is real memory.
+        drop(body);
         let max_attempts = self.cfg.export_max_attempts;
         let mut attempt = 0u32;
         // The real host, not a hardcoded one — self-hosted and local Tinybird
@@ -1793,7 +1828,7 @@ impl ExportWorker {
                     warn!(datasource, status, attempt, "Retrying Tinybird batch");
                 }
                 Err(error) => {
-                    last_status = "transport".to_string();
+                    last_status = "transport".to_owned();
                     span_handle.record("maple.ingest.outcome", "retry");
                     span_handle.record("error.type", "transport");
                     span_handle.record("otel.status_description", error.to_string().as_str());
@@ -1827,6 +1862,11 @@ impl ExportWorker {
     }
 
     #[hotpath::measure]
+    #[expect(
+        clippy::cognitive_complexity,
+        clippy::too_many_lines,
+        reason = "one export attempt plus the retry and error classification around it"
+    )]
     async fn post_clickhouse(
         &self,
         org_id: &str,
@@ -1843,7 +1883,12 @@ impl ExportWorker {
             return Ok(ClickHouseExportOutcome::Dropped);
         };
 
-        let compressed = bytes::Bytes::from(gzip(body)?);
+        let compressed = bytes::Bytes::from(gzip(&body)?);
+        // `gzip` only borrows now, so nothing else frees this. The uncompressed
+        // batch is up to INGEST_BATCH_MAX_BYTES and is never read again — during
+        // an upstream outage the retry loop below runs for minutes, and holding
+        // it that long, once per in-flight lane, is real memory.
+        drop(body);
         let max_attempts = self.cfg.export_max_attempts;
         let mut attempt = 0u32;
         // Set on every retryable failure; only read when the retry budget is
@@ -1964,7 +2009,7 @@ impl ExportWorker {
             span.record("db.namespace", target.database.as_str());
 
             let sql = build_clickhouse_insert_sql(mapping, org_id);
-            let endpoint_url = target.endpoint.trim_end_matches('/').to_string();
+            let endpoint_url = target.endpoint.trim_end_matches('/').to_owned();
             let mut request_url = match url::Url::parse(&endpoint_url) {
                 Ok(url) => url,
                 Err(error) => {
@@ -2073,7 +2118,7 @@ impl ExportWorker {
                         "Retrying ClickHouse batch"
                     );
                     self.clickhouse_breakers.on_failure(org_id, Instant::now());
-                    last_status = bucket.to_string();
+                    last_status = bucket.to_owned();
                 }
                 Err(error) => {
                     span.record("maple.ingest.outcome", "retry");
@@ -2088,7 +2133,7 @@ impl ExportWorker {
                         "Retrying ClickHouse batch after transport error"
                     );
                     self.clickhouse_breakers.on_failure(org_id, Instant::now());
-                    last_status = "transport".to_string();
+                    last_status = "transport".to_owned();
                 }
             }
 
@@ -2173,7 +2218,7 @@ fn build_clickhouse_insert_sql(mapping: &InsertMapping, org_id: &str) -> String 
             if *select == clickhouse_insert_mappings::ORG_PLACEHOLDER {
                 org_literal.clone()
             } else {
-                (*select).to_string()
+                (*select).to_owned()
             }
         })
         .collect::<Vec<_>>()
@@ -2192,10 +2237,10 @@ fn escape_clickhouse_sql_literal(value: &str) -> String {
 }
 
 #[hotpath::measure]
-fn gzip(body: Vec<u8>) -> Result<Vec<u8>, String> {
+fn gzip(body: &[u8]) -> Result<Vec<u8>, String> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
     encoder
-        .write_all(&body)
+        .write_all(body)
         .map_err(|error| format!("gzip Tinybird body: {error}"))?;
     encoder
         .finish()
@@ -2203,6 +2248,10 @@ fn gzip(body: Vec<u8>) -> Result<Vec<u8>, String> {
 }
 
 #[hotpath::measure]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one branch per OTLP shape, flattened into the row this datasource stores"
+)]
 fn encode_traces(
     datasources: &DatasourceNames,
     org_id: &str,
@@ -2225,15 +2274,15 @@ fn encode_traces(
             .get("service.name")
             .and_then(Value::as_str)
             .unwrap_or("")
-            .to_string();
+            .to_owned();
 
         for scope_spans in &resource_spans.scope_spans {
             let scope = scope_spans.scope.as_ref();
             let scope_attrs = scope
                 .map(|scope| attr_map(&scope.attributes))
                 .unwrap_or_default();
-            let scope_name = scope.map(|scope| scope.name.as_str()).unwrap_or("");
-            let scope_version = scope.map(|scope| scope.version.as_str()).unwrap_or("");
+            let scope_name = scope.map_or("", |scope| scope.name.as_str());
+            let scope_version = scope.map_or("", |scope| scope.version.as_str());
 
             for span in &scope_spans.spans {
                 let trace_id = bytes_hex(&span.trace_id);
@@ -2253,7 +2302,7 @@ fn encode_traces(
                     && !span.trace_state.contains("th:")
                 {
                     span_attrs.insert(
-                        "SampleRate".to_string(),
+                        "SampleRate".to_owned(),
                         json!(format_sample_rate(sample_rate)),
                     );
                 }
@@ -2309,7 +2358,7 @@ fn encode_traces(
                     "scope_attributes": scope_attrs,
                     "duration": span.end_time_unix_nano.saturating_sub(span.start_time_unix_nano),
                     "status_code": status_code(span.status.as_ref().map(|status| status.code).unwrap_or_default()),
-                    "status_message": span.status.as_ref().map(|status| status.message.as_str()).unwrap_or(""),
+                    "status_message": span.status.as_ref().map_or("", |status| status.message.as_str()),
                     "span_attributes": span_attrs,
                     "events_timestamp": events_timestamp,
                     "events_name": events_name,
@@ -2332,7 +2381,7 @@ fn encode_traces(
         routing_key,
         TelemetrySignal::Traces,
         datasources.traces.clone(),
-        rows,
+        &rows,
     );
     Ok((frames, stats))
 }
@@ -2355,15 +2404,15 @@ fn encode_logs(
             .get("service.name")
             .and_then(Value::as_str)
             .unwrap_or("")
-            .to_string();
+            .to_owned();
 
         for scope_logs in &resource_logs.scope_logs {
             let scope = scope_logs.scope.as_ref();
             let scope_attrs = scope
                 .map(|scope| attr_map(&scope.attributes))
                 .unwrap_or_default();
-            let scope_name = scope.map(|scope| scope.name.as_str()).unwrap_or("");
-            let scope_version = scope.map(|scope| scope.version.as_str()).unwrap_or("");
+            let scope_name = scope.map_or("", |scope| scope.name.as_str());
+            let scope_version = scope.map_or("", |scope| scope.version.as_str());
 
             for log in &scope_logs.log_records {
                 let trace_id = bytes_hex(&log.trace_id);
@@ -2393,11 +2442,16 @@ fn encode_logs(
         routing_key,
         TelemetrySignal::Logs,
         datasources.logs.clone(),
-        rows,
+        &rows,
     );
     Ok((frames, stats))
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each argument is one column of the row being encoded; grouping them into a struct \
+              would only move the same list one level away from the JSON it builds"
+)]
 fn encode_log_row(
     log: &LogRecord,
     service_name: &str,
@@ -2428,6 +2482,10 @@ fn encode_log_row(
 }
 
 #[hotpath::measure]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one branch per OTLP shape, flattened into the row this datasource stores"
+)]
 fn encode_metrics(
     datasources: &DatasourceNames,
     org_id: &str,
@@ -2446,15 +2504,15 @@ fn encode_metrics(
             .get("service.name")
             .and_then(Value::as_str)
             .unwrap_or("")
-            .to_string();
+            .to_owned();
 
         for scope_metrics in &resource_metrics.scope_metrics {
             let scope = scope_metrics.scope.as_ref();
             let scope_attrs = scope
                 .map(|scope| attr_map(&scope.attributes))
                 .unwrap_or_default();
-            let scope_name = scope.map(|scope| scope.name.as_str()).unwrap_or("");
-            let scope_version = scope.map(|scope| scope.version.as_str()).unwrap_or("");
+            let scope_name = scope.map_or("", |scope| scope.name.as_str());
+            let scope_version = scope.map_or("", |scope| scope.version.as_str());
 
             for metric in &scope_metrics.metrics {
                 routing_key = hash64(&metric.name);
@@ -2521,7 +2579,7 @@ fn encode_metrics(
                                 &datasources.metrics_histogram,
                                 extend(
                                     row,
-                                    json!({
+                                    &json!({
                                         "count": point.count,
                                         "sum": point.sum.unwrap_or(0.0),
                                         "bucket_counts": point.bucket_counts,
@@ -2559,14 +2617,14 @@ fn encode_metrics(
                                 &datasources.metrics_exponential_histogram,
                                 extend(
                                     row,
-                                    json!({
+                                    &json!({
                                         "count": point.count,
                                         "sum": point.sum.unwrap_or(0.0),
                                         "scale": point.scale,
                                         "zero_count": point.zero_count,
-                                        "positive_offset": positive.map(|b| b.offset).unwrap_or(0),
+                                        "positive_offset": positive.map_or(0, |b| b.offset),
                                         "positive_bucket_counts": positive.map(|b| b.bucket_counts.clone()).unwrap_or_default(),
-                                        "negative_offset": negative.map(|b| b.offset).unwrap_or(0),
+                                        "negative_offset": negative.map_or(0, |b| b.offset),
                                         "negative_bucket_counts": negative.map(|b| b.bucket_counts.clone()).unwrap_or_default(),
                                         "min": point.min,
                                         "max": point.max,
@@ -2592,7 +2650,7 @@ fn encode_metrics(
             routing_key,
             TelemetrySignal::Metrics,
             datasource,
-            rows,
+            &rows,
         ));
     }
 
@@ -2605,7 +2663,11 @@ fn encode_metrics(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each argument is one column of the row being encoded; grouping them into a struct \
+              would only move the same list one level away from the JSON it builds"
+)]
 fn push_metric_number_row(
     by_datasource: &mut BTreeMap<String, Vec<Vec<u8>>>,
     datasource: &str,
@@ -2623,6 +2685,10 @@ fn push_metric_number_row(
 ) -> Result<(), PipelineError> {
     let value = match point.value {
         Some(number_data_point::Value::AsDouble(value)) => value,
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "the row carries one numeric column, so int points widen to f64 on the way in"
+        )]
         Some(number_data_point::Value::AsInt(value)) => value as f64,
         None => 0.0,
     };
@@ -2648,10 +2714,14 @@ fn push_metric_number_row(
         point.flags,
         &point.exemplars,
     );
-    push_json(by_datasource, datasource, extend(row, extra))
+    push_json(by_datasource, datasource, extend(row, &extra))
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each argument is one column of the row being encoded; grouping them into a struct \
+              would only move the same list one level away from the JSON it builds"
+)]
 fn metric_common_row(
     metric: &opentelemetry_proto::tonic::metrics::v1::Metric,
     service_name: &str,
@@ -2667,8 +2737,7 @@ fn metric_common_row(
     flags: u32,
     exemplars: &[Exemplar],
 ) -> Value {
-    let (trace_ids, span_ids, timestamps, values, filtered_attributes) =
-        encode_exemplars(exemplars);
+    let exemplars = encode_exemplars(exemplars);
     json!({
         "resource_attributes": resource_attrs,
         "resource_schema_url": resource_schema_url,
@@ -2684,17 +2753,24 @@ fn metric_common_row(
         "start_timestamp": format_timestamp_nano(start_time_unix_nano),
         "timestamp": format_timestamp_nano(time_unix_nano),
         "flags": flags,
-        "exemplars_trace_id": trace_ids,
-        "exemplars_span_id": span_ids,
-        "exemplars_timestamp": timestamps,
-        "exemplars_value": values,
-        "exemplars_filtered_attributes": filtered_attributes
+        "exemplars_trace_id": exemplars.trace_ids,
+        "exemplars_span_id": exemplars.span_ids,
+        "exemplars_timestamp": exemplars.timestamps,
+        "exemplars_value": exemplars.values,
+        "exemplars_filtered_attributes": exemplars.filtered_attributes
     })
 }
 
-fn encode_exemplars(
-    exemplars: &[Exemplar],
-) -> (Vec<String>, Vec<String>, Vec<String>, Vec<f64>, Vec<Value>) {
+/// The exemplar columns of one metric row: five parallel arrays, one per column.
+struct EncodedExemplars {
+    trace_ids: Vec<String>,
+    span_ids: Vec<String>,
+    timestamps: Vec<String>,
+    values: Vec<f64>,
+    filtered_attributes: Vec<Value>,
+}
+
+fn encode_exemplars(exemplars: &[Exemplar]) -> EncodedExemplars {
     let mut trace_ids = Vec::with_capacity(exemplars.len());
     let mut span_ids = Vec::with_capacity(exemplars.len());
     let mut timestamps = Vec::with_capacity(exemplars.len());
@@ -2708,6 +2784,10 @@ fn encode_exemplars(
             Some(opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsDouble(value)) => {
                 value
             }
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "exemplars share the f64 column of the point they annotate"
+            )]
             Some(opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsInt(value)) => {
                 value as f64
             }
@@ -2715,7 +2795,13 @@ fn encode_exemplars(
         });
         filtered_attributes.push(Value::Object(attr_map(&exemplar.filtered_attributes)));
     }
-    (trace_ids, span_ids, timestamps, values, filtered_attributes)
+    EncodedExemplars {
+        trace_ids,
+        span_ids,
+        timestamps,
+        values,
+        filtered_attributes,
+    }
 }
 
 fn push_json(
@@ -2724,13 +2810,13 @@ fn push_json(
     value: Value,
 ) -> Result<(), PipelineError> {
     by_datasource
-        .entry(datasource.to_string())
+        .entry(datasource.to_owned())
         .or_default()
         .push(json_line(value)?);
     Ok(())
 }
 
-fn extend(mut base: Value, extra: Value) -> Value {
+fn extend(mut base: Value, extra: &Value) -> Value {
     if let (Some(base), Some(extra)) = (base.as_object_mut(), extra.as_object()) {
         for (key, value) in extra {
             base.insert(key.clone(), value.clone());
@@ -2744,19 +2830,19 @@ fn rows_to_frames(
     routing_key: u64,
     signal: TelemetrySignal,
     datasource: String,
-    rows: Vec<Vec<u8>>,
+    rows: &[Vec<u8>],
 ) -> Vec<EncodedFrame> {
     if rows.is_empty() {
         return Vec::new();
     }
     let mut payload = Vec::with_capacity(rows.iter().map(Vec::len).sum::<usize>() + rows.len());
-    for row in &rows {
+    for row in rows {
         payload.extend_from_slice(row);
         payload.push(b'\n');
     }
     vec![EncodedFrame {
         routing_key,
-        org_id: org_id.to_string(),
+        org_id: org_id.to_owned(),
         signal,
         destination: ExportDestination::Tinybird,
         datasource,
@@ -2796,18 +2882,32 @@ fn should_keep_trace(org_id: &str, trace_id: &str, span: &Span, policy: &Samplin
     } else {
         format!("{org_id}:{trace_id}")
     };
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "float-to-int casts saturate, so ratios of 0.0 and 1.0 land exactly on 0 and \
+                  u64::MAX; the mantissa loss in between moves the threshold by less than one trace"
+    )]
     let threshold = (ratio * u64::MAX as f64) as u64;
     hash64(&key) <= threshold
 }
 
 fn format_sample_rate(sample_rate: f64) -> String {
     if sample_rate.fract() == 0.0 {
-        format!("{}", sample_rate as u64)
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "the branch has already established an integral value, and saturation is the \
+                      right answer for the out-of-range rates that never reach here"
+        )]
+        let whole = sample_rate as u64;
+        format!("{whole}")
     } else {
         format!("{sample_rate:.6}")
             .trim_end_matches('0')
             .trim_end_matches('.')
-            .to_string()
+            .to_owned()
     }
 }
 
@@ -2891,12 +2991,16 @@ fn bytes_hex(bytes: &[u8]) -> String {
 
 fn format_timestamp_nano(unix_nano: u64) -> String {
     if unix_nano == 0 {
-        return "1970-01-01 00:00:00.000000000".to_string();
+        return "1970-01-01 00:00:00.000000000".to_owned();
     }
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "u64 nanoseconds divided by a billion cannot reach i64::MAX seconds"
+    )]
     let secs = (unix_nano / 1_000_000_000) as i64;
     let nanos = (unix_nano % 1_000_000_000) as u32;
     let Some(dt) = chrono::DateTime::from_timestamp(secs, nanos) else {
-        return "1970-01-01 00:00:00.000000000".to_string();
+        return "1970-01-01 00:00:00.000000000".to_owned();
     };
     dt.format("%Y-%m-%d %H:%M:%S.%f").to_string()
 }
@@ -2959,11 +3063,11 @@ mod tests {
             shard: 0,
             start: 0,
             end: 0,
-            org_id: "org_test".to_string(),
+            org_id: "org_test".to_owned(),
             queued_bytes: 0,
             signal: TelemetrySignal::Traces,
             destination: ExportDestination::Tinybird,
-            datasource: "spans".to_string(),
+            datasource: "spans".to_owned(),
             row_count: 0,
             payload: Vec::new(),
             source_span,
@@ -3036,8 +3140,8 @@ mod tests {
 
     fn test_cfg() -> TinybirdConfig {
         TinybirdConfig {
-            endpoint: "http://tinybird.test".to_string(),
-            token: "token".to_string(),
+            endpoint: "http://tinybird.test".to_owned(),
+            token: "token".to_owned(),
             queue_dir: std::env::temp_dir(),
             queue_max_bytes: 1024 * 1024,
             org_queue_max_bytes: 1024 * 1024,
@@ -3051,9 +3155,9 @@ mod tests {
             clickhouse_export_timeout: Duration::from_secs(5),
             clickhouse_breaker: ClickHouseBreakerConfig::default(),
             datasources: DatasourceNames::defaults(),
-            datasource_session_replays: "session_replays".to_string(),
-            datasource_session_replay_events: "session_replay_events".to_string(),
-            datasource_session_events: "session_events".to_string(),
+            datasource_session_replays: "session_replays".to_owned(),
+            datasource_session_replay_events: "session_replay_events".to_owned(),
+            datasource_session_events: "session_events".to_owned(),
         }
     }
 
@@ -3067,10 +3171,10 @@ mod tests {
 
         let provider = Arc::new(StaticClickHouseTargetProvider {
             target: ClickHouseTarget {
-                endpoint: "http://127.0.0.1:1".to_string(),
-                user: "ingest".to_string(),
+                endpoint: "http://127.0.0.1:1".to_owned(),
+                user: "ingest".to_owned(),
                 password: String::new(),
-                database: "maple".to_string(),
+                database: "maple".to_owned(),
             },
         });
 
@@ -3083,7 +3187,7 @@ mod tests {
         .await
         .expect("ClickHouse-only pipeline should not require Tinybird credentials");
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     fn unique_test_dir(name: &str) -> PathBuf {
@@ -3112,20 +3216,22 @@ mod tests {
             .read_to_string(&mut decoded)
             .expect("fake Tinybird should receive gzip NDJSON");
 
-        let _ = tx.send(FakeTinybirdImport {
-            datasource: query.get("name").cloned().unwrap_or_default(),
-            authorization: headers
-                .get(AUTHORIZATION)
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            content_encoding: headers
-                .get(CONTENT_ENCODING)
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            body: decoded,
-        });
+        drop(
+            tx.send(FakeTinybirdImport {
+                datasource: query.get("name").cloned().unwrap_or_default(),
+                authorization: headers
+                    .get(AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                content_encoding: headers
+                    .get(CONTENT_ENCODING)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                body: decoded,
+            }),
+        );
 
         StatusCode::OK
     }
@@ -3141,31 +3247,33 @@ mod tests {
             .read_to_string(&mut decoded)
             .expect("fake ClickHouse should receive gzip NDJSON");
 
-        let _ = tx.send(FakeClickHouseImport {
-            query: query.get("query").cloned().unwrap_or_default(),
-            database: query.get("database").cloned().unwrap_or_default(),
-            user: headers
-                .get("x-clickhouse-user")
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            key: headers
-                .get("x-clickhouse-key")
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            content_type: headers
-                .get(CONTENT_TYPE)
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            content_encoding: headers
-                .get(CONTENT_ENCODING)
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default()
-                .to_string(),
-            body: decoded,
-        });
+        drop(
+            tx.send(FakeClickHouseImport {
+                query: query.get("query").cloned().unwrap_or_default(),
+                database: query.get("database").cloned().unwrap_or_default(),
+                user: headers
+                    .get("x-clickhouse-user")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                key: headers
+                    .get("x-clickhouse-key")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                content_type: headers
+                    .get(CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                content_encoding: headers
+                    .get(CONTENT_ENCODING)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned(),
+                body: decoded,
+            }),
+        );
 
         StatusCode::OK
     }
@@ -3188,8 +3296,7 @@ mod tests {
                     .and_then(|raw| raw.trim().parse::<u64>().ok())
                     .unwrap_or(0);
                 let shard_size = std::fs::metadata(&shard_path)
-                    .map(|meta| meta.len())
-                    .unwrap_or(u64::MAX);
+                    .map_or(u64::MAX, |meta| meta.len());
                 if cursor_offset > 0 || shard_size == 0 {
                     return;
                 }
@@ -3197,21 +3304,21 @@ mod tests {
             }
         })
         .await
-        .expect("export worker should drain the shard (cursor advance or truncation) after Tinybird success")
+        .expect("export worker should drain the shard (cursor advance or truncation) after Tinybird success");
     }
 
     fn string_kv(key: &str, value: &str) -> KeyValue {
         KeyValue {
-            key: key.to_string(),
+            key: key.to_owned(),
             value: Some(AnyValue {
-                value: Some(any_value::Value::StringValue(value.to_string())),
+                value: Some(any_value::Value::StringValue(value.to_owned())),
             }),
         }
     }
 
     fn bool_kv(key: &str, value: bool) -> KeyValue {
         KeyValue {
-            key: key.to_string(),
+            key: key.to_owned(),
             value: Some(AnyValue {
                 value: Some(any_value::Value::BoolValue(value)),
             }),
@@ -3248,7 +3355,7 @@ mod tests {
     #[test]
     fn sampling_keeps_errors_even_when_ratio_low() {
         let policy = SamplingPolicy {
-            trace_sample_ratio: 0.000001,
+            trace_sample_ratio: 0.000_001,
             always_keep_error_spans: true,
             always_keep_slow_spans_ms: None,
         };
@@ -3268,10 +3375,10 @@ mod tests {
     fn wal_round_trips_frame() {
         let frame = EncodedFrame {
             routing_key: 1,
-            org_id: "org_1".to_string(),
+            org_id: "org_1".to_owned(),
             signal: TelemetrySignal::Traces,
             destination: ExportDestination::ClickHouse,
-            datasource: "traces".to_string(),
+            datasource: "traces".to_owned(),
             row_count: 1,
             payload: br#"{"a":1}"#.to_vec(),
         };
@@ -3286,7 +3393,7 @@ mod tests {
         assert_eq!(decoded.datasource, "traces");
         assert_eq!(decoded.payload, br#"{"a":1}"#);
         assert!(decoded.end > 0);
-        let _ = std::fs::remove_file(path);
+        drop(std::fs::remove_file(path));
     }
 
     #[test]
@@ -3303,8 +3410,8 @@ mod tests {
                 }),
                 scope_spans: vec![ScopeSpans {
                     scope: Some(InstrumentationScope {
-                        name: "maple-sdk".to_string(),
-                        version: "1.2.3".to_string(),
+                        name: "maple-sdk".to_owned(),
+                        version: "1.2.3".to_owned(),
                         attributes: vec![string_kv("scope.attr", "scope-value")],
                         dropped_attributes_count: 0,
                     }),
@@ -3312,20 +3419,20 @@ mod tests {
                         trace_id: vec![0x11; 16],
                         span_id: vec![0x22; 8],
                         parent_span_id: vec![0x33; 8],
-                        name: "POST /checkout".to_string(),
+                        name: "POST /checkout".to_owned(),
                         kind: span::SpanKind::Server as i32,
                         start_time_unix_nano: 1_700_000_000_000_000_000,
                         end_time_unix_nano: 1_700_000_000_250_000_000,
                         attributes: vec![string_kv("http.route", "/checkout")],
                         status: Some(Status {
                             code: status::StatusCode::Ok as i32,
-                            message: "ok".to_string(),
+                            message: "ok".to_owned(),
                         }),
                         ..Default::default()
                     }],
-                    schema_url: "https://scope.schema".to_string(),
+                    schema_url: "https://scope.schema".to_owned(),
                 }],
-                schema_url: "https://resource.schema".to_string(),
+                schema_url: "https://resource.schema".to_owned(),
             }],
         };
 
@@ -3362,14 +3469,14 @@ mod tests {
         let rule =
             |source_context, source_key: &str, target_key: &str, operation| AttributeMappingRule {
                 source_context,
-                source_key: source_key.to_string(),
-                target_key: target_key.to_string(),
+                source_key: source_key.to_owned(),
+                target_key: target_key.to_owned(),
                 operation,
             };
 
         // span -> span copy keeps the source key.
         let mut span_attrs = Map::new();
-        span_attrs.insert("http.status_code".to_string(), json!("200"));
+        span_attrs.insert("http.status_code".to_owned(), json!("200"));
         apply_attribute_mappings(
             &[rule(
                 MappingSourceContext::Span,
@@ -3385,7 +3492,7 @@ mod tests {
 
         // span -> span move deletes the source key.
         let mut span_attrs = Map::new();
-        span_attrs.insert("old.key".to_string(), json!("v"));
+        span_attrs.insert("old.key".to_owned(), json!("v"));
         apply_attribute_mappings(
             &[rule(
                 MappingSourceContext::Span,
@@ -3401,7 +3508,7 @@ mod tests {
 
         // resource -> span promotes a resource attribute onto the span.
         let mut resource_attrs = Map::new();
-        resource_attrs.insert("deployment.env".to_string(), json!("prod"));
+        resource_attrs.insert("deployment.env".to_owned(), json!("prod"));
         let mut span_attrs = Map::new();
         apply_attribute_mappings(
             &[rule(
@@ -3419,8 +3526,8 @@ mod tests {
 
         // an existing target key is never overwritten.
         let mut span_attrs = Map::new();
-        span_attrs.insert("src".to_string(), json!("from-src"));
-        span_attrs.insert("dst".to_string(), json!("customer-set"));
+        span_attrs.insert("src".to_owned(), json!("from-src"));
+        span_attrs.insert("dst".to_owned(), json!("customer-set"));
         apply_attribute_mappings(
             &[rule(
                 MappingSourceContext::Span,
@@ -3457,7 +3564,7 @@ mod tests {
             severity_number: 17,
             severity_text: String::new(),
             body: Some(AnyValue {
-                value: Some(any_value::Value::StringValue("payment failed".to_string())),
+                value: Some(any_value::Value::StringValue("payment failed".to_owned())),
             }),
             attributes: vec![bool_kv("retryable", true)],
             trace_id: vec![0xaa; 16],
@@ -3474,8 +3581,8 @@ mod tests {
                 }),
                 scope_logs: vec![opentelemetry_proto::tonic::logs::v1::ScopeLogs {
                     scope: Some(InstrumentationScope {
-                        name: "logger".to_string(),
-                        version: "4.5.6".to_string(),
+                        name: "logger".to_owned(),
+                        version: "4.5.6".to_owned(),
                         attributes: Vec::new(),
                         dropped_attributes_count: 0,
                     }),
@@ -3541,8 +3648,8 @@ mod tests {
                 }),
                 scope_logs: vec![opentelemetry_proto::tonic::logs::v1::ScopeLogs {
                     scope: Some(InstrumentationScope {
-                        name: "e2e-logger".to_string(),
-                        version: "1.0.0".to_string(),
+                        name: "e2e-logger".to_owned(),
+                        version: "1.0.0".to_owned(),
                         attributes: Vec::new(),
                         dropped_attributes_count: 0,
                     }),
@@ -3550,10 +3657,10 @@ mod tests {
                         time_unix_nano: 1_700_000_002_000_000_000,
                         observed_time_unix_nano: 1_700_000_002_000_000_000,
                         severity_number: 9,
-                        severity_text: "INFO".to_string(),
+                        severity_text: "INFO".to_owned(),
                         body: Some(AnyValue {
                             value: Some(any_value::Value::StringValue(
-                                "hello fake tinybird".to_string(),
+                                "hello fake tinybird".to_owned(),
                             )),
                         }),
                         attributes: vec![string_kv("component", "pipeline-e2e")],
@@ -3589,10 +3696,14 @@ mod tests {
         assert_eq!(row["span_id"], "dddddddddddddddd");
 
         wait_for_export_drain(queue_dir.clone(), 0, ExportDestination::Tinybird).await;
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "an end-to-end scenario test; the setup is the test"
+    )]
     async fn pipeline_exports_ready_org_to_clickhouse_without_tinybird_calls() {
         let (ch_tx, mut ch_rx) = mpsc::unbounded_channel();
         let ch_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
@@ -3629,9 +3740,9 @@ mod tests {
         let provider = Arc::new(StaticClickHouseTargetProvider {
             target: ClickHouseTarget {
                 endpoint: format!("http://{ch_addr}"),
-                user: "ingest".to_string(),
+                user: "ingest".to_owned(),
                 password: String::new(),
-                database: "maple".to_string(),
+                database: "maple".to_owned(),
             },
         });
         let pipeline = TelemetryPipeline::new_with_clickhouse(
@@ -3718,13 +3829,13 @@ mod tests {
             assert!(!import.query.contains(import.body.trim()));
         }
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        sleep(Duration::from_millis(50)).await;
         assert!(
             tb_rx.try_recv().is_err(),
             "ready org should not export native frames to Tinybird"
         );
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[tokio::test]
@@ -3764,9 +3875,9 @@ mod tests {
         let provider = Arc::new(StaticClickHouseTargetProvider {
             target: ClickHouseTarget {
                 endpoint: format!("http://{ch_addr}"),
-                user: "ingest".to_string(),
-                password: "secret".to_string(),
-                database: "maple".to_string(),
+                user: "ingest".to_owned(),
+                password: "secret".to_owned(),
+                database: "maple".to_owned(),
             },
         });
         let pipeline = TelemetryPipeline::new_with_clickhouse(
@@ -3799,7 +3910,7 @@ mod tests {
             "ClickHouse-routed frames should not fall back to Tinybird"
         );
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     /// Holds the request open ~forever so the ClickHouse lane worker stays
@@ -3859,15 +3970,15 @@ mod tests {
         let provider = Arc::new(StaticClickHouseTargetProvider {
             target: ClickHouseTarget {
                 endpoint: format!("http://{ch_addr}"),
-                user: "ingest".to_string(),
+                user: "ingest".to_owned(),
                 password: String::new(),
-                database: "maple".to_string(),
+                database: "maple".to_owned(),
             },
         });
         let pipeline = TelemetryPipeline::new_with_clickhouse(
             cfg,
             Client::builder()
-                .timeout(Duration::from_secs(120))
+                .timeout(Duration::from_mins(2))
                 .build()
                 .unwrap(),
             Some(provider),
@@ -3907,7 +4018,7 @@ mod tests {
             .expect("fake Tinybird channel should stay open");
         assert_eq!(import.datasource, "logs");
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[tokio::test]
@@ -3946,9 +4057,9 @@ mod tests {
         let provider = Arc::new(StaticClickHouseTargetProvider {
             target: ClickHouseTarget {
                 endpoint: format!("http://{ch_addr}"),
-                user: "ingest".to_string(),
+                user: "ingest".to_owned(),
                 password: String::new(),
-                database: "maple".to_string(),
+                database: "maple".to_owned(),
             },
         });
         let pipeline = TelemetryPipeline::new_with_clickhouse_validation(
@@ -3997,7 +4108,7 @@ mod tests {
             "breaker-open batches must shed without hitting the target"
         );
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[test]
@@ -4110,19 +4221,19 @@ mod tests {
 
         let tb_frame = EncodedFrame {
             routing_key: 0,
-            org_id: "org_a".to_string(),
+            org_id: "org_a".to_owned(),
             signal: TelemetrySignal::Traces,
             destination: ExportDestination::Tinybird,
-            datasource: "traces".to_string(),
+            datasource: "traces".to_owned(),
             row_count: 1,
             payload: br#"{"a":1}"#.to_vec(),
         };
         let ch_frame = EncodedFrame {
             routing_key: 0,
-            org_id: "org_b".to_string(),
+            org_id: "org_b".to_owned(),
             signal: TelemetrySignal::Logs,
             destination: ExportDestination::ClickHouse,
-            datasource: "logs".to_string(),
+            datasource: "logs".to_owned(),
             row_count: 1,
             payload: br#"{"b":2}"#.to_vec(),
         };
@@ -4157,10 +4268,16 @@ mod tests {
         assert_eq!(ch_frames[0].datasource, "logs");
         assert_eq!(ch_frames[0].payload, br#"{"b":2}"#);
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[test]
+    #[expect(
+        clippy::cognitive_complexity,
+        clippy::too_many_lines,
+        reason = "one assertion block per metric datasource; the point of the test is that they \
+                  sit side by side"
+    )]
     fn metric_encoder_matches_all_tinybird_datasource_shapes() {
         let base_point = NumberDataPoint {
             attributes: vec![string_kv("route", "/checkout")],
@@ -4179,16 +4296,16 @@ mod tests {
                 }),
                 scope_metrics: vec![opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
                     scope: Some(InstrumentationScope {
-                        name: "meter".to_string(),
-                        version: "7.8.9".to_string(),
+                        name: "meter".to_owned(),
+                        version: "7.8.9".to_owned(),
                         attributes: Vec::new(),
                         dropped_attributes_count: 0,
                     }),
                     metrics: vec![
                         Metric {
-                            name: "requests_total".to_string(),
-                            description: "requests".to_string(),
-                            unit: "1".to_string(),
+                            name: "requests_total".to_owned(),
+                            description: "requests".to_owned(),
+                            unit: "1".to_owned(),
                             data: Some(metric::Data::Sum(Sum {
                                 data_points: vec![base_point.clone()],
                                 aggregation_temporality: AggregationTemporality::Delta as i32,
@@ -4197,9 +4314,9 @@ mod tests {
                             metadata: Vec::new(),
                         },
                         Metric {
-                            name: "cpu_ratio".to_string(),
-                            description: "cpu".to_string(),
-                            unit: "1".to_string(),
+                            name: "cpu_ratio".to_owned(),
+                            description: "cpu".to_owned(),
+                            unit: "1".to_owned(),
                             data: Some(metric::Data::Gauge(Gauge {
                                 data_points: vec![NumberDataPoint {
                                     value: Some(number_data_point::Value::AsDouble(0.75)),
@@ -4209,9 +4326,9 @@ mod tests {
                             metadata: Vec::new(),
                         },
                         Metric {
-                            name: "request_duration_ms".to_string(),
-                            description: "latency".to_string(),
-                            unit: "ms".to_string(),
+                            name: "request_duration_ms".to_owned(),
+                            description: "latency".to_owned(),
+                            unit: "ms".to_owned(),
                             data: Some(metric::Data::Histogram(Histogram {
                                 data_points: vec![HistogramDataPoint {
                                     attributes: vec![string_kv("route", "/checkout")],
@@ -4230,9 +4347,9 @@ mod tests {
                             metadata: Vec::new(),
                         },
                         Metric {
-                            name: "payload_bytes".to_string(),
-                            description: "payload".to_string(),
-                            unit: "By".to_string(),
+                            name: "payload_bytes".to_owned(),
+                            description: "payload".to_owned(),
+                            unit: "By".to_owned(),
                             data: Some(metric::Data::ExponentialHistogram(ExponentialHistogram {
                                 data_points: vec![ExponentialHistogramDataPoint {
                                     attributes: vec![string_kv("route", "/checkout")],
@@ -4326,7 +4443,7 @@ mod tests {
     // ResourceAttributes uses `$.resource_attributes.maple_org_id` for OrgId,
     // which is already covered by the `resource_attributes` map.
     mod schema_contract {
-        pub const LOGS: &[&str] = &[
+        pub(super) const LOGS: &[&str] = &[
             "timestamp",
             "trace_id",
             "span_id",
@@ -4344,7 +4461,7 @@ mod tests {
             "log_attributes",
         ];
 
-        pub const TRACES: &[&str] = &[
+        pub(super) const TRACES: &[&str] = &[
             "start_time",
             "trace_id",
             "span_id",
@@ -4400,13 +4517,13 @@ mod tests {
             v
         }
 
-        pub fn metrics_sum() -> Vec<&'static str> {
+        pub(super) fn metrics_sum() -> Vec<&'static str> {
             with(&["value", "aggregation_temporality", "is_monotonic"])
         }
-        pub fn metrics_gauge() -> Vec<&'static str> {
+        pub(super) fn metrics_gauge() -> Vec<&'static str> {
             with(&["value"])
         }
-        pub fn metrics_histogram() -> Vec<&'static str> {
+        pub(super) fn metrics_histogram() -> Vec<&'static str> {
             with(&[
                 "count",
                 "sum",
@@ -4417,7 +4534,7 @@ mod tests {
                 "aggregation_temporality",
             ])
         }
-        pub fn metrics_exponential_histogram() -> Vec<&'static str> {
+        pub(super) fn metrics_exponential_histogram() -> Vec<&'static str> {
             with(&[
                 "count",
                 "sum",
@@ -4454,7 +4571,7 @@ mod tests {
             time_unix_nano: 1_700_000_001_123_456_789,
             observed_time_unix_nano: 1_700_000_001_123_456_789,
             severity_number: 17,
-            severity_text: "ERROR".to_string(),
+            severity_text: "ERROR".to_owned(),
             body: Some(AnyValue {
                 value: Some(any_value::Value::StringValue("payment failed".into())),
             }),
@@ -4479,15 +4596,15 @@ mod tests {
                 }),
                 scope_logs: vec![opentelemetry_proto::tonic::logs::v1::ScopeLogs {
                     scope: Some(InstrumentationScope {
-                        name: "billing-logger".to_string(),
-                        version: "2.0.1".to_string(),
+                        name: "billing-logger".to_owned(),
+                        version: "2.0.1".to_owned(),
                         attributes: vec![string_kv("scope.key", "scope-value")],
                         dropped_attributes_count: 0,
                     }),
                     log_records: vec![populated_log()],
-                    schema_url: "https://scope.schema/logs".to_string(),
+                    schema_url: "https://scope.schema/logs".to_owned(),
                 }],
-                schema_url: "https://resource.schema/logs".to_string(),
+                schema_url: "https://resource.schema/logs".to_owned(),
             }],
         }
     }
@@ -4505,8 +4622,8 @@ mod tests {
                 }),
                 scope_spans: vec![ScopeSpans {
                     scope: Some(InstrumentationScope {
-                        name: "checkout-tracer".to_string(),
-                        version: "3.4.5".to_string(),
+                        name: "checkout-tracer".to_owned(),
+                        version: "3.4.5".to_owned(),
                         attributes: vec![string_kv("scope.key", "scope-value")],
                         dropped_attributes_count: 0,
                     }),
@@ -4514,25 +4631,29 @@ mod tests {
                         trace_id: vec![0x11; 16],
                         span_id: vec![0x22; 8],
                         parent_span_id: vec![0x33; 8],
-                        trace_state: "vendor=foo".to_string(),
-                        name: "POST /checkout".to_string(),
+                        trace_state: "vendor=foo".to_owned(),
+                        name: "POST /checkout".to_owned(),
                         kind: span::SpanKind::Server as i32,
                         start_time_unix_nano: 1_700_000_000_000_000_000,
                         end_time_unix_nano: 1_700_000_000_250_000_000,
                         attributes: vec![string_kv("http.route", "/checkout")],
                         status: Some(Status {
                             code: status::StatusCode::Ok as i32,
-                            message: "ok".to_string(),
+                            message: "ok".to_owned(),
                         }),
                         ..Default::default()
                     }],
-                    schema_url: "https://scope.schema/traces".to_string(),
+                    schema_url: "https://scope.schema/traces".to_owned(),
                 }],
-                schema_url: "https://resource.schema/traces".to_string(),
+                schema_url: "https://resource.schema/traces".to_owned(),
             }],
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "a fixture that is one literal per metric shape"
+    )]
     fn one_of_each_metric_request() -> ExportMetricsServiceRequest {
         let base = NumberDataPoint {
             attributes: vec![string_kv("route", "/checkout")],
@@ -4554,16 +4675,16 @@ mod tests {
                 }),
                 scope_metrics: vec![opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
                     scope: Some(InstrumentationScope {
-                        name: "meter".to_string(),
-                        version: "7.8.9".to_string(),
+                        name: "meter".to_owned(),
+                        version: "7.8.9".to_owned(),
                         attributes: Vec::new(),
                         dropped_attributes_count: 0,
                     }),
                     metrics: vec![
                         Metric {
-                            name: "requests_total".to_string(),
-                            description: "requests".to_string(),
-                            unit: "1".to_string(),
+                            name: "requests_total".to_owned(),
+                            description: "requests".to_owned(),
+                            unit: "1".to_owned(),
                             data: Some(metric::Data::Sum(Sum {
                                 data_points: vec![base.clone()],
                                 aggregation_temporality: AggregationTemporality::Delta as i32,
@@ -4572,9 +4693,9 @@ mod tests {
                             metadata: Vec::new(),
                         },
                         Metric {
-                            name: "cpu_ratio".to_string(),
-                            description: "cpu".to_string(),
-                            unit: "1".to_string(),
+                            name: "cpu_ratio".to_owned(),
+                            description: "cpu".to_owned(),
+                            unit: "1".to_owned(),
                             data: Some(metric::Data::Gauge(Gauge {
                                 data_points: vec![NumberDataPoint {
                                     value: Some(number_data_point::Value::AsDouble(0.75)),
@@ -4584,9 +4705,9 @@ mod tests {
                             metadata: Vec::new(),
                         },
                         Metric {
-                            name: "request_duration_ms".to_string(),
-                            description: "latency".to_string(),
-                            unit: "ms".to_string(),
+                            name: "request_duration_ms".to_owned(),
+                            description: "latency".to_owned(),
+                            unit: "ms".to_owned(),
                             data: Some(metric::Data::Histogram(Histogram {
                                 data_points: vec![HistogramDataPoint {
                                     attributes: vec![string_kv("route", "/checkout")],
@@ -4605,9 +4726,9 @@ mod tests {
                             metadata: Vec::new(),
                         },
                         Metric {
-                            name: "payload_bytes".to_string(),
-                            description: "payload".to_string(),
-                            unit: "By".to_string(),
+                            name: "payload_bytes".to_owned(),
+                            description: "payload".to_owned(),
+                            unit: "By".to_owned(),
                             data: Some(metric::Data::ExponentialHistogram(ExponentialHistogram {
                                 data_points: vec![ExponentialHistogramDataPoint {
                                     attributes: vec![string_kv("route", "/checkout")],
@@ -4899,15 +5020,15 @@ mod tests {
                 }),
                 scope_metrics: vec![opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
                     scope: Some(InstrumentationScope {
-                        name: "meter".to_string(),
-                        version: "1.0.0".to_string(),
+                        name: "meter".to_owned(),
+                        version: "1.0.0".to_owned(),
                         attributes: Vec::new(),
                         dropped_attributes_count: 0,
                     }),
                     metrics: vec![Metric {
-                        name: "summary_metric".to_string(),
-                        description: "".into(),
-                        unit: "".into(),
+                        name: "summary_metric".to_owned(),
+                        description: String::new(),
+                        unit: String::new(),
                         data: Some(metric::Data::Summary(Summary {
                             data_points: vec![SummaryDataPoint {
                                 attributes: vec![],
@@ -4991,7 +5112,7 @@ mod tests {
         assert_eq!(row["status_code"], "Ok");
 
         wait_for_export_drain(queue_dir.clone(), 0, ExportDestination::Tinybird).await;
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[tokio::test]
@@ -5059,7 +5180,7 @@ mod tests {
             assert_row_keys_match(&row, &expected_keys, datasource);
         }
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[tokio::test]
@@ -5082,10 +5203,10 @@ mod tests {
 
         let frame = EncodedFrame {
             routing_key: 0,
-            org_id: "org_contract".to_string(),
+            org_id: "org_contract".to_owned(),
             signal: TelemetrySignal::Traces,
             destination: ExportDestination::Tinybird,
-            datasource: "traces".to_string(),
+            datasource: "traces".to_owned(),
             row_count: 1,
             payload: vec![0u8; 200],
         };
@@ -5099,8 +5220,7 @@ mod tests {
         // Third append would overflow before the fix would let us truncate.
         wal.append(0, &frame)
             .await
-            .err()
-            .expect("third append exceeds shard budget");
+            .expect_err("third append exceeds shard budget");
 
         // Drain the cursor to EOF — this should truncate the lane file.
         wal.mark_exported(0, end_b).await.expect("mark_exported");
@@ -5128,7 +5248,7 @@ mod tests {
             .expect("append after drain should succeed");
         assert_eq!(start_c, 0, "next append starts from a fresh file");
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[tokio::test]
@@ -5146,10 +5266,10 @@ mod tests {
         let wal = ShardedWal::open(&cfg).expect("open WAL");
         let frame = EncodedFrame {
             routing_key: 0,
-            org_id: "org_contract".to_string(),
+            org_id: "org_contract".to_owned(),
             signal: TelemetrySignal::Traces,
             destination: ExportDestination::Tinybird,
-            datasource: "traces".to_string(),
+            datasource: "traces".to_owned(),
             row_count: 1,
             payload: vec![0u8; 100],
         };
@@ -5172,7 +5292,7 @@ mod tests {
             std::fs::read_to_string(queue_dir.join("shard-000-tinybird.cursor")).unwrap();
         assert_eq!(cursor_after_partial.trim(), end_a.to_string());
 
-        let _ = std::fs::remove_dir_all(queue_dir);
+        drop(std::fs::remove_dir_all(queue_dir));
     }
 
     /// Cross-language contract with the Prometheus scraper (apps/scraper).
@@ -5198,12 +5318,12 @@ mod tests {
                     let payload = std::str::from_utf8(&frame.payload)
                         .unwrap()
                         .trim()
-                        .to_string();
+                        .to_owned();
                     let rows = payload
                         .lines()
                         .map(|line| serde_json::from_str(line).unwrap())
                         .collect();
-                    (frame.datasource.clone(), rows)
+                    (frame.datasource, rows)
                 })
                 .collect()
         }
@@ -5225,13 +5345,9 @@ mod tests {
                     .resource
                     .get_or_insert_with(Resource::default);
                 resource.attributes.push(KeyValue {
-                    key: "maple_org_id".to_string(),
+                    key: "maple_org_id".to_owned(),
                     value: Some(AnyValue {
-                        value: Some(
-                            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
-                                "org_scraper".to_string(),
-                            ),
-                        ),
+                        value: Some(any_value::Value::StringValue("org_scraper".to_owned())),
                     }),
                 });
             }

--- a/apps/ingest/src/usage_metrics.rs
+++ b/apps/ingest/src/usage_metrics.rs
@@ -76,6 +76,10 @@ pub const BYTES_PER_BILLED_GB: f64 = 1_000_000_000.0;
 /// The single conversion from measured bytes to the billable GB value reported to
 /// Autumn. Exists so the counter in this module and `AutumnTracker::track` cannot
 /// drift onto different bases — `billable_gb_round_trips_measured_bytes` pins it.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "a byte counter would have to pass 9 petabytes in one process before f64 loses a byte"
+)]
 pub fn billable_gb(bytes: u64) -> f64 {
     bytes as f64 / BYTES_PER_BILLED_GB
 }
@@ -105,6 +109,7 @@ pub fn usage_cardinality_view(instrument: &Instrument) -> Option<Stream> {
 /// Holder for the usage provider and its two counters. Lives in `AppState`
 /// rather than a `LazyLock` static (unlike `metrics.rs`) precisely because the
 /// provider is not global — there is nothing to look it up from.
+#[derive(Debug)]
 pub struct UsageMetrics {
     provider: SdkMeterProvider,
     bytes: Counter<u64>,
@@ -143,8 +148,8 @@ impl UsageMetrics {
     /// diverge — `billable_gb_round_trips_measured_bytes` pins that basis.
     pub fn record(&self, org_id: &str, signal: &str, bytes: u64, items: u64) {
         let attrs = [
-            KeyValue::new(ATTR_ORG_ID, org_id.to_string()),
-            KeyValue::new(ATTR_SIGNAL, signal.to_string()),
+            KeyValue::new(ATTR_ORG_ID, org_id.to_owned()),
+            KeyValue::new(ATTR_SIGNAL, signal.to_owned()),
         ];
         self.bytes.add(bytes, &attrs);
         self.items.add(items, &attrs);
@@ -233,7 +238,7 @@ mod tests {
                                 .map(|kv| kv.value.as_str().to_string())
                         };
                         captured.push(Point {
-                            metric: metric.name().to_string(),
+                            metric: metric.name().to_owned(),
                             org_id: attr(ATTR_ORG_ID),
                             signal: attr(ATTR_SIGNAL),
                             overflow: attr("otel.metric.overflow").is_some(),
@@ -272,7 +277,7 @@ mod tests {
     fn harness() -> (UsageMetrics, CaptureExporter) {
         let exporter = CaptureExporter::new(Temporality::Delta);
         let reader = PeriodicReader::builder(exporter.clone(), OtelTokio)
-            .with_interval(Duration::from_secs(3600))
+            .with_interval(Duration::from_hours(1))
             .build();
         let provider = SdkMeterProvider::builder()
             .with_reader(reader)
@@ -365,7 +370,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cardinality_view_admits_more_orgs_than_the_sdk_default() {
         const ORGS: usize = 3_000;
-        assert!(
+        const _: () = assert!(
             ORGS > 2_000 && ORGS < USAGE_CARDINALITY_LIMIT,
             "test must straddle the SDK default without exceeding our own limit"
         );
@@ -396,6 +401,11 @@ mod tests {
     /// same count through `billable_gb` to `AutumnTracker::track`, so a warehouse
     /// total divided by this divisor is directly comparable to an invoice.
     #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "the cast back to u64 is what the assertion is testing"
+    )]
     fn billable_gb_round_trips_measured_bytes() {
         for bytes in [0_u64, 1, 999, 1_000_000_000, 2_500_000_000, 7_812_345_678] {
             assert_eq!(

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+# Clippy CONFIG (thresholds and behavior). Lint LEVELS don't work in this
+# file - they live in apps/ingest/Cargo.toml under [lints.rust]/[lints.clippy].
+
+# unwrap/expect/panic lints target production code; tests assert with them by design.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true


### PR DESCRIPTION
Turns on a strict clippy lint set for `apps/ingest` and takes the crate to zero
warnings under it. Self-contained against `main` — the lint config
(`apps/ingest/Cargo.toml` `[lints.rust]`/`[lints.clippy]` plus a root
`clippy.toml`) ships in this PR.

`cargo clippy --all-targets`: **735 unique warnings → 0**. `cargo test`: 152
passed, the same count as `main`.

## What was mechanical

`cargo clippy --fix --all-targets` covered ~570: `str_to_string`,
`map_unwrap_or`, `use_self`, `uninlined_format_args`, `unreachable_pub`,
`manual_let_else`, `unused_qualifications`, `redundant_closure_for_method_calls`,
`duration_suboptimal_units`.

## What needed a decision

**Casts** — reviewed individually rather than blanket-allowed:

| Site | Call |
| --- | --- |
| `encode_wal_frame` | Folded the three width checks into the `try_from`s that needed them, and added the **missing `row_count` guard** — a `usize` row count over `u32::MAX` was silently truncating into the WAL header. The only real truncation bug in the set. |
| Duration → `u64`/`i64` millis | `try_from(..).unwrap_or(MAX)` behind a `duration_millis` helper; `current_time_millis` now returns the `i64` both callers were casting to anyway. |
| `decompressed_len` | Dropped the 64 KiB stack array — `io::copy` into `io::sink()` already returns the byte count. |
| Shard routing, sampler threshold, `format_sample_rate`, `billable_gb`, OTel int→f64 points, load-test rate math | Correct as written. Each carries an `#[expect(..., reason = "...")]` naming the invariant. |

**`let _ =` (46 sites)** — became `drop(..)`, behaviour-preserving. Two exceptions where the discarded value was worth having:

- `CloudflareConnectorResolver::record_success`/`record_failure` returned a `Result` **no caller read**, so a failed connector-health write vanished. Now infallible, logged at debug.
- `monitor_process` in the load generator stops when its receiver is gone.

**Other deliberate behaviour changes:**

- `ReplayBlobStore` gets a hand-written `Debug`. `missing_debug_implementations` wanted a derive, which would have put the S3 signing credentials one `{:?}` from a log line.
- `pace` uses `saturating_sub` instead of `unwrap()` on `checked_sub`.
- `hex` / `uri_encode_path` / `hex_prefix` build from a nibble table instead of a `format!` per byte.
- `build_logs_payload` no longer returns a `Result` it never failed with.

**Two `needless_pass_by_value` fixes needed an explicit `drop`.** `gzip` and
`rows_to_frames` used to *consume* their argument and free it. Borrowing instead
left the uncompressed export batch (up to `INGEST_BATCH_MAX_BYTES`, default
4 MiB) alive across the export retry loop — which runs up to 20 attempts with
backoff, i.e. minutes during an upstream outage, once per in-flight lane — and
left the row buffers alive across the WAL append/fsync. Both are now dropped
where the old signatures dropped them. Caught by a reviewing agent, not by any
benchmark.

**Structure** — the 22 functions tripping `too_many_lines`/`cognitive_complexity`
keep their shape under `#[expect(..., reason = "...")]`. They are request
handlers, protocol encoders, retry loops and scenario tests where the length is
one linear pass; splitting them would thread a dozen locals through helpers.
That refactor should be made on purpose, not as a side effect of a lint sweep —
the `#[expect]`s make each one individually revisitable.

## Interaction with the `hotpath` profiler

- `telemetry::HttpClient` became a `pub use ... as` re-export instead of a
  `pub type` alias. `unused_qualifications` wanted
  `hotpath::wrap::reqwest::Client` shortened to `Client`, which would silently
  break the `--features hotpath` build where those are different types.
  (`#[expect]` misbehaves on a type alias here — it suppresses the lint and then
  reports itself unfulfilled — so the re-export is the honest fix.)
- `main`'s two `#[allow(clippy::too_many_arguments)]` became `#[expect]` with
  reasons, since `allow_attributes` is denied.

**Scope of the zero-warning claim:** default features, which is what CI builds
and what ships. `cargo clippy --features hotpath` still reports 32 — 24
`large_futures` from the profiler's own instrumentation of the request handlers
(newly *visible* because this PR enables `pedantic`, not newly introduced), and
8 `#[expect]`s that go unfulfilled because `#[hotpath::measure]` rewrites those
bodies so the complexity lints no longer fire. Silencing the first group would
mean `Box::pin`-ing request handlers, a real perf change that does not belong
in a lint PR.

## Verification

- `cargo clippy --all-targets` → 0 warnings; `cargo test` → 152 passed (identical to `main`)
- CI `Cargo test and load benchmark` passes on the pinned Rust 1.94.1
- Every hunk of the diff (389 total) was audited for unintended behaviour change.
  `r2.rs`'s SigV4 helpers were checked by exhaustive differential test — all 256
  byte values through `hex`, every Unicode scalar through `uri_encode_path` —
  byte-identical to baseline. `encode_wal_frame`'s new guard was shown
  unreachable for any input that previously encoded.
- Criterion `ingest_accept` benchmarks, 7 alternating rounds per tree:
  +0.6 % / +0.2 % median, against 4–9 % run-to-run variance of the *same*
  binary. `decompressed_len` measured 32 % faster on small replay chunks and a
  wash on large ones; `r2::hex` 30× faster.

## Formatting

rustfmt ran only on the files this touched, and `main`'s pre-existing drift was
restored afterwards, so the diff carries no unrelated reformatting —
`metrics.rs` still has exactly the 5 unformatted hunks it had before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)