### PR TITLE
fix(web): fold maple_ span attributes into the Maple Internal section

### DIFF
--- a/apps/local-ui/src/components/log-detail-sheet.tsx
+++ b/apps/local-ui/src/components/log-detail-sheet.tsx
@@ -1,7 +1,7 @@
 // BOUNDARY: This module intentionally carries opaque values; callers decode them before domain use.
 // Intentionally divergent from the web app's `@/components/logs/log-detail-sheet`:
 // that one is wired to effect-atom (trace timeline, correlated logs) and a wider
-// sub-component family local mode doesn't have. The shareable pieces (AttributesTable,
+// sub-component family local mode doesn't have. The shareable pieces (AttributesSection,
 // SeverityBadge, severity/format libs) already come from @maple/ui.
 
 import { useMemo, useState } from "react"
@@ -20,7 +20,7 @@ import {
 	PulseIcon,
 	XmarkIcon,
 } from "@maple/ui/components/icons"
-import { CopyableValue, AttributesTable, ResourceAttributesSection } from "@maple/ui/components/attributes"
+import { CopyableValue, AttributesSection, ResourceAttributesSection } from "@maple/ui/components/attributes"
 import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { cn } from "@maple/ui/lib/utils"
 import type { LocalLog } from "../lib/log-shape"
@@ -266,7 +266,7 @@ function LogAttributesPanel({ log }: { log: LocalLog }) {
 				/>
 			)}
 
-			<AttributesTable
+			<AttributesSection
 				attributes={log.logAttributes}
 				title="Log Attributes"
 				searchQuery={attrSearch}

--- a/apps/local-ui/src/components/span-detail-panel.tsx
+++ b/apps/local-ui/src/components/span-detail-panel.tsx
@@ -1,6 +1,6 @@
 // Intentionally divergent from the web app's `@/components/traces/span-detail-panel`:
 // that one is wired to effect-atom, infra correlation, and timezone preferences local
-// mode doesn't have. The shareable pieces (AttributesTable, SeverityBadge,
+// mode doesn't have. The shareable pieces (AttributesSection, SeverityBadge,
 // HttpSpanLabel, format/colors libs) already come from @maple/ui.
 
 import { useState } from "react"
@@ -12,7 +12,7 @@ import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@maple/ui/components/ui/tabs"
 import { ScrollArea } from "@maple/ui/components/ui/scroll-area"
 import { XmarkIcon, ClockIcon, CircleInfoIcon, CodeIcon } from "@maple/ui/components/icons"
-import { CopyableValue, AttributesTable, ResourceAttributesSection } from "@maple/ui/components/attributes"
+import { CopyableValue, AttributesSection, ResourceAttributesSection } from "@maple/ui/components/attributes"
 import { getCacheInfo, cacheResultStyles } from "@maple/ui/lib/cache"
 import { getServiceColor } from "@maple/ui/lib/colors"
 import { formatDuration } from "@maple/ui/lib/format"
@@ -183,7 +183,7 @@ export function SpanDetailPanel({ span, onClose }: SpanDetailPanelProps) {
 							</div>
 
 							{span.isMissing ? (
-								<AttributesTable
+								<AttributesSection
 									attributes={span.spanAttributes ?? {}}
 									title="Span Attributes"
 									groupByNamespace
@@ -197,7 +197,7 @@ export function SpanDetailPanel({ span, onClose }: SpanDetailPanelProps) {
 								</div>
 							) : (
 								<>
-									<AttributesTable
+									<AttributesSection
 										attributes={detail.data?.spanAttributes ?? span.spanAttributes ?? {}}
 										title="Span Attributes"
 										groupByNamespace

--- a/apps/web/src/components/attributes/attributes-section.test.tsx
+++ b/apps/web/src/components/attributes/attributes-section.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { AttributesSection } from "@/components/attributes"
+
+afterEach(() => {
+	cleanup()
+})
+
+/**
+ * The gateway stamps `maple_*` keys on spans as well as resources (`maple_ai.*`
+ * since the AI-session work), so the "Maple Internal" fold has to key off the
+ * prefix wherever an attribute map is rendered — not off which map it is.
+ */
+describe("AttributesSection", () => {
+	it("folds maple_ keys out of the main table into Maple Internal", () => {
+		render(
+			<AttributesSection
+				title="Span Attributes"
+				attributes={{
+					"http.request.method": "GET",
+					"maple_ai.vendor.id": "anthropic",
+					"maple_ai.session.id": "sess_123",
+				}}
+			/>,
+		)
+
+		expect(screen.getByText("Maple Internal (2)")).toBeTruthy()
+		// Collapsed by default: the internal keys are not in the open table.
+		expect(screen.queryByText("maple_ai.vendor.id")).toBeNull()
+		expect(screen.getByText("http.request.method")).toBeTruthy()
+	})
+
+	it("renders no fold when nothing is internal", () => {
+		render(<AttributesSection title="Span Attributes" attributes={{ "http.route": "/v1" }} />)
+
+		expect(screen.queryByText(/Maple Internal/)).toBeNull()
+	})
+})

--- a/apps/web/src/components/attributes/index.ts
+++ b/apps/web/src/components/attributes/index.ts
@@ -4,6 +4,7 @@
 export {
 	CopyableValue,
 	AttributesTable,
+	AttributesSection,
 	ResourceAttributesSection,
 	tryParseJson,
 } from "@maple/ui/components/attributes"

--- a/apps/web/src/components/logs/log-attributes-panel.tsx
+++ b/apps/web/src/components/logs/log-attributes-panel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { SearchInput } from "@maple/ui/components/ui/search-input"
-import { AttributesTable, ResourceAttributesSection } from "@/components/attributes"
+import { AttributesSection, ResourceAttributesSection } from "@/components/attributes"
 import type { Log } from "@/api/warehouse/logs"
 
 interface LogAttributesPanelProps {
@@ -27,7 +27,7 @@ export function LogAttributesPanel({ log }: LogAttributesPanelProps) {
 				/>
 			)}
 
-			<AttributesTable
+			<AttributesSection
 				attributes={log.logAttributes}
 				title="Log Attributes"
 				searchQuery={attrSearch}

--- a/apps/web/src/components/traces/span-detail-panel.tsx
+++ b/apps/web/src/components/traces/span-detail-panel.tsx
@@ -21,7 +21,7 @@ import { ServiceDot } from "@maple/ui/components/service-dot"
 import type { SpanNode, SpanDetailResult } from "@/api/warehouse/traces"
 import { disabledResultAtom } from "@/lib/services/atoms/disabled-result-atom"
 import { getSpanDetailResultAtom, listLogsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
-import { CopyableValue, AttributesTable, ResourceAttributesSection } from "@/components/attributes"
+import { CopyableValue, AttributesSection, ResourceAttributesSection } from "@/components/attributes"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { formatTimestampInTimezone } from "@/lib/timezone-format"
 import { HttpSpanLabel } from "@maple/ui/components/traces/http-span-label"
@@ -437,7 +437,7 @@ export function SpanDetailPanel({
 							{/* Span + Resource Attributes — loaded lazily for the
 							    selected span (see detailResult above) */}
 							{span.isMissing ? (
-								<AttributesTable
+								<AttributesSection
 									attributes={span.spanAttributes ?? {}}
 									title="Span Attributes"
 								/>
@@ -453,7 +453,7 @@ export function SpanDetailPanel({
 									))
 									.onError(() => (
 										<>
-											<AttributesTable
+											<AttributesSection
 												attributes={span.spanAttributes ?? {}}
 												title="Span Attributes"
 											/>
@@ -464,7 +464,7 @@ export function SpanDetailPanel({
 									))
 									.onSuccess((detail) => (
 										<>
-											<AttributesTable
+											<AttributesSection
 												attributes={detail.spanAttributes}
 												title="Span Attributes"
 											/>

--- a/packages/ui/src/components/attributes/attributes-table.tsx
+++ b/packages/ui/src/components/attributes/attributes-table.tsx
@@ -220,7 +220,13 @@ export function AttributesTable({ attributes, title, searchQuery, groupByNamespa
 	)
 }
 
-function partitionResourceAttributes(attrs: Record<string, string>) {
+/**
+ * Splits Maple's own attributes (the `maple_` namespace the gateway stamps —
+ * `maple_org_id`, `maple_ai.*`, …) out of whatever the instrumentation sent.
+ * They're useful when you go looking, and noise when you don't, so they get
+ * their own collapsed section instead of a row among the customer's own keys.
+ */
+function partitionInternalAttributes(attrs: Record<string, string>) {
 	const standard: Record<string, string> = {}
 	const internal: Record<string, string> = {}
 	for (const [key, value] of Object.entries(attrs)) {
@@ -233,23 +239,26 @@ function partitionResourceAttributes(attrs: Record<string, string>) {
 	return { standard, internal }
 }
 
-export function ResourceAttributesSection({
+/**
+ * An `AttributesTable` with the `maple_` keys folded into a collapsed
+ * "Maple Internal" table beneath it. Use this anywhere a raw attribute map from
+ * the pipeline is shown — span, resource, or log — since any of them can carry
+ * gateway-stamped keys.
+ */
+export function AttributesSection({
 	attributes,
+	title,
 	searchQuery,
 	groupByNamespace,
-}: {
-	attributes: Record<string, string>
-	searchQuery?: string
-	groupByNamespace?: boolean
-}) {
-	const { standard, internal } = partitionResourceAttributes(attributes)
+}: AttributesTableProps) {
+	const { standard, internal } = partitionInternalAttributes(attributes)
 	const internalCount = Object.keys(internal).length
 
 	return (
 		<div className="space-y-2">
 			<AttributesTable
 				attributes={standard}
-				title="Resource Attributes"
+				title={title}
 				searchQuery={searchQuery}
 				groupByNamespace={groupByNamespace}
 			/>
@@ -274,5 +283,20 @@ export function ResourceAttributesSection({
 				</Collapsible>
 			)}
 		</div>
+	)
+}
+
+export function ResourceAttributesSection({
+	attributes,
+	searchQuery,
+	groupByNamespace,
+}: Omit<AttributesTableProps, "title">) {
+	return (
+		<AttributesSection
+			attributes={attributes}
+			title="Resource Attributes"
+			searchQuery={searchQuery}
+			groupByNamespace={groupByNamespace}
+		/>
 	)
 }

--- a/packages/ui/src/components/attributes/index.ts
+++ b/packages/ui/src/components/attributes/index.ts
@@ -1,4 +1,10 @@
-export { CopyableValue, AttributesTable, ResourceAttributesSection, tryParseJson } from "./attributes-table"
+export {
+	CopyableValue,
+	AttributesTable,
+	AttributesSection,
+	ResourceAttributesSection,
+	tryParseJson,
+} from "./attributes-table"
 export type { AttributesTableProps } from "./attributes-table"
 export { CollapsibleJsonValue } from "./json-value"
 export { AttributesProvider, useAttributesConfig } from "./context"


### PR DESCRIPTION
## Summary

The span details pane rendered the gateway's own `maple_ai.*` attributes inline, among the attributes the instrumentation sent.

The "Maple Internal" fold was built on the **resource** attributes section only (`partitionResourceAttributes`). The AI-session work stamps `maple_ai.vendor.id` / `maple_ai.session.id` at the **span** level — they are per-call facts, so they cannot live on the resource — and span attributes rendered through a plain `AttributesTable` with no partition.

## Changes

- `packages/ui/src/components/attributes/attributes-table.tsx` — generalize the partition into `AttributesSection`: same `maple_` prefix rule, same collapsed "Maple Internal (n)" table, now parameterized by title. `ResourceAttributesSection` becomes a thin wrapper over it, so resource behaviour is unchanged.
- Span attributes use it in both panes: `apps/web/src/components/traces/span-detail-panel.tsx` (all three branches — missing-span, error fallback, loaded) and `apps/local-ui/src/components/span-detail-panel.tsx`.
- Log attribute panels use it too, so any attribute map off the pipeline gets the same treatment wherever gateway-stamped keys can appear. The log row chips already skip `maple_` via `SKIP_PREFIXES`; this makes the panel consistent with them.

## Testing

- New `apps/web/src/components/attributes/attributes-section.test.tsx` (2 tests, passing): `maple_ai.*` keys leave the main table and land in a collapsed "Maple Internal (2)" fold; no fold renders when nothing is internal.
- `@maple/web` typecheck clean. `@maple/ui` / `@maple/local-ui` typecheck fails locally only on `TS2307: Cannot find module '@tanstack/charts'` across `charts/**` and `plot/**` — a missing local install, pre-existing and untouched by this change.
- Not verified against the running UI: the local stack (Docker, Tinybird local, collector) was down, so the jsdom test covers the partition logic instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789728611&installation_model_id=427786&pr_number=536&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F536&signature=dba073c66ca625f3ac0f1026b39a9c49f587b774fd370ab78ce3bd8c280d446a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->