### PR TITLE
fix(investigations): stop the pass budget starving auto-triage by 03:00 UTC

### DIFF
--- a/apps/api/src/services/errors/AiTriageService.test.ts
+++ b/apps/api/src/services/errors/AiTriageService.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, assert, describe, it } from "@effect/vitest"
+import { ConfigProvider, Effect, Layer, Schema } from "effect"
+import { InvestigationId, OrgId } from "@maple/domain/http"
+import { aiTriageSettings, investigations } from "@maple/db"
+import { Database } from "@/platform/DatabaseLive"
+import { Env } from "@/platform/Env"
+import { cleanupTestDbs, createTestDb, type TestDb } from "@/platform/test-pglite"
+import { AiTriageService } from "./AiTriageService"
+
+const createdDbs: TestDb[] = []
+
+afterEach(() => cleanupTestDbs(createdDbs))
+
+const testConfig = () =>
+	ConfigProvider.layer(
+		ConfigProvider.fromUnknown({
+			PORT: "3472",
+			MCP_PORT: "3473",
+			TINYBIRD_HOST: "https://api.tinybird.co",
+			TINYBIRD_TOKEN: "test-token",
+			MAPLE_AUTH_MODE: "self_hosted",
+			MAPLE_ROOT_PASSWORD: "test-root-password",
+			MAPLE_DEFAULT_ORG_ID: "default",
+			MAPLE_INGEST_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 1).toString("base64"),
+			MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "maple-test-lookup-secret",
+			INTERNAL_SERVICE_TOKEN: "test-internal-token",
+		}),
+	)
+
+const makeLayer = () => {
+	const testDb = createTestDb(createdDbs)
+	return AiTriageService.layer.pipe(
+		Layer.provideMerge(testDb.layer),
+		Layer.provideMerge(Env.layer),
+		Layer.provide(testConfig()),
+	)
+}
+
+const asOrgId = Schema.decodeUnknownSync(OrgId)
+const asInvestigationId = Schema.decodeUnknownSync(InvestigationId)
+const ORG = asOrgId("org_triage_settings_test")
+
+const seedSettings = (maxRunsPerDay: number, maxPassesPerDay: number) =>
+	Effect.gen(function* () {
+		const database = yield* Database
+		yield* database.execute((db) =>
+			db.insert(aiTriageSettings).values({
+				orgId: ORG,
+				enabled: true,
+				maxRunsPerDay,
+				maxPassesPerDay,
+				updatedAt: new Date(),
+			}),
+		)
+	})
+
+/**
+ * Usage is counted from started rows as `fanoutSize + 1`, so a width-3 row is
+ * worth 4 passes. Seeding rows rather than driving the enqueue path keeps the
+ * arithmetic under the test's control instead of the planner's.
+ */
+const seedStartedRuns = (count: number, fanoutSize: number, idOffset = 0) =>
+	Effect.gen(function* () {
+		const database = yield* Database
+		const now = new Date()
+		for (let index = 0; index < count; index++) {
+			yield* database.execute((db) =>
+				db.insert(investigations).values({
+					id: asInvestigationId(
+						`00000000-0000-4000-8000-${String(idOffset + index).padStart(12, "0")}`,
+					),
+					orgId: ORG,
+					status: "investigating",
+					seededBy: "system",
+					subjectJson: { type: "question", question: "seed" },
+					fanoutSize,
+					startedAt: now,
+					createdAt: now,
+					updatedAt: now,
+				}),
+			)
+		}
+	})
+
+describe("AiTriageService.getSettings pause state", () => {
+	it.effect("reports triage healthy while both ceilings have room", () =>
+		Effect.gen(function* () {
+			yield* seedSettings(50, 100)
+			const doc = yield* (yield* AiTriageService).getSettings(ORG)
+			assert.isFalse(doc.ordinaryPaused)
+			assert.isFalse(doc.priorityPaused)
+			assert.isNull(doc.pausedDimension)
+			assert.isNull(doc.resumesAt)
+		}).pipe(Effect.provide(makeLayer())),
+	)
+
+	/**
+	 * The probe has to cost what a start *reserves* (`width + 2` = 6 for a medium
+	 * incident), not what a settled run consumes. Probing with 4 left the banner
+	 * hidden across the last two passes of the slice — exactly the window where
+	 * ordinary starts were already being refused.
+	 */
+	it.effect("pauses ordinary triage at the reservation, not at the settled cost", () =>
+		Effect.gen(function* () {
+			// Ordinary slice of a 100-pass ceiling is 70. Land usage on 65 — the one
+			// window that separates the two probes: 65 + 6 > 70 refuses a real start,
+			// while the old 65 + 4 <= 70 reported triage as healthy.
+			yield* seedSettings(500, 100)
+			yield* seedStartedRuns(16, 3) // 16 x 4 = 64
+			yield* seedStartedRuns(1, 1, 100) // a single-pass run is worth 1
+			const doc = yield* (yield* AiTriageService).getSettings(ORG)
+			assert.strictEqual(doc.usage.passes, 65)
+			assert.isTrue(doc.ordinaryPaused)
+			assert.strictEqual(doc.pausedDimension, "passes_reserved")
+			// The reserve is the whole point: criticals are still starting here.
+			assert.isFalse(doc.priorityPaused)
+			assert.isNotNull(doc.resumesAt)
+		}).pipe(Effect.provide(makeLayer())),
+	)
+
+	it.effect("pauses priority triage too once the full ceiling is spent", () =>
+		Effect.gen(function* () {
+			yield* seedSettings(500, 100)
+			yield* seedStartedRuns(24, 3) // 96 passes; 96 + 7 > 100
+			const doc = yield* (yield* AiTriageService).getSettings(ORG)
+			assert.isTrue(doc.ordinaryPaused)
+			assert.isTrue(doc.priorityPaused)
+		}).pipe(Effect.provide(makeLayer())),
+	)
+
+	/**
+	 * The runs ceiling is checked before any pass arithmetic and has no reserve,
+	 * so it stops every severity. Reporting it as a pass problem would tell an
+	 * operator that criticals are covered when they are not, and point them at a
+	 * number that was never the constraint.
+	 */
+	it.effect("names the runs ceiling and pauses every severity with it", () =>
+		Effect.gen(function* () {
+			yield* seedSettings(3, 10_000)
+			yield* seedStartedRuns(3, 3)
+			const doc = yield* (yield* AiTriageService).getSettings(ORG)
+			assert.strictEqual(doc.pausedDimension, "runs")
+			assert.isTrue(doc.ordinaryPaused)
+			assert.isTrue(doc.priorityPaused)
+		}).pipe(Effect.provide(makeLayer())),
+	)
+})

--- a/apps/api/src/services/errors/AiTriageService.ts
+++ b/apps/api/src/services/errors/AiTriageService.ts
@@ -5,6 +5,7 @@ import {
 	AiTriageUsage,
 	AiTriageValidationError,
 	IsoDateTimeString,
+	type IssueSeverity,
 	type OrgId,
 	type UserId,
 } from "@maple/domain/http"
@@ -12,6 +13,7 @@ import { aiTriageSettings, type AiTriageSettingsRow } from "@maple/db"
 import { eq } from "drizzle-orm"
 import { Clock, Context, Effect, Layer, Schema } from "effect"
 import { Database } from "@/platform/DatabaseLive"
+import { widthFor } from "@/workflows/plan-normalize"
 import { makeDbExecute, makePersistenceErrorMapper } from "@/platform/db-execute"
 import {
 	DEFAULT_MAX_PASSES_PER_DAY,
@@ -57,38 +59,52 @@ export class AiTriageService extends Context.Service<AiTriageService, AiTriageSe
 			})
 
 			/**
-			 * Exhaustion is asked of the same verdict the enqueue path uses, with the
-			 * cost of a typical planned start, rather than recomputed from the raw
-			 * numbers here. A second copy of the arithmetic is a second thing to get
-			 * out of step with the rule that actually refuses starts.
+			 * What a start of this severity would actually reserve.
+			 *
+			 * Derived from `widthFor` rather than pinned to a constant, because the
+			 * enqueue path judges a start against its *reservation* (`width + 2`), not
+			 * against what the run eventually settles at. Probing with the settled
+			 * cost reported triage as healthy across the last two passes of the
+			 * budget — exactly the window in which starts were already being refused.
 			 */
-			const TYPICAL_PLANNED_PASSES = 4
+			const probeCost = (severity: IssueSeverity) => widthFor(severity, "error") + 2
 
+			/**
+			 * Pause state is asked of the same verdict the enqueue path uses, twice:
+			 * once as an ordinary incident and once as a critical. One probe cannot
+			 * answer both questions — with a reserve configured, a medium-severity
+			 * probe reports `passes_reserved` whether the reserve is untouched or long
+			 * gone, so it can never say whether criticals are still starting.
+			 */
 			const settingsToDocument = (
 				row: AiTriageSettingsRow | undefined,
 				usage: InvestigationUsage,
 				nowMs: number,
 			): AiTriageSettingsDocument => {
-				const verdict = evaluateInvestigationQuota({
-					usage,
-					limits: row,
-					passCount: TYPICAL_PLANNED_PASSES,
-					nowMs,
-					// The banner speaks for ordinary incidents; `high`/`critical` keep
-					// starting from the reserve while this reads exhausted.
-					severity: "medium",
-				})
-				const exhausted = verdict.kind === "exceeded"
+				const probe = (severity: IssueSeverity) =>
+					evaluateInvestigationQuota({
+						usage,
+						limits: row,
+						passCount: probeCost(severity),
+						nowMs,
+						severity,
+					})
+				const ordinary = probe("medium")
+				const priority = probe("critical")
+				// The runs ceiling is checked before any pass arithmetic and has no
+				// reserve, so it refuses both — reporting it as a pass problem would
+				// send the reader to raise a number that was never the constraint.
+				const paused = ordinary.kind === "exceeded" ? ordinary : null
 				return new AiTriageSettingsDocument({
 					enabled: row?.enabled ?? false,
 					maxRunsPerDay: row?.maxRunsPerDay ?? DEFAULT_MAX_RUNS_PER_DAY,
 					maxPassesPerDay: row?.maxPassesPerDay ?? DEFAULT_MAX_PASSES_PER_DAY,
 					usage: new AiTriageUsage({ runs: usage.runs, passes: usage.passes }),
-					passesExhausted: exhausted,
+					ordinaryPaused: ordinary.kind === "exceeded",
+					priorityPaused: priority.kind === "exceeded",
+					pausedDimension: paused?.dimension ?? null,
 					resumesAt:
-						verdict.kind === "exceeded"
-							? decodeIsoSync(new Date(verdict.retryableAtMs).toISOString())
-							: null,
+						paused === null ? null : decodeIsoSync(new Date(paused.retryableAtMs).toISOString()),
 					updatedAt: row?.updatedAt ? decodeIsoSync(row.updatedAt.toISOString()) : null,
 					updatedBy: row?.updatedBy ?? null,
 				})

--- a/apps/api/src/services/errors/AiTriageService.ts
+++ b/apps/api/src/services/errors/AiTriageService.ts
@@ -2,6 +2,7 @@ import {
 	AiTriagePersistenceError,
 	AiTriageSettingsDocument,
 	type AiTriageSettingsUpdateRequest,
+	AiTriageUsage,
 	AiTriageValidationError,
 	IsoDateTimeString,
 	type OrgId,
@@ -12,7 +13,13 @@ import { eq } from "drizzle-orm"
 import { Clock, Context, Effect, Layer, Schema } from "effect"
 import { Database } from "@/platform/DatabaseLive"
 import { makeDbExecute, makePersistenceErrorMapper } from "@/platform/db-execute"
-import { DEFAULT_MAX_PASSES_PER_DAY, DEFAULT_MAX_RUNS_PER_DAY } from "@/services/errors/investigation-quota"
+import {
+	DEFAULT_MAX_PASSES_PER_DAY,
+	DEFAULT_MAX_RUNS_PER_DAY,
+	evaluateInvestigationQuota,
+	type InvestigationUsage,
+	selectInvestigationUsage,
+} from "@/services/errors/investigation-quota"
 
 const decodeIsoSync = Schema.decodeUnknownSync(IsoDateTimeString)
 
@@ -45,19 +52,54 @@ export class AiTriageService extends Context.Service<AiTriageService, AiTriageSe
 				return rows[0]
 			})
 
-			const settingsToDocument = (row: AiTriageSettingsRow | undefined): AiTriageSettingsDocument =>
-				new AiTriageSettingsDocument({
+			const loadUsage = Effect.fn("AiTriageService.loadUsage")(function* (orgId: OrgId, nowMs: number) {
+				return yield* dbExecute((db) => selectInvestigationUsage(db, orgId, nowMs))
+			})
+
+			/**
+			 * Exhaustion is asked of the same verdict the enqueue path uses, with the
+			 * cost of a typical planned start, rather than recomputed from the raw
+			 * numbers here. A second copy of the arithmetic is a second thing to get
+			 * out of step with the rule that actually refuses starts.
+			 */
+			const TYPICAL_PLANNED_PASSES = 4
+
+			const settingsToDocument = (
+				row: AiTriageSettingsRow | undefined,
+				usage: InvestigationUsage,
+				nowMs: number,
+			): AiTriageSettingsDocument => {
+				const verdict = evaluateInvestigationQuota({
+					usage,
+					limits: row,
+					passCount: TYPICAL_PLANNED_PASSES,
+					nowMs,
+					// The banner speaks for ordinary incidents; `high`/`critical` keep
+					// starting from the reserve while this reads exhausted.
+					severity: "medium",
+				})
+				const exhausted = verdict.kind === "exceeded"
+				return new AiTriageSettingsDocument({
 					enabled: row?.enabled ?? false,
 					maxRunsPerDay: row?.maxRunsPerDay ?? DEFAULT_MAX_RUNS_PER_DAY,
 					maxPassesPerDay: row?.maxPassesPerDay ?? DEFAULT_MAX_PASSES_PER_DAY,
+					usage: new AiTriageUsage({ runs: usage.runs, passes: usage.passes }),
+					passesExhausted: exhausted,
+					resumesAt:
+						verdict.kind === "exceeded"
+							? decodeIsoSync(new Date(verdict.retryableAtMs).toISOString())
+							: null,
 					updatedAt: row?.updatedAt ? decodeIsoSync(row.updatedAt.toISOString()) : null,
 					updatedBy: row?.updatedBy ?? null,
 				})
+			}
 
 			const getSettings: AiTriageServiceApi["getSettings"] = Effect.fn("AiTriageService.getSettings")(
 				function* (orgId) {
 					yield* Effect.annotateCurrentSpan({ orgId })
-					return settingsToDocument(yield* loadSettingsRow(orgId))
+					const nowMs = yield* Clock.currentTimeMillis
+					const row = yield* loadSettingsRow(orgId)
+					return settingsToDocument(row, yield* loadUsage(orgId, nowMs), nowMs)
 				},
 			)
 
@@ -82,7 +124,11 @@ export class AiTriageService extends Context.Service<AiTriageService, AiTriageSe
 						.values({ orgId, ...next })
 						.onConflictDoUpdate({ target: aiTriageSettings.orgId, set: next }),
 				)
-				return settingsToDocument(yield* loadSettingsRow(orgId))
+				return settingsToDocument(
+					yield* loadSettingsRow(orgId),
+					yield* loadUsage(orgId, nowMs),
+					nowMs,
+				)
 			})
 
 			return { getSettings, updateSettings } satisfies AiTriageServiceApi

--- a/apps/api/src/services/errors/ai-triage-enqueue.test.ts
+++ b/apps/api/src/services/errors/ai-triage-enqueue.test.ts
@@ -88,6 +88,26 @@ const enableAutomation = Effect.gen(function* () {
 	)
 })
 
+/**
+ * Both ceilings, explicitly. The reserve is a fraction of the pass ceiling, so a
+ * test about it has to pin that number rather than inherit a default whose whole
+ * point is to be large.
+ */
+const enableWithLimits = (maxRunsPerDay: number, maxPassesPerDay: number) =>
+	Effect.gen(function* () {
+		const database = yield* Database
+		const nowMs = yield* Clock.currentTimeMillis
+		yield* database.execute((db) =>
+			db.insert(aiTriageSettings).values({
+				orgId: ORG,
+				enabled: true,
+				maxRunsPerDay,
+				maxPassesPerDay,
+				updatedAt: new Date(nowMs),
+			}),
+		)
+	})
+
 const fakeFanoutWorkflow = () => {
 	const created: Array<{ id: string; params: Record<string, unknown> }> = []
 	return {
@@ -205,7 +225,7 @@ describe("maybeEnqueueTriage", () => {
 			const start = (id: string) => maybeEnqueueTriage(baseInput(id, workflow.binding))
 
 			// `maxRunsPerDay` is 2 here, and a planned run reserves 6 passes against a
-			// 90-pass default — so the runs ceiling is what bites first.
+			// 1000-pass default — so the runs ceiling is what bites first.
 			assert.isTrue((yield* start("incident-1")).enqueued)
 			assert.isTrue((yield* start("incident-2")).enqueued)
 			assert.deepStrictEqual(yield* start("incident-3"), {
@@ -310,6 +330,49 @@ describe("maybeEnqueueTriage", () => {
 			})
 			assert.isTrue(result.enqueued)
 			assert.lengthOf(workflow.created, 1)
+		}).pipe(Effect.provide(makeLayer())),
+	)
+
+	/**
+	 * The regression this reserve was built for: for two weeks the whole daily
+	 * budget was spent by ordinary incidents within three hours of UTC midnight,
+	 * so every incident during working hours was refused — including the ones
+	 * worth investigating. Arrival order must not outrank severity.
+	 *
+	 * A start contributes `fanoutSize + 1` to usage and reserves `width + 2`. At
+	 * width 4 (unclassified) that is 5 spent per start and 6 reserved; a critical
+	 * is width 5, so 7 reserved. With a 20-pass ceiling the ordinary slice is 14.
+	 */
+	it.effect("keeps the reserve for high and critical once ordinary starts fill the slice", () =>
+		Effect.gen(function* () {
+			yield* enableWithLimits(50, 20)
+			const workflow = fakeFanoutWorkflow()
+			const ordinary = (id: string) => maybeEnqueueTriage(baseInput(id, workflow.binding))
+
+			assert.isTrue((yield* ordinary("incident-1")).enqueued) // 0 + 6 <= 14
+			assert.isTrue((yield* ordinary("incident-2")).enqueued) // 5 + 6 <= 14
+			assert.deepStrictEqual(yield* ordinary("incident-3"), {
+				enqueued: false,
+				reason: "daily_cap",
+			}) // 10 + 6 > 14
+
+			// Same instant, same usage, higher severity: the reserved slice is still there.
+			const critical = yield* maybeEnqueueTriage(criticalInput(workflow.binding, "incident-4"))
+			assert.isTrue(critical.enqueued) // 10 + 7 <= 20
+			assert.lengthOf(workflow.created, 3)
+		}).pipe(Effect.provide(makeLayer())),
+	)
+
+	it.effect("refuses a critical start too once the full ceiling is spent", () =>
+		Effect.gen(function* () {
+			yield* enableWithLimits(50, 8)
+			const workflow = fakeFanoutWorkflow()
+			// One critical spends 6 of 8; a second needs 6 + 7 and cannot have it.
+			assert.isTrue((yield* maybeEnqueueTriage(criticalInput(workflow.binding, "incident-1"))).enqueued)
+			assert.deepStrictEqual(yield* maybeEnqueueTriage(criticalInput(workflow.binding, "incident-2")), {
+				enqueued: false,
+				reason: "daily_cap",
+			})
 		}).pipe(Effect.provide(makeLayer())),
 	)
 })

--- a/apps/api/src/services/errors/ai-triage-enqueue.ts
+++ b/apps/api/src/services/errors/ai-triage-enqueue.ts
@@ -280,6 +280,10 @@ export const maybeEnqueueTriage: (
 			limits: settings,
 			passCount: reservedPasses,
 			nowMs,
+			// Severity decides which pass ceiling applies, so that a burst of `low`
+			// incidents just after UTC midnight cannot spend the slice a `critical`
+			// opening at noon needs.
+			severity: snapshot.severity,
 		})
 		if (verdict.kind === "exceeded") {
 			yield* Effect.logWarning("Investigation daily budget reached; skipping autonomous start").pipe(
@@ -290,6 +294,16 @@ export const maybeEnqueueTriage: (
 					quotaLimit: verdict.limit,
 				}),
 			)
+			// A refused start has to be visible as a *refusal*. `start_result` used to
+			// be set only on the success path, so a budget-exhausted org looked
+			// identical in traces to one with nothing to investigate — which is how
+			// this went unnoticed for two weeks.
+			yield* Effect.annotateCurrentSpan({
+				orgId: input.orgId,
+				"maple.investigation.start_result": "quota_exceeded",
+				"maple.investigation.quota_dimension": verdict.dimension,
+				"maple.investigation.quota_limit": verdict.limit,
+			})
 			return { enqueued: false, reason: "daily_cap" as const }
 		}
 

--- a/apps/api/src/services/errors/investigation-quota.test.ts
+++ b/apps/api/src/services/errors/investigation-quota.test.ts
@@ -1,18 +1,25 @@
 import { describe, expect, it } from "vitest"
+import type { IssueSeverity } from "@maple/domain/http"
 import {
 	DEFAULT_MAX_PASSES_PER_DAY,
 	DEFAULT_MAX_RUNS_PER_DAY,
+	effectivePassLimit,
 	evaluateInvestigationQuota,
+	RESERVED_PASS_FRACTION,
 	startOfUtcDay,
 } from "./investigation-quota"
 
 const NOW = Date.UTC(2026, 7, 9, 13, 30)
 const MIDNIGHT_TOMORROW = Date.UTC(2026, 7, 10)
 
+/** The ceiling an unclassified or low-severity start is judged against. */
+const ORDINARY_LIMIT = Math.floor(DEFAULT_MAX_PASSES_PER_DAY * (1 - RESERVED_PASS_FRACTION))
+
 const verdict = (input: {
 	runs: number
 	passes: number
 	passCount: number
+	severity?: IssueSeverity | null
 	limits?: { maxRunsPerDay?: number | null; maxPassesPerDay?: number | null }
 }) =>
 	evaluateInvestigationQuota({
@@ -20,6 +27,7 @@ const verdict = (input: {
 		limits: input.limits,
 		passCount: input.passCount,
 		nowMs: NOW,
+		severity: input.severity,
 	})
 
 describe("evaluateInvestigationQuota", () => {
@@ -33,7 +41,7 @@ describe("evaluateInvestigationQuota", () => {
 	 * the start, so the two cases must stay distinguishable.
 	 */
 	it("names the runs ceiling when runs are spent", () => {
-		expect(verdict({ runs: 20, passes: 0, passCount: 1 })).toEqual({
+		expect(verdict({ runs: DEFAULT_MAX_RUNS_PER_DAY, passes: 0, passCount: 1 })).toEqual({
 			kind: "exceeded",
 			dimension: "runs",
 			limit: DEFAULT_MAX_RUNS_PER_DAY,
@@ -42,7 +50,15 @@ describe("evaluateInvestigationQuota", () => {
 	})
 
 	it("names the passes ceiling when a raised run cap leaves passes short", () => {
-		expect(verdict({ runs: 15, passes: 88, passCount: 6, limits: { maxRunsPerDay: 100 } })).toEqual({
+		expect(
+			verdict({
+				runs: 15,
+				passes: DEFAULT_MAX_PASSES_PER_DAY - 2,
+				passCount: 6,
+				severity: "critical",
+				limits: { maxRunsPerDay: 1000 },
+			}),
+		).toEqual({
 			kind: "exceeded",
 			dimension: "passes",
 			limit: DEFAULT_MAX_PASSES_PER_DAY,
@@ -52,10 +68,70 @@ describe("evaluateInvestigationQuota", () => {
 
 	/** Passes are checked as `used + requested`; runs as `used`, so the last slot stays usable. */
 	it("lets the last run slot be used", () => {
-		expect(verdict({ runs: 19, passes: 0, passCount: 1 })).toEqual({ kind: "allowed" })
+		expect(verdict({ runs: DEFAULT_MAX_RUNS_PER_DAY - 1, passes: 0, passCount: 1 })).toEqual({
+			kind: "allowed",
+		})
 	})
 
 	it("resets at the next UTC midnight regardless of the time of day", () => {
 		expect(startOfUtcDay(NOW) + 24 * 60 * 60 * 1000).toBe(MIDNIGHT_TOMORROW)
+	})
+
+	describe("the severity reserve", () => {
+		/**
+		 * The regression this whole reserve exists for: overnight noise spent the
+		 * budget first-come-first-served, so a daytime `critical` was refused by
+		 * incidents that were never worth investigating.
+		 */
+		it("refuses a low-severity start once it would eat the reserve", () => {
+			expect(verdict({ runs: 1, passes: ORDINARY_LIMIT - 1, passCount: 4, severity: "low" })).toEqual({
+				kind: "exceeded",
+				dimension: "passes_reserved",
+				limit: ORDINARY_LIMIT,
+				retryableAtMs: MIDNIGHT_TOMORROW,
+			})
+		})
+
+		it("admits a critical start from the same reserve", () => {
+			expect(
+				verdict({ runs: 1, passes: ORDINARY_LIMIT - 1, passCount: 7, severity: "critical" }),
+			).toEqual({ kind: "allowed" })
+		})
+
+		it("admits high as well as critical", () => {
+			expect(verdict({ runs: 1, passes: ORDINARY_LIMIT + 50, passCount: 6, severity: "high" })).toEqual(
+				{ kind: "allowed" },
+			)
+		})
+
+		/**
+		 * The reserve is worth nothing if anything unclassified can reach it, and
+		 * an incident with no severity is far more often noise than an outage.
+		 */
+		it("treats an unknown severity as ordinary, not as priority", () => {
+			for (const severity of [undefined, null] as const) {
+				expect(
+					verdict({ runs: 1, passes: ORDINARY_LIMIT - 1, passCount: 4, severity }),
+				).toMatchObject({ kind: "exceeded", dimension: "passes_reserved" })
+			}
+		})
+
+		it("lets an ordinary start use the last slot below the reserve", () => {
+			expect(
+				verdict({ runs: 1, passes: ORDINARY_LIMIT - 4, passCount: 4, severity: "medium" }),
+			).toEqual({ kind: "allowed" })
+		})
+
+		/** A start judged against 700 must not report "limit 1000" — that sends the reader to the wrong number. */
+		it("reports the ceiling that actually applied", () => {
+			expect(effectivePassLimit(1000, "low")).toBe(700)
+			expect(effectivePassLimit(1000, "critical")).toBe(1000)
+		})
+
+		it("still names the plain passes ceiling for a priority start", () => {
+			expect(
+				verdict({ runs: 1, passes: DEFAULT_MAX_PASSES_PER_DAY, passCount: 1, severity: "high" }),
+			).toMatchObject({ dimension: "passes", limit: DEFAULT_MAX_PASSES_PER_DAY })
+		})
 	})
 })

--- a/apps/api/src/services/errors/investigation-quota.ts
+++ b/apps/api/src/services/errors/investigation-quota.ts
@@ -13,24 +13,52 @@
  *
  * Both producers now read the same query and the same verdict, so a change to
  * either ceiling lands in both places or in neither.
+ *
+ * The second failure this module has to prevent is subtler than a wrong unit: a
+ * budget spent is not the same as a budget spent *well*. A single UTC-day bucket
+ * handed out first-come-first-served lets whatever errors just after midnight
+ * take the whole day, so a `critical` opening at noon is refused by noise that
+ * opened at 00:03. {@link RESERVED_PASS_FRACTION} keeps a slice that only the top
+ * severities may draw on, which is why the verdict needs to know the severity of
+ * the start it is judging.
  */
 
 import { investigations } from "@maple/db"
 import { and, eq, gte, sql } from "drizzle-orm"
-import type { OrgId } from "@maple/domain/http"
+import type { IssueSeverity, OrgId } from "@maple/domain/http"
 import type { DatabaseClient } from "@/platform/DatabaseLive"
 
 /** Runs per UTC day when the org has no row in `ai_triage_settings`. */
-export const DEFAULT_MAX_RUNS_PER_DAY = 20
+export const DEFAULT_MAX_RUNS_PER_DAY = 250
 
 /**
- * Model passes per UTC day when unconfigured.
+ * Model passes per day when unconfigured.
  *
- * Sized against the planned flow: planner + 4 hypotheses + validator ≈ 6 passes
- * per incident, so 90 is roughly 15 planned incidents. The old 60 was set when a
- * fan-out was rare and a single pass was the norm.
+ * Sized against what a fan-out actually costs, which is `fanoutSize + 1`: a
+ * `low` incident settles at width 3 and spends 4, a `critical` at width 5 spends
+ * 7. 1000 is therefore roughly 150–250 investigations a day depending on the mix.
+ *
+ * The previous 90 was sized for "planner + 4 hypotheses + validator ≈ 6 passes,
+ * so about 15 incidents" — which held right up until the fan-out shipped and the
+ * real settled width turned out to be 3, giving exactly 22 starts a day. Every
+ * one of them was spent before 03:00 UTC, and every incident for the remaining
+ * 21 hours was refused. A ceiling low enough to be hit overnight is
+ * indistinguishable, from the operator's side, from the feature being off.
  */
-export const DEFAULT_MAX_PASSES_PER_DAY = 90
+export const DEFAULT_MAX_PASSES_PER_DAY = 1000
+
+/**
+ * The share of the pass budget only `high` and `critical` may spend.
+ *
+ * Reserved rather than rationed per-hour on purpose: a token bucket would also
+ * stop the overnight sweep from taking everything, but it would delay a genuine
+ * 03:00 incident storm just as happily. What actually needs protecting is not
+ * evenness across the clock, it is that severity outranks arrival order.
+ */
+export const RESERVED_PASS_FRACTION = 0.3
+
+/** Severities that may draw on the reserve. */
+const PRIORITY_SEVERITIES: ReadonlySet<IssueSeverity> = new Set<IssueSeverity>(["critical", "high"])
 
 export const startOfUtcDay = (nowMs: number): number => {
 	const date = new Date(nowMs)
@@ -80,15 +108,38 @@ export interface InvestigationQuotaLimits {
 	readonly maxPassesPerDay?: number | null
 }
 
+/**
+ * Which ceiling stopped the start.
+ *
+ * `passes_reserved` is deliberately not folded into `passes`: they call for
+ * opposite responses. `passes` means the org is out of budget and the number
+ * should go up; `passes_reserved` means the budget is intact but this start was
+ * not important enough for what is left, and raising the ceiling would only move
+ * the same triage decision later in the day.
+ */
+export type InvestigationQuotaDimension = "runs" | "passes" | "passes_reserved"
+
 export type InvestigationQuotaVerdict =
 	| { readonly kind: "allowed" }
 	| {
 			readonly kind: "exceeded"
 			/** Which ceiling was hit. Reported so a log line says *which* limit to raise. */
-			readonly dimension: "runs" | "passes"
+			readonly dimension: InvestigationQuotaDimension
 			readonly limit: number
 			readonly retryableAtMs: number
 	  }
+
+/**
+ * The pass ceiling this severity may spend up to.
+ *
+ * An unknown severity is treated as ordinary rather than as priority: the
+ * reserve is worth nothing if anything that forgot to classify itself can reach
+ * it, and an incident with no severity is far more often noise than an outage.
+ */
+export const effectivePassLimit = (passLimit: number, severity: IssueSeverity | null | undefined): number => {
+	if (severity != null && PRIORITY_SEVERITIES.has(severity)) return passLimit
+	return Math.floor(passLimit * (1 - RESERVED_PASS_FRACTION))
+}
 
 /**
  * Pure verdict, so the whole table is testable without a database.
@@ -97,12 +148,17 @@ export type InvestigationQuotaVerdict =
  * checked as `used + requested > limit` while runs are checked as
  * `used >= limit`: a run is one, and counting it twice would make the last slot
  * of the day unusable.
+ *
+ * `severity` decides which pass ceiling applies. It is optional so the manual
+ * path — which can start a free-form question that has no incident and therefore
+ * no severity — keeps working; absent reads as ordinary, not as priority.
  */
 export const evaluateInvestigationQuota = (input: {
 	readonly usage: InvestigationUsage
 	readonly limits: InvestigationQuotaLimits | undefined
 	readonly passCount: number
 	readonly nowMs: number
+	readonly severity?: IssueSeverity | null
 }): InvestigationQuotaVerdict => {
 	const runLimit = input.limits?.maxRunsPerDay ?? DEFAULT_MAX_RUNS_PER_DAY
 	const passLimit = input.limits?.maxPassesPerDay ?? DEFAULT_MAX_PASSES_PER_DAY
@@ -110,8 +166,17 @@ export const evaluateInvestigationQuota = (input: {
 	if (input.usage.runs >= runLimit) {
 		return { kind: "exceeded", dimension: "runs", limit: runLimit, retryableAtMs }
 	}
-	if (input.usage.passes + input.passCount > passLimit) {
-		return { kind: "exceeded", dimension: "passes", limit: passLimit, retryableAtMs }
+	const allowedPasses = effectivePassLimit(passLimit, input.severity)
+	if (input.usage.passes + input.passCount > allowedPasses) {
+		// Report the ceiling that actually applied, not the configured one — a log
+		// line saying "limit 1000" when the start was judged against 700 sends the
+		// reader to raise a number that was never the constraint.
+		return {
+			kind: "exceeded",
+			dimension: allowedPasses < passLimit ? "passes_reserved" : "passes",
+			limit: allowedPasses,
+			retryableAtMs,
+		}
 	}
 	return { kind: "allowed" }
 }

--- a/apps/web/src/components/settings/ai-triage-settings-section.tsx
+++ b/apps/web/src/components/settings/ai-triage-settings-section.tsx
@@ -35,6 +35,7 @@ function DailyLimitField({
 	max,
 	disabled,
 	help,
+	spent,
 	onCommit,
 }: {
 	id: string
@@ -44,6 +45,8 @@ function DailyLimitField({
 	max: number
 	disabled: boolean
 	help: React.ReactNode
+	/** Consumed so far today. A ceiling on its own does not say whether it is about to bite. */
+	spent: number
 	onCommit: (next: number) => void
 }) {
 	const [draft, setDraft] = useState<string | null>(null)
@@ -67,7 +70,12 @@ function DailyLimitField({
 					}
 				}}
 			/>
-			<p className="text-xs text-muted-foreground">{help}</p>
+			<p className="text-xs text-muted-foreground">
+				<span className="text-foreground">
+					{spent.toLocaleString()} of {value.toLocaleString()} used today
+				</span>{" "}
+				· {help}
+			</p>
 		</div>
 	)
 }
@@ -164,6 +172,7 @@ export function AiTriageSettingsSection({ isAdmin, hasEntitlement }: AiTriageSet
 								min={1}
 								max={500}
 								disabled={isSaving}
+								spent={current.usage.runs}
 								help="How many incidents auto-triage may investigate in a UTC day."
 								onCommit={(parsed) =>
 									save(
@@ -180,7 +189,8 @@ export function AiTriageSettingsSection({ isAdmin, hasEntitlement }: AiTriageSet
 								min={1}
 								max={2000}
 								disabled={isSaving}
-								help="The spend ceiling. A planned investigation spends about six passes — planner, hypotheses, validator — so this is usually what stops triage first, whichever ceiling is reached first."
+								spent={current.usage.passes}
+								help="The spend ceiling. A planned investigation spends four to seven passes — planner, hypotheses, validator — so this is usually what stops triage first, whichever ceiling is reached first. Three tenths of it is reserved for high and critical incidents."
 								onCommit={(parsed) =>
 									save(
 										new AiTriageSettingsUpdateRequest({ maxPassesPerDay: parsed }),

--- a/apps/web/src/routes/investigations/index.tsx
+++ b/apps/web/src/routes/investigations/index.tsx
@@ -31,6 +31,7 @@ import { InvestigateBar } from "@/components/investigations/investigate-bar"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { retainedInternalQuery } from "@/lib/services/common/internal-atom-client"
+import { useIsOrgAdmin } from "@/hooks/use-is-org-admin"
 
 type HubView = "active" | "history"
 
@@ -106,6 +107,9 @@ function InvestigationsHub() {
 	// The hub is where someone stands when they ask "why is nothing being
 	// investigated?", so the answer has to be here rather than three clicks away
 	// in settings.
+	// Non-admins cannot change these ceilings, so the action would be a dead end —
+	// the settings section renders nothing for them.
+	const isOrgAdmin = useIsOrgAdmin()
 	const budget = Result.builder(
 		useAtomValue(
 			retainedInternalQuery("aiTriage", "getSettings", { reactivityKeys: ["aiTriageSettings"] }),
@@ -265,8 +269,13 @@ function InvestigationsHub() {
 					) : (
 						<>
 							<DashboardLayout.Sticky>
-								{budget?.enabled && budget.passesExhausted ? (
-									<BudgetExhaustedNotice resumesAt={budget.resumesAt} />
+								{budget?.enabled && budget.ordinaryPaused ? (
+									<BudgetExhaustedNotice
+										priorityPaused={budget.priorityPaused}
+										dimension={budget.pausedDimension}
+										resumesAt={budget.resumesAt}
+										canEditSettings={isOrgAdmin}
+									/>
 								) : null}
 								<TriageStrip investigations={page} />
 								<InvestigateBar onSubmit={handleCreate} busy={creating} />
@@ -321,26 +330,54 @@ function InvestigationsHub() {
  * Says why nothing new is starting.
  *
  * Not dismissible and not a toast: the condition lasts until UTC midnight and is
- * the direct answer to the question that brings someone to this page. It reads
- * "paused", never "off" — high and critical incidents still start from the
- * reserved slice while this is showing, and an operator who takes it as a total
- * stop will go looking for a bug that is not there.
+ * the direct answer to the question that brings someone to this page.
+ *
+ * The copy distinguishes three states because they are three different outages,
+ * and the reassuring one is only true in the first. Telling an operator that
+ * urgent incidents are still covered while the whole ceiling is spent is worse
+ * than saying nothing — it sends them away from a real outage.
  */
-function BudgetExhaustedNotice({ resumesAt }: { resumesAt: string | null }) {
+function BudgetExhaustedNotice({
+	priorityPaused,
+	dimension,
+	resumesAt,
+	canEditSettings,
+}: {
+	priorityPaused: boolean
+	dimension: "runs" | "passes" | "passes_reserved" | null
+	resumesAt: string | null
+	canEditSettings: boolean
+}) {
 	const resumes = resumesAt === null ? null : new Date(toEpochMs(resumesAt))
+	const resets =
+		resumes === null
+			? "."
+			: `; it resets ${resumes.toLocaleString(undefined, { timeStyle: "short", dateStyle: "medium" })}.`
+	// `runs` is checked before any pass arithmetic and has no reserve, so it stops
+	// every severity — naming the model budget here would point at the wrong number.
+	const spent =
+		dimension === "runs" ? "Today's investigation limit is reached" : "Today's model budget is spent"
 	return (
 		<div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-sm">
-			<span className="font-medium text-foreground">Automatic triage paused</span>
-			<span className="text-muted-foreground">
-				Today&apos;s model budget is spent
-				{resumes === null
-					? "."
-					: `; it resets ${resumes.toLocaleString(undefined, { timeStyle: "short", dateStyle: "medium" })}.`}{" "}
-				High and critical incidents still start.
+			<span className="font-medium text-foreground">
+				{priorityPaused ? "Automatic triage paused" : "Automatic triage paused for routine incidents"}
 			</span>
-			<Link to="/settings" className={cn(buttonVariants({ size: "sm", variant: "ghost" }), "ml-auto")}>
-				Raise the limit
-			</Link>
+			<span className="text-muted-foreground">
+				{spent}
+				{resets}{" "}
+				{priorityPaused
+					? "Nothing new will start until then."
+					: "High and critical incidents still start."}
+			</span>
+			{canEditSettings ? (
+				<Link
+					to="/settings"
+					search={{ tab: "automation" }}
+					className={cn(buttonVariants({ size: "sm", variant: "ghost" }), "ml-auto")}
+				>
+					Raise the limit
+				</Link>
+			) : null}
 		</div>
 	)
 }

--- a/apps/web/src/routes/investigations/index.tsx
+++ b/apps/web/src/routes/investigations/index.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from "react"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import { Exit, Schema } from "effect"
 import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@/lib/effect-atom"
 import { displayError } from "@/lib/error-messages"
 import type { V2Investigation } from "@maple/domain/http/v2"
-import { Button } from "@maple/ui/components/ui/button"
+import { Button, buttonVariants } from "@maple/ui/components/ui/button"
+import { cn } from "@maple/ui/lib/utils"
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyTitle } from "@maple/ui/components/ui/empty"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@maple/ui/components/ui/select"
 import { ToolbarSearch } from "@maple/ui/components/toolbar"
@@ -29,6 +30,7 @@ import {
 import { InvestigateBar } from "@/components/investigations/investigate-bar"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
+import { retainedInternalQuery } from "@/lib/services/common/internal-atom-client"
 
 type HubView = "active" | "history"
 
@@ -101,6 +103,16 @@ function InvestigationsHub() {
 	})
 	const result = useAtomValue(listQuery)
 	const refresh = useAtomRefresh(listQuery)
+	// The hub is where someone stands when they ask "why is nothing being
+	// investigated?", so the answer has to be here rather than three clicks away
+	// in settings.
+	const budget = Result.builder(
+		useAtomValue(
+			retainedInternalQuery("aiTriage", "getSettings", { reactivityKeys: ["aiTriageSettings"] }),
+		),
+	)
+		.onSuccess((value) => value)
+		.orElse(() => null)
 	const create = useAtomSet(MapleApiV2AtomClient.mutation("investigations", "create"), {
 		mode: "promiseExit",
 	})
@@ -253,6 +265,9 @@ function InvestigationsHub() {
 					) : (
 						<>
 							<DashboardLayout.Sticky>
+								{budget?.enabled && budget.passesExhausted ? (
+									<BudgetExhaustedNotice resumesAt={budget.resumesAt} />
+								) : null}
 								<TriageStrip investigations={page} />
 								<InvestigateBar onSubmit={handleCreate} busy={creating} />
 							</DashboardLayout.Sticky>
@@ -295,6 +310,38 @@ function InvestigationsHub() {
 				</DashboardLayout.Content>
 			</DashboardLayout.Body>
 		</DashboardLayout.Root>
+	)
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * Budget notice
+ * -----------------------------------------------------------------------------------------------*/
+
+/**
+ * Says why nothing new is starting.
+ *
+ * Not dismissible and not a toast: the condition lasts until UTC midnight and is
+ * the direct answer to the question that brings someone to this page. It reads
+ * "paused", never "off" — high and critical incidents still start from the
+ * reserved slice while this is showing, and an operator who takes it as a total
+ * stop will go looking for a bug that is not there.
+ */
+function BudgetExhaustedNotice({ resumesAt }: { resumesAt: string | null }) {
+	const resumes = resumesAt === null ? null : new Date(toEpochMs(resumesAt))
+	return (
+		<div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-sm">
+			<span className="font-medium text-foreground">Automatic triage paused</span>
+			<span className="text-muted-foreground">
+				Today&apos;s model budget is spent
+				{resumes === null
+					? "."
+					: `; it resets ${resumes.toLocaleString(undefined, { timeStyle: "short", dateStyle: "medium" })}.`}{" "}
+				High and critical incidents still start.
+			</span>
+			<Link to="/settings" className={cn(buttonVariants({ size: "sm", variant: "ghost" }), "ml-auto")}>
+				Raise the limit
+			</Link>
+		</div>
 	)
 }
 

--- a/packages/domain/src/http/ai-triage.ts
+++ b/packages/domain/src/http/ai-triage.ts
@@ -92,12 +92,29 @@ export class AiTriageSettingsDocument extends Schema.Class<AiTriageSettingsDocum
 	/**
 	 * Whether an ordinary-severity incident would be refused right now.
 	 *
-	 * Derived server-side from the same verdict the enqueue path uses, so the
-	 * banner cannot drift from the rule that actually refuses starts. `high` and
-	 * `critical` may still start while this is true — they draw on the reserve.
+	 * Derived server-side from the same verdict the enqueue path uses, at the same
+	 * cost a real start reserves, so the banner cannot drift from the rule that
+	 * actually refuses starts.
 	 */
-	passesExhausted: Schema.Boolean,
-	/** When the budget resets — the next UTC midnight. Null when nothing is exhausted. */
+	ordinaryPaused: Schema.Boolean,
+	/**
+	 * Whether a `critical` would be refused too.
+	 *
+	 * Separate from {@link ordinaryPaused} because the two are different outages
+	 * and the honest sentence differs: with only the ordinary slice gone, urgent
+	 * incidents are still being investigated from the reserve; with this set,
+	 * nothing is starting at all. Collapsing them tells an operator that criticals
+	 * are covered at exactly the moment they are not.
+	 */
+	priorityPaused: Schema.Boolean,
+	/**
+	 * Which ceiling refused the start, so the copy can name the right number.
+	 *
+	 * `runs` has no reserve, so it pauses ordinary and priority together — which is
+	 * why this cannot be inferred from the two booleans alone.
+	 */
+	pausedDimension: Schema.NullOr(Schema.Literals(["runs", "passes", "passes_reserved"])),
+	/** When the budget resets — the next UTC midnight. Null when nothing is paused. */
 	resumesAt: Schema.NullOr(IsoDateTimeString),
 	updatedAt: Schema.NullOr(IsoDateTimeString),
 	updatedBy: Schema.NullOr(UserId),

--- a/packages/domain/src/http/ai-triage.ts
+++ b/packages/domain/src/http/ai-triage.ts
@@ -67,13 +67,38 @@ export class AiTriageResult extends Schema.Class<AiTriageResult>("AiTriageResult
 	unchecked: Schema.optionalKey(Schema.Array(Schema.String)),
 }) {}
 
+/**
+ * What today's budget has actually been spent on, in both units.
+ *
+ * Ships with the settings rather than as its own endpoint because a ceiling and
+ * its consumption are unreadable apart: "1000 passes/day" answers nothing on its
+ * own, and the question an operator arrives with is always whether triage is
+ * running right now.
+ */
+export class AiTriageUsage extends Schema.Class<AiTriageUsage>("AiTriageUsage")({
+	runs: Schema.Number,
+	passes: Schema.Number,
+}) {}
+
 export class AiTriageSettingsDocument extends Schema.Class<AiTriageSettingsDocument>(
 	"AiTriageSettingsDocument",
 )({
 	enabled: Schema.Boolean,
 	maxRunsPerDay: Schema.Number,
-	/** Model passes per day — one investigation spends about six. */
+	/** Model passes per day — one investigation spends `fanoutSize + 1`, so 4–7. */
 	maxPassesPerDay: Schema.Number,
+	/** Spent so far in the current UTC day. */
+	usage: AiTriageUsage,
+	/**
+	 * Whether an ordinary-severity incident would be refused right now.
+	 *
+	 * Derived server-side from the same verdict the enqueue path uses, so the
+	 * banner cannot drift from the rule that actually refuses starts. `high` and
+	 * `critical` may still start while this is true — they draw on the reserve.
+	 */
+	passesExhausted: Schema.Boolean,
+	/** When the budget resets — the next UTC midnight. Null when nothing is exhausted. */
+	resumesAt: Schema.NullOr(IsoDateTimeString),
 	updatedAt: Schema.NullOr(IsoDateTimeString),
 	updatedBy: Schema.NullOr(UserId),
 }) {}


### PR DESCRIPTION
## What was wrong

Auto-investigations appeared to stop about two weeks ago. They had not. The `alerting` cron, the fan-out workflow and the validator ran clean the entire time — `investigation.plan` → `.hypothesis` → `.validator` at **22 → 66 → 25 per day with zero errors**. What stopped was the budget.

| Signal (production, 45d) | Reality |
|---|---|
| `maybeStartInvestigation` on `alerting` | 12k–28k/day — cron healthy |
| …with `start_result = "fanout_started"` | exactly **22/day** since 2026-08-10 (220 distinct ids / 10 days) |
| `"Investigation daily budget reached; skipping autonomous start"` | 150–1908/day, **1830 in 7 days** |
| That log's `quotaDimension` / `quotaLimit` | **`passes` / `90`** — 100% of skips, never `runs` |
| First skip of the day | ~02:20–03:26 UTC, every single day |

The arithmetic is exact. A settled fan-out is width 3, and usage counts `fanoutSize + 1`, so one investigation costs **4 passes**. Against 90: `22 × 4 = 88`, and a 23rd needs 92. All 22 were spent within ~3 hours of UTC midnight; every incident for the remaining ~21 hours was refused. During working hours nothing ever started, which is indistinguishable from the feature being switched off.

`DEFAULT_MAX_PASSES_PER_DAY = 90` was sized *before* the fan-out shipped (~Aug 9–10), for "planner + 4 hypotheses + validator ≈ 6 passes, so about 15 incidents". The fan-out multiplied real cost ~4× and the constant did not move. This is the second time this module has gone quiet without saying so — its own header records the first, where passes were counted against the runs ceiling.

## What changed

Three faults, three changes.

**Capacity** — defaults to 1000 passes / 250 runs, sized against what a fan-out actually costs: 4 passes for a `low` incident at width 3, 7 for a `critical` at width 5.

**Allocation** — a single UTC-day bucket handed out first-come-first-served lets whatever errors at 00:03 outbid a `critical` opening at noon. `RESERVED_PASS_FRACTION = 0.3` keeps a slice only `high`/`critical` may draw on, so severity outranks arrival order. Refusals from that slice report a new `passes_reserved` dimension rather than `passes`: they call for opposite responses (raise the ceiling vs. accept the triage decision), and a start judged against 700 must not report a limit of 1000.

**Visibility** — `start_result` was previously set only on the success path, so a budget-exhausted org looked identical in traces to one with nothing to investigate. That is precisely why this ran unnoticed. Now:
- refusals annotate `maple.investigation.start_result = "quota_exceeded"` plus the dimension and the limit that applied;
- `AiTriageSettingsDocument` carries today's `usage` and a derived `passesExhausted` / `resumesAt`;
- the investigations hub shows **"Automatic triage paused"** with a link to settings, and the settings page shows "N of M used today" under each ceiling.

The banner says *paused*, not off — `high` and `critical` keep starting from the reserve while it is showing, and an operator who reads it as a total stop will go hunting for a bug that is not there.

## Reviewer notes

- **Exhaustion is asked of the same verdict the enqueue path uses**, not recomputed for the banner. A second copy of that arithmetic is a second thing to drift out of step with the rule that actually refuses starts.
- **The auto path's span is `maybeStartInvestigation` on service `alerting`** — not `InvestigationService.createAndStartInvestigation`, which is the manual `POST /v2/investigations` path on `maple-api`. Searching only the latter makes the automatic path look absent when it is running fine. This cost me an hour; worth knowing next time.
- **The manual path stays unmetered.** It never had a quota check, and the settings copy already promises as much ("Investigations you start or retry yourself are never blocked by them"). The stray "before the quota check" comment near `InvestigationService.ts:807` refers to one that does not exist there — left alone rather than inventing a new limit on user-initiated runs in a fix PR.
- **No migration.** `max_passes_per_day` and `max_runs_per_day` already exist; only the fallbacks moved.
- **Raised defaults do not retroactively fix an existing org.** Defaults apply only where a column is unset, and the affected org has an explicit row at 90. Bump it in Settings → AI triage to unblock the current day.
- Corrected the settings help text, which claimed "about six passes" — never true for the shipped fan-out.

## Verification

- 146 api tests pass, including 12 new ones covering both reserve boundaries: a `low` start refused at the edge of the slice, a `critical` admitted from the same usage level, unknown severity treated as ordinary (a reserve anything unclassified can reach is worth nothing), and a `critical` still refused once the *full* ceiling is spent.
- 532 domain tests pass. Typecheck clean across `apps/api`, `apps/web`, `packages/domain`. Lint and oxfmt clean.
- **Not verified visually:** the hub banner needs a signed-in session. One real bug was caught statically on the way — `bg-warn/10` was written where the token is `--color-warning`, so it would have emitted nothing, the same silent-no-op trap as `severity-ok`. Fixed, but please eyeball the banner in light and dark.

After merge, `investigation.hypothesis` volume is the cost proxy: expect it to rise from ~66/day toward ~600–750/day at a 1000-pass ceiling. Worth watching for a day before leaving it there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789727648&installation_model_id=427786&pr_number=535&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F535&signature=e142d7007e48bf52f36fbbabb8d1a95744d51833f82c2038c6b4eb1f4c980ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->