### PR TITLE
test(api): run the integration SQL catalog through the ClickHouse e2e sweep

### DIFF
--- a/apps/api/src/services/warehouse/sql-catalog.clickhouse.e2e.test.ts
+++ b/apps/api/src/services/warehouse/sql-catalog.clickhouse.e2e.test.ts
@@ -9,11 +9,18 @@
 // `DESCRIBE (SELECT …)` type-checks without reading a row, so this is cheap:
 // ~80 unique shapes, a few seconds on top of a job that already boots the
 // server and replays the migrations.
+//
+// Covers both catalogs: `@maple/query-engine`'s own (pipes, query specs, core
+// builders) and `@maple/query-engine-integrations`' (Cloudflare, PlanetScale,
+// AI builders), which lives with those builders because the core package must
+// not depend on the integrations package.
 
 import { afterAll, assert, beforeAll, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
+import type { CompiledQuery } from "@maple/query-engine/ch"
 import { collectSqlCatalog, dedupeByFingerprint } from "@maple/query-engine/sql-catalog"
 import { normalizeSqlForClickHouseClient } from "@maple/query-engine/execution"
+import { collectIntegrationCatalog } from "@maple/query-engine-integrations/catalog"
 import {
 	applyRealMigrations,
 	clickhouseE2eEnabled,
@@ -35,8 +42,23 @@ const IDENTITY_COLUMN_ALLOWLIST: ReadonlySet<string> = new Set([])
 
 const database = uniqueDatabase("maple_sql_catalog_e2e")
 
-/** Deduped so N fixtures over one shape cost one analyzer round trip. */
-const catalog = dedupeByFingerprint(collectSqlCatalog())
+/** The subset of a catalog entry the sweep reads — the core and integration
+ *  catalogs are separate types (`@maple/query-engine` must not import the
+ *  integrations package), but both satisfy this shape. */
+interface SweepEntry {
+	readonly id: string
+	readonly sql: string
+	readonly compiled?: CompiledQuery<unknown>
+	readonly sampleValues?: Readonly<Record<string, unknown>>
+}
+
+/** Core catalog deduped so N fixtures over one shape cost one analyzer round
+ *  trip; the integration catalog has no fingerprints and every fixture is a
+ *  distinct shape, so it is appended as-is. */
+const catalog: ReadonlyArray<SweepEntry> = [
+	...dedupeByFingerprint(collectSqlCatalog()),
+	...collectIntegrationCatalog(),
+]
 
 describe.skipIf(!clickhouseE2eEnabled)("SQL catalog analyzer sweep", () => {
 	beforeAll(async () => {

--- a/packages/query-engine-integrations/src/catalog.ts
+++ b/packages/query-engine-integrations/src/catalog.ts
@@ -4,7 +4,9 @@
 // import this package (the dependency runs one way), so the fixtures live with
 // the builders instead. Same contract as the core catalog — compile the REAL
 // exported builder with production-shaped params, so every SQL shape the
-// product can emit is enumerated and snapshotted.
+// product can emit is enumerated and snapshotted. The ClickHouse e2e sweep in
+// apps/api (`sql-catalog.clickhouse.e2e.test.ts`) analyzes these fixtures
+// against the real migrations alongside the core catalog.
 
 import { compile, compileUnion, type CompiledQuery } from "@maple/query-engine/ch"
 import * as CH from "./index"


### PR DESCRIPTION
## Summary

`collectIntegrationCatalog()` from `@maple/query-engine-integrations/catalog` was only consumed by the integrations package's own unit tests — the Cloudflare/PlanetScale/AI fixtures never ran through the real-ClickHouse analyzer sweep, while a comment in `catalog.ts` claimed the sweep's quoted/unquoted 64-bit decode assertion covered them.

- Append the integration catalog to the sweep's entry list in `sql-catalog.clickhouse.e2e.test.ts`. The two catalogs are separate types (the core package must not import the integrations package), but both satisfy the small structural shape the sweep reads, captured as a local `SweepEntry` interface. The core catalog is still deduped by fingerprint; the 12 integration fixtures are distinct shapes and are appended as-is.
- Document the wiring in `catalog.ts`'s header, which makes the existing ai-sessions row-schema comment accurate rather than aspirational.

## Testing

- Ran the sweep against a real ClickHouse (`CLICKHOUSE_E2E=1`): 157 tests passed, and the verbose reporter confirms all 12 `builder:*` integration fixtures executed, including both 64-bit wire-shape decode passes for the AI-session fixtures that carry row schemas.
- Integrations package unit tests: 287 passed.
- Repo typecheck green (40/40 turbo tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789765940&installation_model_id=427786&pr_number=544&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F544&signature=411db3b1cb3712be44fda963c53622c8b16073b0b852df65859bc8a1e839c07b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->