### PR TITLE
feat(analytics): Events card + eventName filter on Web Analytics

### DIFF
--- a/apps/api/src/routes/internal/query-engine.http.ts
+++ b/apps/api/src/routes/internal/query-engine.http.ts
@@ -61,6 +61,7 @@ import {
 	WebAnalyticsTimeseriesResponse,
 	WebAnalyticsPageviewsResponse,
 	WebAnalyticsPagesResponse,
+	WebAnalyticsEventsResponse,
 	WebAnalyticsBreakdownsResponse,
 	CommitSha,
 	FingerprintHash,
@@ -1690,6 +1691,24 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleInternalApi, "query
 							host: String(row.host),
 							pagePath: String(row.pagePath),
 							pageViews: Number(row.pageViews) || 0,
+							sessions: Number(row.sessions) || 0,
+						})),
+					})
+				}),
+			)
+			.handle("webAnalyticsEvents", ({ payload }) =>
+				Effect.gen(function* () {
+					const tenant = yield* CurrentTenant.Context
+					const rows = yield* withWebEventsFallback(
+						(t, pl) => runQuery(Queries.webAnalyticsEvents, t, pl),
+						(t, pl) => runQuery(Queries.webAnalyticsEventsRaw, t, pl),
+						tenant,
+						payload,
+					)
+					return new WebAnalyticsEventsResponse({
+						data: rows.map((row) => ({
+							name: String(row.name),
+							events: Number(row.events) || 0,
 							sessions: Number(row.sessions) || 0,
 						})),
 					})

--- a/apps/api/src/services/warehouse/web-analytics-parity.clickhouse.e2e.test.ts
+++ b/apps/api/src/services/warehouse/web-analytics-parity.clickhouse.e2e.test.ts
@@ -285,6 +285,9 @@ const FILTER_CASES: ReadonlyArray<{ readonly label: string; readonly filters: CH
 	// narrow the page-view source through a subquery.
 	{ label: "replays-dimension", filters: { country: "DE" } },
 	{ label: "replays-dimension+path", filters: { country: "DE", pagePath: "/pricing" } },
+	// The event semi-join, alone and composed with a page filter.
+	{ label: "event", filters: { eventName: "signup_started" } },
+	{ label: "event+path", filters: { eventName: "signup_started", pagePath: "/pricing" } },
 	{
 		label: "all-dimensions",
 		filters: {
@@ -298,6 +301,7 @@ const FILTER_CASES: ReadonlyArray<{ readonly label: string; readonly filters: CH
 			language: "en-US",
 			utmSource: "twitter",
 			visitorType: "new",
+			eventName: "signup_started",
 		},
 	},
 ]
@@ -324,6 +328,10 @@ const QUERIES: ReadonlyArray<{
 	{
 		name: "webAnalyticsPages",
 		compile: (filters) => CH.compile(CH.webAnalyticsPagesQuery({ ...filters, limit: 100 }), window).sql,
+	},
+	{
+		name: "webAnalyticsEvents",
+		compile: (filters) => CH.compile(CH.webAnalyticsEventsQuery({ ...filters, limit: 100 }), window).sql,
 	},
 	{
 		name: "webAnalyticsBreakdowns",

--- a/apps/web/src/api/warehouse/web-analytics.ts
+++ b/apps/web/src/api/warehouse/web-analytics.ts
@@ -1,4 +1,4 @@
-// One filter schema shared by all five queries, so the /analytics route builds a
+// One filter schema shared by all six queries, so the /analytics route builds a
 // single filter object and every panel narrows identically. See
 // packages/query-engine/src/ch/queries/web-analytics.ts for why the page reads
 // two tables and what each half covers.
@@ -6,6 +6,7 @@
 import { Effect, Schema } from "effect"
 import {
 	WebAnalyticsBreakdownsRequest,
+	WebAnalyticsEventsRequest,
 	WebAnalyticsPagesRequest,
 	WebAnalyticsPageviewsRequest,
 	WebAnalyticsSummaryRequest,
@@ -27,6 +28,7 @@ const WebAnalyticsFilterFields = {
 	utmMedium: Schema.optional(Schema.String),
 	utmCampaign: Schema.optional(Schema.String),
 	visitorType: Schema.optional(Schema.Literals(["new", "returning"])),
+	eventName: Schema.optional(Schema.String),
 } as const
 
 const TimeWindowFields = {
@@ -53,6 +55,12 @@ const WebAnalyticsPagesInputSchema = Schema.Struct({
 	limit: Schema.optional(PositiveInt),
 })
 
+const WebAnalyticsEventsInputSchema = Schema.Struct({
+	...TimeWindowFields,
+	...WebAnalyticsFilterFields,
+	limit: Schema.optional(PositiveInt),
+})
+
 const WebAnalyticsBreakdownsInputSchema = Schema.Struct({
 	...TimeWindowFields,
 	...WebAnalyticsFilterFields,
@@ -62,6 +70,7 @@ const WebAnalyticsBreakdownsInputSchema = Schema.Struct({
 export type GetWebAnalyticsSummaryInput = (typeof WebAnalyticsSummaryInputSchema)["Encoded"]
 export type GetWebAnalyticsTimeseriesInput = (typeof WebAnalyticsTimeseriesInputSchema)["Encoded"]
 export type GetWebAnalyticsPagesInput = (typeof WebAnalyticsPagesInputSchema)["Encoded"]
+export type GetWebAnalyticsEventsInput = (typeof WebAnalyticsEventsInputSchema)["Encoded"]
 export type GetWebAnalyticsBreakdownsInput = (typeof WebAnalyticsBreakdownsInputSchema)["Encoded"]
 
 export interface WebAnalyticsSummary {
@@ -112,6 +121,13 @@ export interface WebAnalyticsPage {
 	host: string
 	pagePath: string
 	pageViews: number
+	sessions: number
+}
+
+/** One `track()` event name, with firings and the distinct sessions that fired it. */
+export interface WebAnalyticsEvent {
+	name: string
+	events: number
 	sessions: number
 }
 
@@ -233,6 +249,29 @@ const getWebAnalyticsPagesEffect = Effect.fn("QueryEngine.getWebAnalyticsPages")
 	)
 
 	return { data: result.data satisfies ReadonlyArray<WebAnalyticsPage> }
+})
+
+export function getWebAnalyticsEvents({ data }: { data: GetWebAnalyticsEventsInput }) {
+	return getWebAnalyticsEventsEffect({ data })
+}
+
+const getWebAnalyticsEventsEffect = Effect.fn("QueryEngine.getWebAnalyticsEvents")(function* ({
+	data,
+}: {
+	data: GetWebAnalyticsEventsInput
+}) {
+	const input = yield* decodeInput(WebAnalyticsEventsInputSchema, data, "getWebAnalyticsEvents")
+
+	const result = yield* runWarehouseQuery("webAnalyticsEvents", () =>
+		Effect.gen(function* () {
+			const client = yield* MapleInternalAtomClient
+			return yield* client.queryEngine.webAnalyticsEvents({
+				payload: new WebAnalyticsEventsRequest(input),
+			})
+		}),
+	)
+
+	return { data: result.data satisfies ReadonlyArray<WebAnalyticsEvent> }
 })
 
 export function getWebAnalyticsBreakdowns({ data }: { data: GetWebAnalyticsBreakdownsInput }) {

--- a/apps/web/src/components/analytics/analytics-breakdown-panel.tsx
+++ b/apps/web/src/components/analytics/analytics-breakdown-panel.tsx
@@ -65,6 +65,11 @@ export interface BreakdownDimension {
 	 * icon follows from the name keep using `analyticsRowIcon`.
 	 */
 	readonly renderIcon?: (row: BreakdownRow) => ReactNode
+	/**
+	 * Column head for `views`, when the dimension carries it. Defaults to "Views";
+	 * the Events dimension ranks by firings and says so.
+	 */
+	readonly viewsLabel?: string
 }
 
 type SortKey = "name" | "count" | "views"
@@ -152,6 +157,7 @@ export function AnalyticsBreakdownPanel({
 	// have them, sessions otherwise — so the bar always tracks the number the
 	// rows are actually ordered by.
 	const hasViews = dimension.rows.some((row) => row.views !== undefined)
+	const viewsLabel = dimension.viewsLabel ?? "Views"
 
 	const rows = useMemo(() => {
 		const total = dimension.rows.reduce((sum, row) => sum + (hasViews ? (row.views ?? 0) : row.count), 0)
@@ -188,6 +194,7 @@ export function AnalyticsBreakdownPanel({
 		rows: sorted,
 		label,
 		hasViews,
+		viewsLabel,
 		hasIcons,
 		selected,
 		waiting,
@@ -257,8 +264,11 @@ export function AnalyticsBreakdownPanel({
 						<div className="flex flex-col gap-1 pe-8">
 							<DialogTitle className="text-base">{dimension.tab}</DialogTitle>
 							<DialogDescription>
-								Ranked by {hasViews ? "page views" : "sessions"} over the selected window.
-								Pick a row to filter the page.
+								Ranked by{" "}
+								{hasViews
+									? (dimension.viewsLabel?.toLowerCase() ?? "page views")
+									: "sessions"}{" "}
+								over the selected window. Pick a row to filter the page.
 							</DialogDescription>
 						</div>
 						<div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
@@ -357,6 +367,7 @@ interface BreakdownTableProps {
 	rows: ReadonlyArray<BreakdownRow & { share: number }>
 	label: (name: string) => string
 	hasViews: boolean
+	viewsLabel: string
 	hasIcons: boolean
 	selected: string | undefined
 	waiting?: boolean
@@ -380,6 +391,7 @@ function BreakdownTable({
 	rows,
 	label,
 	hasViews,
+	viewsLabel,
 	hasIcons,
 	selected,
 	waiting,
@@ -420,7 +432,7 @@ function BreakdownTable({
 				/>
 				{hasViews ? (
 					<ColumnHead<SortKey>
-						label="Views"
+						label={viewsLabel}
 						width={ranked ? "w-16 sm:w-24" : "w-16"}
 						align="right"
 						sortKey="views"

--- a/apps/web/src/components/analytics/analytics-filter-sidebar.tsx
+++ b/apps/web/src/components/analytics/analytics-filter-sidebar.tsx
@@ -3,7 +3,7 @@ import { Result } from "@/lib/effect-atom"
 import { Separator } from "@maple/ui/components/ui/separator"
 import { cn } from "@maple/ui/lib/utils"
 
-import type { WebAnalyticsBreakdowns } from "@/api/warehouse/web-analytics"
+import type { WebAnalyticsBreakdowns, WebAnalyticsEvent } from "@/api/warehouse/web-analytics"
 import type { QueryAtomFailure } from "@/lib/services/atoms/warehouse-query-atoms"
 import {
 	FilterSection,
@@ -32,6 +32,7 @@ import { browserIconFor, deviceIconFor } from "@/components/replays/session-icon
 
 interface AnalyticsFilterSidebarProps {
 	breakdownsResult: Result.Result<WebAnalyticsBreakdowns, QueryAtomFailure>
+	eventsResult: Result.Result<{ data: ReadonlyArray<WebAnalyticsEvent> }, QueryAtomFailure>
 	filters: AnalyticsFilters
 	onFilterChange: (key: AnalyticsFilterKey, value: string | undefined) => void
 	onClearFilters: () => void
@@ -60,6 +61,7 @@ const utmSourceIcon = (name: string) => (isHostLike(name) ? hostIcon(name) : nul
 
 export function AnalyticsFilterSidebar({
 	breakdownsResult,
+	eventsResult,
 	filters,
 	onFilterChange,
 	onClearFilters,
@@ -70,6 +72,11 @@ export function AnalyticsFilterSidebar({
 		.onSuccess((breakdowns, result) => (
 			<AnalyticsFilterSidebarView
 				breakdowns={breakdowns}
+				// Decorative beside the breakdowns: a slow or failed events query
+				// drops the Event section rather than blanking the whole sidebar.
+				events={Result.builder(eventsResult)
+					.onSuccess((rows) => rows.data)
+					.orElse(() => [])}
 				waiting={result.waiting}
 				filters={filters}
 				onFilterChange={onFilterChange}
@@ -81,12 +88,14 @@ export function AnalyticsFilterSidebar({
 
 function AnalyticsFilterSidebarView({
 	breakdowns,
+	events,
 	waiting,
 	filters,
 	onFilterChange,
 	onClearFilters,
 }: {
 	breakdowns: WebAnalyticsBreakdowns
+	events: ReadonlyArray<WebAnalyticsEvent>
 	waiting: boolean
 	filters: AnalyticsFilters
 	onFilterChange: (key: AnalyticsFilterKey, value: string | undefined) => void
@@ -146,6 +155,16 @@ function AnalyticsFilterSidebarView({
 					options={toOptions(breakdowns.entryPaths)}
 					{...single("pagePath")}
 				/>
+				{/* Counts are sessions that fired the event, matching every other count
+				    in this rail; firings live on the card. Hidden outright when nothing
+				    is tracked — an empty "Event" section would read as a broken filter. */}
+				{events.length > 0 || filters.eventName ? (
+					<SearchableFilterSection
+						title={FILTER_SECTION_LABEL_TEXT.eventName}
+						options={events.map((event) => ({ name: event.name, count: event.sessions }))}
+						{...single("eventName")}
+					/>
+				) : null}
 				<SearchableFilterSection
 					title={FILTER_SECTION_LABEL_TEXT.referrerHost}
 					options={toOptions(breakdowns.referrerHosts)}

--- a/apps/web/src/components/analytics/filters.ts
+++ b/apps/web/src/components/analytics/filters.ts
@@ -23,6 +23,7 @@ export const analyticsFilterSearchFields = {
 	utmMedium: Schema.optional(Schema.String),
 	utmCampaign: Schema.optional(Schema.String),
 	visitorType: Schema.optional(Schema.Literals(["new", "returning"])),
+	eventName: Schema.optional(Schema.String),
 }
 
 export interface AnalyticsFilters {
@@ -38,6 +39,8 @@ export interface AnalyticsFilters {
 	utmMedium?: string
 	utmCampaign?: string
 	visitorType?: "new" | "returning"
+	/** Sessions in which a `track(eventName)` call fired. */
+	eventName?: string
 }
 
 export type AnalyticsFilterKey = keyof AnalyticsFilters
@@ -56,6 +59,7 @@ export const FILTER_CHIP_LABEL: Record<AnalyticsFilterKey, string> = {
 	utmMedium: "utm_medium",
 	utmCampaign: "utm_campaign",
 	visitorType: "visitor",
+	eventName: "event",
 } satisfies Record<AnalyticsFilterKey, string>
 
 /** Filter key → sidebar section heading. Sentence case, matching the rest of the app. */
@@ -72,6 +76,7 @@ export const FILTER_SECTION_LABEL: Record<AnalyticsFilterKey, string> = {
 	utmMedium: "UTM medium",
 	utmCampaign: "UTM campaign",
 	visitorType: "Visitor",
+	eventName: "Event",
 } satisfies Record<AnalyticsFilterKey, string>
 
 const FILTER_KEYS = Object.keys(FILTER_CHIP_LABEL) as ReadonlyArray<AnalyticsFilterKey>

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -107,6 +107,7 @@ import {
 import { getAiSessionsFacets, listAiSessions } from "@/api/warehouse/ai-sessions"
 import {
 	getWebAnalyticsBreakdowns,
+	getWebAnalyticsEvents,
 	getWebAnalyticsPages,
 	getWebAnalyticsPageviews,
 	getWebAnalyticsSummary,
@@ -253,7 +254,7 @@ export const replaysFacetsResultAtom = makeQueryAtomFamily(getReplaysFacets, {
 	staleTime: 30_000,
 })
 
-// Web analytics — one page, five atoms, all 30s. Traffic numbers are watched
+// Web analytics — one page, six atoms, all 30s. Traffic numbers are watched
 // during a launch, so a longer TTL reads as a stalled page; a shorter one just
 // re-runs the same 30-day-TTL scans.
 export const webAnalyticsSummaryResultAtom = makeQueryAtomFamily(getWebAnalyticsSummary, {
@@ -269,6 +270,10 @@ export const webAnalyticsPageviewsResultAtom = makeQueryAtomFamily(getWebAnalyti
 })
 
 export const webAnalyticsPagesResultAtom = makeQueryAtomFamily(getWebAnalyticsPages, {
+	staleTime: 30_000,
+})
+
+export const webAnalyticsEventsResultAtom = makeQueryAtomFamily(getWebAnalyticsEvents, {
 	staleTime: 30_000,
 })
 

--- a/apps/web/src/routes/analytics/index.tsx
+++ b/apps/web/src/routes/analytics/index.tsx
@@ -12,7 +12,7 @@ import { QueryErrorState } from "@/components/common/query-error-state"
 import { PageHero } from "@/components/infra/primitives/page-hero"
 import { PlayRotateClockwiseIcon } from "@/components/icons"
 import { chartBucketSeconds } from "@/components/infra/chart-utils"
-import type { WebAnalyticsBreakdowns } from "@/api/warehouse/web-analytics"
+import type { WebAnalyticsBreakdowns, WebAnalyticsEvent } from "@/api/warehouse/web-analytics"
 import type { QueryAtomFailure } from "@/lib/services/atoms/warehouse-query-atoms"
 import {
 	AnalyticsBreakdownPanel,
@@ -44,6 +44,7 @@ import {
 } from "@/components/analytics/filters"
 import {
 	webAnalyticsBreakdownsResultAtom,
+	webAnalyticsEventsResultAtom,
 	webAnalyticsPagesResultAtom,
 	webAnalyticsPageviewsResultAtom,
 	webAnalyticsSummaryResultAtom,
@@ -62,6 +63,7 @@ const analyticsSearchSchema = Schema.Struct({
 
 const DEFAULT_PRESET = "7d"
 const PAGES_LIMIT = 100
+const EVENTS_LIMIT = 100
 const BREAKDOWN_LIMIT = 50
 
 export const Route = createFileRoute("/analytics/")({
@@ -119,6 +121,15 @@ function WebAnalyticsPage() {
 		}),
 	)
 
+	// Its own query, not a branch of the breakdowns union: custom events live on
+	// the page-view source, not `session_replays`. Read here rather than in the
+	// content so the sidebar's Event section and the Events card share one fetch.
+	const eventsResult = useRetainedRefreshableResultValue(
+		webAnalyticsEventsResultAtom({
+			data: { startTime, endTime, limit: EVENTS_LIMIT, ...filters },
+		}),
+	)
+
 	const chips = activeFilterChips(filters)
 
 	return (
@@ -129,6 +140,7 @@ function WebAnalyticsPage() {
 					<DashboardLayout.Filters>
 						<AnalyticsFilterSidebar
 							breakdownsResult={breakdownsResult}
+							eventsResult={eventsResult}
 							filters={filters}
 							onFilterChange={onFilterChange}
 							onClearFilters={onClearFilters}
@@ -206,6 +218,7 @@ function WebAnalyticsPage() {
 									endTime={endTime}
 									filters={filters}
 									breakdownsResult={breakdownsResult}
+									eventsResult={eventsResult}
 									onToggleFilter={onToggleFilter}
 								/>
 							</div>
@@ -256,12 +269,14 @@ function AnalyticsContent({
 	endTime,
 	filters,
 	breakdownsResult,
+	eventsResult,
 	onToggleFilter,
 }: {
 	startTime: string
 	endTime: string
 	filters: AnalyticsFilters
 	breakdownsResult: Result.Result<WebAnalyticsBreakdowns, QueryAtomFailure>
+	eventsResult: Result.Result<{ data: ReadonlyArray<WebAnalyticsEvent> }, QueryAtomFailure>
 	onToggleFilter: (key: AnalyticsFilterKey, value: string) => void
 }) {
 	const bucketSeconds = chartBucketSeconds(startTime, endTime)
@@ -509,6 +524,29 @@ function AnalyticsContent({
 						},
 					]
 
+					const events = Result.builder(eventsResult)
+						.onSuccess((rows) => rows.data)
+						.orElse(() => [])
+
+					const eventDimensions: ReadonlyArray<BreakdownDimension> = [
+						{
+							tab: "Events",
+							// Ranked by firings, with the sessions that fired each beside it —
+							// the same two-column shape as Pages, read from the same source.
+							rows: events.map((event) => ({
+								name: event.name,
+								count: event.sessions,
+								views: event.events,
+							})),
+							filterKey: "eventName",
+							noun: "event",
+							nounPlural: "events",
+							viewsLabel: "Events",
+							emptyMessage:
+								'No custom events in the selected window. Send one with track("name", props) from the browser SDK.',
+						},
+					]
+
 					// `items-start` so each card sizes to its own content instead of
 					// stretching to match the tallest in its row — a Devices card with
 					// three rows should not be as tall as a Pages card with fifty.
@@ -521,6 +559,7 @@ function AnalyticsContent({
 						{ id: "content", dimensions: pageDimensions },
 						{ id: "technology", dimensions: devices },
 						{ id: "audience", dimensions: geography },
+						{ id: "events", dimensions: eventDimensions },
 					]
 
 					return (

--- a/packages/domain/src/http/query-engine.ts
+++ b/packages/domain/src/http/query-engine.ts
@@ -1181,6 +1181,8 @@ const WebAnalyticsFilterFields = {
 	utmMedium: Schema.optional(Schema.String),
 	utmCampaign: Schema.optional(Schema.String),
 	visitorType: Schema.optional(Schema.Literals(["new", "returning"])),
+	// Sessions in which a `track(eventName)` call fired.
+	eventName: Schema.optional(Schema.String),
 } as const
 
 export class WebAnalyticsSummaryRequest extends Schema.Class<WebAnalyticsSummaryRequest>(
@@ -1273,6 +1275,27 @@ export class WebAnalyticsPagesResponse extends Schema.Class<WebAnalyticsPagesRes
 			host: Schema.String,
 			pagePath: Schema.String,
 			pageViews: Schema.Number,
+			sessions: Schema.Number,
+		}),
+	),
+}) {}
+
+export class WebAnalyticsEventsRequest extends Schema.Class<WebAnalyticsEventsRequest>(
+	"WebAnalyticsEventsRequest",
+)({
+	startTime: TinybirdDateTime,
+	endTime: TinybirdDateTime,
+	limit: Schema.optional(Schema.Number),
+	...WebAnalyticsFilterFields,
+}) {}
+
+export class WebAnalyticsEventsResponse extends Schema.Class<WebAnalyticsEventsResponse>(
+	"WebAnalyticsEventsResponse",
+)({
+	data: Schema.Array(
+		Schema.Struct({
+			name: Schema.String,
+			events: Schema.Number,
 			sessions: Schema.Number,
 		}),
 	),
@@ -2152,6 +2175,13 @@ export class QueryEngineApiGroup extends HttpApiGroup.make("queryEngine")
 		HttpApiEndpoint.post("webAnalyticsPages", "/web-analytics-pages", {
 			payload: WebAnalyticsPagesRequest,
 			success: WebAnalyticsPagesResponse,
+			error: queryEngineEndpointErrors,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.post("webAnalyticsEvents", "/web-analytics-events", {
+			payload: WebAnalyticsEventsRequest,
+			success: WebAnalyticsEventsResponse,
 			error: queryEngineEndpointErrors,
 		}),
 	)

--- a/packages/query-engine/src/__sql_baseline__/catalog.sql
+++ b/packages/query-engine/src/__sql_baseline__/catalog.sql
@@ -1979,7 +1979,7 @@ SELECT
         LIMIT 2
         FORMAT JSON
 
--- builder:web-analytics:webAnalyticsBreakdownsQuery:all-dimensions-filtered  [81a04a1d]
+-- builder:web-analytics:webAnalyticsBreakdownsQuery:all-dimensions-filtered  [dd21e64d]
 SELECT
           if(ReferrerHost = '', '(none)', ReferrerHost) AS name,
           uniq(SessionId) AS count,
@@ -2007,6 +2007,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
         GROUP BY name
         ORDER BY count DESC
         LIMIT 50
@@ -2038,6 +2047,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
           AND Country != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2070,6 +2088,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
           AND DeviceType != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2102,6 +2129,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
           AND BrowserName != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2134,6 +2170,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
           AND OsName != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2166,6 +2211,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
           AND Language != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2198,6 +2252,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
         GROUP BY name
         ORDER BY count DESC
         LIMIT 50
@@ -2229,6 +2292,15 @@ SELECT
           AND UtmSource = 'twitter'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
         GROUP BY name
         ORDER BY count DESC
         LIMIT 50
@@ -2260,6 +2332,15 @@ SELECT
           AND UtmSource = 'twitter'
           AND UtmMedium = 'social'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
         GROUP BY name
         ORDER BY count DESC
         LIMIT 50
@@ -2291,6 +2372,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
           AND EntryPath != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2323,6 +2413,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
           AND ExitPath != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2355,13 +2454,22 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
           AND Host != ''
         GROUP BY name
         ORDER BY count DESC
         LIMIT 50
 FORMAT JSON
 
--- builder:web-analytics:webAnalyticsBreakdownsQuery:all-dimensions-filtered-rollup  [fd0344cd]
+-- builder:web-analytics:webAnalyticsBreakdownsQuery:all-dimensions-filtered-rollup  [99fac2d3]
 SELECT
           if(ReferrerHost = '', '(none)', ReferrerHost) AS name,
           uniq(SessionId) AS count,
@@ -2389,6 +2497,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
         GROUP BY name
         ORDER BY count DESC
         LIMIT 50
@@ -2420,6 +2537,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
           AND Country != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2452,6 +2578,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
           AND DeviceType != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2484,6 +2619,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
           AND BrowserName != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2516,6 +2660,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
           AND OsName != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2548,6 +2701,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
           AND Language != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2580,6 +2742,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
         GROUP BY name
         ORDER BY count DESC
         LIMIT 50
@@ -2611,6 +2782,15 @@ SELECT
           AND UtmSource = 'twitter'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
         GROUP BY name
         ORDER BY count DESC
         LIMIT 50
@@ -2642,6 +2822,15 @@ SELECT
           AND UtmSource = 'twitter'
           AND UtmMedium = 'social'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
         GROUP BY name
         ORDER BY count DESC
         LIMIT 50
@@ -2673,6 +2862,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
           AND EntryPath != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2705,6 +2903,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
           AND ExitPath != ''
         GROUP BY name
         ORDER BY count DESC
@@ -2737,6 +2944,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
           AND Host != ''
         GROUP BY name
         ORDER BY count DESC
@@ -3051,6 +3267,120 @@ SELECT
         LIMIT 50
 FORMAT JSON
 
+-- builder:web-analytics:webAnalyticsEventsQuery:default  [7a2203c7]
+SELECT
+          Message AS name,
+          count() AS events,
+          uniq(SessionId) AS sessions
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message != ''
+        GROUP BY name
+        ORDER BY events DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- builder:web-analytics:webAnalyticsEventsQuery:default-rollup  [d3ea0b13]
+SELECT
+          EventName AS name,
+          count() AS events,
+          uniq(SessionId) AS sessions
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName != ''
+        GROUP BY name
+        ORDER BY events DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- builder:web-analytics:webAnalyticsEventsQuery:semi-joined  [9f5b9302]
+SELECT
+          Message AS name,
+          count() AS events,
+          uniq(SessionId) AS sessions
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND Country = 'DE'
+        GROUP BY sessionId)
+          AND Message != ''
+        GROUP BY name
+        ORDER BY events DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- builder:web-analytics:webAnalyticsEventsQuery:semi-joined-rollup  [ebdeba2a]
+SELECT
+          EventName AS name,
+          count() AS events,
+          uniq(SessionId) AS sessions
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_replays
+        WHERE OrgId = 'org_sql_catalog'
+          AND StartTime >= '2026-01-01 10:30:00'
+          AND StartTime <= '2026-01-03 14:15:00'
+          AND Country = 'DE'
+        GROUP BY sessionId)
+          AND EventName != ''
+        GROUP BY name
+        ORDER BY events DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- builder:web-analytics:webAnalyticsEventsQuery:url-filtered  [8b46502c]
+SELECT
+          Message AS name,
+          count() AS events,
+          uniq(SessionId) AS sessions
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND domain(Url) = 'maple.dev'
+          AND Message != ''
+        GROUP BY name
+        ORDER BY events DESC
+        LIMIT 100
+        FORMAT JSON
+
+-- builder:web-analytics:webAnalyticsEventsQuery:url-filtered-rollup  [18968e6e]
+SELECT
+          EventName AS name,
+          count() AS events,
+          uniq(SessionId) AS sessions
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND Host = 'maple.dev'
+          AND EventName != ''
+        GROUP BY name
+        ORDER BY events DESC
+        LIMIT 100
+        FORMAT JSON
+
 -- builder:web-analytics:webAnalyticsPagesQuery:default  [ee65a1f8]
 SELECT
           domain(Url) AS host,
@@ -3273,7 +3603,7 @@ SELECT
           AND StartTime <= '2026-01-03 14:15:00'
         FORMAT JSON
 
--- builder:web-analytics:webAnalyticsSummaryQuery:filtered  [5b45919d]
+-- builder:web-analytics:webAnalyticsSummaryQuery:filtered  [5a9fc283]
 SELECT
           uniqIf(VisitorId, VisitorId != '') AS visitors,
           uniq(SessionId) AS sessions,
@@ -3305,9 +3635,18 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM session_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Type = 'custom'
+          AND Message = 'signup_started'
+        GROUP BY sessionId)
         FORMAT JSON
 
--- builder:web-analytics:webAnalyticsSummaryQuery:filtered-rollup  [3746231e]
+-- builder:web-analytics:webAnalyticsSummaryQuery:filtered-rollup  [b2b3770a]
 SELECT
           uniqIf(VisitorId, VisitorId != '') AS visitors,
           uniq(SessionId) AS sessions,
@@ -3339,6 +3678,15 @@ SELECT
           AND UtmMedium = 'social'
           AND UtmCampaign = 'launch'
           AND VisitorIsNew = 1
+          AND SessionId IN (SELECT
+          SessionId AS sessionId
+        FROM web_events
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND Kind = 'custom'
+          AND EventName = 'signup_started'
+        GROUP BY sessionId)
         FORMAT JSON
 
 -- builder:web-analytics:webAnalyticsTimeseriesQuery:default  [bdbaa144]

--- a/packages/query-engine/src/ch/builder-fixtures.ts
+++ b/packages/query-engine/src/ch/builder-fixtures.ts
@@ -79,6 +79,7 @@ const WEB_ANALYTICS_ALL_FILTERS = {
 	utmMedium: "social",
 	utmCampaign: "launch",
 	visitorType: "new",
+	eventName: "signup_started",
 } as const
 
 const webAnalyticsVariants = (
@@ -126,6 +127,25 @@ const webAnalyticsFixtures: ReadonlyArray<BuilderFixture> = [
 	),
 	...webAnalyticsVariants("webAnalyticsPagesQuery", "semi-joined", (useWebEvents) =>
 		CH.compile(CH.webAnalyticsPagesQuery({ limit: 100, country: "DE", useWebEvents }), window),
+	),
+	...webAnalyticsVariants("webAnalyticsEventsQuery", "default", (useWebEvents) =>
+		CH.compile(CH.webAnalyticsEventsQuery({ limit: 100, useWebEvents }), window),
+	),
+	...webAnalyticsVariants("webAnalyticsEventsQuery", "url-filtered", (useWebEvents) =>
+		CH.compile(CH.webAnalyticsEventsQuery({ limit: 100, host: "maple.dev", useWebEvents }), window),
+	),
+	// `eventName` alongside a replays dimension: the replays semi-join must appear
+	// and the event's own filter must NOT — this is the breakdown it is picked from.
+	...webAnalyticsVariants("webAnalyticsEventsQuery", "semi-joined", (useWebEvents) =>
+		CH.compile(
+			CH.webAnalyticsEventsQuery({
+				limit: 100,
+				country: "DE",
+				eventName: "signup_started",
+				useWebEvents,
+			}),
+			window,
+		),
 	),
 	...webAnalyticsVariants("webAnalyticsBreakdownsQuery", "default", (useWebEvents) =>
 		CH.compileUnion(CH.webAnalyticsBreakdownsQuery({ useWebEvents }), window),

--- a/packages/query-engine/src/ch/index.ts
+++ b/packages/query-engine/src/ch/index.ts
@@ -157,6 +157,7 @@ export {
 	webAnalyticsTimeseriesQuery,
 	webAnalyticsPageviewsTimeseriesQuery,
 	webAnalyticsPagesQuery,
+	webAnalyticsEventsQuery,
 	webAnalyticsBreakdownsQuery,
 	type WebAnalyticsFilters,
 	type WebAnalyticsFacetKey,

--- a/packages/query-engine/src/ch/queries/web-analytics.ts
+++ b/packages/query-engine/src/ch/queries/web-analytics.ts
@@ -25,6 +25,15 @@ import { WEB_ANALYTICS_UNSET } from "@maple/domain/query-engine"
  */
 const NAVIGATION = "navigation"
 
+/**
+ * The custom-event discriminator, the other value `web_events.Kind` takes. A
+ * `track(name)` call lands as `Type = 'custom'` with the name in `Message` on the
+ * raw table and as `Kind = 'custom'` / `EventName = name` on the rollup.
+ */
+const CUSTOM = "custom"
+
+type EventKind = typeof NAVIGATION | typeof CUSTOM
+
 // assumeNotNull(x) — drops the Nullable wrapper for a caller whose WHERE (or, as
 // below, whose `-If` condition) already excludes the NULLs. Generic per call
 // site, so declared here rather than via defineFn — same as session-replays.ts.
@@ -65,6 +74,12 @@ export interface WebAnalyticsFilters {
 	/** `new` keeps first-ever sessions for a visitor, `returning` the rest. */
 	readonly visitorType?: "new" | "returning"
 	/**
+	 * Sessions in which a `track(eventName)` call fired — a semi-join on
+	 * `SessionId` against the custom rows of the page-view source, independent of
+	 * `host` / `pagePath` (see {@link eventSessionsSubquery}).
+	 */
+	readonly eventName?: string
+	/**
 	 * Read page views from the `web_events` rollup instead of `session_events`.
 	 *
 	 * Purely a source swap — every predicate below has a one-to-one counterpart on
@@ -91,6 +106,7 @@ export type WebAnalyticsFacetKey =
 	| "entryPath"
 	| "exitPath"
 	| "host"
+	| "eventName"
 
 type ReplaysAccessor = ColumnAccessor<typeof SessionReplays.columns>
 type EventsAccessor = ColumnAccessor<typeof SessionEvents.columns>
@@ -109,11 +125,26 @@ function navigationConditionsRaw(
 	filters: WebAnalyticsFilters,
 	only?: "host" | "pagePath",
 ): Array<CH.Condition | undefined> {
+	return eventConditionsRaw($, filters, NAVIGATION, only)
+}
+
+/**
+ * The predicate {@link navigationConditionsRaw} is the page-view case of: the
+ * same org / time / URL bounds over raw `session_events`, for either of the two
+ * event types product analytics reads. Custom events carry the `Url` of the page
+ * they fired on, so `host` / `pagePath` mean the same thing for both kinds.
+ */
+function eventConditionsRaw(
+	$: EventsAccessor,
+	filters: WebAnalyticsFilters,
+	kind: EventKind,
+	only?: "host" | "pagePath",
+): Array<CH.Condition | undefined> {
 	return [
 		$.OrgId.eq(param.string("orgId")),
 		$.Timestamp.gte(param.dateTime("startTime")),
 		$.Timestamp.lte(param.dateTime("endTime")),
-		$.Type.eq(NAVIGATION),
+		$.Type.eq(kind),
 		only === "pagePath" ? undefined : CH.when(filters.host, (v: string) => CH.domain_($.Url).eq(v)),
 		only === "host" ? undefined : CH.when(filters.pagePath, (v: string) => CH.path_($.Url).eq(v)),
 	]
@@ -134,11 +165,21 @@ function navigationConditionsRollup(
 	filters: WebAnalyticsFilters,
 	only?: "host" | "pagePath",
 ): Array<CH.Condition | undefined> {
+	return eventConditionsRollup($, filters, NAVIGATION, only)
+}
+
+/** The rollup counterpart of {@link eventConditionsRaw}. */
+function eventConditionsRollup(
+	$: WebEventsAccessor,
+	filters: WebAnalyticsFilters,
+	kind: EventKind,
+	only?: "host" | "pagePath",
+): Array<CH.Condition | undefined> {
 	return [
 		$.OrgId.eq(param.string("orgId")),
 		$.Timestamp.gte(param.dateTime("startTime")),
 		$.Timestamp.lte(param.dateTime("endTime")),
-		$.Kind.eq(NAVIGATION),
+		$.Kind.eq(kind),
 		only === "pagePath" ? undefined : CH.when(filters.host, (v: string) => $.Host.eq(v)),
 		only === "host" ? undefined : CH.when(filters.pagePath, (v: string) => $.PagePath.eq(v)),
 	]
@@ -179,6 +220,46 @@ function navigationSessionsSubquery(
 				.select(($) => ({ sessionId: $.SessionId }))
 				.where(($) => navigationConditionsRaw($, filters, only))
 				.groupBy("sessionId")
+}
+
+/**
+ * `SELECT SessionId FROM <page-view source> WHERE <custom event named eventName>` —
+ * which sessions fired the selected `track()` event.
+ *
+ * Deliberately independent of `host` / `pagePath`: "sessions that fired
+ * `signup_started`" and "sessions that viewed `/pricing`" compose as two
+ * semi-joins, so an event filter never silently narrows to events fired *on*
+ * the filtered page. The `EventName` skip index on the rollup is what makes the
+ * equality cheap for a rare event.
+ */
+function eventSessionsSubquery(
+	filters: WebAnalyticsFilters,
+	eventName: string,
+): CHQuery<any, { readonly sessionId: string }, any> {
+	return filters.useWebEvents
+		? from(WebEvents)
+				.select(($) => ({ sessionId: $.SessionId }))
+				.where(($) => [...eventConditionsRollup($, {}, CUSTOM), $.EventName.eq(eventName)])
+				.groupBy("sessionId")
+		: from(SessionEvents)
+				.select(($) => ({ sessionId: $.SessionId }))
+				.where(($) => [...eventConditionsRaw($, {}, CUSTOM), $.Message.eq(eventName)])
+				.groupBy("sessionId")
+}
+
+/**
+ * The `eventName` semi-join clause, appended to every query on the page —
+ * source-independent, like {@link replaysSemiJoin}. `exclude` lets the events
+ * breakdown drop its own filter so the alternatives stay listed.
+ */
+function eventSemiJoin(
+	sessionId: CH.Expr<string>,
+	filters: WebAnalyticsFilters,
+	exclude?: WebAnalyticsFacetKey,
+): CH.Condition | undefined {
+	return exclude !== "eventName" && filters.eventName !== undefined
+		? inSubquery(sessionId, eventSessionsSubquery(filters, filters.eventName))
+		: undefined
 }
 
 /**
@@ -246,6 +327,7 @@ function replaysWhere(
 		CH.when(filters.visitorType, (v: "new" | "returning") =>
 			v === "new" ? $.VisitorIsNew.eq(1) : $.VisitorIsNew.eq(0),
 		),
+		eventSemiJoin($.SessionId, filters, exclude),
 	]
 }
 
@@ -275,11 +357,16 @@ function needsSessionSemiJoin(filters: WebAnalyticsFilters): boolean {
  * recursing into `navigationSessionsSubquery`: `session_events` filters both
  * directly off `Url`, and routing them through `session_replays` would silently
  * drop the sessions with no analytics block from the page-view numbers.
+ * `eventName` is left out for the same reason — the event source applies it
+ * directly via {@link eventSemiJoin}, so threading it through here would only
+ * nest the same semi-join twice.
  */
 function matchingSessionsSubquery(filters: WebAnalyticsFilters) {
 	return from(SessionReplays)
 		.select(($) => ({ sessionId: $.SessionId }))
-		.where(($) => replaysWhere($, { ...filters, host: undefined, pagePath: undefined }))
+		.where(($) =>
+			replaysWhere($, { ...filters, host: undefined, pagePath: undefined, eventName: undefined }),
+		)
 		.groupBy("sessionId")
 }
 
@@ -300,7 +387,11 @@ function navigationWhereRaw(
 	$: EventsAccessor,
 	filters: WebAnalyticsFilters,
 ): Array<CH.Condition | undefined> {
-	return [...navigationConditionsRaw($, filters), replaysSemiJoin($.SessionId, filters)]
+	return [
+		...navigationConditionsRaw($, filters),
+		replaysSemiJoin($.SessionId, filters),
+		eventSemiJoin($.SessionId, filters),
+	]
 }
 
 /** WHERE conditions for the page-view queries over the `web_events` rollup. */
@@ -308,7 +399,11 @@ function navigationWhereRollup(
 	$: WebEventsAccessor,
 	filters: WebAnalyticsFilters,
 ): Array<CH.Condition | undefined> {
-	return [...navigationConditionsRollup($, filters), replaysSemiJoin($.SessionId, filters)]
+	return [
+		...navigationConditionsRollup($, filters),
+		replaysSemiJoin($.SessionId, filters),
+		eventSemiJoin($.SessionId, filters),
+	]
 }
 
 // Summary KPIs
@@ -533,6 +628,69 @@ export function webAnalyticsPagesQuery(
 				.where(($) => [...navigationWhereRaw($, opts), CH.domain_($.Url).neq("")])
 				.groupBy("host", "pagePath")
 				.orderBy(["pageViews", "desc"])
+				.limit(limit)
+				.format("JSON")
+}
+
+// Top custom events
+
+export interface WebAnalyticsEventsOpts extends WebAnalyticsFilters {
+	readonly limit?: number
+}
+
+export interface WebAnalyticsEventsOutput {
+	readonly name: string
+	readonly events: number
+	readonly sessions: number
+}
+
+/**
+ * Most-fired `track()` events by name — `count()` of firings and the distinct
+ * sessions that fired each, over the custom rows of the page-view source.
+ *
+ * `host` / `pagePath` narrow to events fired *on* that page, the same reading as
+ * the Pages query; the `session_replays` dimensions reach it through the semi-join.
+ * Its own `eventName` filter is excluded — this is the breakdown that filter is
+ * picked from, and the alternatives have to stay listed beside the selection.
+ *
+ * A customer's `track('$pageview')` shows up here as an event called `$pageview`
+ * on purpose: `Kind` / `Type` is the discriminator, never the name. Empty names
+ * cannot reach the table (the SDK trims and drops them) but are guarded anyway so
+ * a malformed row can never render as a blank first line.
+ */
+export function webAnalyticsEventsQuery(
+	opts: WebAnalyticsEventsOpts = {},
+): CHQuery<any, WebAnalyticsEventsOutput, any> {
+	const limit = opts.limit ?? 100
+	return opts.useWebEvents
+		? from(WebEvents)
+				.select(($) => ({
+					name: $.EventName,
+					events: CH.count(),
+					sessions: CH.uniq($.SessionId),
+				}))
+				.where(($) => [
+					...eventConditionsRollup($, opts, CUSTOM),
+					replaysSemiJoin($.SessionId, opts),
+					$.EventName.neq(""),
+				])
+				.groupBy("name")
+				.orderBy(["events", "desc"])
+				.limit(limit)
+				.format("JSON")
+		: from(SessionEvents)
+				.select(($) => ({
+					name: $.Message,
+					events: CH.count(),
+					sessions: CH.uniq($.SessionId),
+				}))
+				.where(($) => [
+					...eventConditionsRaw($, opts, CUSTOM),
+					replaysSemiJoin($.SessionId, opts),
+					$.Message.neq(""),
+				])
+				.groupBy("name")
+				.orderBy(["events", "desc"])
 				.limit(limit)
 				.format("JSON")
 }

--- a/packages/query-engine/src/registry/queries.ts
+++ b/packages/query-engine/src/registry/queries.ts
@@ -37,6 +37,7 @@ import type {
 	WebAnalyticsTimeseriesRequest,
 	WebAnalyticsPageviewsRequest,
 	WebAnalyticsPagesRequest,
+	WebAnalyticsEventsRequest,
 	WebAnalyticsBreakdownsRequest,
 } from "@maple/domain/http"
 import { Match } from "effect"
@@ -640,6 +641,7 @@ const webAnalyticsFilters = (
 		readonly utmMedium?: string
 		readonly utmCampaign?: string
 		readonly visitorType?: "new" | "returning"
+		readonly eventName?: string
 	},
 	useWebEvents: boolean,
 ): CH.WebAnalyticsFilters => ({
@@ -655,6 +657,7 @@ const webAnalyticsFilters = (
 	utmMedium: payload.utmMedium,
 	utmCampaign: payload.utmCampaign,
 	visitorType: payload.visitorType,
+	eventName: payload.eventName,
 	useWebEvents,
 })
 
@@ -725,6 +728,23 @@ const webAnalyticsPagesDef = (useWebEvents: boolean) => ({
 
 export const webAnalyticsPages = defineQuery(webAnalyticsPagesDef(true))
 export const webAnalyticsPagesRaw = defineQuery(webAnalyticsPagesDef(false))
+
+const webAnalyticsEventsDef = (useWebEvents: boolean) => ({
+	id: "webAnalyticsEvents" as const,
+	profile: "aggregation" as const,
+	cache: timeRangeCache,
+	compile: (payload: WebAnalyticsEventsRequest, orgId: string) =>
+		CH.compile(
+			CH.webAnalyticsEventsQuery({
+				...webAnalyticsFilters(payload, useWebEvents),
+				limit: payload.limit,
+			}),
+			{ orgId, startTime: payload.startTime, endTime: payload.endTime },
+		),
+})
+
+export const webAnalyticsEvents = defineQuery(webAnalyticsEventsDef(true))
+export const webAnalyticsEventsRaw = defineQuery(webAnalyticsEventsDef(false))
 
 const webAnalyticsBreakdownsDef = (useWebEvents: boolean) => ({
 	id: "webAnalyticsBreakdowns" as const,


### PR DESCRIPTION
## What

Adds a **custom events** card to the Web Analytics page and an `eventName` page filter.

- **Query engine** — `webAnalyticsEventsQuery`: top `track()` event names by firings (`count()`) with distinct sessions (`uniq(SessionId)`); rollup (`web_events.Kind='custom'`) / raw (`session_events.Type='custom'`) pair behind the existing `withWebEventsFallback`. `host`/`pagePath` narrow to the page the event fired on (same reading as Pages); replays dimensions reach it via the existing semi-join; its own `eventName` filter is excluded so the alternatives stay listed.
- **`eventName` filter** on the shared `WebAnalyticsFilters`: a single `SessionId IN (SELECT … WHERE Kind='custom' AND EventName = ?)` semi-join, appended to `replaysWhere` and both `navigationWhere*` (so KPIs, chart, pages and all 12 breakdown branches narrow). `matchingSessionsSubquery` strips it to avoid nesting the same semi-join twice. `navigationConditions*` generalised into `eventConditions*(kind)`.
- **Contract/API** — `WebAnalyticsEventsRequest/Response`, `POST /web-analytics-events`, handler; registry pair `webAnalyticsEvents`/`…Raw`.
- **Web** — 5th "Events" card (Event / Events / Sessions, `viewsLabel` on `BreakdownDimension`), sidebar "Event" section (hidden when nothing is tracked), `?eventName=` URL param + `event:<name>` chip, `webAnalyticsEventsResultAtom`.
- **Tests** — builder fixtures (default / url-filtered / semi-joined) + regenerated `catalog.sql` baseline; parity e2e gains the events query plus `event` / `event+path` filter cases (seed already has custom rows).

## Why

`track()` events were ingested and rolled up into `web_events` but nothing outside the per-session replay rail aggregated them.

## Reviewer notes

- Baseline diff: the `eventName` semi-join is inlined into every branch of the `all-dimensions-filtered` breakdown union (same shape as the navigation semi-join); the new `webAnalyticsEventsQuery:semi-joined` fixture shows own-filter exclusion.
- Verified in the dev app against real data: 40 event names render; clicking a row set `?eventName=onboarding_started`, narrowed sessions 86.3K → 528 across KPIs/sidebar, kept all rows in the card with the selection highlighted; chip clears it.
- `bun typecheck`, `sql-catalog.test.ts`, `src/ch` unit tests green. **ClickHouse parity e2e not run locally** — CI `clickhouse-schema-e2e` should cover it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789946068&installation_model_id=427786&pr_number=565&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F565&signature=8bd897d981d5345a17f2e1ca5fc62a20838a51bfbbee559d5740a4dae3d601fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->