### PR TITLE
fix(ingest): build with rust 1.94, unbreaking the deploy

### DIFF
--- a/.github/workflows/aws-probe.yml
+++ b/.github/workflows/aws-probe.yml
@@ -106,7 +106,7 @@ jobs:
                       -v "$PWD/apps/ingest:/app" \
                       -v "$RUNNER_TEMP/ingest-target:/target" \
                       -w /app \
-                      rust:1.88-bookworm \
+                      rust:1.94-bookworm \
                       cargo build --release --target-dir /target
                   cp "$RUNNER_TEMP/ingest-target/release/maple-ingest" apps/ingest/dist/maple-ingest
 

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -81,7 +81,7 @@ jobs:
             # between runs, so an unchanged ingest is a no-op and a one-crate
             # change is about a minute. Dockerfile.prebuilt then COPYs the result.
             #
-            # Inside rust:1.88-bookworm rather than on the runner: the runtime base
+            # Inside rust:1.94-bookworm rather than on the runner: the runtime base
             # is debian:bookworm-slim (glibc 2.36) and ubuntu-24.04 ships 2.39, so a
             # host-built binary starts and immediately dies with
             # `version 'GLIBC_2.39' not found`.
@@ -113,7 +113,7 @@ jobs:
                       -v "$PWD/apps/ingest:/app" \
                       -v "$RUNNER_TEMP/ingest-target:/target" \
                       -w /app \
-                      rust:1.88-bookworm \
+                      rust:1.94-bookworm \
                       cargo build --release --target-dir /target
                   cp "$RUNNER_TEMP/ingest-target/release/maple-ingest" apps/ingest/dist/maple-ingest
 

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -91,7 +91,7 @@ jobs:
                       -v "$PWD/apps/ingest:/app" \
                       -v "$RUNNER_TEMP/ingest-target:/target" \
                       -w /app \
-                      rust:1.88-bookworm \
+                      rust:1.94-bookworm \
                       cargo build --release --target-dir /target
                   cp "$RUNNER_TEMP/ingest-target/release/maple-ingest" apps/ingest/dist/maple-ingest
 

--- a/apps/ingest/Dockerfile
+++ b/apps/ingest/Dockerfile
@@ -1,5 +1,5 @@
 # Build context: apps/ingest/ (via Railway rootDirectory)
-FROM rust:1.88 AS build
+FROM rust:1.94-bookworm AS build
 WORKDIR /app
 
 COPY . .

--- a/clippy.toml
+++ b/clippy.toml
@@ -5,3 +5,8 @@
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 allow-panic-in-tests = true
+
+# Deploy builders (Dockerfile, deploy workflows) and mise pin this toolchain;
+# suggestion lints must not propose APIs newer than it (see the
+# duration_constructors incident: a clippy suggestion broke rust:1.88 builds).
+msrv = "1.94"


### PR DESCRIPTION
Ingest deploys have failed since #523: the clippy cleanup adopted `Duration::from_mins`/`from_hours` (pedantic suggestion), which need rust ≥ 1.91. CI builds with the mise-pinned 1.94.1 and stayed green, but the Railway Dockerfile and the deploy workflows build in `rust:1.88` images, so both the GH `Build ingest binary` step and Railway's Dockerfile build die with `E0658: use of unstable library feature 'duration_constructors'` (main.rs:1470/:1570/:2181). The previous Railway deployment is still serving.

- `rust:1.88` → `rust:1.94-bookworm` in `apps/ingest/Dockerfile` (explicit bookworm pin so build-stage glibc can't drift past the `debian:bookworm-slim` runner stage), `deploy-prd.yml`, `deploy-stg.yml`, `aws-probe.yml`.
- `msrv = "1.94"` in `clippy.toml`, so MSRV-gated suggestion lints can't propose beyond-toolchain APIs again — this is the guard that would have prevented the incident.

Verified: ingest tests green (171), clippy zero warnings with the msrv pin, `rust:1.94-bookworm` exists on Docker Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789727197&installation_model_id=427786&pr_number=534&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F534&signature=e59f310ad0936d06f74f6d05e9e7f23b86d5ade99cf2fced2f6705500388e658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->