### PR TITLE
fix(ios): pin the SDK build that reports where a request's time went

### DIFF
--- a/apps/ios/Packages/MapleAPI/Package.resolved
+++ b/apps/ios/Packages/MapleAPI/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MapleTechLabs/maple-swift",
       "state" : {
-        "revision" : "84d33eddbd7334843ea6455cfd1f65353e44afee",
-        "version" : "0.2.0"
+        "revision" : "96e44a0e136fa87339131a45363c2427fa804ed7",
+        "version" : "0.2.1"
       }
     },
     {

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -39,7 +39,7 @@ packages:
     # target called Maple.
     MapleSwift:
         url: https://github.com/MapleTechLabs/maple-swift
-        exactVersion: 0.2.0
+        exactVersion: 0.2.1
 
 settings:
     base:


### PR DESCRIPTION
Bumps `maple-swift` to **0.2.1**, which records `URLSession`'s connection phases on client spans.

## Why

The mobile screens load slowly and `maple-api` is not the reason. Joining 241 iOS client spans to their own `maple-api` server span in the same trace:

| Phase | p50 | p95 |
|---|---|---|
| Before the server | **404 ms** | **1,148 ms** |
| Server work | 233 ms | 857 ms |
| After the server responded | 97 ms | 759 ms |

Two thirds of every request happens outside the API. Home's five requests do fan out in parallel — that part is fine — but in trace `85db338c…` the app held two *completed* responses for **12.6 s**, both ending at the same instant, long after the API had answered them in ~220 ms.

Contention is implicated: a request with no concurrent peers has an 89 ms post-server tail; with peers it is 496 ms p50 / 5,820 ms p95, and the request's own payload size does not explain the difference (~18 KB in every bucket).

## Why the traces could not say more

The SDK's relay delegate implemented `didReceive` / `didCompleteWithError` but not `didFinishCollecting`, so `URLSessionTaskMetrics` — which `URLSession` had been measuring all along — was built and discarded. That is why 404 ms of pre-server time had no attribution.

0.2.1 keeps them. The gap now resolves into `maple.http.{queued,dns,connect,tls,request,ttfb,response}_ms`, plus `maple.http.connection.reused` and semconv's `http.request.resend_count` and `network.protocol.{name,version}`.

`maple.http.queued_ms` vs `response_ms` is what separates "connection setup" from "body transfer stuck behind something", which is the open question.

## Scope

Instrument only — no app-side behaviour changes. The fix follows the numbers this produces rather than the current best guess at them.

Two things found along the way, left for separate changes:

- `ui.screen` spans measure time-on-screen (max observed: 11 hours) and sit in the same latency rollup as real operations, which is why `list_services` reports maple-ios P95 = 12.62 s. That number is currently meaningless.
- Home fetches `/alerts/rules?limit=100` (42 KB) and `/error_issues?limit=100` (39 KB), where the issues response is used only to compute two integers. Trimming it needs a count endpoint on the API side.

## Verification

- `xcodegen generate` + `xcodebuild -scheme Maple` against 0.2.1: **BUILD SUCCEEDED**
- maple-swift: `MapleTracingTests` 60 passed (5 new), `MapleReplayTests` 80 passed

`project.yml` is the only durable pin — the generated `.pbxproj` and its `Package.resolved` are gitignored.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789814221&installation_model_id=427786&pr_number=549&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F549&signature=5db984752daf1ea3d7e51127b7493d21dca52ad0f8ab943bf7f39472407adf51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->