### PR TITLE
fix(api): give the v2 route harness the LiveActivitiesService its groups need

### DIFF
--- a/apps/api/src/routes/v2/v2-test-support.ts
+++ b/apps/api/src/routes/v2/v2-test-support.ts
@@ -10,6 +10,7 @@ import { ErrorIssueReadModelsService } from "@/services/errors/ErrorIssueReadMod
 import { IngestAttributeMappingService } from "@/services/org/IngestAttributeMappingService"
 import { InvestigationService } from "@/services/errors/InvestigationService"
 import { OrganizationService } from "@/services/org/OrganizationService"
+import { LiveActivitiesService } from "@/services/push/LiveActivitiesService"
 import { MobileDevicesService } from "@/services/push/MobileDevicesService"
 import { OrgIngestKeysService } from "@/services/org/OrgIngestKeysService"
 import { RecommendationIssueService } from "@/services/errors/RecommendationIssueService"
@@ -78,9 +79,11 @@ export const AllV2GroupLayersLive = Layer.mergeAll(
 	HttpV2InvestigationsLive,
 	HttpV2AnomaliesLive,
 	HttpV2OrganizationLive,
-	// Real service, no stub: it needs only the Database every harness already
-	// provides, and its own route test is the only place that calls it.
-	HttpV2MobileDevicesLive.pipe(Layer.provide(MobileDevicesService.layer)),
+	// Real services, no stubs: they need only the Database every harness already
+	// provides, and their own route tests are the only places that call them.
+	HttpV2MobileDevicesLive.pipe(
+		Layer.provide(Layer.mergeAll(MobileDevicesService.layer, LiveActivitiesService.layer)),
+	),
 	HttpV2SessionReplaysLive,
 	HttpV2TracesLive,
 	HttpV2LogsLive,


### PR DESCRIPTION
`main` is red on both API shards. The mobile-devices group started requiring
`LiveActivitiesService` when Live Activities landed, but the shared v2 route
harness only provided `MobileDevicesService`.

Every v2 route test builds the whole group set, so one missing service took out
~150 tests across alerts, api_keys, config-resources, integrations and the
alchemy provider integration — none of which touch push. They all failed with:

```
Service not found: @maple/api/services/push/LiveActivitiesService
```

It needs only the Database the harness already provides, so it is wired for
real alongside `MobileDevicesService` rather than stubbed.

Verified on a clean checkout of `main` plus this commit: the full API suite
passes, 2180 tests, 174 files.

This is the tail of #538, which merged about eight seconds after these shards
went red.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789735310&installation_model_id=427786&pr_number=539&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F539&signature=998900b665d3e54a5da012b2243ec95ce06e7cea322e61f184957a911eab5e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->