### PR TITLE
fix(push): App Store builds registered as sandbox; dead tokens disabled silently

### DIFF
--- a/apps/api/src/services/push/MobilePushService.ts
+++ b/apps/api/src/services/push/MobilePushService.ts
@@ -242,6 +242,22 @@ export class MobilePushService extends Context.Service<MobilePushService, Mobile
 							break
 						case "unregistered":
 							unregistered += 1
+							// Loud on purpose: a disabled row is silence on the phone until
+							// the app re-registers, and the reason names the fix
+							// (`BadDeviceToken` = wrong environment for the token,
+							// `DeviceTokenNotForTopic` = a build signed for another app id).
+							yield* Effect.logWarning(
+								"Mobile push: Apple says the token is dead, disabling device",
+							).pipe(
+								Effect.annotateLogs({
+									orgId: event.orgId,
+									deviceId: device.id,
+									environment: device.environment,
+									bundleId: device.bundleId,
+									appVersion: device.appVersion ?? "",
+									reason: result.reason,
+								}),
+							)
 							yield* devices.disable(device.id, result.reason).pipe(Effect.ignore)
 							break
 						case "failed":

--- a/apps/ingest/Cargo.lock
+++ b/apps/ingest/Cargo.lock
@@ -80,6 +80,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +313,12 @@ dependencies = [
  "num-traits",
  "windows-link",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "ciborium"
@@ -674,6 +695,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +743,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -992,6 +1040,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1077,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "hotpath"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce755d457a63bdd0c95e4c91511daad1b58b33209543b7f38027b676f387e5e"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "cfg-if",
+ "crossbeam-channel",
+ "futures-util",
+ "hdrhistogram",
+ "hotpath-macros",
+ "hotpath-meta",
+ "http",
+ "libc",
+ "pin-project-lite",
+ "prettytable-rs",
+ "quanta",
+ "regex",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "tiny_http",
+ "tokio",
+]
+
+[[package]]
+name = "hotpath-macros"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a903af89a8429cb07790c3818bc15270b394f80af1bc254e5ccf9c7de2961770"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "hotpath-macros-meta"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc0ab94ffbb2ee77f4a897df02b5a137a10cf24d69bda936e59aff4dd456e61"
+
+[[package]]
+name = "hotpath-meta"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053481f6cec8f775a3276c7f6e2f21123111d28261e4edc15ea7421c445964bb"
+dependencies = [
+ "hotpath-macros-meta",
 ]
 
 [[package]]
@@ -1468,6 +1580,7 @@ dependencies = [
  "dotenvy",
  "flate2",
  "hmac 0.12.1",
+ "hotpath",
  "moka",
  "num_cpus",
  "opentelemetry",
@@ -1531,6 +1644,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1922,6 +2045,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,6 +2102,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2110,6 +2261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2296,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2214,6 +2385,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2223,6 +2395,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2231,6 +2404,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2241,6 +2415,21 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.2",
+ "serde",
+ "thiserror 2.0.18",
+ "tower-service",
 ]
 
 [[package]]
@@ -2623,6 +2812,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2889,18 @@ checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -3035,6 +3247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,6 +3278,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -3339,6 +3563,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,6 +3586,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/apps/ingest/Cargo.toml
+++ b/apps/ingest/Cargo.toml
@@ -65,6 +65,20 @@ deadpool-postgres = "0.14"
 tokio-postgres-rustls = "0.13"
 rustls = { version = "0.23", features = ["ring"] }
 webpki-roots = "0.26"
+# Opt-in profiler (https://hotpath.rs). Every macro is a no-op and no profiler
+# code is compiled unless `--features hotpath` is passed; the `tokio` and
+# `reqwest-0-13` features only exist so the `hotpath::wrap::*` type aliases
+# resolve to the raw tokio/reqwest types in normal builds.
+hotpath = { version = "0.23", features = ["tokio", "reqwest-0-13"] }
+
+[features]
+default = []
+# `cargo run --features hotpath` prints a timing report on exit; add
+# `hotpath-alloc` for allocation tracking (swaps in a counting allocator around
+# jemalloc). Never enable by default — the report and metrics server cost real
+# CPU on the request path.
+hotpath = ["hotpath/hotpath"]
+hotpath-alloc = ["hotpath/hotpath-alloc"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/apps/ingest/LOAD_TESTS.md
+++ b/apps/ingest/LOAD_TESTS.md
@@ -49,6 +49,45 @@ Those benchmarks measure WAL-acked native accepts for representative log and
 trace OTLP batches. CI runs them on every PR via `--output-format=bencher`
 and embeds the result in the PR comment.
 
+## Profiling with hotpath
+
+The crate carries opt-in [hotpath](https://hotpath.rs) instrumentation: the
+request stages in `main.rs` (`resolve_ingest_key`, `decode_and_enrich_payload`,
+`process_decoded_payload`, `forward_to_collector`, …), the pipeline in
+`telemetry.rs` (`accept_*_to`, `commit_frames`, WAL `append_inner` /
+`mark_exported`, `export_and_mark`, `post_tinybird` / `post_clickhouse`, the
+`encode_*` row encoders, `gzip`), the shared outbound reqwest client
+(per-endpoint latency/error counts) and tokio runtime metrics. All of it is a
+no-op unless the `hotpath` cargo feature is on — never enable it in a deploy.
+
+```sh
+cargo build --release --features hotpath            # timings + HTTP + runtime
+cargo build --release --features hotpath,hotpath-alloc   # + allocations (wraps jemalloc)
+```
+
+Run the binary as usual; the report prints on exit (SIGINT). The load harness
+SIGKILLs ingest and discards its stdout, so there the easiest route is the live
+TUI: `cargo install hotpath --features tui`, then `hotpath console` while the
+run is going (ingest serves profiler metrics on port 6770). To get a file
+instead, make ingest write the report and exit on a timer that fires *before*
+the harness finishes — the harness will report the tail as failures, which is
+expected:
+
+```sh
+HOTPATH_OUTPUT_PATH=/tmp/ingest-hotpath.txt HOTPATH_SHUTDOWN_MS=60000 \
+LOAD_TEST_INGEST_BIN=target/release/maple-ingest LOAD_TEST_REQUESTS=500000 \
+target/release/load_test
+```
+
+`HOTPATH_OUTPUT_FORMAT=json` gives machine-readable output and
+`HOTPATH_REPORT=functions-timing,http` restricts sections. Profile release
+builds; unoptimized futures are large enough that debug-profile timings are
+not representative.
+
+The request entry points (`handle_*`, `handle_*_inner`, `accept_grpc_decoded`)
+are deliberately not measured: wrapping their futures overflowed the tokio
+worker stack. Measure a stage beneath them instead of re-adding those.
+
 On pull requests, the `Ingest Rust Tests` workflow runs the load harness
 **three times** on the PR and (when the same `LOAD_TEST_INGEST_MODE` is
 supported on the base branch) three times on the base branch, then posts

--- a/apps/ingest/src/autumn.rs
+++ b/apps/ingest/src/autumn.rs
@@ -320,7 +320,7 @@ async fn flush_all(
 /// for replay payloads that belong to an already-metered browser session.
 #[derive(Clone)]
 pub struct AutumnEntitlements {
-    client: Client,
+    client: maple_ingest::telemetry::HttpClient,
     secret_key: String,
     api_url: String,
 }
@@ -364,7 +364,12 @@ pub enum AutumnReserveOutcome {
 }
 
 impl AutumnEntitlements {
-    pub fn new(client: Client, secret_key: String, api_url: &str) -> Self {
+    pub fn new(
+        client: impl Into<maple_ingest::telemetry::HttpClient>,
+        secret_key: String,
+        api_url: &str,
+    ) -> Self {
+        let client = client.into();
         let api_url = api_url.trim_end_matches('/').to_string();
         info!("Autumn native billing enforcement enabled");
 

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -1,3 +1,12 @@
+// The tonic `#[async_trait]` export handlers nest deep enough that, with the
+// `#[hotpath::measure]` futures layered inside them under `--features hotpath`,
+// rustc's layout query overflows the default limit of 128.
+#![recursion_limit = "256"]
+
+// Under `--features hotpath-alloc`, `#[hotpath::main(allocator = ...)]` installs
+// its own counting allocator wrapped around jemalloc, so this static must step
+// aside or the two `#[global_allocator]`s collide at link time.
+#[cfg(not(feature = "hotpath-alloc"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
@@ -823,7 +832,9 @@ struct ClickHouseTargetRow {
 
 struct AppState {
     config: AppConfig,
-    http_client: Client,
+    /// The raw `reqwest::Client` in normal builds; the hotpath-instrumented
+    /// wrapper (same request API) under `--features hotpath`.
+    http_client: hotpath::wrap::reqwest::Client,
     telemetry_pipeline: Option<TelemetryPipeline>,
     /// Set once the key store has answered a probe. Drives `/ready`; never
     /// `/health` — see the comment on `health()`.
@@ -1470,8 +1481,12 @@ fn endpoint_loopback_to_self(forward_endpoint: &str, bind_port: u16) -> bool {
 }
 
 #[tokio::main]
+#[hotpath::main(allocator = tikv_jemallocator::Jemalloc)]
 async fn main() {
     let _ = dotenvy::dotenv();
+    // No-op unless `--features hotpath`: exports tokio runtime metrics (workers,
+    // park/unpark, queue depth) into the profiler report alongside function timings.
+    hotpath::tokio_runtime!();
 
     let config = match AppConfig::from_env() {
         Ok(config) => config,
@@ -1499,7 +1514,10 @@ async fn main() {
         .http2_keep_alive_timeout(Duration::from_secs(5))
         .build()
     {
-        Ok(client) => client,
+        // `http!` is identity unless `--features hotpath`, where it reports
+        // per-endpoint request counts/latency/errors (Tinybird, ClickHouse,
+        // the forward collector, Autumn, R2 — all outbound calls share this pool).
+        Ok(client) => hotpath::http!(client, label = "outbound"),
         Err(error) => {
             eprintln!("HTTP client init error: {error}");
             std::process::exit(1);
@@ -2083,6 +2101,13 @@ async fn ready(State(state): State<Arc<AppState>>) -> Response {
     }
 }
 
+// The request entry points (`handle_*`, `handle_*_inner`, `accept_grpc_decoded`)
+// are deliberately not `#[hotpath::measure]`d: wrapping their futures pushed the
+// fully-inlined request state machine over the 2 MB tokio worker stack
+// (release overflowed at the axum handlers, debug one level down). The stages
+// underneath — `resolve_ingest_key`, `decode_and_enrich_payload`,
+// `process_decoded_payload`, `forward_to_collector`, and the pipeline in
+// `telemetry.rs` — are measured and add up to the same work.
 async fn handle_traces(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -3824,6 +3849,7 @@ fn detect_payload_format(content_type: &str) -> Result<PayloadFormat, ApiError> 
     ))
 }
 
+#[hotpath::measure]
 fn decode_payload(body: &Bytes, content_encoding: Option<&str>) -> Result<Vec<u8>, ApiError> {
     match content_encoding {
         None => Ok(body.to_vec()),
@@ -3841,6 +3867,7 @@ fn decode_payload(body: &Bytes, content_encoding: Option<&str>) -> Result<Vec<u8
     }
 }
 
+#[hotpath::measure]
 fn encode_payload(payload: &[u8], content_encoding: Option<&str>) -> Result<Vec<u8>, ApiError> {
     match content_encoding {
         None => Ok(payload.to_vec()),
@@ -3859,6 +3886,7 @@ fn encode_payload(payload: &[u8], content_encoding: Option<&str>) -> Result<Vec<
     }
 }
 
+#[hotpath::measure]
 fn decode_and_enrich_payload(
     signal: Signal,
     payload_format: PayloadFormat,
@@ -4049,6 +4077,7 @@ fn native_rows_pipeline_for<'a>(
         .ok_or_else(|| ApiError::service_unavailable(unavailable_message))
 }
 
+#[hotpath::measure]
 async fn forward_to_collector(
     state: &AppState,
     signal: Signal,
@@ -4164,6 +4193,7 @@ async fn forward_to_collector(
         .map_err(|_| ApiError::service_unavailable("Telemetry backend unavailable"))
 }
 
+#[hotpath::measure]
 async fn process_decoded_payload(
     state: &AppState,
     signal: Signal,
@@ -4204,6 +4234,7 @@ async fn process_decoded_payload(
     Ok(StatusCode::OK.into_response())
 }
 
+#[hotpath::measure]
 async fn accept_native_decoded_payload(
     state: &AppState,
     signal: Signal,
@@ -4327,6 +4358,7 @@ impl OrgRoutingResolver {
 }
 
 impl IngestKeyResolver {
+    #[hotpath::measure]
     async fn resolve_ingest_key(&self, raw_key: &str) -> Result<Option<ResolvedIngestKey>, String> {
         // Recorded on `ingest.authenticate` when this runs under the HTTP path;
         // a no-op elsewhere (the field is only declared on that span).
@@ -4428,6 +4460,7 @@ impl CloudflareConnectorResolver {
 }
 
 impl SamplingPolicyResolver {
+    #[hotpath::measure]
     async fn resolve_policy(&self, org_id: &str) -> SamplingPolicy {
         if let Some(policy) = self.cache.get(org_id).await {
             return policy;
@@ -4488,6 +4521,7 @@ fn parse_attribute_mapping_row(row: AttributeMappingRow) -> Option<AttributeMapp
 }
 
 impl AttributeMappingResolver {
+    #[hotpath::measure]
     async fn resolve_mappings(&self, org_id: &str) -> Arc<Vec<AttributeMappingRule>> {
         if let Some(rules) = self.cache.get(org_id).await {
             return rules;
@@ -6260,7 +6294,7 @@ mod tests {
                 replay_blob_store: None,
                 trust_proxy_geo: false,
             },
-            http_client,
+            http_client: http_client.into(),
             telemetry_pipeline: Some(telemetry_pipeline),
             resolver: IngestKeyResolver {
                 store: Arc::clone(&key_store),

--- a/apps/ingest/src/r2.rs
+++ b/apps/ingest/src/r2.rs
@@ -66,7 +66,7 @@ pub fn replay_object_key(org_id: &str, session_id: &str, chunk_seq: u32) -> Stri
 /// Writes replay chunk payloads to an S3-compatible bucket.
 #[derive(Clone)]
 pub struct ReplayBlobStore {
-    client: reqwest::Client,
+    client: crate::telemetry::HttpClient,
     /// Origin only, no trailing slash: `https://<account>.r2.cloudflarestorage.com`.
     endpoint: String,
     host: String,
@@ -79,7 +79,7 @@ pub struct ReplayBlobStore {
 
 impl ReplayBlobStore {
     pub fn new(
-        client: reqwest::Client,
+        client: impl Into<crate::telemetry::HttpClient>,
         endpoint: String,
         bucket: String,
         access_key_id: String,
@@ -90,7 +90,7 @@ impl ReplayBlobStore {
         let endpoint = endpoint.trim_end_matches('/').to_string();
         let host = host_from_endpoint(&endpoint);
         Self {
-            client,
+            client: client.into(),
             endpoint,
             host,
             bucket,

--- a/apps/ingest/src/telemetry.rs
+++ b/apps/ingest/src/telemetry.rs
@@ -26,7 +26,13 @@ use opentelemetry_proto::tonic::metrics::v1::{
     metric, number_data_point, Exemplar, NumberDataPoint,
 };
 use opentelemetry_proto::tonic::trace::v1::{span, status, Span};
+#[cfg(test)]
 use reqwest::Client;
+
+/// The shared outbound HTTP client type: plain `reqwest::Client` in normal
+/// builds, hotpath's instrumented wrapper (same request API) under
+/// `--features hotpath`.
+pub type HttpClient = hotpath::wrap::reqwest::Client;
 use serde::Serialize;
 use serde_json::{json, Map, Value};
 use tokio::sync::mpsc;
@@ -652,13 +658,16 @@ struct EncodedFrame {
 }
 
 impl TelemetryPipeline {
-    pub async fn new(cfg: TinybirdConfig, http: Client) -> Result<Self, String> {
+    // `HttpClient` is the raw `reqwest::Client` in normal builds and the
+    // hotpath-instrumented wrapper under `--features hotpath`; `impl Into<_>`
+    // lets callers (and tests) keep handing in a plain `reqwest::Client`.
+    pub async fn new(cfg: TinybirdConfig, http: impl Into<HttpClient>) -> Result<Self, String> {
         Self::new_with_clickhouse(cfg, http, None).await
     }
 
     pub async fn new_with_clickhouse(
         cfg: TinybirdConfig,
-        http: Client,
+        http: impl Into<HttpClient>,
         clickhouse_targets: Option<Arc<dyn ClickHouseTargetProvider>>,
     ) -> Result<Self, String> {
         Self::new_with_clickhouse_validation(cfg, http, clickhouse_targets, true).await
@@ -666,10 +675,11 @@ impl TelemetryPipeline {
 
     pub async fn new_with_clickhouse_validation(
         cfg: TinybirdConfig,
-        http: Client,
+        http: impl Into<HttpClient>,
         clickhouse_targets: Option<Arc<dyn ClickHouseTargetProvider>>,
         require_tinybird_credentials: bool,
     ) -> Result<Self, String> {
+        let http: HttpClient = http.into();
         cfg.validate_for_pipeline(require_tinybird_credentials)?;
         std::fs::create_dir_all(&cfg.queue_dir)
             .map_err(|error| format!("create ingest WAL dir: {error}"))?;
@@ -684,6 +694,9 @@ impl TelemetryPipeline {
 
         for shard in 0..cfg.wal_shards {
             for destination in ExportDestination::ALL {
+                // Deliberately not `hotpath::channel!`-wrapped: commit_frames
+                // relies on `try_reserve_owned` permits (reserve before the WAL
+                // append), which the profiler's Sender wrapper does not expose.
                 let (sender, receiver) = mpsc::channel(cfg.queue_channel_capacity);
                 debug_assert_eq!(lane_senders.len(), lane_index(shard, destination));
                 lane_senders.push(sender);
@@ -732,6 +745,7 @@ impl TelemetryPipeline {
         .await
     }
 
+    #[hotpath::measure]
     pub async fn accept_traces_to(
         &self,
         org_id: &str,
@@ -766,6 +780,7 @@ impl TelemetryPipeline {
             .await
     }
 
+    #[hotpath::measure]
     pub async fn accept_logs_to(
         &self,
         org_id: &str,
@@ -792,6 +807,7 @@ impl TelemetryPipeline {
             .await
     }
 
+    #[hotpath::measure]
     pub async fn accept_metrics_to(
         &self,
         org_id: &str,
@@ -830,6 +846,7 @@ impl TelemetryPipeline {
         .await
     }
 
+    #[hotpath::measure]
     pub async fn accept_rows_to(
         &self,
         org_id: &str,
@@ -847,6 +864,7 @@ impl TelemetryPipeline {
         Ok(stats)
     }
 
+    #[hotpath::measure]
     async fn commit_frames(
         &self,
         frames: Vec<EncodedFrame>,
@@ -985,6 +1003,7 @@ impl TelemetryPipeline {
         release_org_queue_bytes(&self.inner.org_queue_bytes, org_id, bytes);
     }
 
+    #[hotpath::measure]
     async fn replay_committed_frames(&self) {
         for lane in 0..self.inner.lane_senders.len() {
             let frames = match self.inner.wal.replay(lane).await {
@@ -1134,6 +1153,7 @@ impl ShardedWal {
         self.append_inner(lane, frame, true).await
     }
 
+    #[hotpath::measure]
     async fn append_inner(
         &self,
         lane: usize,
@@ -1186,6 +1206,7 @@ impl ShardedWal {
             .map_err(|error| format!("join WAL replay: {error}"))?
     }
 
+    #[hotpath::measure]
     async fn mark_exported(&self, lane: usize, offset: u64) -> Result<(), String> {
         let shard_ref = Arc::clone(
             self.lanes
@@ -1547,7 +1568,7 @@ struct ExportWorker {
     org_queue_bytes: Arc<DashMap<String, Arc<AtomicU64>>>,
     clickhouse_breakers: Arc<ClickHouseBreakerRegistry>,
     clickhouse_targets: Option<Arc<dyn ClickHouseTargetProvider>>,
-    http: Client,
+    http: HttpClient,
     receiver: mpsc::Receiver<QueuedFrame>,
 }
 
@@ -1612,6 +1633,7 @@ impl ExportWorker {
         }
     }
 
+    #[hotpath::measure]
     async fn export_and_mark(&self, frames: Vec<QueuedFrame>) -> Result<(), String> {
         if frames.is_empty() {
             return Ok(());
@@ -1682,6 +1704,7 @@ impl ExportWorker {
         Ok(())
     }
 
+    #[hotpath::measure]
     async fn post_tinybird(
         &self,
         datasource: &str,
@@ -1803,6 +1826,7 @@ impl ExportWorker {
         }
     }
 
+    #[hotpath::measure]
     async fn post_clickhouse(
         &self,
         org_id: &str,
@@ -2167,6 +2191,7 @@ fn escape_clickhouse_sql_literal(value: &str) -> String {
     value.replace('\\', "\\\\").replace('\'', "\\'")
 }
 
+#[hotpath::measure]
 fn gzip(body: Vec<u8>) -> Result<Vec<u8>, String> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
     encoder
@@ -2177,6 +2202,7 @@ fn gzip(body: Vec<u8>) -> Result<Vec<u8>, String> {
         .map_err(|error| format!("finish gzip Tinybird body: {error}"))
 }
 
+#[hotpath::measure]
 fn encode_traces(
     datasources: &DatasourceNames,
     org_id: &str,
@@ -2311,6 +2337,7 @@ fn encode_traces(
     Ok((frames, stats))
 }
 
+#[hotpath::measure]
 fn encode_logs(
     datasources: &DatasourceNames,
     org_id: &str,
@@ -2400,6 +2427,7 @@ fn encode_log_row(
     }))
 }
 
+#[hotpath::measure]
 fn encode_metrics(
     datasources: &DatasourceNames,
     org_id: &str,

--- a/apps/ios/Maple/Push/PushRegistrar.swift
+++ b/apps/ios/Maple/Push/PushRegistrar.swift
@@ -157,28 +157,42 @@ final class PushRegistrar: NSObject {
 	}
 }
 
-/// Which APNs host the token belongs to. Development builds carry
-/// `aps-environment = development` in the embedded provisioning profile;
-/// TestFlight and App Store builds carry `production`. The simulator has no
-/// profile and no real APNs, so it reads as sandbox.
+/// Which APNs host the token belongs to. Getting this wrong is not a degraded
+/// mode: Apple answers a token sent to the other host with `BadDeviceToken`
+/// and the server disables the device, so the phone goes silent.
+///
+/// Xcode-installed builds carry `aps-environment = development` in the
+/// embedded provisioning profile; TestFlight archives carry `production`.
+/// **App Store installs have no embedded profile at all** — Apple strips it
+/// when it re-signs — and their tokens are production, so "no profile" must
+/// mean production. The simulator also has no profile, but a simulator token
+/// is undeliverable from a server on either host, so nothing is lost by
+/// treating it the same way.
 enum PushEnvironmentDetector {
 	static let current: PushEnvironment = {
 		guard let path = Bundle.main.path(forResource: "embedded", ofType: "mobileprovision"),
 			let data = FileManager.default.contents(atPath: path),
 			let text = String(data: data, encoding: .isoLatin1)
 		else {
-			return .sandbox
+			return .production
 		}
-		// The profile is CMS-wrapped XML; the plist is readable in the clear.
-		if let range = text.range(of: "<key>aps-environment</key>") {
-			let tail = text[range.upperBound...]
-			if tail.range(of: "<string>production</string>")?.lowerBound == tail.range(of: "<string>")?.lowerBound {
-				return .production
-			}
-			return .sandbox
-		}
-		return .sandbox
+		return parse(profile: text)
 	}()
+
+	/// The profile is CMS-wrapped XML; the entitlements plist is readable in
+	/// the clear. Only a profile that positively says `development` is a
+	/// sandbox token — anything else (`production`, or a profile without the
+	/// key) is treated as production, the direction that at worst costs a
+	/// dev-build push rather than every real user's.
+	static func parse(profile text: String) -> PushEnvironment {
+		guard let keyRange = text.range(of: "<key>aps-environment</key>") else { return .production }
+		let tail = text[keyRange.upperBound...]
+		guard let open = tail.range(of: "<string>"),
+			let close = tail[open.upperBound...].range(of: "</string>")
+		else { return .production }
+		let value = tail[open.upperBound..<close.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines)
+		return value == "development" ? .sandbox : .production
+	}
 }
 
 /// APNs and notification callbacks arrive on UIKit's app delegate; this

--- a/apps/ios/Maple/Push/PushRegistrar.swift
+++ b/apps/ios/Maple/Push/PushRegistrar.swift
@@ -161,11 +161,13 @@ final class PushRegistrar: NSObject {
 /// mode: Apple answers a token sent to the other host with `BadDeviceToken`
 /// and the server disables the device, so the phone goes silent.
 ///
-/// Xcode-installed builds carry `aps-environment = development` in the
-/// embedded provisioning profile; TestFlight archives carry `production`.
-/// **App Store installs have no embedded profile at all** — Apple strips it
-/// when it re-signs — and their tokens are production, so "no profile" must
-/// mean production. The simulator also has no profile, but a simulator token
+/// Xcode-installed (and ad-hoc) builds carry `aps-environment = development`
+/// or `production` in the embedded provisioning profile. **TestFlight and App
+/// Store installs have no embedded profile at all** — anything uploaded through
+/// App Store Connect is re-signed by Apple, which strips it — and their tokens
+/// are production, so "no profile" must mean production. (Observed 2026-08-18:
+/// a TestFlight build read as sandbox here, its token went to the sandbox host,
+/// Apple answered `BadDeviceToken`, and the server disabled the phone.) The simulator also has no profile, but a simulator token
 /// is undeliverable from a server on either host, so nothing is lost by
 /// treating it the same way.
 enum PushEnvironmentDetector {

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -68,8 +68,8 @@ The server side is `apps/api/src/services/push` + `platform/Apns.ts`; it sends
 only when `APNS_TEAM_ID` / `APNS_KEY_ID` / `APNS_PRIVATE_KEY` are set on the
 alerting worker. `aps-environment` in the entitlements is `development` and
 Xcode flips it for archives; the app reads whichever landed in the embedded
-profile to pick the APNs host, and treats a missing profile (App Store installs
-have none) as production. The simulator on Apple silicon does get a token, but
+profile to pick the APNs host, and treats a missing profile (TestFlight and App Store
+installs have none — Apple re-signs and strips it) as production. The simulator on Apple silicon does get a token, but
 nothing is delivered to it from a Worker — registering from the simulator
 leaves a row Apple rejects with `BadDeviceToken`, which disables it.
 

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -68,8 +68,10 @@ The server side is `apps/api/src/services/push` + `platform/Apns.ts`; it sends
 only when `APNS_TEAM_ID` / `APNS_KEY_ID` / `APNS_PRIVATE_KEY` are set on the
 alerting worker. `aps-environment` in the entitlements is `development` and
 Xcode flips it for archives; the app reads whichever landed in the embedded
-profile to pick the APNs host. The simulator on Apple silicon does get a
-token, but nothing is delivered to it from a Worker.
+profile to pick the APNs host, and treats a missing profile (App Store installs
+have none) as production. The simulator on Apple silicon does get a token, but
+nothing is delivered to it from a Worker — registering from the simulator
+leaves a row Apple rejects with `BadDeviceToken`, which disables it.
 
 ## Running without a sign-in
 


### PR DESCRIPTION
## What broke

Confirmed on the phone: a TestFlight build, and its row registered as `sandbox` — i.e. a production token sent to the sandbox host, the `BadDeviceToken` path.

Prod telemetry today: both registered devices sent \`environment = sandbox\`; both APNs sends returned 400, landed in the \`unregistered\` branch, and the rows were disabled with **no log line** — so push looked like silence rather than "Apple rejected token X because Y". Every incident since has had 0 targets.

## Fixes

- **iOS \`PushEnvironmentDetector\`**: a missing \`embedded.mobileprovision\` now means **production**. App Store installs have no embedded profile (Apple strips it on re-sign), so the old \`.sandbox\` fallback sent every App Store user's production token to the sandbox host → \`BadDeviceToken\` → device disabled. Only a profile that positively says \`development\` is sandbox now; parsing pulled into a testable \`parse(profile:)\`.
- **\`MobilePushService\`**: the \`unregistered\` branch logs a warning with \`deviceId\`, \`environment\`, \`bundleId\`, \`appVersion\` and Apple's \`reason\` before disabling, so the next one of these is a 30-second diagnosis.
- README note that registering from the simulator leaves a row Apple rejects.

## Verification

- \`MobilePushService.test.ts\` passes, \`tsc\` clean for \`apps/api\`.
- \`xcodebuild\` for the simulator: BUILD SUCCEEDED.

## After merge

Relaunch the TestFlight build so the phone re-registers (registration clears \`disabled_at\`); the next incident should land. \`select environment, disabled_reason from mobile_devices\` on prod tells whether today's 400s were \`BadDeviceToken\` (environment mismatch / simulator token) or \`DeviceTokenNotForTopic\` (build signed under another team) — this PR fixes the former; the latter is a signing question, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789668551&installation_model_id=427786&pr_number=524&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F524&signature=e4c96b2f4fb7c1fa60ac3ae959322b2106bfddecc4c3018df6412572f3f714d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->