### PR TITLE
fix(api): record expected MCP 4xx, blocked repos and upstream timeouts as Ok spans

### DIFF
--- a/apps/api/src/chat/turn-runner.ts
+++ b/apps/api/src/chat/turn-runner.ts
@@ -20,6 +20,7 @@
  */
 import * as MapleCloudflareSDK from "@maple-dev/effect-sdk/cloudflare"
 import { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
+import { MCP_ANTICIPATED_ERROR_IDENTIFIERS } from "@/mcp/expected-failures"
 import {
 	decodeChatTurnTenant,
 	type ChatMessage,
@@ -35,7 +36,7 @@ const telemetry = MapleCloudflareSDK.make({
 	serviceName: "maple-api",
 	serviceNamespace: "backend",
 	repositoryUrl: "https://github.com/Makisuo/maple",
-	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
+	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS, ...MCP_ANTICIPATED_ERROR_IDENTIFIERS],
 })
 
 export interface RunChatSessionTurnInput {

--- a/apps/api/src/mcp/dispatcher.test.ts
+++ b/apps/api/src/mcp/dispatcher.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, expect, it } from "@effect/vitest"
 import { Context, Effect, Schema, Tracer } from "effect"
 import type { InternalRpcToolNotFoundError } from "@maple/domain/internal-rpc"
 import { McpToolExecutor, listMcpTools } from "./dispatcher"
+import { MCP_ANTICIPATED_ERROR_IDENTIFIERS } from "./expected-failures"
 import { mapleToolCatalog, toInputSchema } from "./tools/registry"
 import type { McpToolRuntimeRequirements } from "./tools/runtime-requirements"
 import type { TenantContext } from "@/services/auth/tenant-context"
@@ -137,6 +138,46 @@ describe("MCP dispatcher", () => {
 				expect(dispatchSpan.attributes.get("result.isError")).toBe(true)
 			}),
 		)
+
+		// Expected 4xx (bad parameters, bad credentials) must not be Error spans —
+		// only 5xx is, per CLAUDE.md. Prod was recording `@maple/mcp/decode-error`
+		// and `McpAuthInvalidError` as Error status + exception events.
+		it.effect("records an expected 4xx as span attributes and a Warn log, not an error", () =>
+			Effect.gen(function* () {
+				const executor = yield* makeValidationExecutor
+				const { spans, tracer } = makeRecordingTracer()
+
+				yield* executor.execute(TENANT, "inspect_trace", {}, "mcp").pipe(Effect.withTracer(tracer))
+
+				const dispatchSpan = spans.find((s) => s.name === "McpToolDispatcher.call")
+				assert.isDefined(dispatchSpan)
+				expect(dispatchSpan.attributes.get("error.type")).toBe("@maple/mcp/decode-error")
+				expect(dispatchSpan.attributes.get("http.response.status_code")).toBe(400)
+
+				// The inner registry span still FAILS with the decode error (the typed
+				// error stays in the error channel); the SDK exporter is what turns it
+				// into an Ok span, keyed off the identifier list below.
+				const registrySpan = spans.find((s) => s.name === "McpToolRegistry.execute")
+				assert.isDefined(registrySpan)
+				expect(MCP_ANTICIPATED_ERROR_IDENTIFIERS).toContain("@maple/mcp/decode-error")
+			}),
+		)
+
+		it("lists both MCP auth failures as anticipated so their spans export as Ok", () => {
+			// `@maple/domain/anticipated-errors` derives its set from domain HTTP
+			// exports and cannot see these apps/api classes.
+			expect(MCP_ANTICIPATED_ERROR_IDENTIFIERS).toEqual(
+				expect.arrayContaining([
+					"@maple/mcp/errors/McpAuthMissingError",
+					"@maple/mcp/errors/McpAuthInvalidError",
+				]),
+			)
+			// Genuine failures must keep their Error spans.
+			expect(MCP_ANTICIPATED_ERROR_IDENTIFIERS).not.toContain(
+				"@maple/mcp/errors/McpAuthUnavailableError",
+			)
+			expect(MCP_ANTICIPATED_ERROR_IDENTIFIERS).not.toContain("@maple/mcp/errors/McpQueryError")
+		})
 
 		it.effect("records result.isError as false for a call that succeeds", () =>
 			Effect.gen(function* () {

--- a/apps/api/src/mcp/dispatcher.ts
+++ b/apps/api/src/mcp/dispatcher.ts
@@ -5,6 +5,7 @@ import { executeRegisteredMcpToolUnscoped, mapleToolCatalog, toInputSchema } fro
 import type { McpToolResult } from "./tools/types"
 import type { McpToolRuntimeRequirements } from "./tools/runtime-requirements"
 import { CurrentMcpTenant } from "./lib/query-warehouse"
+import { recordExpectedMcpFailure } from "./expected-failures"
 import type { TenantContext } from "@/services/auth/tenant-context"
 
 /**
@@ -35,8 +36,7 @@ const callMcpToolUnscoped = Effect.fn("McpToolDispatcher.call")(function* (name:
 	yield* Effect.annotateCurrentSpan("maple.mcp.tool", name)
 	return yield* executeRegisteredMcpToolUnscoped(name, input).pipe(
 		Effect.catchTag("@maple/mcp/decode-error", (error) =>
-			Effect.logWarning("Invalid parameters").pipe(
-				Effect.annotateLogs({ error: error.errorMessage }),
+			recordExpectedMcpFailure(error, "Invalid parameters").pipe(
 				Effect.as({
 					isError: true,
 					content: [
@@ -69,17 +69,18 @@ const callMcpToolUnscoped = Effect.fn("McpToolDispatcher.call")(function* (name:
 						content: [{ type: "text", text: `${error._tag}: ${error.message}` }],
 					} satisfies McpToolResult),
 				),
+			// Missing/invalid credentials are expected 401s, not failures: they are
+			// recorded on the span as attributes + a Warn log (see
+			// `expected-failures.ts`), never as an Error status or exception event.
 			"@maple/mcp/errors/McpAuthMissingError": (error) =>
-				Effect.logError("MCP authentication failed").pipe(
-					Effect.annotateLogs({ "error.message": error.message, "error.type": error._tag }),
+				recordExpectedMcpFailure(error, "MCP authentication failed").pipe(
 					Effect.as({
 						isError: true,
 						content: [{ type: "text", text: `${error._tag}: ${error.message}` }],
 					} satisfies McpToolResult),
 				),
 			"@maple/mcp/errors/McpAuthInvalidError": (error) =>
-				Effect.logError("MCP authentication failed").pipe(
-					Effect.annotateLogs({ "error.message": error.message, "error.type": error._tag }),
+				recordExpectedMcpFailure(error, "MCP authentication failed").pipe(
 					Effect.as({
 						isError: true,
 						content: [{ type: "text", text: `${error._tag}: ${error.message}` }],

--- a/apps/api/src/mcp/expected-failures.ts
+++ b/apps/api/src/mcp/expected-failures.ts
@@ -1,0 +1,56 @@
+import { Effect } from "effect"
+
+/**
+ * MCP failures that are expected 4xx client outcomes, not bugs: a bad or absent
+ * credential, or a tool call whose parameters do not decode. Per CLAUDE.md only
+ * 5xx is an `Error` span, so these must leave the span status Ok — with the
+ * outcome recorded as attributes and a Warn log — instead of an exception event.
+ *
+ * The mechanism is the same one `@maple/domain/anticipated-errors` drives for
+ * HTTP: the SDK's tracer exports a span whose failure is caused *entirely* by an
+ * anticipated identifier as OTLP `Ok` with no `exception` event. That set is
+ * derived by reflection over the domain HTTP exports and cannot see these
+ * classes — they live in `apps/api/src/mcp` — so they are listed here and spread
+ * into the runtime telemetry configs alongside it.
+ *
+ * `McpAuthUnavailableError` (503) and `McpQueryError` are deliberately absent:
+ * they are real failures and keep their Error spans.
+ */
+const MCP_EXPECTED_FAILURE_STATUS = {
+	"@maple/mcp/decode-error": 400,
+	"@maple/mcp/errors/McpAuthMissingError": 401,
+	"@maple/mcp/errors/McpAuthInvalidError": 401,
+} satisfies Record<string, number>
+
+// Keyed by a plain string so a `_tag` off any failure can be looked up without
+// narrowing it into the literal union first.
+const expectedStatusByTag = new Map<string, number>(Object.entries(MCP_EXPECTED_FAILURE_STATUS))
+
+/** Spread into `anticipatedErrorIdentifiers` next to `ANTICIPATED_ERROR_IDENTIFIERS`. */
+export const MCP_ANTICIPATED_ERROR_IDENTIFIERS: ReadonlyArray<string> = [...expectedStatusByTag.keys()]
+
+/**
+ * Record an expected MCP 4xx on the current span and log it at Warn.
+ *
+ * A no-op for any other failure, so it is safe to hang off a broad `tapError`:
+ * genuine failures keep their Error span and are logged by their own handler.
+ * The error itself stays in the typed Effect error channel either way — only
+ * span recording changes here.
+ */
+export const recordExpectedMcpFailure = (
+	error: { readonly _tag: string; readonly message: string },
+	logMessage: string,
+): Effect.Effect<void> => {
+	const status = expectedStatusByTag.get(error._tag)
+	if (status === undefined) return Effect.void
+	return Effect.annotateCurrentSpan({
+		"error.type": error._tag,
+		"http.response.status_code": status,
+	}).pipe(
+		Effect.andThen(
+			Effect.logWarning(logMessage).pipe(
+				Effect.annotateLogs({ "error.message": error.message, "error.type": error._tag }),
+			),
+		),
+	)
+}

--- a/apps/api/src/mcp/lib/resolve-tenant.ts
+++ b/apps/api/src/mcp/lib/resolve-tenant.ts
@@ -11,6 +11,7 @@ import {
 	McpAuthUnavailableError,
 	McpInvalidTenantError,
 } from "@/mcp/tools/types"
+import { recordExpectedMcpFailure } from "@/mcp/expected-failures"
 
 const INTERNAL_SERVICE_PREFIX = "maple_svc_"
 const decodeOrgId = Schema.decodeUnknownEffect(OrgId)
@@ -66,39 +67,105 @@ export const mcpResourceForRequest = (request: Request) => {
 	return `${protocol}://${host}/mcp`
 }
 
-export const resolveMcpTenantContext = Effect.fn("resolveMcpTenantContext")(function* (request: Request) {
-	const token = getBearerToken(request.headers)
+export const resolveMcpTenantContext = Effect.fn("resolveMcpTenantContext")(
+	function* (request: Request) {
+		const token = getBearerToken(request.headers)
 
-	// Internal service auth (e.g. chat agent)
-	if (token && token.startsWith(INTERNAL_SERVICE_PREFIX)) {
-		const provided = token.slice(INTERNAL_SERVICE_PREFIX.length)
-		const env = yield* Env
-		const expected = Option.match(env.INTERNAL_SERVICE_TOKEN, {
-			onNone: () => undefined,
-			onSome: (value) => Redacted.value(value),
-		})
-
-		if (!expected) {
-			return yield* new McpAuthMissingError({
-				message: "INTERNAL_SERVICE_TOKEN is not configured on the server",
+		// Internal service auth (e.g. chat agent)
+		if (token && token.startsWith(INTERNAL_SERVICE_PREFIX)) {
+			const provided = token.slice(INTERNAL_SERVICE_PREFIX.length)
+			const env = yield* Env
+			const expected = Option.match(env.INTERNAL_SERVICE_TOKEN, {
+				onNone: () => undefined,
+				onSome: (value) => Redacted.value(value),
 			})
-		}
 
-		if (
-			provided.length === expected.length &&
-			timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
-		) {
-			const orgId = Option.match(env.MAPLE_ORG_ID_OVERRIDE, {
-				onNone: () => request.headers.get("x-org-id"),
-				onSome: (value) => value,
-			})
-			if (!orgId) {
+			if (!expected) {
 				return yield* new McpAuthMissingError({
-					message: "x-org-id header is required for internal service auth",
+					message: "INTERNAL_SERVICE_TOKEN is not configured on the server",
 				})
 			}
 
-			const validOrgId = yield* decodeOrgId(orgId).pipe(
+			if (
+				provided.length === expected.length &&
+				timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
+			) {
+				const orgId = Option.match(env.MAPLE_ORG_ID_OVERRIDE, {
+					onNone: () => request.headers.get("x-org-id"),
+					onSome: (value) => value,
+				})
+				if (!orgId) {
+					return yield* new McpAuthMissingError({
+						message: "x-org-id header is required for internal service auth",
+					})
+				}
+
+				const validOrgId = yield* decodeOrgId(orgId).pipe(
+					Effect.mapError(
+						(e) =>
+							new McpInvalidTenantError({
+								message: e.message,
+								field: "orgId",
+							}),
+					),
+				)
+				const validUserId = yield* decodeUserId("internal-service").pipe(
+					Effect.mapError(
+						(e) =>
+							new McpInvalidTenantError({
+								message: e.message,
+								field: "userId",
+							}),
+					),
+				)
+				return {
+					orgId: validOrgId,
+					userId: validUserId,
+					roles: [],
+					authMode: "self_hosted",
+				} as McpTenantContext
+			}
+
+			return yield* new McpAuthInvalidError({
+				message: "Internal service token mismatch",
+			})
+		}
+
+		const apiKeys = yield* ApiKeysService
+		const apiKeyResolved = yield* apiKeys.resolveByBearer(token).pipe(
+			Effect.catchTag("@maple/http/errors/ApiKeyLookupPersistenceError", () =>
+				Effect.fail(
+					new McpAuthUnavailableError({
+						message: "API key validation is temporarily unavailable",
+					}),
+				),
+			),
+		)
+
+		if (Option.isSome(apiKeyResolved)) {
+			const resolved = apiKeyResolved.value
+			const expectedResource = mcpResourceForRequest(request)
+			const isMcpOAuthToken = resolved.mcpOAuthResource !== null
+			if (
+				isMcpOAuthToken &&
+				(resolved.kind !== "mcp" ||
+					resolved.mcpOAuthResource !== expectedResource ||
+					resolved.scopes?.includes("mcp:tools") !== true)
+			) {
+				return yield* new McpAuthInvalidError({
+					message: "OAuth token is not valid for this MCP resource",
+					reason: "invalid_target",
+				})
+			}
+			// Manual MCP/API keys remain legacy full-access credentials. Scoped keys
+			// are accepted only when they are audience-bound MCP OAuth tokens.
+			if (!isMcpOAuthToken && resolved.scopes !== null) {
+				return yield* new McpAuthInvalidError({
+					message: "Restricted API keys are not supported by the MCP server",
+					reason: "insufficient_scope",
+				})
+			}
+			const validOrgId = yield* decodeOrgId(resolved.orgId).pipe(
 				Effect.mapError(
 					(e) =>
 						new McpInvalidTenantError({
@@ -107,7 +174,7 @@ export const resolveMcpTenantContext = Effect.fn("resolveMcpTenantContext")(func
 						}),
 				),
 			)
-			const validUserId = yield* decodeUserId("internal-service").pipe(
+			const validUserId = yield* decodeUserId(resolved.userId).pipe(
 				Effect.mapError(
 					(e) =>
 						new McpInvalidTenantError({
@@ -116,111 +183,54 @@ export const resolveMcpTenantContext = Effect.fn("resolveMcpTenantContext")(func
 						}),
 				),
 			)
+
+			// Actor resolution: prefer an explicit agent override header, else the
+			// key's pinned agentActorId metadata. Both must be a valid ActorId; we
+			// silently drop malformed values rather than failing the request.
+			const keyActorId = extractAgentActorIdFromMetadata(resolved.metadataJson)
+			const headerActorId = request.headers.get(AGENT_ACTOR_HEADER)
+			const actorIdCandidate = headerActorId ?? keyActorId
+			const actorIdOpt =
+				actorIdCandidate == null
+					? Option.none<
+							ReturnType<typeof decodeActorIdOption> extends Option.Option<infer A> ? A : never
+						>()
+					: decodeActorIdOption(actorIdCandidate)
+			const actorId = Option.getOrUndefined(actorIdOpt)
+
 			return {
 				orgId: validOrgId,
 				userId: validUserId,
-				roles: [],
+				roles: resolved.roles ?? apiKeyDefaultRoles,
 				authMode: "self_hosted",
+				...(actorId ? { actorId } : undefined),
 			} as McpTenantContext
 		}
 
-		return yield* new McpAuthInvalidError({
-			message: "Internal service token mismatch",
-		})
-	}
-
-	const apiKeys = yield* ApiKeysService
-	const apiKeyResolved = yield* apiKeys.resolveByBearer(token).pipe(
-		Effect.catchTag("@maple/http/errors/ApiKeyLookupPersistenceError", () =>
-			Effect.fail(
-				new McpAuthUnavailableError({
-					message: "API key validation is temporarily unavailable",
-				}),
-			),
-		),
-	)
-
-	if (Option.isSome(apiKeyResolved)) {
-		const resolved = apiKeyResolved.value
-		const expectedResource = mcpResourceForRequest(request)
-		const isMcpOAuthToken = resolved.mcpOAuthResource !== null
-		if (
-			isMcpOAuthToken &&
-			(resolved.kind !== "mcp" ||
-				resolved.mcpOAuthResource !== expectedResource ||
-				resolved.scopes?.includes("mcp:tools") !== true)
-		) {
-			return yield* new McpAuthInvalidError({
-				message: "OAuth token is not valid for this MCP resource",
-				reason: "invalid_target",
-			})
-		}
-		// Manual MCP/API keys remain legacy full-access credentials. Scoped keys
-		// are accepted only when they are audience-bound MCP OAuth tokens.
-		if (!isMcpOAuthToken && resolved.scopes !== null) {
-			return yield* new McpAuthInvalidError({
-				message: "Restricted API keys are not supported by the MCP server",
-				reason: "insufficient_scope",
-			})
-		}
-		const validOrgId = yield* decodeOrgId(resolved.orgId).pipe(
+		// Fall back to existing Clerk / self-hosted session auth
+		const auth = yield* AuthService
+		const tenant = yield* auth.resolveMcpTenant(toHeaderRecord(request.headers)).pipe(
 			Effect.mapError(
-				(e) =>
-					new McpInvalidTenantError({
-						message: e.message,
-						field: "orgId",
+				(error) =>
+					new McpAuthInvalidError({
+						message: error.message || "Authentication failed (no details available)",
+						reason: "session_auth_fallback",
 					}),
 			),
 		)
-		const validUserId = yield* decodeUserId(resolved.userId).pipe(
-			Effect.mapError(
-				(e) =>
-					new McpInvalidTenantError({
-						message: e.message,
-						field: "userId",
-					}),
-			),
-		)
-
-		// Actor resolution: prefer an explicit agent override header, else the
-		// key's pinned agentActorId metadata. Both must be a valid ActorId; we
-		// silently drop malformed values rather than failing the request.
-		const keyActorId = extractAgentActorIdFromMetadata(resolved.metadataJson)
-		const headerActorId = request.headers.get(AGENT_ACTOR_HEADER)
-		const actorIdCandidate = headerActorId ?? keyActorId
-		const actorIdOpt =
-			actorIdCandidate == null
-				? Option.none<
-						ReturnType<typeof decodeActorIdOption> extends Option.Option<infer A> ? A : never
-					>()
-				: decodeActorIdOption(actorIdCandidate)
-		const actorId = Option.getOrUndefined(actorIdOpt)
 
 		return {
-			orgId: validOrgId,
-			userId: validUserId,
-			roles: resolved.roles ?? apiKeyDefaultRoles,
-			authMode: "self_hosted",
-			...(actorId ? { actorId } : undefined),
-		} as McpTenantContext
-	}
-
-	// Fall back to existing Clerk / self-hosted session auth
-	const auth = yield* AuthService
-	const tenant = yield* auth.resolveMcpTenant(toHeaderRecord(request.headers)).pipe(
-		Effect.mapError(
-			(error) =>
-				new McpAuthInvalidError({
-					message: error.message || "Authentication failed (no details available)",
-					reason: "session_auth_fallback",
-				}),
-		),
-	)
-
-	return {
-		orgId: tenant.orgId,
-		userId: tenant.userId,
-		roles: [...tenant.roles],
-		authMode: tenant.authMode,
-	}
-})
+			orgId: tenant.orgId,
+			userId: tenant.userId,
+			roles: [...tenant.roles],
+			authMode: tenant.authMode,
+		}
+	},
+	// Missing/invalid credentials are an expected 401, not a failure: annotate the
+	// span and log at Warn so it exports with an Ok status (the tag is also listed
+	// in MCP_ANTICIPATED_ERROR_IDENTIFIERS, which suppresses the exception event).
+	// Runs inside the span — `Effect.fn` pipeline transforms wrap the body, and the
+	// span wraps them. The typed error itself is untouched.
+	(effect) =>
+		Effect.tapError(effect, (error) => recordExpectedMcpFailure(error, "MCP authentication failed")),
+)

--- a/apps/api/src/services/integrations/PlanetScaleService.test.ts
+++ b/apps/api/src/services/integrations/PlanetScaleService.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, assert, describe, it } from "@effect/vitest"
-import { ConfigProvider, Effect, Layer, Schema } from "effect"
+import { ConfigProvider, Effect, Fiber, Layer, Schema } from "effect"
+import { TestClock } from "effect/testing"
 import { FetchHttpClient } from "effect/unstable/http"
 import { OrgId, UserId } from "@maple/domain/http"
 import { Env } from "@/platform/Env"
@@ -166,6 +167,53 @@ describe("PlanetScaleService", () => {
 			const second = yield* service.pollAllOrgs()
 			assert.strictEqual(second.skipped, 1)
 			assert.strictEqual(second.refreshed, 0)
+		}).pipe(
+			Effect.provideService(FetchHttpClient.Fetch, stub),
+			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),
+		)
+	})
+
+	// A PlanetScale slowdown timed out the inventory listing for 5+ orgs at once and
+	// each failed on the first stall. The listing now gets two extra attempts before
+	// the tick gives up.
+	it.effect("retries a timed-out inventory listing before failing the org", () => {
+		const testDb = createTestDb(trackedDbs)
+		let databaseListAttempts = 0
+		// The connect flow lists databases too; only the poll under test may hang.
+		let hangDatabaseListings = false
+		const baseStub = stubApi({ databases: [], branchesByDatabase: {} })
+		const stub = (async (input: string | URL | Request, init?: RequestInit) => {
+			const url =
+				typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+			// Only the databases listing hangs; the OAuth/token calls must still answer.
+			if (hangDatabaseListings && /\/databases\?/.test(url)) {
+				databaseListAttempts += 1
+				return new Promise<Response>(() => {})
+			}
+			return baseStub(input, init)
+		}) as typeof fetch
+		globalThis.fetch = stub
+
+		return Effect.gen(function* () {
+			yield* connect("org_1")
+			const service = yield* PlanetScaleService
+			hangDatabaseListings = true
+
+			// `it.effect` runs on TestClock, so the 15s request timeout and the jittered
+			// backoff between attempts only elapse when the clock is advanced.
+			const poll = yield* Effect.forkChild(service.pollAllOrgs())
+			// Give the fiber a real macrotask to reach (and re-reach) the pending fetch
+			// before each virtual advance — the stubbed request never settles, so only
+			// the timeout can move it along.
+			for (let tick = 0; tick < 12; tick++) {
+				yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 10)))
+				yield* TestClock.adjust("20 seconds")
+			}
+			const summary = yield* Fiber.join(poll)
+
+			assert.strictEqual(summary.failures, 1)
+			// 1 initial attempt + REQUEST_TIMEOUT_RETRIES.
+			assert.strictEqual(databaseListAttempts, 3)
 		}).pipe(
 			Effect.provideService(FetchHttpClient.Fetch, stub),
 			Effect.provide(Layer.mergeAll(makeLayer(testDb), Layer.succeed(FetchHttpClient.Fetch, stub))),

--- a/apps/api/src/services/integrations/PlanetScaleService.ts
+++ b/apps/api/src/services/integrations/PlanetScaleService.ts
@@ -21,7 +21,7 @@ import {
 	type PlanetScaleEventRow,
 } from "@maple/db"
 import { and, desc, eq, gte, inArray, isNull, lt, lte, or } from "drizzle-orm"
-import { Cause, Clock, Context, Duration, Effect, Layer, Schema } from "effect"
+import { Cause, Clock, Context, Duration, Effect, Layer, Schedule, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { Database } from "@/platform/DatabaseLive"
 import { Env } from "@/platform/Env"
@@ -60,6 +60,25 @@ const DEPLOY_REQUESTS_CONCURRENCY = 2
 /** Tick-overlap lease. */
 const LEASE_MS = Duration.toMillis(Duration.minutes(4))
 const REQUEST_TIMEOUT = Duration.seconds(15)
+/**
+ * Extra attempts after a timed-out request, before the call fails. A PlanetScale
+ * slowdown timed out the inventory listing for 5+ orgs at once; a single retry
+ * rides out a stall that short without extending the tick meaningfully (worst
+ * case 3 × 15s for one path). Jittered so every org's tick doesn't re-hit a
+ * struggling API in lockstep. Only timeouts retry — an HTTP error is returned by
+ * the caller's own taxonomy (revoked / upstream) and must not be replayed.
+ */
+const REQUEST_TIMEOUT_RETRIES = 2
+const REQUEST_RETRY_BASE_DELAY = Duration.millis(500)
+/**
+ * Tagged onto the exhausted-timeout failure so the tick can tell "PlanetScale is
+ * slow" from "PlanetScale rejected us" without matching on a message string. A
+ * genuine upstream 504 classifies the same way, which is correct — both are the
+ * provider failing to answer in time.
+ */
+const UPSTREAM_TIMEOUT_STATUS = 504
+const isUpstreamTimeout = (error: { readonly _tag: string; readonly status?: number }) =>
+	error._tag === "@maple/http/errors/IntegrationsUpstreamError" && error.status === UPSTREAM_TIMEOUT_STATUS
 const ORG_CONCURRENCY = 3
 const INVENTORY_WRITE_CONCURRENCY = 4
 /** Pagination caps — a runaway org can't make a tick unbounded. */
@@ -328,15 +347,20 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 								cause: error,
 							}),
 					),
-					Effect.timeoutOrElse({
-						duration: REQUEST_TIMEOUT,
-						orElse: () =>
-							Effect.fail(
-								new IntegrationsUpstreamError({
-									message: `PlanetScale API request timed out: ${path}`,
-								}),
-							),
+					Effect.timeout(REQUEST_TIMEOUT),
+					Effect.retry({
+						while: (error) => error._tag === "TimeoutError",
+						times: REQUEST_TIMEOUT_RETRIES,
+						schedule: Schedule.exponential(REQUEST_RETRY_BASE_DELAY).pipe(Schedule.jittered),
 					}),
+					Effect.catchTag("TimeoutError", () =>
+						Effect.fail(
+							new IntegrationsUpstreamError({
+								message: `PlanetScale API request timed out: ${path}`,
+								status: UPSTREAM_TIMEOUT_STATUS,
+							}),
+						),
+					),
 				)
 			})
 
@@ -945,20 +969,31 @@ export class PlanetScaleService extends Context.Service<PlanetScaleService, Plan
 					Effect.ignore,
 				)
 				// Fail inside a span so poll failures surface in find_errors, mirroring
-				// the Cloudflare poller's observeDatasetFailure seam.
-				yield* Effect.fail(result.error).pipe(
+				// the Cloudflare poller's observeDatasetFailure seam — EXCEPT an upstream
+				// timeout, which is a transient provider slowdown (theirs timed out 5+ orgs
+				// at once) that the next tick refreshes, not a Maple failure. That one is
+				// recorded on an Ok span as `error.type` + a Warn log, per CLAUDE.md's
+				// "only 5xx is Error" rule; both paths still log identically.
+				const timedOut = isUpstreamTimeout(result.error)
+				yield* (
+					timedOut
+						? Effect.annotateCurrentSpan({ "error.type": "upstream_timeout" })
+						: Effect.fail(result.error)
+				).pipe(
 					Effect.withSpan("PlanetScaleService.inventoryPollFailed", {
 						attributes: { orgId: connection.orgId },
 					}),
 					Effect.catchCause((cause) =>
-						Cause.hasInterruptsOnly(cause)
-							? Effect.interrupt
-							: Effect.logWarning("PlanetScale inventory refresh failed").pipe(
-									Effect.annotateLogs({
-										orgId: connection.orgId,
-										error: Cause.pretty(cause),
-									}),
-								),
+						Cause.hasInterruptsOnly(cause) ? Effect.interrupt : Effect.void,
+					),
+					Effect.andThen(
+						Effect.logWarning("PlanetScale inventory refresh failed").pipe(
+							Effect.annotateLogs({
+								orgId: connection.orgId,
+								"error.type": timedOut ? "upstream_timeout" : result.error._tag,
+								error: result.error.message,
+							}),
+						),
 					),
 				)
 				return { outcome: "failed" as const, deployEvents }

--- a/apps/api/src/services/integrations/vcs/VcsProviderClient.ts
+++ b/apps/api/src/services/integrations/vcs/VcsProviderClient.ts
@@ -10,6 +10,7 @@ import type {
 	VcsProviderError,
 	VcsProviderId,
 	VcsRateLimitedError,
+	VcsRepositoryBlockedError,
 	VcsRepositoryRef,
 	VcsRepoUnavailableError,
 	VcsSyncJob,
@@ -64,7 +65,11 @@ export interface VcsProviderClient {
 		installation: VcsInstallation,
 	) => Effect.Effect<
 		ReadonlyArray<RepoUpsertInput>,
-		VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError | VcsRateLimitedError
+		| VcsProviderError
+		| VcsInstallationGoneError
+		| VcsRepoUnavailableError
+		| VcsRepositoryBlockedError
+		| VcsRateLimitedError
 	>
 
 	/**
@@ -96,7 +101,10 @@ export interface VcsProviderClient {
 		installation: VcsInstallation,
 		repo: VcsRepositoryRef,
 		opts: { readonly sinceMs: number; readonly untilMs?: number; readonly branch: string },
-	) => Effect.Effect<VcsCommitFetch, VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError>
+	) => Effect.Effect<
+		VcsCommitFetch,
+		VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError | VcsRepositoryBlockedError
+	>
 
 	/**
 	 * All branch names of a repo (never the commits on them), normalized. `truncated`
@@ -109,7 +117,11 @@ export interface VcsProviderClient {
 		repo: VcsRepositoryRef,
 	) => Effect.Effect<
 		{ readonly branches: ReadonlyArray<BranchUpsertInput>; readonly truncated: boolean },
-		VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError | VcsRateLimitedError
+		| VcsProviderError
+		| VcsInstallationGoneError
+		| VcsRepoUnavailableError
+		| VcsRepositoryBlockedError
+		| VcsRateLimitedError
 	>
 
 	/**
@@ -124,7 +136,7 @@ export interface VcsProviderClient {
 		sha: GitCommitSha,
 	) => Effect.Effect<
 		Option.Option<CommitUpsertInput>,
-		VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError
+		VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError | VcsRepositoryBlockedError
 	>
 
 	/** Search source within one repository visible to this installation. */
@@ -135,7 +147,11 @@ export interface VcsProviderClient {
 		opts: { readonly path?: string; readonly limit: number },
 	) => Effect.Effect<
 		ReadonlyArray<VcsCodeSearchMatch>,
-		VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError | VcsRateLimitedError
+		| VcsProviderError
+		| VcsInstallationGoneError
+		| VcsRepoUnavailableError
+		| VcsRepositoryBlockedError
+		| VcsRateLimitedError
 	>
 
 	/** Fetch a UTF-8 source file. `Option.none` is an expected missing path/ref. */
@@ -146,6 +162,6 @@ export interface VcsProviderClient {
 		ref: string,
 	) => Effect.Effect<
 		Option.Option<VcsSourceFile>,
-		VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError
+		VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError | VcsRepositoryBlockedError
 	>
 }

--- a/apps/api/src/services/integrations/vcs/VcsSyncService.ts
+++ b/apps/api/src/services/integrations/vcs/VcsSyncService.ts
@@ -14,6 +14,7 @@ import {
 	type VcsRepo,
 	type VcsRepoDecodeError,
 	type VcsRepoPersistenceError,
+	type VcsRepositoryBlockedError,
 	type VcsRepoUnavailableError,
 	VcsSyncJob,
 } from "@maple/domain/http"
@@ -109,6 +110,40 @@ export class VcsSyncService extends Context.Service<VcsSyncService, VcsSyncServi
 					}),
 				)
 			})
+
+			/**
+			 * A repository the provider permanently refuses (DMCA/legal block). TERMINAL:
+			 * the job drains here so the queue never redelivers it — a single blocked repo
+			 * was costing ~12 retries per scheduled run, every 12h, indefinitely. The block
+			 * is recorded on the repo row (`sync_status = "error"` + `last_sync_error`), the
+			 * span stays Ok with `error.type`, and the operator sees a Warn log.
+			 */
+			const drainBlockedRepository = (
+				installation: VcsInstallation,
+				repository: VcsRepo,
+				error: VcsRepositoryBlockedError,
+				scope: "commits" | "branches",
+			) =>
+				Effect.annotateCurrentSpan({
+					[`vcs.${scope}.outcome`]: "skipped",
+					[`vcs.${scope}.reason`]: "repository_blocked",
+					"error.type": "vcs_repository_blocked",
+					...(error.status !== undefined
+						? { "http.response.status_code": error.status }
+						: undefined),
+				}).pipe(
+					Effect.andThen(repo.markRepoSyncError(repository.id, error.message)),
+					Effect.andThen(
+						Effect.logWarning("[VCS] Repository blocked by provider — sync disabled").pipe(
+							Effect.annotateLogs({
+								provider: installation.provider,
+								externalRepoId: repository.externalRepoId,
+								status: error.status,
+								"error.message": error.message,
+							}),
+						),
+					),
+				)
 
 			const syncCommits = (
 				provider: VcsProviderClient,
@@ -262,6 +297,10 @@ export class VcsSyncService extends Context.Service<VcsSyncService, VcsSyncServi
 					//  - VcsRepoUnavailableError (repo gone) → record on the repo and drain.
 					//  - VcsInstallationGoneError → propagates to processMessage (disconnect).
 					//  - VcsProviderError (transient) → propagates so the queue retries.
+					//  - VcsRepositoryBlockedError (legal block) → terminal, drain (never retried).
+					Effect.catchTag("@maple/http/errors/VcsRepositoryBlockedError", (error) =>
+						drainBlockedRepository(installation, repository, error, "commits"),
+					),
 					Effect.catchTag("@maple/http/errors/VcsRepoUnavailableError", (error) =>
 						Effect.annotateCurrentSpan({
 							"vcs.commits.outcome": "skipped",
@@ -384,6 +423,9 @@ export class VcsSyncService extends Context.Service<VcsSyncService, VcsSyncServi
 					// A repo-scoped fetch failure drains here (branch sync owns no sync_status —
 					// that belongs to the commit backfill). Installation-gone propagates to the
 					// disconnect handler in processMessage.
+					Effect.catchTag("@maple/http/errors/VcsRepositoryBlockedError", (error) =>
+						drainBlockedRepository(installation, repository, error, "branches"),
+					),
 					Effect.catchTag("@maple/http/errors/VcsRepoUnavailableError", () =>
 						Effect.annotateCurrentSpan({
 							"vcs.branches.outcome": "skipped",
@@ -526,134 +568,153 @@ export class VcsSyncService extends Context.Service<VcsSyncService, VcsSyncServi
 			// reason-specific branching); processMessage only resolves the installation
 			// and dispatches by kind.
 
-			const handleInstallationSync = Effect.fn("VcsSyncService.handleInstallationSync")(function* (
-				provider: VcsProviderClient,
-				installation: VcsInstallation,
-				job: InstallationSyncJob,
-			) {
-				yield* Effect.annotateCurrentSpan({
-					"vcs.installation.sync_reason": job.reason,
-					"vcs.installation.id": installation.id,
-					"vcs.installation.external_id": installation.externalInstallationId,
-					"vcs.provider": installation.provider,
-				})
-				// Status-transition reasons change the gate's answer for subsequent jobs
-				// rather than processing data themselves.
-				if (job.reason === "suspend" || job.reason === "deleted") {
-					const status = job.reason === "suspend" ? "suspended" : "disconnected"
-					yield* repo.markInstallationStatus(installation.id, status)
+			const handleInstallationSync = Effect.fn("VcsSyncService.handleInstallationSync")(
+				function* (
+					provider: VcsProviderClient,
+					installation: VcsInstallation,
+					job: InstallationSyncJob,
+				) {
 					yield* Effect.annotateCurrentSpan({
-						"vcs.installation.transition": status,
+						"vcs.installation.sync_reason": job.reason,
+						"vcs.installation.id": installation.id,
+						"vcs.installation.external_id": installation.externalInstallationId,
+						"vcs.provider": installation.provider,
+					})
+					// Status-transition reasons change the gate's answer for subsequent jobs
+					// rather than processing data themselves.
+					if (job.reason === "suspend" || job.reason === "deleted") {
+						const status = job.reason === "suspend" ? "suspended" : "disconnected"
+						yield* repo.markInstallationStatus(installation.id, status)
+						yield* Effect.annotateCurrentSpan({
+							"vcs.installation.transition": status,
+							"vcs.installation_sync.outcome": "handled",
+							"vcs.installation_sync.reason": job.reason,
+						})
+						return
+					}
+					let active = installation
+					// Reasons that represent a (re)connection or provider re-enable restore the
+					// installation to active before the gate, so the sync proceeds. This is what
+					// makes the dashboard's reconnect flow actually revive a previously
+					// disconnected/suspended row: completeConnect re-enqueues "created"/"updated"
+					// for the same external id, and upsertInstallation leaves status untouched on
+					// conflict (status is owned here) — so without this it would stay disconnected
+					// and the gate below would drop the sync. Idempotent for a fresh install
+					// (already active). A bare data refresh (scheduled / repositories_*) must NOT
+					// reactivate: a stray webhook can't silently revive an integration the user
+					// removed on GitHub.
+					const reactivates =
+						job.reason === "unsuspend" || job.reason === "created" || job.reason === "updated"
+					if (reactivates && installation.status !== "active") {
+						// Reflect the new status on the entity we already hold rather than re-reading it.
+						yield* repo.markInstallationStatus(installation.id, "active")
+						active = new VcsInstallation({ ...installation, status: "active", suspendedAt: null })
+						yield* Effect.annotateCurrentSpan({ "vcs.installation.transition": "active" })
+					}
+
+					if (!(yield* ensureProcessable(active, job.kind))) {
+						yield* Effect.annotateCurrentSpan({
+							"vcs.installation_sync.outcome": "skipped",
+							"vcs.installation_sync.reason": "installation_not_processable",
+						})
+						return
+					}
+
+					// A newly-created installation gives the org a clean single-installation
+					// slate: hard-delete every *other* installation (and its repos/commits) for
+					// the same org + provider. A user can remove the old GitHub installation on
+					// GitHub's side without Maple ever receiving the `installation.deleted` webhook
+					// (delivery isn't guaranteed), stranding a stale "active" row — which would
+					// otherwise leave the org with several active installations, a state the
+					// dashboard (one active installation per org) does not support. Purge (not just
+					// suspend) so nothing lingers. Idempotent: a duplicate "created" — the GitHub
+					// webhook and the dashboard callback each enqueue one — finds no siblings left.
+					// "updated" (a reconnect) runs the same purge; it just finds nothing to remove.
+					if (job.reason === "created" || job.reason === "updated") {
+						const superseded = (yield* repo.listInstallationsByOrg(active.orgId)).filter(
+							(other) => other.provider === active.provider && other.id !== active.id,
+						)
+						if (superseded.length > 0) {
+							yield* Effect.forEach(
+								superseded,
+								(other) => repo.purgeInstallation(active.orgId, other.id),
+								{
+									discard: true,
+								},
+							)
+							yield* Effect.annotateCurrentSpan({
+								"vcs.installation.superseded": superseded.length,
+							})
+							yield* Effect.logInfo(
+								"[VCS] Purged superseded VCS installations after new install",
+							).pipe(
+								Effect.annotateLogs({
+									provider: active.provider,
+									externalInstallationId: active.externalInstallationId,
+									orgId: active.orgId,
+									superseded: superseded.length,
+								}),
+							)
+						}
+					}
+
+					const repos = yield* provider.fetchRepositories(active)
+					yield* repo.upsertRepositories(installation, repos)
+					yield* Effect.annotateCurrentSpan({ "vcs.repositories.reconciled": repos.length })
+
+					// Reconcile removals: soft-delete local repos no longer visible
+					// upstream. The row and its synced commits are kept (a re-grant
+					// reactivates via upsertRepositories); the "removed" status pauses
+					// any further event processing for them. A user must explicitly
+					// purge to drop the data. The periodic "scheduled" reconcile runs
+					// this too, so it catches a `repositories_removed` webhook we missed.
+					if (job.reason === "repositories_removed" || job.reason === "scheduled") {
+						const remoteIds = new Set(repos.map((r) => r.externalRepoId))
+						const local = yield* repo.listRepositoriesByInstallation(installation.id, "active")
+						yield* Effect.forEach(
+							local.filter((r) => !remoteIds.has(r.externalRepoId)),
+							(r) => repo.markRepositoryRemoved(r.id),
+							{ discard: true },
+						)
+					}
+
+					// Per repo: sync its branch list (names only); sync-branches then enqueues
+					// the commit backfill, keeping all commit-sync enqueuing in one place.
+					yield* queue.sendBatch(
+						repos.map(
+							(r): VcsSyncJob => ({
+								kind: "sync-branches",
+								provider: installation.provider,
+								externalInstallationId: installation.externalInstallationId,
+								externalRepoId: r.externalRepoId,
+								owner: r.owner,
+								name: r.name,
+							}),
+						),
+					)
+					yield* Effect.annotateCurrentSpan({
 						"vcs.installation_sync.outcome": "handled",
 						"vcs.installation_sync.reason": job.reason,
 					})
-					return
-				}
-				let active = installation
-				// Reasons that represent a (re)connection or provider re-enable restore the
-				// installation to active before the gate, so the sync proceeds. This is what
-				// makes the dashboard's reconnect flow actually revive a previously
-				// disconnected/suspended row: completeConnect re-enqueues "created"/"updated"
-				// for the same external id, and upsertInstallation leaves status untouched on
-				// conflict (status is owned here) — so without this it would stay disconnected
-				// and the gate below would drop the sync. Idempotent for a fresh install
-				// (already active). A bare data refresh (scheduled / repositories_*) must NOT
-				// reactivate: a stray webhook can't silently revive an integration the user
-				// removed on GitHub.
-				const reactivates =
-					job.reason === "unsuspend" || job.reason === "created" || job.reason === "updated"
-				if (reactivates && installation.status !== "active") {
-					// Reflect the new status on the entity we already hold rather than re-reading it.
-					yield* repo.markInstallationStatus(installation.id, "active")
-					active = new VcsInstallation({ ...installation, status: "active", suspendedAt: null })
-					yield* Effect.annotateCurrentSpan({ "vcs.installation.transition": "active" })
-				}
-
-				if (!(yield* ensureProcessable(active, job.kind))) {
-					yield* Effect.annotateCurrentSpan({
-						"vcs.installation_sync.outcome": "skipped",
-						"vcs.installation_sync.reason": "installation_not_processable",
-					})
-					return
-				}
-
-				// A newly-created installation gives the org a clean single-installation
-				// slate: hard-delete every *other* installation (and its repos/commits) for
-				// the same org + provider. A user can remove the old GitHub installation on
-				// GitHub's side without Maple ever receiving the `installation.deleted` webhook
-				// (delivery isn't guaranteed), stranding a stale "active" row — which would
-				// otherwise leave the org with several active installations, a state the
-				// dashboard (one active installation per org) does not support. Purge (not just
-				// suspend) so nothing lingers. Idempotent: a duplicate "created" — the GitHub
-				// webhook and the dashboard callback each enqueue one — finds no siblings left.
-				// "updated" (a reconnect) runs the same purge; it just finds nothing to remove.
-				if (job.reason === "created" || job.reason === "updated") {
-					const superseded = (yield* repo.listInstallationsByOrg(active.orgId)).filter(
-						(other) => other.provider === active.provider && other.id !== active.id,
-					)
-					if (superseded.length > 0) {
-						yield* Effect.forEach(
-							superseded,
-							(other) => repo.purgeInstallation(active.orgId, other.id),
-							{
-								discard: true,
-							},
-						)
-						yield* Effect.annotateCurrentSpan({
-							"vcs.installation.superseded": superseded.length,
-						})
-						yield* Effect.logInfo(
-							"[VCS] Purged superseded VCS installations after new install",
-						).pipe(
-							Effect.annotateLogs({
-								provider: active.provider,
-								externalInstallationId: active.externalInstallationId,
-								orgId: active.orgId,
-								superseded: superseded.length,
-							}),
-						)
-					}
-				}
-
-				const repos = yield* provider.fetchRepositories(active)
-				yield* repo.upsertRepositories(installation, repos)
-				yield* Effect.annotateCurrentSpan({ "vcs.repositories.reconciled": repos.length })
-
-				// Reconcile removals: soft-delete local repos no longer visible
-				// upstream. The row and its synced commits are kept (a re-grant
-				// reactivates via upsertRepositories); the "removed" status pauses
-				// any further event processing for them. A user must explicitly
-				// purge to drop the data. The periodic "scheduled" reconcile runs
-				// this too, so it catches a `repositories_removed` webhook we missed.
-				if (job.reason === "repositories_removed" || job.reason === "scheduled") {
-					const remoteIds = new Set(repos.map((r) => r.externalRepoId))
-					const local = yield* repo.listRepositoriesByInstallation(installation.id, "active")
-					yield* Effect.forEach(
-						local.filter((r) => !remoteIds.has(r.externalRepoId)),
-						(r) => repo.markRepositoryRemoved(r.id),
-						{ discard: true },
-					)
-				}
-
-				// Per repo: sync its branch list (names only); sync-branches then enqueues
-				// the commit backfill, keeping all commit-sync enqueuing in one place.
-				yield* queue.sendBatch(
-					repos.map(
-						(r): VcsSyncJob => ({
-							kind: "sync-branches",
-							provider: installation.provider,
-							externalInstallationId: installation.externalInstallationId,
-							externalRepoId: r.externalRepoId,
-							owner: r.owner,
-							name: r.name,
-						}),
+				},
+				// The repository *listing* is installation-scoped, so a legal block there is
+				// not attributable to one repo row — there is nothing to mark. It is still
+				// terminal: drain rather than let the queue retry it forever.
+				(effect) =>
+					Effect.catchTag(effect, "@maple/http/errors/VcsRepositoryBlockedError", (error) =>
+						Effect.annotateCurrentSpan({
+							"vcs.installation_sync.outcome": "skipped",
+							"vcs.installation_sync.reason": "repository_blocked",
+							"error.type": "vcs_repository_blocked",
+						}).pipe(
+							Effect.andThen(
+								Effect.logWarning(
+									"[VCS] Provider blocked the repository listing — installation sync skipped",
+								).pipe(Effect.annotateLogs({ "error.message": error.message })),
+							),
+						),
 					),
-				)
-				yield* Effect.annotateCurrentSpan({
-					"vcs.installation_sync.outcome": "handled",
-					"vcs.installation_sync.reason": job.reason,
-				})
-			})
+			)
 
 			const handleSyncCommits = Effect.fn("VcsSyncService.handleSyncCommits")(function* (
 				provider: VcsProviderClient,

--- a/apps/api/src/services/integrations/vcs/__tests__/vcs.test.ts
+++ b/apps/api/src/services/integrations/vcs/__tests__/vcs.test.ts
@@ -6,6 +6,7 @@ import {
 	VcsProviderError,
 	VcsRateLimitedError,
 	VcsRepoDecodeError,
+	VcsRepositoryBlockedError,
 	VcsRepoUnavailableError,
 	VcsSyncJob,
 	VcsWebhookParseError,
@@ -677,6 +678,65 @@ describe("GithubProvider.fetchBranches", () => {
 			),
 		),
 	)
+
+	// A DMCA takedown answers 451 with a `block` body. It never clears on retry, so
+	// the provider must classify it as terminal rather than as a generic (retryable)
+	// VcsProviderError — the classification the year-long retry loop hinged on.
+	it.effect("classifies a 451 legal block as a terminal VcsRepositoryBlockedError", () =>
+		Effect.gen(function* () {
+			const provider = yield* GithubProvider
+			const installation = { externalInstallationId: "42" } as VcsInstallation
+			const error = yield* Effect.flip(
+				provider.fetchBranches(installation, {
+					externalRepoId: "7",
+					owner: "octo",
+					name: "repo",
+				}),
+			)
+			assert.strictEqual(error._tag, "@maple/http/errors/VcsRepositoryBlockedError")
+		}).pipe(
+			Effect.provide(
+				stubbedProviderLayer([
+					tokenResponse,
+					() =>
+						jsonResponse(
+							{ message: "Repository access blocked", block: { reason: "dmca" } },
+							{ status: 451 },
+						),
+				]),
+			),
+		),
+	)
+
+	// The same block body also arrives as a 403. A plain 403 (permissions) stays
+	// retryable — the body, not the status, is what makes it terminal.
+	it.effect("classifies a 403 carrying a block body as terminal, a plain 403 as transient", () =>
+		Effect.gen(function* () {
+			const provider = yield* GithubProvider
+			const installation = { externalInstallationId: "42" } as VcsInstallation
+			const ref = { externalRepoId: "7", owner: "octo", name: "repo" }
+			const blocked = yield* Effect.flip(provider.fetchBranches(installation, ref))
+			assert.strictEqual(blocked._tag, "@maple/http/errors/VcsRepositoryBlockedError")
+			const transient = yield* Effect.flip(provider.fetchBranches(installation, ref))
+			assert.strictEqual(transient._tag, "@maple/http/errors/VcsProviderError")
+		}).pipe(
+			Effect.provide(
+				stubbedProviderLayer([
+					tokenResponse,
+					() =>
+						jsonResponse(
+							{ message: "Repository access blocked", block: { reason: "dmca" } },
+							{ status: 403, headers: { "x-ratelimit-remaining": "42" } },
+						),
+					() =>
+						jsonResponse(
+							{ message: "Resource not accessible by integration" },
+							{ status: 403, headers: { "x-ratelimit-remaining": "42" } },
+						),
+				]),
+			),
+		),
+	)
 })
 
 describe("VcsRepository", () => {
@@ -1180,6 +1240,7 @@ describe("VcsSyncService orchestrator", () => {
 			| VcsProviderError
 			| VcsInstallationGoneError
 			| VcsRepoUnavailableError
+			| VcsRepositoryBlockedError
 			| VcsRateLimitedError
 	}
 
@@ -2382,6 +2443,46 @@ describe("VcsSyncService orchestrator", () => {
 				orchestratorLayer(testDb, {
 					sent,
 					fetchBranchesError: new VcsProviderError({ message: "upstream", status: 503 }),
+				}),
+			),
+		)
+	})
+
+	// A 451 (DMCA/legal block) never clears on retry. Before this it arrived as a
+	// generic VcsProviderError and was retried ~12x per scheduled run, every 12h,
+	// for a year. It must drain and be recorded on the repo row instead.
+	it.effect("sync-branches drains a VcsRepositoryBlockedError and records it on the repo", () => {
+		const testDb = createTestDb(trackedDbs)
+		const sent: Array<VcsSyncJob> = []
+		return Effect.gen(function* () {
+			const svc = yield* VcsSyncService
+			const repo = yield* VcsRepository
+			const orgId = asOrgId("org_orch")
+			yield* seedInstallation(repo, orgId)
+			yield* upsertReposFor(repo, "42", oneRepo)
+			// Succeeds (no failure → the queue never redelivers) and enqueues nothing.
+			yield* svc.processMessage(
+				Schema.encodeSync(VcsSyncJob)({
+					kind: "sync-branches",
+					provider: "github",
+					externalInstallationId: "42",
+					externalRepoId: "7",
+					owner: "octo",
+					name: "repo",
+				}),
+			)
+			assert.strictEqual(sent.length, 0)
+			const stored = yield* reposOfInstallation(repo, "42", "all")
+			assert.strictEqual(stored[0]!.syncStatus, "error")
+			assert.ok(stored[0]!.lastSyncError?.includes("Repository access blocked"))
+		}).pipe(
+			Effect.provide(
+				orchestratorLayer(testDb, {
+					sent,
+					fetchBranchesError: new VcsRepositoryBlockedError({
+						message: 'List branches failed: 451 {"message":"Repository access blocked"}',
+						status: 451,
+					}),
 				}),
 			),
 		)

--- a/apps/api/src/services/integrations/vcs/vendor/github/GithubProvider.ts
+++ b/apps/api/src/services/integrations/vcs/vendor/github/GithubProvider.ts
@@ -10,6 +10,7 @@ import {
 	type VcsProviderId,
 	VcsRateLimitedError,
 	type VcsRepositoryRef,
+	VcsRepositoryBlockedError,
 	VcsRepoUnavailableError,
 	type VcsSyncJob,
 	VcsWebhookParseError,
@@ -113,13 +114,32 @@ const parsePayload = <A, E>(event: string, decoded: Effect.Effect<A, E>) =>
 // everything else (incl. 401/403/5xx) is transient and retryable.
 const isGone = (status?: number) => status === 404 || status === 410
 
+// GitHub answers 451 for a repository taken down for legal reasons, and carries
+// the same `{"block":{"reason":"dmca"}}` body on the 403 variant. Neither clears
+// on retry, so both are terminal — matched on the body rather than on 403 alone,
+// which is otherwise an ordinary (retryable) permission failure.
+const BLOCK_BODY = /"block"\s*:|Repository access blocked/
+const isBlocked = (error: GithubAppError) =>
+	error.status === 451 || (error.status === 403 && BLOCK_BODY.test(error.message))
+
 const toVcsError = (
 	error: GithubAppError,
-): VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError | VcsRateLimitedError => {
+):
+	| VcsProviderError
+	| VcsInstallationGoneError
+	| VcsRepoUnavailableError
+	| VcsRepositoryBlockedError
+	| VcsRateLimitedError => {
 	if (error.retryAfterSeconds !== undefined) {
 		return new VcsRateLimitedError({
 			message: error.message,
 			retryAfterSeconds: error.retryAfterSeconds,
+		})
+	}
+	if (isBlocked(error)) {
+		return new VcsRepositoryBlockedError({
+			message: error.message,
+			...(!(error.status === undefined) ? { status: error.status } : undefined),
 		})
 	}
 	if (isGone(error.status)) {
@@ -138,7 +158,7 @@ const toVcsError = (
 // `fetchCommits` keeps the port's 3-way error channel (no VcsRateLimitedError).
 const toVcsCommitError = (
 	error: GithubAppError,
-): VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError => {
+): VcsProviderError | VcsInstallationGoneError | VcsRepoUnavailableError | VcsRepositoryBlockedError => {
 	const mapped = toVcsError(error)
 	return mapped._tag === "@maple/http/errors/VcsRateLimitedError"
 		? new VcsProviderError({ message: mapped.message })

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -2,6 +2,7 @@
 import type { MessageBatch, ScheduledController } from "@cloudflare/workers-types"
 import * as MapleCloudflareSDK from "@maple-dev/effect-sdk/cloudflare"
 import { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
+import { MCP_ANTICIPATED_ERROR_IDENTIFIERS } from "./mcp/expected-failures"
 import {
 	layerFromEnvRecord,
 	runScheduledEffect,
@@ -62,7 +63,7 @@ const telemetry = MapleCloudflareSDK.make({
 	dropSpanNames: ["McpServer/Notifications."],
 	// Expected 4xx outcomes (validation, not-found, unauthorized, …) record as
 	// Ok spans instead of errors — see @maple/domain/anticipated-errors.
-	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
+	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS, ...MCP_ANTICIPATED_ERROR_IDENTIFIERS],
 })
 
 // `HttpMiddleware.tracer` ends the root server span on a deferred macrotask

--- a/packages/domain/src/http/vcs.ts
+++ b/packages/domain/src/http/vcs.ts
@@ -432,6 +432,24 @@ export class VcsRepoUnavailableError extends Schema.TaggedError<VcsRepoUnavailab
 ) {}
 
 /**
+ * The provider is permanently refusing access to a specific repository for a
+ * reason retrying cannot clear: GitHub answers `451 Unavailable For Legal
+ * Reasons` (DMCA takedown, `{"block":{"reason":"dmca"}}`) or a `403` carrying
+ * the same block body. Distinct from `VcsRepoUnavailableError` (deleted /
+ * renamed / access lost) so the two are separable in telemetry — a blocked repo
+ * needs an operator, a gone repo needs nothing.
+ *
+ * TERMINAL: the sync consumer must drain the job, never redeliver it. A DMCA
+ * block on one repo retried ~12x per scheduled run, every 12h, for a year before
+ * this existed.
+ */
+export class VcsRepositoryBlockedError extends Schema.TaggedError<VcsRepositoryBlockedError>()(
+	"@maple/http/errors/VcsRepositoryBlockedError",
+	{ message: Schema.String, status: Schema.optionalKey(Schema.Number) },
+	{ httpApiStatus: 451 },
+) {}
+
+/**
  * A provider rate limit too far out to wait inline. `retryAfterSeconds` is seconds
  * until the budget resets (from `retry-after` / rate-limit headers). The sync
  * consumer redelivers the failed job with this delay; backfill catches it earlier


### PR DESCRIPTION
Three expected conditions were closing spans as Error and minting issues:

- MCP: a malformed bearer JWT (`McpAuthInvalidError`), a missing one, and a
  tool call with a missing required param (`@maple/mcp/decode-error`) already
  map to 401/400 but still recorded an exception. They now go through the
  existing anticipated-errors mechanism (`recordExpectedMcpFailure`): the
  span stays Ok with `error.type` and `http.response.status_code`, the log
  drops to Warn, and the identifiers are registered alongside the domain
  set in the worker and chat turn runner so the exporter treats them the
  same way. Typed errors are unchanged.
- VCS: a DMCA-blocked GitHub repo (451, or 403 with a block body) was
  retried on every 12-hourly sync for a year. New `VcsRepositoryBlockedError`
  is terminal — `VcsSyncService` drains it without retry, sets
  `sync_status="error"` + `last_sync_error` on the repo, annotates
  `error.type=vcs_repository_blocked`, and logs Warn. Plain 403 stays
  retryable; 404/410 were already `VcsRepoUnavailableError`.
- PlanetScale inventory tick: a slow list endpoint failed the whole tick on
  the first 15s timeout. `apiGetJson` now retries twice with jittered
  exponential backoff on TimeoutError only, and a final timeout is recorded
  as `error.type=upstream_timeout` on an Ok `inventoryPollFailed` span
  (status 504) rather than an exception; other failures still fail it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789682913&installation_model_id=427786&pr_number=527&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F527&signature=6754d46c52e35280244d117515198e42416b55a57974ea2785687a04670a0f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Verification
`bunx vitest run src/mcp/dispatcher.test.ts src/services/integrations/vcs/__tests__/vcs.test.ts src/services/integrations/PlanetScaleService.test.ts` → 124 passed · `packages/domain` anticipated-errors tests pass · tsc clean for `apps/api` and `packages/domain`.

Note: `resolve-tenant.ts` diff looks large because the generator body gained one indent level (wrapped in an `Effect.fn` pipeline so the annotation lands inside the span).
