### PR TITLE
fix(ios): join write requests and screen loads to the traces they belong to

### DIFF
--- a/apps/ios/Maple/Telemetry/Telemetry.swift
+++ b/apps/ios/Maple/Telemetry/Telemetry.swift
@@ -193,8 +193,10 @@ private struct ScreenSpanModifier: ViewModifier {
 				// win — it is what the session transcript is built from.
 				span?.end()
 				span = Maple.trackScreen(name)
+				Telemetry.Visit.began(name, span: span)
 			}
 			.onDisappear {
+				Telemetry.Visit.ended(name, span: span)
 				span?.end()
 				span = nil
 			}
@@ -211,7 +213,9 @@ private struct ScreenSpanModifier: ViewModifier {
 				// never reach `didEnterBackground`, so the span is still running and
 				// must not be replaced.
 				guard phase == .active, let current = span, current.hasEnded else { return }
+				Telemetry.Visit.ended(name, span: current)
 				span = Maple.trackScreen(name)
+				Telemetry.Visit.began(name, span: span)
 			}
 	}
 }
@@ -360,6 +364,42 @@ extension Telemetry {
 			pending?.span.setAttribute(Key.pushOrganizationSwitched, true)
 		}
 	}
+
+	/// The open `ui.screen` span for a screen, so a load can hang under the visit
+	/// that caused it.
+	///
+	/// `trackScreen` hands the span back but nothing carries it: the SDK starts it
+	/// without making it ambient, and rightly so — a span that lives for the whole
+	/// visit is not a scope anything can nest inside. The result was that every
+	/// `ui.screen` arrived as a childless root while the load it caused sat in a
+	/// trace of its own. Registering by name is the same shape `PushOpen` already
+	/// uses to parent a load to the tap that asked for it.
+	@MainActor
+	enum Visit {
+		private static var spans: [String: Span] = [:]
+
+		static func began(_ screen: String, span: Span?) {
+			guard let span else { return }
+			spans[screen] = span
+		}
+
+		static func ended(_ screen: String, span: Span?) {
+			guard let span, spans[screen] === span else { return }
+			spans.removeValue(forKey: screen)
+		}
+
+		/// A span the SDK closed behind our back — backgrounding closes every open
+		/// screen span — is not a parent: a child that starts after its parent ended
+		/// draws as a bar hanging outside the one above it.
+		static func parent(for screen: String) -> Span? {
+			guard let span = spans[screen] else { return nil }
+			guard !span.hasEnded else {
+				spans.removeValue(forKey: screen)
+				return nil
+			}
+			return span
+		}
+	}
 }
 
 // MARK: - Screen loads
@@ -387,7 +427,10 @@ extension Telemetry {
 		]
 		if let organizationId { attributes[Key.organizationId] = .string(organizationId) }
 
-		let state = await withParent(PushOpen.parent(for: screen)) {
+		// A tapped notification owns the story when there is one — tap → load →
+		// requests. Otherwise the visit does.
+		let parent = PushOpen.parent(for: screen) ?? Visit.parent(for: screen)
+		let state = await withParent(parent) {
 			await Telemetry.span(Name.screenLoad, attributes: attributes) { span in
 				let state = await body()
 				record(state, on: span)

--- a/apps/ios/Packages/MapleAPI/Package.resolved
+++ b/apps/ios/Packages/MapleAPI/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MapleTechLabs/maple-swift",
       "state" : {
-        "revision" : "39cf7c0b01db01588a89ee0e7daf1b378d89e6d6",
-        "version" : "0.3.1"
+        "revision" : "23c66901415564154e56a88f9d70263d86438ea3",
+        "version" : "0.3.3"
       }
     },
     {

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -39,7 +39,7 @@ packages:
     # target called Maple.
     MapleSwift:
         url: https://github.com/MapleTechLabs/maple-swift
-        exactVersion: 0.3.1
+        exactVersion: 0.3.3
 
 settings:
     base:


### PR DESCRIPTION
`push.sync` rendered as a single childless root span — no HTTP child, no `maple-api` server span. Two separate causes, both fixed here.

## Writes were never traced

The Swift SDK's `URLProtocol` interceptor declined any request with an `httpBodyStream`, on the theory that it only skipped streamed uploads. Foundation hands a `URLProtocol` **every** body as a stream — `httpBody`, `from: Data`, `fromFile:` and a delegate-fed stream alike — so it skipped every POST, PUT and PATCH the app makes: no client span, and no `traceparent`, which left the API's server span in a trace of its own.

Three days of production traffic, org-scoped:

| Span | Count | Roots |
|---|---|---|
| `GET` (Client) | 893 | 331 |
| `POST` (Client) | **0** | — |
| `push.sync` | 19 | 19, all childless |

Fixed in maple-swift 0.3.3 (the relay now carries the body across, preserving the app's framing); this bumps the pin.

## `ui.screen` was never a parent

`trackScreen` returns the span but nothing carries it, and the SDK is right not to make it ambient — a span that runs for the whole visit is not a scope anything can nest inside. So all 347 `ui.screen` spans arrived as childless roots while the load each one caused sat in its own trace.

`Telemetry.Visit` registers the open span by screen name and `screenLoad` hangs under it — the same shape `PushOpen` already uses to parent a load to the notification tap that asked for it. A tapped notification still wins when there is one, and a span the SDK closed on backgrounding is skipped rather than adopted as a parent that ended before its child began.

## Verification

- 107 `MapleTracingTests` pass, including new cases asserting `traceparent` **and** byte-identical bodies on what actually left the process, one per URLSession body API.
- `xcodebuild build -scheme Maple` succeeds against 0.3.3.
- Post-merge check: `POST` Client spans should appear with `roots = 0`, and `push.sync` traces should contain a `maple-api` `http.server POST` span.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789921182&installation_model_id=427786&pr_number=561&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F561&signature=1900d8ee2aa3a261a0e532b04260db94c2ff6436e6360972003098836f4fbc49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->