### PR TITLE
fix(web,cli): give fetch failures a message, and stop recording expected outcomes as errors

### DIFF
--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -92,6 +92,10 @@ if (checkpointProbeDataDir !== undefined) {
 		// the span `Error` and are reported by `runMain`.
 		Effect.catchTags({
 			"@maple/cli/ServerStateError": recoverExpected,
+			// `maple checkpoint` against a server whose chDB config has no
+			// `<backups>` stanza: a refused precondition with an actionable fix, not
+			// a failure. Same category as the already-running guard above.
+			"@maple/cli/CheckpointPreconditionError": recoverExpected,
 			// Mode resolution ("No Maple backend found", "Cannot use --remote and
 			// --local together") reaches here as a `WarehouseConfigError`, remapped by
 			// `WarehouseExecutorFromMode` in core/warehouse.ts. `pipeName` is the

--- a/apps/cli/src/commands/server.ts
+++ b/apps/cli/src/commands/server.ts
@@ -352,15 +352,31 @@ const startDetached = (
 		const bindAddr = serverUrl(host, port)
 		const connectAddr = serverUrl(advertiseHost, port)
 		const probeAddr = serverProbeUrl(host, port)
-		let up = false
-		for (let i = 0; i < 100; i++) {
-			yield* Effect.sleep("100 millis")
-			if (yield* probeHealth(probeAddr)) {
-				up = true
-				break
+		// One span for the whole readiness wait, never one per probe. The probes
+		// themselves are untraced (see `probeHealth`), so a boot shows up as a
+		// single `server.wait_ready` carrying how many attempts it took — instead of
+		// ~10 `Error` client spans for the ECONNREFUSEDs that are the expected
+		// answer while the child is still binding. The span succeeds either way;
+		// missing the deadline is reported by the `ServerError` below, once.
+		const up = yield* Effect.gen(function* () {
+			for (let attempt = 1; attempt <= 100; attempt++) {
+				yield* Effect.sleep("100 millis")
+				if (yield* probeHealth(probeAddr)) {
+					yield* Effect.annotateCurrentSpan({ "maple.server.probe_attempt": attempt })
+					return true
+				}
+				if (!isProcessAlive(child.pid)) {
+					// Child died early — stop waiting.
+					yield* Effect.annotateCurrentSpan({
+						"maple.server.probe_attempt": attempt,
+						"maple.server.exited_early": true,
+					})
+					return false
+				}
 			}
-			if (!isProcessAlive(child.pid)) break // child died early — stop waiting
-		}
+			yield* Effect.annotateCurrentSpan({ "maple.server.probe_attempt": 100 })
+			return false
+		}).pipe(Effect.withSpan("server.wait_ready", { attributes: { "server.address": probeAddr } }))
 		if (!up) {
 			return yield* new ServerError({
 				message: `background server did not come up within 10s — check ${prettyPath(logPath)}`,
@@ -741,7 +757,17 @@ export const checkpoint = Command.make("checkpoint", { dataDir: dataDirFlag, hos
 				dataDir,
 				host: connectionHostForBindHost(a.host),
 				port: a.port,
-			}).pipe(Effect.mapError((e) => new ServerError({ message: e.message })))
+			}).pipe(
+				// Only genuine create failures become a `ServerError`. A refused
+				// precondition (`CheckpointPreconditionError`) passes straight through
+				// to `bin.ts`, which recovers it like any other expected outcome —
+				// re-wrapping it here is what billed a second error event per refusal.
+				Effect.mapError((e) =>
+					e._tag === "@maple/cli/CheckpointPreconditionError"
+						? e
+						: new ServerError({ message: e.message }),
+				),
+			)
 			yield* Effect.sync(() =>
 				process.stdout.write(
 					`${green("✓")} checkpoint created\n` +

--- a/apps/cli/src/server/checkpoints.ts
+++ b/apps/cli/src/server/checkpoints.ts
@@ -197,6 +197,34 @@ export class CheckpointCreateError extends Schema.TaggedError<CheckpointCreateEr
 	{ ...checkpointErrorFields, checkpointId: CheckpointId },
 ) {}
 
+/**
+ * A checkpoint the CLI *correctly refuses to take*: the running server's chDB
+ * config carries no `<backups>` stanza, so `BACKUP DATABASE` cannot work.
+ *
+ * Its own tag, and never a `CheckpointCreateError`, because nothing failed —
+ * this is the CLI reporting an unmet precondition with an actionable fix, the
+ * same category as "maple is already running". It used to bill two error events
+ * per occurrence (an `Error` span on `CheckpointService.create`, plus the
+ * `ServerError` the command re-wrapped it into). `bin.ts` now recovers it via
+ * `recoverExpected`, which annotates `maple.cli.outcome`, prints the message and
+ * exits 1 with the root span `Ok`. The `expected` marker states that intent on
+ * the error itself rather than only in the recovery list.
+ */
+/** Kept verbatim — it is the whole remedy the user gets. */
+const MISSING_BACKUPS_CONFIG_MESSAGE =
+	"the running server's chDB config has no `<backups>` stanza, so it " +
+	"cannot take checkpoints. Restart `maple start` without " +
+	"`--chdb-config-file` to use the generated default, or add " +
+	"`<backups><allowed_disk>default</allowed_disk>" +
+	"<allowed_path>backups</allowed_path></backups>` to your config."
+
+export class CheckpointPreconditionError extends Schema.TaggedError<CheckpointPreconditionError>()(
+	"@maple/cli/CheckpointPreconditionError",
+	{ dataDir: Schema.String, message: Schema.String },
+) {
+	readonly expected = true
+}
+
 export class CheckpointRecoveryError extends Schema.TaggedError<CheckpointRecoveryError>()(
 	"@maple/cli/CheckpointRecoveryError",
 	checkpointErrorFields,
@@ -1425,7 +1453,7 @@ const removeCompletedRetirement = async (
 	await faults.afterRetirementCleanupRemoval?.(cleanup)
 }
 
-export const createCheckpoint = Effect.fn("CheckpointService.create")(function* (options: CheckpointOptions) {
+const createCheckpointTraced = Effect.fn("CheckpointService.create")(function* (options: CheckpointOptions) {
 	const operationId = newCheckpointOperationId()
 	const checkpointId = newCheckpointId()
 	const createError = (error: unknown): CheckpointCreateError =>
@@ -1440,6 +1468,10 @@ export const createCheckpoint = Effect.fn("CheckpointService.create")(function* 
 		"maple.checkpoint.operation_id": operationId,
 		"maple.checkpoint.id": checkpointId,
 	})
+	// Settled into a value rather than left in the failure channel: `Effect.fn`
+	// derives this span's status from that channel, and a refused precondition
+	// must not close `CheckpointService.create` as `Error`. `createCheckpoint`
+	// below re-raises it once the span has closed, so callers still see a failure.
 	return yield* withMaintenance(options.dataDir, operationId, createError, () =>
 		Effect.gen(function* () {
 			const prepared = yield* Effect.tryPromise({
@@ -1491,22 +1523,18 @@ export const createCheckpoint = Effect.fn("CheckpointService.create")(function* 
 			})
 			yield* postCheckpointBackup(options.host, options.port, options.dataDir, checkpointId).pipe(
 				Effect.mapError((error) =>
-					createError(
-						isMissingBackupConfigurationError(error)
-							? new Error(
-									// `maple start` generates a backups-enabled config when
-									// `--chdb-config-file` is absent, so reaching this means the
-									// server was started with a custom config carrying no
-									// `<backups>` stanza — or with a build predating that default.
-									"the running server's chDB config has no `<backups>` stanza, so it " +
-										"cannot take checkpoints. Restart `maple start` without " +
-										"`--chdb-config-file` to use the generated default, or add " +
-										"`<backups><allowed_disk>default</allowed_disk>" +
-										"<allowed_path>backups</allowed_path></backups>` to your config.",
-									{ cause: error },
-								)
-							: error,
-					),
+					isMissingBackupConfigurationError(error)
+						? // `maple start` generates a backups-enabled config when
+							// `--chdb-config-file` is absent, so reaching this means the
+							// server was started with a custom config carrying no
+							// `<backups>` stanza — or with a build predating that default.
+							// An unmet precondition, not a failure: see
+							// `CheckpointPreconditionError`.
+							new CheckpointPreconditionError({
+								dataDir: resolve(options.dataDir),
+								message: MISSING_BACKUPS_CONFIG_MESSAGE,
+							})
+						: createError(error),
 				),
 			)
 			return yield* Effect.tryPromise({
@@ -1590,8 +1618,26 @@ export const createCheckpoint = Effect.fn("CheckpointService.create")(function* 
 				catch: createError,
 			})
 		}),
+	).pipe(
+		Effect.catchTag("@maple/cli/CheckpointPreconditionError", (refusal) =>
+			Effect.as(Effect.annotateCurrentSpan({ "maple.checkpoint.refused": refusal._tag }), refusal),
+		),
 	)
 })
+
+/**
+ * Create a checkpoint, or refuse with an expected outcome.
+ *
+ * The refusal travels back through the span as a value (see the note inside
+ * `createCheckpointTraced`) and is turned back into a failure here, outside it —
+ * so the caller's control flow is unchanged while the span stays `Ok`.
+ */
+export const createCheckpoint = (options: CheckpointOptions) =>
+	createCheckpointTraced(options).pipe(
+		Effect.flatMap((outcome) =>
+			outcome instanceof CheckpointPreconditionError ? Effect.fail(outcome) : Effect.succeed(outcome),
+		),
+	)
 
 const parseResetTransaction = (value: unknown, expectedDataDir: string): ResetTransaction => {
 	const transaction = Schema.decodeUnknownSync(ResetTransactionSchema)(value)

--- a/apps/cli/test/expected-outcomes.test.ts
+++ b/apps/cli/test/expected-outcomes.test.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { chdbConfigPath, resolveChdbConfigFile } from "../src/commands/server"
+import { CheckpointPreconditionError } from "../src/server/checkpoints"
 import { recoverExpected } from "../src/core/outcomes"
 
 /** Run an effect, capturing anything written to stderr and restoring the real
@@ -41,6 +42,25 @@ describe("expected CLI outcomes", () => {
 			}),
 		)
 		strictEqual(output, "maple is already running (PID 4242) — stop it with `maple stop`\n")
+	})
+
+	// The "no `<backups>` stanza" refusal used to bill two error events: an Error
+	// span on `CheckpointService.create` plus the `ServerError` the command
+	// re-wrapped it into. It is now an expected outcome carrying the same text.
+	it("recovers the checkpoint precondition refusal with its message intact", async () => {
+		const refusal = new CheckpointPreconditionError({
+			dataDir: "/home/u/.maple/data",
+			message:
+				"the running server's chDB config has no `<backups>` stanza, so it " +
+				"cannot take checkpoints. Restart `maple start` without " +
+				"`--chdb-config-file` to use the generated default, or add " +
+				"`<backups><allowed_disk>default</allowed_disk>" +
+				"<allowed_path>backups</allowed_path></backups>` to your config.",
+		})
+
+		strictEqual(refusal._tag, "@maple/cli/CheckpointPreconditionError")
+		strictEqual(refusal.expected, true)
+		strictEqual(await captureStderr(recoverExpected(refusal)), `${refusal.message}\n`)
 	})
 
 	it("still exits non-zero, so scripts and CI keep their old behaviour", async () => {

--- a/apps/web/src/api/warehouse/query-builder-timeseries.test.ts
+++ b/apps/web/src/api/warehouse/query-builder-timeseries.test.ts
@@ -49,3 +49,36 @@ describe("resolveStrategy (wire shape → package shape)", () => {
 		).toEqual(LAB_EMPTY_RANGE_STRATEGY)
 	})
 })
+
+/**
+ * An empty window used to fail with `WarehouseInvalidInputError`, which marked
+ * the span `Error` and billed an exception event per tile per refresh (24 in 20
+ * minutes from one user paging a quiet dashboard). It is an answer now, and
+ * every caller already renders zero rows as its own empty state.
+ */
+describe("empty window response", () => {
+	it("answers with zero rows and diagnostics describing the requested window", () => {
+		expect(
+			__testables.emptyTimeseriesResponse({
+				startTime: "2026-01-01 00:00:00",
+				endTime: "2026-01-01 01:00:00",
+				queries: [],
+				comparison: { mode: "previous_period" },
+			}),
+		).toEqual({
+			data: [],
+			diagnostics: {
+				primaryWindow: { startTime: "2026-01-01 00:00:00", endTime: "2026-01-01 01:00:00" },
+				comparison: {
+					mode: "previous_period",
+					includePercentChange: true,
+					shiftedByMs: 0,
+					previousStartTime: null,
+					previousEndTime: null,
+				},
+				queries: [],
+				previousQueries: [],
+			},
+		})
+	})
+})

--- a/apps/web/src/api/warehouse/query-builder-timeseries.ts
+++ b/apps/web/src/api/warehouse/query-builder-timeseries.ts
@@ -5,6 +5,7 @@ import {
 	LAB_EMPTY_RANGE_STRATEGY,
 	type EmptyRangeFallbackStrategy,
 	type TimeseriesQuerySetDiagnostics,
+	type TimeseriesQuerySetResult,
 	fallbackStrategyFromWire,
 	runTimeseriesQuerySet,
 } from "@maple/query-engine/query-set"
@@ -71,6 +72,38 @@ function resolveStrategy(input: QueryBuilderTimeseriesInput): EmptyRangeFallback
 	return fallbackStrategyFromWire(input.strategy, LAB_EMPTY_RANGE_STRATEGY)
 }
 
+/**
+ * What this endpoint answers with when every query ran and the window simply
+ * held nothing.
+ *
+ * An empty window is a normal answer, not a failure: raising it as
+ * `WarehouseInvalidInputError` marked the span `Error` and billed an exception
+ * event per tile per refresh (24 in 20 minutes from one user paging a quiet
+ * dashboard). Every caller already renders zero rows as its own empty state —
+ * chart tiles via `WidgetEmptyState`, the metric chart and the lab inline — so
+ * the empty shape is all they need.
+ *
+ * The diagnostics describe exactly that: the requested window, the comparison
+ * the caller asked for, and no per-query entries, because no query produced one.
+ */
+function emptyTimeseriesResponse(input: QueryBuilderTimeseriesInput): QueryBuilderTimeseriesResponse {
+	return {
+		data: [],
+		diagnostics: {
+			primaryWindow: { startTime: input.startTime, endTime: input.endTime },
+			comparison: {
+				mode: input.comparison?.mode ?? "none",
+				includePercentChange: input.comparison?.includePercentChange ?? true,
+				shiftedByMs: 0,
+				previousStartTime: null,
+				previousEndTime: null,
+			},
+			queries: [],
+			previousQueries: [],
+		},
+	}
+}
+
 const executor = makeWarehouseExecutor("queryEngine.timeseriesQuery")
 
 export function getQueryBuilderTimeseries({ data }: { data: QueryBuilderTimeseriesInput }) {
@@ -102,8 +135,16 @@ const getQueryBuilderTimeseriesEffect = Effect.fn("QueryEngine.getQueryBuilderTi
 		Effect.catchTags({
 			"@maple/query-engine/query-set/QuerySetInputError": (error) =>
 				invalidWarehouseInput("getQueryBuilderTimeseries", error.message),
+			// Empty `details` means every query executed and none matched anything:
+			// that is an empty result, so answer with one instead of failing. A
+			// populated `details` carries a real per-query failure and stays an error.
 			"@maple/query-engine/query-set/QuerySetNoDataError": (error) =>
-				invalidWarehouseInput("getQueryBuilderTimeseries", error.message),
+				error.details.length === 0
+					? Effect.succeed({
+							rows: [],
+							diagnostics: emptyTimeseriesResponse(input).diagnostics,
+						} satisfies TimeseriesQuerySetResult)
+					: invalidWarehouseInput("getQueryBuilderTimeseries", error.message),
 		}),
 	)
 
@@ -122,4 +163,5 @@ const getQueryBuilderTimeseriesEffect = Effect.fn("QueryEngine.getQueryBuilderTi
 
 export const __testables = {
 	resolveStrategy,
+	emptyTimeseriesResponse,
 }

--- a/apps/web/src/hooks/use-widget-data.test.ts
+++ b/apps/web/src/hooks/use-widget-data.test.ts
@@ -45,3 +45,24 @@ describe("use-widget-data hidden series transform", () => {
 		expect(transformed).toEqual([{ bucket: "2026-04-12T00:00:00.000Z", B: 20, F1: 0.5 }])
 	})
 })
+
+/**
+ * `getQueryBuilderTimeseries` answers an empty window with an empty envelope
+ * instead of failing (the failure was billed as an error event per tile per
+ * refresh). The tile still has to read as "no data": a `sum` transform over zero
+ * rows is `0`, which a stat tile would otherwise render as a real measurement.
+ */
+describe("use-widget-data empty envelope", () => {
+	it("recognizes a successful response that carried no rows", () => {
+		expect(__testables.isEmptyDataEnvelope({ data: [] })).toBe(true)
+		expect(__testables.isEmptyDataEnvelope({ data: [], diagnostics: { queries: [] } })).toBe(true)
+	})
+
+	it("leaves a response with rows, or no envelope at all, alone", () => {
+		expect(__testables.isEmptyDataEnvelope({ data: [{ bucket: "x", A: 1 }] })).toBe(false)
+		expect(__testables.isEmptyDataEnvelope([])).toBe(false)
+		expect(__testables.isEmptyDataEnvelope({ data: { total: 0 } })).toBe(false)
+		expect(__testables.isEmptyDataEnvelope(null)).toBe(false)
+		expect(__testables.isEmptyDataEnvelope(42)).toBe(false)
+	})
+})

--- a/apps/web/src/hooks/use-widget-data.ts
+++ b/apps/web/src/hooks/use-widget-data.ts
@@ -289,6 +289,20 @@ const EXPECTED_EMPTY_MESSAGES = new Set([
 	"No enabled queries to run",
 ])
 
+/**
+ * A successful response that carried no rows.
+ *
+ * `getQueryBuilderTimeseries` used to *fail* on an empty window, which is what
+ * put "No query data found in selected time range" on the error path here. It
+ * now answers with an empty envelope, so the emptiness has to be recognised on
+ * the success path instead — otherwise a stat tile would format a transformed
+ * empty array (a `sum` of nothing is `0`) as a real reading.
+ */
+const isEmptyDataEnvelope = (raw: unknown): boolean => {
+	if (typeof raw !== "object" || raw === null || !("data" in raw)) return false
+	return Array.isArray(raw.data) && raw.data.length === 0
+}
+
 const isExpectedEmptyDataError = (error: unknown): boolean => {
 	if (typeof error !== "object" || error === null) return false
 	const message = (error as { message?: unknown }).message
@@ -572,8 +586,12 @@ export function useWidgetDataSource(
 				const kind = classifyWidgetErrorKind(error)
 				return { status: "error", title, message, kind } as const
 			})
-			.onSuccess(
-				(rawData) => ({ status: "ready", data: toReadyWidgetData(rawData, transform) }) as const,
+			.onSuccess((rawData) =>
+				isEmptyDataEnvelope(rawData)
+					? // Same muted "No data" frame the empty-window failure used to
+						// produce; `WidgetFrame` keys off this exact message.
+						({ status: "error", message: "No query data found in selected time range" } as const)
+					: ({ status: "ready", data: toReadyWidgetData(rawData, transform) } as const),
 			)
 			.orElse(() => ({ status: "error", message: "Unknown error" }) as const)
 	}, [result, transform, disableReason, isStatic, enabled, waitingOnVariables, exceedsListCap, narrowed])
@@ -599,6 +617,7 @@ export function useWidgetData(widget: DashboardWidget, enabled = true, options?:
 
 export const __testables = {
 	applyTransform,
+	isEmptyDataEnvelope,
 	filterHiddenSeriesRows,
 	isSeriesNameHidden,
 }

--- a/apps/web/src/lib/services/common/telemetry.test.ts
+++ b/apps/web/src/lib/services/common/telemetry.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { isCancellation, tracedFetch } from "./telemetry"
+import { describeFetchFailure, isCancellation, tracedFetch } from "./telemetry"
 
 /**
  * Every Electric ShapeStream fetch flows through `tracedFetch`, and Electric
@@ -42,6 +42,40 @@ describe("isCancellation", () => {
 	it("tolerates null and undefined causes", () => {
 		expect(isCancellation(null, undefined)).toBe(false)
 		expect(isCancellation(undefined, undefined)).toBe(false)
+	})
+})
+
+/**
+ * `TracedFetchError` used to carry no message at all, so 37 exception events a
+ * day said only that *a* fetch failed. These pin the parts that make one
+ * diagnosable — and that the query string never rides along.
+ */
+describe("describeFetchFailure", () => {
+	it("names the method, path and transport cause", () => {
+		expect(
+			describeFetchFailure({
+				method: "GET",
+				path: "/api/v1/traces",
+				cause: new TypeError("Failed to fetch"),
+			}),
+		).toBe("Fetch failed: GET /api/v1/traces — TypeError: Failed to fetch")
+	})
+
+	it("includes the status when there was a response", () => {
+		expect(
+			describeFetchFailure({
+				method: "POST",
+				path: "/internal/query-engine/execute",
+				status: 503,
+				cause: new Error("Service Unavailable"),
+			}),
+		).toBe("Fetch failed: POST /internal/query-engine/execute (HTTP 503) — Error: Service Unavailable")
+	})
+
+	it("still identifies the call when the cause carries nothing", () => {
+		expect(describeFetchFailure({ method: "GET", path: "/api/v1/thing", cause: undefined })).toBe(
+			"Fetch failed: GET /api/v1/thing",
+		)
 	})
 })
 

--- a/apps/web/src/lib/services/common/telemetry.ts
+++ b/apps/web/src/lib/services/common/telemetry.ts
@@ -39,7 +39,47 @@ type FetchOutcome =
 	| { readonly ok: true; readonly response: Response }
 	| { readonly ok: false; readonly cause: unknown }
 
+const causeName = (cause: unknown): string | null =>
+	typeof cause === "object" && cause !== null && "name" in cause && typeof cause.name === "string"
+		? cause.name
+		: null
+
+const causeMessage = (cause: unknown): string | null => {
+	if (cause instanceof Error) return cause.message.length > 0 ? cause.message : null
+	if (typeof cause === "string") return cause.length > 0 ? cause : null
+	return null
+}
+
+/**
+ * The human half of a `TracedFetchError`.
+ *
+ * These arrived with an empty exception message and were therefore
+ * undiagnosable: a transport rejection carries no response, so nothing in the
+ * span said which call failed or how. Method + path + (when there is one) status
+ * + the cause's name/message is enough to tell "the API is down" apart from
+ * "this one endpoint 500s".
+ *
+ * The path is `URL.pathname` on purpose — a query string can carry ids, filter
+ * values and search text, none of which belong in an error message.
+ *
+ * Exported for tests.
+ */
+export const describeFetchFailure = (input: {
+	readonly method: string
+	readonly path: string
+	readonly status?: number | undefined
+	readonly cause: unknown
+}): string => {
+	const where = `${input.method} ${input.path}`
+	const status = input.status === undefined ? "" : ` (HTTP ${input.status})`
+	const name = causeName(input.cause)
+	const message = causeMessage(input.cause)
+	const detail = [name, message].filter((part) => part !== null).join(": ")
+	return `Fetch failed: ${where}${status}${detail.length > 0 ? ` — ${detail}` : ""}`
+}
+
 class TracedFetchError extends Data.TaggedError("@maple/web/TracedFetchError")<{
+	readonly message: string
 	readonly cause: unknown
 }> {}
 
@@ -88,10 +128,26 @@ export const tracedFetch = (
 						return outcome
 					}
 					if (isCancellation(outcome.cause, init?.signal)) {
-						yield* Effect.annotateCurrentSpan("maple.http.cancelled", true)
+						// An abort is an expected outcome (navigation away, Electric
+						// pause/resume), so the span stays `Ok` and only says what happened.
+						yield* Effect.annotateCurrentSpan({
+							"maple.http.cancelled": true,
+							"error.type": "aborted",
+						})
 						return outcome
 					}
-					return yield* new TracedFetchError({ cause: outcome.cause })
+					yield* Effect.annotateCurrentSpan(
+						"error.type",
+						causeName(outcome.cause) ?? "TracedFetchError",
+					)
+					return yield* new TracedFetchError({
+						cause: outcome.cause,
+						message: describeFetchFailure({
+							method,
+							path: parsed.pathname,
+							cause: outcome.cause,
+						}),
+					})
 				}).pipe(
 					Effect.withSpan("http.client", {
 						kind: "client",


### PR DESCRIPTION
Web:
- `TracedFetchError` arrived with an empty exception message, so 37 events a
  day were undiagnosable. `describeFetchFailure` now builds it from method,
  URL pathname (no query string), HTTP status when there is a response, and
  the cause's name/message for transport failures. Navigation aborts were
  already kept Ok; they now also annotate `error.type=aborted`.
- A query set that ran every query and matched nothing raised
  `WarehouseInvalidInputError` ("No query data found in selected time
  range") — one user paging a quiet dashboard produced 24 error events. It
  now returns an empty envelope with diagnostics; the widget hook maps that
  to the same muted empty state so a stat tile does not render `sum([])` as
  a real zero. A populated `details` still fails (that is a per-query
  failure), and the decode error is untouched.

CLI:
- The "chDB config has no <backups> stanza" refusal is a correct precondition
  message but was recorded as an Error span and re-wrapped into
  `ServerError`, billing two events per occurrence. It is now
  `CheckpointPreconditionError` (expected), returned as a value inside the
  checkpoint span and recovered by `recoverExpected` at the root, so the
  root span closes Ok with the outcome annotated and exit code unchanged.
- The startup readiness loop is one `server.wait_ready` span annotating the
  attempt count; only the deadline miss is reported, once, by the existing
  `ServerError`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789682924&installation_model_id=427786&pr_number=530&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F530&signature=d88d2eb62a9a5e1c3c26b80059c75d1627f551c36b3346ab94df2fb8c37b48fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Verification
`apps/web` 125 vitest · `apps/cli` 54 bun tests · tsc clean both.

Not in this PR: breakdown/list adapters still fail on `QuerySetNoDataError` (out of the reported scope — only the timeseries path produced error events).
