### PR TITLE
fix(scraper): back off billing-blocked targets and stop recording 402 as an error

### DIFF
--- a/apps/scraper/src/OtlpIngest.test.ts
+++ b/apps/scraper/src/OtlpIngest.test.ts
@@ -1,8 +1,9 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer, Redacted } from "effect"
+import { Effect, Exit, Layer, Redacted } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { OtlpIngest } from "./OtlpIngest"
 import { ScraperEnv, type ScraperEnvConfig } from "./Env"
+import { endedSpansNamed, makeCapturingTracer } from "./testing/capturing-tracer"
 import type { OtlpExportRequest } from "./prometheus/otlp"
 
 const testEnv: ScraperEnvConfig = {
@@ -122,6 +123,49 @@ describe("OtlpIngest", () => {
 				Effect.flip,
 			)
 			assert.strictEqual(error.status, 401)
+		}).pipe(Effect.provide(TestLayer)),
+	)
+
+	// A 4xx is the gateway telling us about the *caller*, not a fault of this
+	// send — only 5xx is `Error` (CLAUDE.md). The typed error still reaches the
+	// caller; it just must not be blamed on the span.
+	it.effect("annotates rather than errors its span on a billing rejection (402)", () =>
+		Effect.gen(function* () {
+			const tracer = makeCapturingTracer()
+			const otlp = yield* OtlpIngest
+			yield* otlp.send("maple_pk_test_key", SAMPLE_REQUEST).pipe(
+				Effect.provideService(
+					FetchHttpClient.Fetch,
+					stubFetch([], () => new Response("metrics limit reached", { status: 402 })),
+				),
+				Effect.provide(tracer.layer),
+				Effect.flip,
+			)
+
+			const spans = endedSpansNamed(tracer.ended, "OtlpIngest.send")
+			assert.lengthOf(spans, 1)
+			assert.isTrue(Exit.isSuccess(spans[0]!.exit))
+			assert.strictEqual(spans[0]!.attributes.get("error.type"), "delivery_blocked")
+			assert.strictEqual(spans[0]!.attributes.get("http.response.status_code"), 402)
+		}).pipe(Effect.provide(TestLayer)),
+	)
+
+	it.effect("still errors its span when the gateway itself fails (5xx)", () =>
+		Effect.gen(function* () {
+			const tracer = makeCapturingTracer()
+			const otlp = yield* OtlpIngest
+			yield* otlp.send("maple_pk_test_key", SAMPLE_REQUEST).pipe(
+				Effect.provideService(
+					FetchHttpClient.Fetch,
+					stubFetch([], () => new Response("boom", { status: 500 })),
+				),
+				Effect.provide(tracer.layer),
+				Effect.flip,
+			)
+
+			const spans = endedSpansNamed(tracer.ended, "OtlpIngest.send")
+			assert.lengthOf(spans, 1)
+			assert.isTrue(Exit.isFailure(spans[0]!.exit))
 		}).pipe(Effect.provide(TestLayer)),
 	)
 })

--- a/apps/scraper/src/OtlpIngest.ts
+++ b/apps/scraper/src/OtlpIngest.ts
@@ -23,34 +23,61 @@ export class OtlpIngest extends Context.Service<OtlpIngest, OtlpIngestApi>()("@m
 		const env = yield* ScraperEnv
 		const client = yield* HttpClient.HttpClient
 
-		const send = Effect.fn("OtlpIngest.send")(function* (ingestKey: string, request: OtlpExportRequest) {
-			const httpRequest = HttpClientRequest.post(`${env.MAPLE_INGEST_URL}/v1/metrics`, {
-				headers: { authorization: `Bearer ${ingestKey}` },
-			}).pipe(HttpClientRequest.bodyText(JSON.stringify(request), "application/json"))
+		/**
+		 * Resolves to `null` on success, or to the error for a rejection the span
+		 * must NOT be blamed for. Carrying a 4xx out of the span as a *value* is
+		 * what keeps `OtlpIngest.send` from closing as `Error`: a 402 (org over
+		 * its billing limit) or any other client-side rejection is expected and
+		 * gets annotated, matching the repo's rule that only 5xx is `Error`. The
+		 * typed `OtlpIngestError` still reaches the caller either way, so
+		 * `ScrapeScheduler` can classify it as `delivery_blocked`.
+		 */
+		const attempt = (ingestKey: string, request: OtlpExportRequest) =>
+			Effect.gen(function* () {
+				const httpRequest = HttpClientRequest.post(`${env.MAPLE_INGEST_URL}/v1/metrics`, {
+					headers: { authorization: `Bearer ${ingestKey}` },
+				}).pipe(HttpClientRequest.bodyText(JSON.stringify(request), "application/json"))
 
-			const response = yield* client.execute(httpRequest).pipe(
-				Effect.annotateSpans("peer.service", "ingest"),
-				Effect.mapError(
-					(error) =>
-						new OtlpIngestError({
-							message: `ingest gateway unreachable: ${error.message}`,
-							status: null,
-						}),
-				),
-			)
-			if (response.status < 200 || response.status >= 300) {
-				const text = yield* response.text.pipe(Effect.orElseSucceed(() => ""))
-				return yield* Effect.fail(
-					new OtlpIngestError({
+				const response = yield* client.execute(httpRequest).pipe(
+					Effect.annotateSpans("peer.service", "ingest"),
+					Effect.mapError(
+						(error) =>
+							new OtlpIngestError({
+								message: `ingest gateway unreachable: ${error.message}`,
+								status: null,
+							}),
+					),
+				)
+				if (response.status < 200 || response.status >= 300) {
+					const text = yield* response.text.pipe(Effect.orElseSucceed(() => ""))
+					const error = new OtlpIngestError({
 						message:
 							response.status === 402
 								? `ingest gateway rejected metrics: billing limit reached (HTTP 402): ${text.slice(0, 200)}`
 								: `ingest gateway returned HTTP ${response.status}: ${text.slice(0, 200)}`,
 						status: response.status,
-					}),
-				)
-			}
-		})
+					})
+					yield* Effect.annotateCurrentSpan("http.response.status_code", response.status)
+					if (response.status >= 400 && response.status < 500) {
+						yield* Effect.annotateCurrentSpan(
+							"error.type",
+							response.status === 402 ? "delivery_blocked" : `ingest_http_${response.status}`,
+						)
+						return error
+					}
+					return yield* Effect.fail(error)
+				}
+				return null
+			})
+
+		const send = (ingestKey: string, request: OtlpExportRequest) =>
+			attempt(ingestKey, request).pipe(
+				// One `withSpan` only — pairing it with `Effect.fn` of the same name
+				// would emit two spans per send.
+				Effect.withSpan("OtlpIngest.send"),
+				// Fail *outside* the span so an annotated 4xx doesn't set its status.
+				Effect.flatMap((rejection) => (rejection === null ? Effect.void : Effect.fail(rejection))),
+			)
 
 		return { send } satisfies OtlpIngestApi
 	}),

--- a/apps/scraper/src/ScrapeScheduler.test.ts
+++ b/apps/scraper/src/ScrapeScheduler.test.ts
@@ -1,11 +1,12 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Duration, Effect, Fiber, Layer, Metric, Redacted, Schema } from "effect"
+import { Duration, Effect, Exit, Fiber, Layer, Metric, Redacted, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { InternalScrapeTarget, ScrapeResultReport, ScrapeTargetId } from "@maple/domain/http"
 import { ApiClient, ApiRequestError, type ApiClientApi, type ScrapeProxyResponse } from "./ApiClient"
 import { OtlpIngest, OtlpIngestError, type OtlpIngestApi } from "./OtlpIngest"
 import {
 	backoffLogMessage,
+	DELIVERY_BLOCKED_BACKOFF,
 	initialJitterMs,
 	makeResultBuffer,
 	nextScrapeDelayMs,
@@ -19,7 +20,14 @@ import {
 } from "./ScrapeScheduler"
 import { ScraperEnv, type ScraperEnvConfig } from "./Env"
 import { bufferedResults } from "./Metrics"
+import { endedSpansNamed, makeCapturingTracer } from "./testing/capturing-tracer"
 import type { OtlpExportRequest } from "./prometheus/otlp"
+
+/** What the ingest gateway returns for an org over its billing limit. */
+const billingLimitError = new OtlpIngestError({
+	message: "ingest gateway rejected metrics: billing limit reached (HTTP 402)",
+	status: 402,
+})
 
 const decodeTarget = Schema.decodeUnknownSync(InternalScrapeTarget)
 
@@ -516,25 +524,87 @@ describe("ScrapeScheduler", () => {
 		}),
 	)
 
-	it.effect("backs off when the ingest gateway blocks delivery (402) instead of re-scraping", () =>
+	it.effect("suspends a target for the full backoff when the gateway blocks delivery (402)", () =>
 		Effect.gen(function* () {
 			// Prod scenario: the org is over its billing limit, so every export is
-			// refused. Scraping again cannot help — the data has nowhere to go.
+			// refused. Scraping again cannot help — the data has nowhere to go, and
+			// only a subscription change clears it, so the loop parks for an hour.
 			const harness = makeHarness([mkTarget(TARGET_A, 10)])
-			harness.ingestImpl = () =>
-				Effect.fail(
-					new OtlpIngestError({
-						message: "ingest gateway rejected metrics: billing limit reached (HTTP 402)",
-						status: 402,
-					}),
-				)
+			harness.ingestImpl = () => Effect.fail(billingLimitError)
 			yield* startScheduler.pipe(Effect.provide(harnessLayer(harness)))
 
 			yield* TestClock.adjust(Duration.seconds(60))
-
-			// Exponential backoff off a 10s base: scrapes at t=0, 10, 30.
-			assert.strictEqual(harness.scrapeCalls.length, 3)
+			// One scrape at t=0, then nothing for the whole hour (the old exponential
+			// ladder scraped at t=0, 10, 30 and capped at 5 minutes).
+			assert.strictEqual(harness.scrapeCalls.length, 1)
 			assert.include(harness.reportedResults[0]?.error ?? "", "billing limit")
+
+			yield* TestClock.adjust(Duration.minutes(58))
+			assert.strictEqual(harness.scrapeCalls.length, 1)
+
+			// t=60min: one probe for recovery.
+			yield* TestClock.adjust(Duration.minutes(2))
+			assert.strictEqual(harness.scrapeCalls.length, 2)
+		}),
+	)
+
+	it.effect("resumes the normal cadence once delivery is unblocked again", () =>
+		Effect.gen(function* () {
+			const harness = makeHarness([mkTarget(TARGET_A, 10)])
+			let blocked = true
+			harness.ingestImpl = () => (blocked ? Effect.fail(billingLimitError) : Effect.void)
+			yield* startScheduler.pipe(Effect.provide(harnessLayer(harness)))
+
+			yield* TestClock.adjust(Duration.seconds(1))
+			assert.strictEqual(harness.scrapeCalls.length, 1)
+
+			// Subscription fixed while the target is parked.
+			blocked = false
+			yield* TestClock.adjust(DELIVERY_BLOCKED_BACKOFF)
+			// The probe at t=60min succeeds…
+			assert.strictEqual(harness.scrapeCalls.length, 2)
+
+			// …and the backoff is cleared: back to the 10s interval.
+			yield* TestClock.adjust(Duration.seconds(30))
+			assert.strictEqual(harness.scrapeCalls.length, 5)
+			assert.isAtLeast(harness.ingestCalls.length, 4)
+		}),
+	)
+
+	it.effect("does not close the scrape span as an error when delivery is blocked (402)", () =>
+		Effect.gen(function* () {
+			// Only 5xx is `Error` (CLAUDE.md): a 402 from our own gateway is an
+			// expected caller-side condition. It used to mint two Error spans and two
+			// error fingerprints every 5 minutes, forever, for a single blocked org.
+			const tracer = makeCapturingTracer()
+			const harness = makeHarness([mkTarget(TARGET_A, 10)])
+			harness.ingestImpl = () => Effect.fail(billingLimitError)
+			yield* startScheduler.pipe(Effect.provide(harnessLayer(harness)), Effect.provide(tracer.layer))
+
+			yield* TestClock.adjust(Duration.seconds(1))
+
+			const spans = endedSpansNamed(tracer.ended, "scraper.scrape_target")
+			assert.lengthOf(spans, 1)
+			assert.isTrue(Exit.isSuccess(spans[0]!.exit))
+			assert.strictEqual(spans[0]!.attributes.get("error.type"), "delivery_blocked")
+			assert.strictEqual(spans[0]!.attributes.get("maple.scrape.outcome"), "delivery_blocked")
+			assert.strictEqual(spans[0]!.attributes.get("http.response.status_code"), 402)
+		}),
+	)
+
+	it.effect("still closes the scrape span as an error for a genuine scrape failure", () =>
+		Effect.gen(function* () {
+			const tracer = makeCapturingTracer()
+			const harness = makeHarness([mkTarget(TARGET_A, 10)])
+			harness.scrapeImpl = () => Effect.succeed(proxyResponse({ status: 503, body: "unavailable" }))
+			yield* startScheduler.pipe(Effect.provide(harnessLayer(harness)), Effect.provide(tracer.layer))
+
+			yield* TestClock.adjust(Duration.seconds(1))
+
+			const spans = endedSpansNamed(tracer.ended, "scraper.scrape_target")
+			assert.lengthOf(spans, 1)
+			assert.isTrue(Exit.isFailure(spans[0]!.exit))
+			assert.strictEqual(spans[0]!.attributes.get("error.type"), "rate_limited")
 		}),
 	)
 
@@ -770,19 +840,25 @@ describe("nextScrapeDelayMs", () => {
 	// Regression: a 402 from our own gateway used to flatten into the generic
 	// "some error" outcome with both backoff flags false, so the target kept
 	// scraping at full cadence and re-POSTing data the gateway would refuse again.
-	it("escalates exponentially when the ingest gateway refuses delivery (402)", () => {
+	// It then climbed the same 5-minute exponential ladder as a rate limit, which
+	// still probed 12x an hour for a condition only a subscription change clears.
+	it("parks flat for the delivery-blocked backoff when the gateway refuses delivery (402)", () => {
+		const blocked = Duration.toMillis(DELIVERY_BLOCKED_BACKOFF)
+		// Independent of the base interval and of how long it has been blocked.
 		assert.strictEqual(
 			nextScrapeDelayMs({ baseMs: 10_000, outcome: deliveryBlocked, consecutiveBackoffs: 0 }),
-			10_000,
+			blocked,
 		)
 		assert.strictEqual(
 			nextScrapeDelayMs({ baseMs: 10_000, outcome: deliveryBlocked, consecutiveBackoffs: 3 }),
-			80_000,
+			blocked,
 		)
 		assert.strictEqual(
-			nextScrapeDelayMs({ baseMs: 60_000, outcome: deliveryBlocked, consecutiveBackoffs: 5 }),
-			Duration.toMillis(Duration.minutes(5)),
+			nextScrapeDelayMs({ baseMs: 300_000, outcome: deliveryBlocked, consecutiveBackoffs: 5 }),
+			blocked,
 		)
+		// …and is not clipped by the rate-limit ceiling.
+		assert.isAbove(blocked, Duration.toMillis(Duration.minutes(5)))
 	})
 
 	it("escalates exponentially on a rejected credential (401/403) too", () => {

--- a/apps/scraper/src/ScrapeScheduler.ts
+++ b/apps/scraper/src/ScrapeScheduler.ts
@@ -49,6 +49,15 @@ const MAX_BUFFERED_RESULTS = 10_000
 const RESULTS_FLUSH_CHUNK_SIZE = 1_000
 /** Upper bound on rate-limit backoff so a target keeps probing for recovery. */
 const MAX_BACKOFF_MS = Duration.toMillis(Duration.minutes(5))
+/**
+ * Flat suspension for a target whose org is over its billing limit (HTTP 402
+ * from our own ingest gateway). Unlike a rate limit, nothing about scraping
+ * again makes this clear — it clears when a human fixes the subscription — so
+ * the loop parks for a long, constant period instead of climbing the 5-minute
+ * exponential ladder. One probe an hour is enough to notice recovery.
+ */
+export const DELIVERY_BLOCKED_BACKOFF = Duration.minutes(60)
+const DELIVERY_BLOCKED_BACKOFF_MS = Duration.toMillis(DELIVERY_BLOCKED_BACKOFF)
 
 /**
  * Why a scrape failed. Every downstream decision — retry policy, the span's
@@ -90,6 +99,8 @@ export interface ScrapeFailed {
 	readonly message: string
 	/** Upstream `Retry-After` translated to ms, when present. */
 	readonly retryAfterMs?: number
+	/** HTTP status behind the failure, when one was seen (402, 429, 503, …). */
+	readonly statusCode?: number
 }
 
 /** The single value a resolved scrape produces. */
@@ -104,11 +115,13 @@ export const scrapeFailed = (fields: {
 	readonly reason: ScrapeFailureReason
 	readonly message: string
 	readonly retryAfterMs?: number | null
+	readonly statusCode?: number | null
 }): ScrapeOutcome => ({
 	_tag: "Failure",
 	reason: fields.reason,
 	message: fields.message,
 	...(fields.retryAfterMs != null ? { retryAfterMs: fields.retryAfterMs } : undefined),
+	...(fields.statusCode != null ? { statusCode: fields.statusCode } : undefined),
 })
 
 /**
@@ -161,11 +174,12 @@ export const backoffLogMessage = (reason: ScrapeFailureReason): string => {
  * The target period before a target's next scrape. The happy path returns the
  * configured interval; the caller ({@link ScrapeScheduler}'s target loop)
  * subtracts the scrape's own elapsed time so the happy-path cadence stays
- * start-to-start. A rate-limited, auth-rejected or delivery-blocked scrape
- * escalates exponentially — honoring `Retry-After` when it is longer — capped
- * at {@link MAX_BACKOFF_MS} so the target keeps probing for recovery (an auth
- * fix needs no restart: the credential is resolved server-side per scrape);
- * that delay runs from scrape end.
+ * start-to-start. A rate-limited or auth-rejected scrape escalates
+ * exponentially — honoring `Retry-After` when it is longer — capped at
+ * {@link MAX_BACKOFF_MS} so the target keeps probing for recovery (an auth fix
+ * needs no restart: the credential is resolved server-side per scrape); a
+ * delivery-blocked one parks flat for {@link DELIVERY_BLOCKED_BACKOFF}. Either
+ * delay runs from scrape end.
  */
 export const nextScrapeDelayMs = ({
 	baseMs,
@@ -177,6 +191,12 @@ export const nextScrapeDelayMs = ({
 	readonly consecutiveBackoffs: number
 }): number => {
 	if (!shouldBackOff(outcome)) return baseMs
+	// A billing block does not decay: park the target for a flat hour rather
+	// than climbing to the 5-minute ceiling and probing 12x as often for a
+	// condition only a subscription change can clear.
+	if (outcome._tag === "Failure" && outcome.reason === "delivery_blocked") {
+		return Math.max(DELIVERY_BLOCKED_BACKOFF_MS, outcome.retryAfterMs ?? 0)
+	}
 	// exponential is always >= baseMs (consecutiveBackoffs >= 0), so baseMs
 	// never needs to be a floor here.
 	const exponential = baseMs * 2 ** consecutiveBackoffs
@@ -405,20 +425,20 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 										converted.dataPointCounts.histogram,
 								})
 							}).pipe(
-								Effect.catch((error) =>
-									Effect.succeed(
+								Effect.catch((error) => {
+									const gatewayStatus =
+										error._tag === "@maple/scraper/OtlpIngestError" ? error.status : null
+									return Effect.succeed(
 										scrapeFailed({
 											message: error.message,
 											// The gateway's 402 is the one failure in here that a
 											// retry provably cannot clear.
 											reason:
-												error._tag === "@maple/scraper/OtlpIngestError" &&
-												error.status === 402
-													? "delivery_blocked"
-													: "scrape_failed",
+												gatewayStatus === 402 ? "delivery_blocked" : "scrape_failed",
+											statusCode: gatewayStatus,
 										}),
-									),
-								),
+									)
+								}),
 								Effect.catchDefect((defect) =>
 									Effect.succeed(
 										scrapeFailed({
@@ -434,6 +454,26 @@ export class ScrapeScheduler extends Context.Service<ScrapeScheduler, ScrapeSche
 								// without parsing the free-text message — the same field the
 								// retry policy and the backoff log line read.
 								yield* Effect.annotateCurrentSpan("error.type", attempt.reason)
+								if (attempt.statusCode != null) {
+									yield* Effect.annotateCurrentSpan(
+										"http.response.status_code",
+										attempt.statusCode,
+									)
+								}
+								// A billing block is an expected, caller-side condition (our own
+								// gateway answering 402), not a fault of this scrape: per the
+								// repo's OTEL posture only 5xx is `Error`. Returning the outcome
+								// instead of failing leaves the span `Ok` with the reason on its
+								// attributes, so a blocked org stops minting an Error span (and a
+								// new error fingerprint) every single interval, forever. The Warn
+								// log below still reports it.
+								if (attempt.reason === "delivery_blocked") {
+									yield* Effect.annotateCurrentSpan(
+										"maple.scrape.outcome",
+										"delivery_blocked",
+									)
+									return attempt
+								}
 								return yield* new ScrapeAttemptFailed({
 									message: attempt.message,
 									reason: attempt.reason,

--- a/apps/scraper/src/testing/capturing-tracer.ts
+++ b/apps/scraper/src/testing/capturing-tracer.ts
@@ -1,0 +1,51 @@
+import { Layer, type Exit, Tracer } from "effect"
+
+export interface EndedSpan {
+	readonly name: string
+	readonly attributes: ReadonlyMap<string, unknown>
+	/** The exit the span closed with — `Failure` is what becomes OTLP `Error`. */
+	readonly exit: Exit.Exit<unknown, unknown>
+}
+
+/**
+ * A tracer that records every span's END, including the exit it closed with.
+ * `Tracer.NativeSpan` doesn't expose the exit status, and the exit is exactly
+ * what decides whether a span is reported as `Error` — which is the contract
+ * these tests pin (an expected 402 must not close a span as an error).
+ */
+export const makeCapturingTracer = () => {
+	const ended: Array<EndedSpan> = []
+	let spanCounter = 0
+	const tracer = Tracer.make({
+		span(options) {
+			const attributes = new Map<string, unknown>()
+			const span: Tracer.Span = {
+				_tag: "Span",
+				name: options.name,
+				traceId: `test-trace-${spanCounter}`,
+				spanId: `test-span-${spanCounter++}`,
+				parent: options.parent,
+				annotations: options.annotations,
+				links: options.links,
+				sampled: options.sampled,
+				kind: options.kind,
+				status: { _tag: "Started", startTime: options.startTime },
+				attributes,
+				end(_endTime, exit) {
+					ended.push({ name: span.name, attributes, exit })
+				},
+				attribute(key, value) {
+					attributes.set(key, value)
+				},
+				event() {},
+				addLinks() {},
+			}
+			return span
+		},
+	})
+	return { ended, layer: Layer.succeed(Tracer.Tracer, tracer) }
+}
+
+/** All recorded spans with the given name, in end order. */
+export const endedSpansNamed = (ended: ReadonlyArray<EndedSpan>, name: string) =>
+	ended.filter((span) => span.name === name)


### PR DESCRIPTION
One target whose org was over its billing limit was scraped every five
minutes, POSTed to the ingest gateway, got 402, and produced two Error spans
per attempt (`OtlpIngest.send` and `scraper.scrape_target`) — 68k error
events a day for a condition a retry provably cannot clear. The scheduler
already classified it as `delivery_blocked`; nothing acted on it.

- `OtlpIngest.send` returns a 4xx `OtlpIngestError` as a value inside the
  span and re-raises outside it, so the span closes Ok with
  `http.response.status_code` and `error.type` (`delivery_blocked` for 402,
  `ingest_http_<status>` otherwise). Transport failures and 5xx still fail
  the span. The typed error still reaches the caller.
- `scrapeOnce` treats `delivery_blocked` as an expected outcome: it annotates
  `error.type`, `maple.scrape.outcome` and the status, keeps the Warn log
  and the reported result, and returns instead of failing the target span.
- `nextScrapeDelayMs` uses a flat `DELIVERY_BLOCKED_BACKOFF` (60 min, or a
  longer Retry-After) instead of the 5-minute exponential ladder; the loop
  already resets on the next success.

Adds a capturing tracer for tests that need span exit status, and covers
402 → Ok/backoff/resume plus a 503 contrast case.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789682909&installation_model_id=427786&pr_number=526&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F526&signature=be440661acfa4612bf0d19fbbd3e3e576712ff6be09ecc4679e7311446caa20b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Verification
`bunx vitest run src/OtlpIngest.test.ts src/ScrapeScheduler.test.ts` → 51 passed · `tsc --noEmit -p apps/scraper` clean.

Not in this PR: a dedicated `last_scrape_reason` column so the UI can render "delivery blocked" as a distinct state — today it surfaces through `last_scrape_error` ("…billing limit reached (HTTP 402)").
