### PR TITLE
fix(cloudflare): treat GraphQL rate limiting as a quiet org-wide backoff

### DIFF
--- a/apps/api/src/services/integrations/CloudflareAnalyticsService.test.ts
+++ b/apps/api/src/services/integrations/CloudflareAnalyticsService.test.ts
@@ -757,7 +757,9 @@ describe("CloudflareAnalyticsService", () => {
 					assert.isBelow(row.backfillAt!.getTime(), HORIZON)
 				}
 				// Budget-bound tick (that's WHY history is incomplete) — the head still won the race.
-				assert.isAbove(summary.callsMade, 40)
+				// Pinned to the cap rather than a magic number so lowering MAX_CALLS_PER_ORG_TICK
+				// (done to stop rate-limiting ourselves) doesn't turn this into a false failure.
+				assert.isAtLeast(summary.callsMade, 20)
 			}).pipe(Effect.provide(makeLayer(testDb, captured)))
 		},
 	)
@@ -989,6 +991,63 @@ describe("CloudflareAnalyticsService", () => {
 			Effect.provide(
 				makeLayer(testDb, captured, {
 					graphqlErrors: [{ message: "not authorized to access these fields" }],
+				}),
+			),
+		)
+	})
+
+	it.effect("a Cloudflare rate limit is a quiet org-wide backoff, not a per-dataset failure", () => {
+		const testDb = createTestDb(trackedDbs)
+		const captured: CapturedIngest[] = []
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(T0)
+			yield* seedConnection()
+			// Several datasets behind the head: without the collapse this tick produced one
+			// CloudflareAnalyticsPollError per dataset × zone-chunk (~1.7k events/day in prod).
+			for (const dataset of ["http_requests", "firewall_events", "dns_queries"]) {
+				yield* seedStateRow({
+					dataset,
+					zoneId: ZONE_ID,
+					zoneName: ZONE_NAME,
+					watermarkAt: new Date(T0 - 30 * MIN),
+					settingsFetchedAt: new Date(T0 - 5 * MIN),
+				})
+			}
+			yield* seedStateRow({
+				dataset: "workers_invocations",
+				watermarkAt: new Date(T0 - 30 * MIN),
+				settingsFetchedAt: new Date(T0 - 5 * MIN),
+			})
+			const service = yield* CloudflareAnalyticsService
+			const summary = yield* service.pollOrg(ORG)
+			// Classified as `rate-limited` → no failure outcome at all, so nothing reaches the
+			// observeDatasetFailure seam that records exception events.
+			assert.strictEqual(summary.failures.length, 0)
+			assert.strictEqual(summary.rowsIngested, 0)
+			// One depleted budget stops the org's tick instead of burning the whole call budget:
+			// at most the settings probe plus the single document that hit the limiter.
+			assert.isAtMost(summary.callsMade, 2)
+
+			const rows = yield* loadStateRows
+			for (const row of rows) {
+				// Our own pacing is not a tenant-facing integration error, and nothing is disabled.
+				assert.isNull(row.lastError, `${row.dataset} must not record a tenant-facing error`)
+				assert.isTrue(row.enabled, `${row.dataset} must stay enabled`)
+				// Frontiers stay put — the same windows are retried after the backoff. (Rows that
+				// discovery created this tick simply have no watermark yet.)
+				if (row.watermarkAt != null) assert.strictEqual(row.watermarkAt.getTime(), T0 - 30 * MIN)
+			}
+			// The lease is held rather than released, so the next tick skips this org for ~5 min.
+			const anchor = rows.find((row) => row.dataset === "workers_invocations" && row.zoneId === "")
+			assert.isNotNull(anchor!.leaseUntil)
+			assert.isAbove(anchor!.leaseUntil!.getTime(), T0)
+			assert.strictEqual(captured.length, 0)
+		}).pipe(
+			Effect.provide(
+				makeLayer(testDb, captured, {
+					graphqlErrors: [
+						{ message: "Rate limiter budget depleted. Please try again after 5 minutes." },
+					],
 				}),
 			),
 		)

--- a/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
@@ -165,9 +165,23 @@ const BACKFILL_MS = 24 * 60 * 60_000
  * comfortably under Cloudflare's 5000-rows-per-selection cap.
  */
 const MAX_WINDOW_MS = 60 * 60_000
-/** Hard per-org call budget per tick so a pathological backfill can't blow the 300/5min limit. */
-const MAX_CALLS_PER_ORG_TICK = 50
+/**
+ * Hard per-org call budget per tick so a pathological backfill can't blow the 300/5min limit.
+ * Cloudflare's GraphQL rate limit is per ACCOUNT-holder, but our budget is per org and the tick
+ * runs `ORG_CONCURRENCY` orgs at a time: at 50 the six polled orgs could ask for 300 queries in
+ * one tick — exactly the limit — which is how we rate-limited ourselves into ~1.7k
+ * `Rate limiter budget depleted` errors a day. 20 keeps a full tick well under the ceiling;
+ * backfill is resumable by construction, so a smaller budget only makes history land slower.
+ */
+const MAX_CALLS_PER_ORG_TICK = 20
 const LEASE_MS = 4 * 60_000
+/**
+ * How long an org sits out after Cloudflare rate-limits it — Cloudflare's own message says "try
+ * again after 5 minutes". Implemented by leaving the tick lease in place until then (see
+ * `releaseLease`), so the backoff is persisted in the mechanism the poller already has and
+ * survives isolate recycling without a new column.
+ */
+const RATE_LIMIT_BACKOFF_MS = 5 * 60_000
 const SETTINGS_TTL_MS = 24 * 60 * 60_000
 /** Zone discovery (REST pagination) runs hourly; poll ticks in between reuse the state rows. */
 const DISCOVERY_TTL_MS = 60 * 60_000
@@ -504,7 +518,7 @@ const ACCOUNT_DATASETS = DATASETS.filter((dataset) => dataset.scope === "account
 // GraphQL error classification
 
 /** Classify GraphQL-level errors (HTTP 200 + errors[]) into the poller's reaction. */
-type GraphqlErrorKind = "authz" | "disabled" | "quantiles-unavailable" | "other"
+type GraphqlErrorKind = "authz" | "disabled" | "quantiles-unavailable" | "rate-limited" | "other"
 
 const graphqlErrorCode = (error: CloudflareGraphqlError): string | null => {
 	const extensions = error.extensions
@@ -529,10 +543,39 @@ const isPlanGatedMessage = (message: string): boolean => {
 	)
 }
 
+/**
+ * Cloudflare enforces ~300 GraphQL queries / 5 min per account and reports exhaustion as an
+ * HTTP 200 + `errors[]` payload ("Rate limiter budget depleted. Please try again after 5
+ * minutes."), so the SDK-level Retry/Retry-After handling never sees it. It is a property of the
+ * ACCOUNT and of our own tick pacing — not of a dataset, a zone, or a tenant — so it must never
+ * become a per-dataset failure event.
+ */
+const isRateLimitedMessage = (message: string): boolean => {
+	const lower = message.toLowerCase()
+	return (
+		lower.includes("rate limiter budget depleted") ||
+		lower.includes("rate limit") ||
+		lower.includes("limit exceeded") ||
+		lower.includes("too many requests")
+	)
+}
+
+const isRateLimitedCode = (code: string | null): boolean =>
+	code != null && /rate[_-]?limit|too[_-]?many[_-]?requests/i.test(code)
+
 const classifyGraphqlErrors = (
 	errors: ReadonlyArray<CloudflareGraphqlError>,
 	quantileNeedles: ReadonlyArray<string>,
 ): GraphqlErrorKind => {
+	// Checked first: a depleted budget voids the whole document, so any other classification of the
+	// same payload would be an artifact of which selection Cloudflare happened to name.
+	if (
+		errors.some(
+			(error) => isRateLimitedMessage(error.message) || isRateLimitedCode(graphqlErrorCode(error)),
+		)
+	) {
+		return "rate-limited"
+	}
 	const messages = errors.map((error) => error.message.toLowerCase())
 	// Plan lacks the dataset's timing-quantile fields → the query referenced an "unknown"/"cannot
 	// query" field, or Cloudflare reports the plan "does not have access to the field". Degrade to
@@ -840,6 +883,7 @@ type PollOutcome =
 	| { readonly kind: "advanced"; readonly ingested: number }
 	| { readonly kind: "quantiles-downgraded" }
 	| { readonly kind: "disabled" }
+	| { readonly kind: "rate-limited"; readonly message: string }
 	| { readonly kind: "failed"; readonly failure: DatasetPollFailure }
 
 /** Typed constructor so each failure site returns `PollOutcome` (widens the failure off `as const`). */
@@ -897,6 +941,19 @@ const documentFailed = (
 			}),
 		},
 	]
+}
+
+/**
+ * The rate-limit twin of {@link documentFailed}: one quiet outcome for the whole document. A
+ * depleted GraphQL budget voids every selection at once, so fanning it out per dataset × zone-chunk
+ * turned one self-inflicted pacing problem into ~1,700 `CloudflareAnalyticsPollError` events a day.
+ * It is expected degradation (like `quantiles-unavailable`), not an incident: the caller logs a
+ * warning, marks the org's tick, and backs off.
+ */
+const documentRateLimited = (item: WorkItem, message: string): Array<PartResult> => {
+	const part = item.parts[0]
+	if (!part) return []
+	return [{ part, outcome: { kind: "rate-limited", message } }]
 }
 
 /**
@@ -1168,11 +1225,19 @@ export class CloudflareAnalyticsService extends Context.Service<
 					.returning(),
 			).pipe(Effect.map((rows) => rows[0] ?? null))
 
-		const releaseLease = (orgId: OrgId, now: number) =>
+		/**
+		 * Release the tick lease. `holdUntilMs` keeps it held instead of clearing it, which is how a
+		 * rate-limited org sits out the next tick(s) — `claimLease` already refuses a live lease, and
+		 * a hold under `2 * LEASE_MS` stays inside its corrupt-lease escape hatch.
+		 */
+		const releaseLease = (orgId: OrgId, now: number, holdUntilMs?: number) =>
 			dbExecute((db) =>
 				db
 					.update(cloudflareAnalyticsState)
-					.set({ leaseUntil: null, updatedAt: new Date(now) })
+					.set({
+						leaseUntil: holdUntilMs == null ? null : new Date(holdUntilMs),
+						updatedAt: new Date(now),
+					})
 					.where(
 						and(
 							eq(cloudflareAnalyticsState.orgId, orgId),
@@ -1475,6 +1540,13 @@ export class CloudflareAnalyticsService extends Context.Service<
 				apiBaseUrl,
 			)
 
+			// Rate limiting is decided over the WHOLE error set before attribution: the budget belongs
+			// to the Cloudflare account, so per-part attribution would multiply one cause into one
+			// failure per dataset × zone-chunk. Collapse to a single quiet outcome instead.
+			if (result.errors.length > 0 && classifyGraphqlErrors(result.errors, []) === "rate-limited") {
+				return documentRateLimited(item, graphqlErrorMessage(result.errors))
+			}
+
 			const results: Array<PartResult> = []
 			const errorsByPart = new Map<WorkPart, CloudflareGraphqlError[]>()
 			const unattributed: CloudflareGraphqlError[] = []
@@ -1527,6 +1599,11 @@ export class CloudflareAnalyticsService extends Context.Service<
 					// this tenant's plan), not an incident — record health quietly and stop polling it.
 					yield* recordError(rowIds, graphqlErrorMessage(partErrors), now, { disable: true })
 					results.push({ part, outcome: { kind: "disabled" } })
+				} else if (kind === "rate-limited") {
+					// Unreachable in practice — each part's error set is a subset of `result.errors`,
+					// which the document-level check above already collapsed. Kept so the branch stays
+					// total: a rate limit is never a per-dataset failure.
+					return documentRateLimited(item, graphqlErrorMessage(partErrors))
 				} else {
 					// authz / other → a genuine failure. Hand it to the org-loop seam, which records
 					// health AND emits telemetry.
@@ -1770,6 +1847,10 @@ export class CloudflareAnalyticsService extends Context.Service<
 			if (claimed == null) return yield* skip("lease held by another tick")
 			const anchor = claimed
 
+			// Set when Cloudflare's GraphQL rate limiter refuses the account. Lives outside the body
+			// below so the lease-releasing finalizer can convert it into the backoff hold.
+			const rateLimitedRef = yield* Ref.make(false)
+
 			return yield* Effect.gen(function* () {
 				// Token failures: revocation disables all rows until reconnect; transient upstream
 				// failures record and retry next tick.
@@ -1881,6 +1962,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 				while (
 					!(yield* Ref.get(revokedRef)) &&
 					!(yield* Ref.get(deliveryBlockedRef)) &&
+					!(yield* Ref.get(rateLimitedRef)) &&
 					budget.calls < MAX_CALLS_PER_ORG_TICK
 				) {
 					const work = buildWorkItems(rows, now)
@@ -1891,7 +1973,8 @@ export class CloudflareAnalyticsService extends Context.Service<
 						if (
 							budget.calls >= MAX_CALLS_PER_ORG_TICK ||
 							(yield* Ref.get(revokedRef)) ||
-							(yield* Ref.get(deliveryBlockedRef))
+							(yield* Ref.get(deliveryBlockedRef)) ||
+							(yield* Ref.get(rateLimitedRef))
 						)
 							break
 						budget.calls += 1
@@ -1961,6 +2044,29 @@ export class CloudflareAnalyticsService extends Context.Service<
 										Effect.sync(() => {
 											for (const row of part.rows) row.enabled = false
 										}),
+									// Expected degradation, handled like `quantiles-downgraded`: a warning and a
+									// span attribute, NOT an exception event. Nothing is written to the state
+									// rows — the windows simply didn't advance and are retried after the
+									// backoff, and stamping `lastError` would surface our own pacing as a
+									// tenant-facing integration error.
+									"rate-limited": ({ message }) =>
+										Effect.logWarning("cloudflare-analytics rate limited by Cloudflare", {
+											orgId,
+											dataset: part.dataset.id,
+											callsMade: budget.calls,
+											backoffMs: RATE_LIMIT_BACKOFF_MS,
+											error: message,
+										}).pipe(
+											Effect.andThen(
+												Effect.annotateCurrentSpan({
+													"cloudflare.poll.outcome": "rate_limited",
+													"maple.cloudflare.rate_limited": true,
+												}),
+											),
+											// Ends the org's tick: every further document would deplete the same
+											// account budget, and the frontier only advances on success.
+											Effect.andThen(Ref.set(rateLimitedRef, true)),
+										),
 									// The one seam: record health to Postgres AND emit an observable signal.
 									failed: ({ failure }) =>
 										Effect.gen(function* () {
@@ -2001,9 +2107,16 @@ export class CloudflareAnalyticsService extends Context.Service<
 				} satisfies PollOrgSummary
 			}).pipe(
 				Effect.ensuring(
-					Clock.currentTimeMillis.pipe(
-						Effect.flatMap((end) =>
-							releaseLease(orgId, end).pipe(
+					Effect.all([Clock.currentTimeMillis, Ref.get(rateLimitedRef)]).pipe(
+						Effect.flatMap(([end, rateLimited]) =>
+							// A rate-limited tick doesn't release the lease — it holds it for the backoff
+							// window, so the next cron tick skips this org instead of re-depleting the
+							// account's GraphQL budget.
+							releaseLease(
+								orgId,
+								end,
+								rateLimited ? end + RATE_LIMIT_BACKOFF_MS : undefined,
+							).pipe(
 								// The ensuring must never fail (that would mask whatever this tick actually
 								// did), but a lease release failure is not nothing — it silently wedges the
 								// org behind a lease until the corrupt-lease escape hatch reclaims it, so log


### PR DESCRIPTION
Cloudflare reports "Rate limiter budget depleted. Please try again after 5
minutes." as HTTP 200 with `errors[]`, so the client-level retry that honours
Retry-After never saw it and `classifyGraphqlErrors` fell through to
`kind: "other"`. Every dataset × zone-chunk then failed inside its span, which
recorded ~1,700 `CloudflareAnalyticsPollError` events a day across all polled
orgs, and the next tick immediately re-depleted the budget.

- New `"rate-limited"` classification, checked first because a depleted
  budget voids the whole document regardless of which selection Cloudflare
  named. Matches the budget-depleted / rate-limit / too-many-requests messages
  and the corresponding GraphQL error codes; "quota exceeded" is deliberately
  not matched.
- `documentRateLimited` collapses the document into one outcome, handled in
  the org loop with a Warn log and `cloudflare.poll.outcome=rate_limited` —
  no exception, no `lastError`/`enabled` writes (our pacing is not a
  tenant-facing integration error).
- The org's poll lease is held for 5 minutes on release, so the next cron
  tick skips the org instead of re-hitting the limit; that sits under the
  corrupt-lease escape hatch so it cannot wedge an org.
- `MAX_CALLS_PER_ORG_TICK` 50 → 20: six orgs at 50 was exactly Cloudflare's
  300 queries / 5 min ceiling. Backfill is resumable, so this only slows
  history, not steady state.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789682916&installation_model_id=427786&pr_number=528&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F528&signature=9d4b5ef035b5f0c25652cfc3b3a316695030fc7aa4597537926ab6022d0d1b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Verification
`CloudflareAnalyticsService.test.ts` 37/37 (new case: rate-limit payload → 0 failures, ≤2 calls, no `lastError`, lease held) · tsc clean.

Deliberately not touched: the SDK-level `Retry` in `CloudflareApiImpl.ts` — Cloudflare returns this as HTTP 200, and retrying in-tick would deepen the depletion.
