### PR TITLE
fix: resolve top open error issues (CLI PID-1 loop, Tinybird missing-table class, api-key touch race)

### DIFF
--- a/apps/api/src/platform/fork-request-scoped.test.ts
+++ b/apps/api/src/platform/fork-request-scoped.test.ts
@@ -45,8 +45,9 @@ describe("forkRequestScoped", () => {
 	// Scope OUTSIDE the middleware stack, so it outlives `pgConnectionMiddleware`.
 	// A handler that forks and then finishes with no further async work must
 	// still get its background DB call onto the socket before the middleware's
-	// `ensuring` releases it — this is the `ApiKeysService.touchLastUsed` shape
-	// on `POST /mcp`, which used to land every call as `SCOPE_CLOSED`.
+	// `ensuring` releases it — this is the shape `ApiKeysService.touchLastUsed` had
+	// on `POST /mcp` (it is awaited inline now), which used to land every call
+	// as `SCOPE_CLOSED`.
 	it.effect("runs the forked DB call before the connection scope closes", () =>
 		Effect.scoped(
 			Effect.gen(function* () {

--- a/apps/api/src/routes/internal/query-engine.http.ts
+++ b/apps/api/src/routes/internal/query-engine.http.ts
@@ -76,6 +76,7 @@ import {
 } from "@maple/domain/http"
 import { Clock, Effect, Match, Option, Schema } from "effect"
 import { QueryEngineService } from "@/services/warehouse/QueryEngineService"
+import { isMissingProductEvents, isMissingServiceOperationsRollup } from "@/services/warehouse/missing-table"
 import { makeDirectRouteCachePolicy, makeExecuteRawSql } from "@maple/query-engine/runtime"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
 import { traceCacheTtlSeconds } from "@/services/warehouse/trace-detail-cache"
@@ -120,47 +121,6 @@ const mapExecError = <A, E, R>(effect: Effect.Effect<A, E, R>, context: string):
  * `Integrations.cloudflareIgnoredFiltersFor` answers that, and the answer ships in the response so the UI can
  * mark a panel zone-wide instead of pretending the filter applied.
  */
-
-const isMissingServiceOperationsRollup = (error: unknown): boolean => {
-	if (typeof error !== "object" || error === null) return false
-	const candidate = error as {
-		readonly _tag?: unknown
-		readonly clickhouseType?: unknown
-		readonly message?: unknown
-	}
-	return (
-		candidate._tag === "@maple/http/errors/WarehouseConfigError" &&
-		(candidate.clickhouseType === "UNKNOWN_TABLE" ||
-			(typeof candidate.message === "string" &&
-				/service_operations_(?:minutely|hourly)/i.test(candidate.message)))
-	)
-}
-
-/**
- * `product_events` arrives with migration 0016, so a BYO cluster that predates
- * it can be perfectly healthy for everything else and still not have the table —
- * the org just hasn't re-applied schema yet. Same shape as the
- * service-operations detector above, and the same reason: the fallback has to
- * be automatic and per-org, because there is no global moment when every cluster
- * has migrated.
- *
- * Only the page-view queries degrade this way — raw `session_events` holds the
- * same browser rows. Funnels have no raw counterpart (server and mobile rows
- * exist only in `product_events`) and must surface the missing-table error.
- */
-const isMissingProductEvents = (error: unknown): boolean => {
-	if (typeof error !== "object" || error === null) return false
-	const candidate = error as {
-		readonly _tag?: unknown
-		readonly clickhouseType?: unknown
-		readonly message?: unknown
-	}
-	return (
-		candidate._tag === "@maple/http/errors/WarehouseConfigError" &&
-		(candidate.clickhouseType === "UNKNOWN_TABLE" ||
-			(typeof candidate.message === "string" && /product_events/i.test(candidate.message)))
-	)
-}
 
 /**
  * Read a rollup table, degrading to the raw-source query on a cluster that does
@@ -292,1566 +252,1575 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleInternalApi, "query
 			WarehouseExecutionError | RawSqlValidationError
 		>(warehouse)
 
-		return handlers
-			.handle("executeBatch", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					// Resolve the org's warehouse route + config ONCE for the batch.
-					// Without it each item independently races resolveRuntimeConfig
-					// and they contend — the same ordering problem the other
-					// fan-out routes call warmRoute for.
-					yield* warehouse.warmRoute(tenant)
+		return (
+			handlers
+				.handle("executeBatch", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						// Resolve the org's warehouse route + config ONCE for the batch.
+						// Without it each item independently races resolveRuntimeConfig
+						// and they contend — the same ordering problem the other
+						// fan-out routes call warmRoute for.
+						yield* warehouse.warmRoute(tenant)
 
-					const results = yield* runQueryEngineBatch({
-						requests: payload.requests,
-						execute: (request) =>
-							queryEngine
-								.execute(tenant, request)
-								.pipe(Effect.map((response) => response.result)),
-					})
-					return new QueryEngineExecuteBatchResponse({ results })
-				}),
-			)
-			.handle("spanHierarchy", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const nowMs = yield* Clock.currentTimeMillis
-					const rows = yield* queryEngine.cachedDirect(
-						tenant,
-						"spanHierarchy",
-						payload,
-						// Wrapped in cachedDirect's effect so the probe only fires on a
-						// cache miss. `trace_detail_spans` is partitioned by
-						// `toDate(Timestamp)`. Without a time predicate the hierarchy query
-						// seeks across every daily partition (~30) — p95 ~8.8s vs ~2.3s when
-						// pruned to one. When the caller has no timestamp (direct URL,
-						// shared link, AI link), resolve one via a cheap LIMIT-1 probe and
-						// derive a ±1h window so the main query can prune. The probe itself
-						// tries the recent window first (see PROBE_RECENT_WINDOW_MS).
-						Effect.gen(function* () {
-							let startTime = payload.startTime
-							let endTime = payload.endTime
-							if (startTime == null || endTime == null) {
-								const probe =
-									(yield* runQueryFirst(Queries.spanHierarchyProbeRecent, tenant, {
-										traceId: payload.traceId,
-										startTime: formatWarehouseDateTime(nowMs - PROBE_RECENT_WINDOW_MS),
-									})) ?? (yield* runQueryFirst(Queries.spanHierarchyProbe, tenant, payload))
-								if (probe?.timestamp != null) {
-									const window = partitionWindowAround(probe.timestamp)
-									startTime = window.startTime
-									endTime = window.endTime
-								}
-							}
-							return yield* runQuery(Queries.spanHierarchy, tenant, {
-								traceId: payload.traceId,
-								spanId: payload.spanId,
-								startTime,
-								endTime,
-							})
-						}),
-						traceCacheTtlSeconds(payload.endTime, nowMs),
-					)
-					const typedRows = rows.map((row) => ({
-						...row,
-						traceId: decodeTraceId(row.traceId),
-						spanId: decodeSpanId(row.spanId),
-						spanName: decodeSpanName(row.spanName),
-						serviceName: decodeServiceName(row.serviceName),
-						statusCode: coerceStatusCode(row.statusCode),
-					}))
-					return new SpanHierarchyResponse({ data: typedRows })
-				}),
-			)
-			.handle("spanDetail", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const row = yield* runQueryFirst(Queries.spanDetail, tenant, payload)
-					return new SpanDetailResponse({
-						data: row
-							? {
-									...row,
-									traceId: decodeTraceId(row.traceId),
-									spanId: decodeSpanId(row.spanId),
-								}
-							: null,
-					})
-				}),
-			)
-			.handle("errorsByType", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.errorsByType, tenant, payload)
-					return new ErrorsByTypeResponse({
-						data: rows.map((row) => ({
-							fingerprintHash: decodeFingerprintHash(row.fingerprintHash),
-							errorLabel: row.errorLabel,
-							sampleMessage: row.sampleMessage,
-							count: Number(row.count),
-							affectedServicesCount: Number(row.affectedServicesCount),
-							firstSeen: String(row.firstSeen),
-							lastSeen: String(row.lastSeen),
-						})),
-					})
-				}),
-			)
-			.handle("errorsTimeseries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.errorsTimeseries, tenant, payload)
-					return new ErrorsTimeseriesResponse({
-						data: rows.map((row) => ({
-							bucket: String(row.bucket),
-							count: Number(row.count),
-						})),
-					})
-				}),
-			)
-			.handle("errorsSpark", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.errorsSpark, tenant, payload)
-					return new ErrorsSparkResponse({
-						data: rows.map((row) => ({
-							fingerprintHash: decodeFingerprintHash(row.fingerprintHash),
-							bucket: String(row.bucket),
-							count: Number(row.count),
-						})),
-					})
-				}),
-			)
-			.handle("errorsSummary", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const row = yield* runQueryFirst(Queries.errorsSummary, tenant, payload)
-					return new ErrorsSummaryResponse({
-						data: row
-							? {
-									totalErrors: Number(row.totalErrors),
-									totalSpans: Number(row.totalSpans),
-									errorRate: Number(row.errorRate),
-									affectedServicesCount: Number(row.affectedServicesCount),
-									affectedTracesCount: Number(row.affectedTracesCount),
-								}
-							: null,
-					})
-				}),
-			)
-			.handle("errorDetailTraces", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.errorDetailTraces, tenant, payload)
-					return new ErrorDetailTracesResponse({
-						data: rows.map((row) => ({
-							traceId: decodeTraceId(row.traceId),
-							startTime: String(row.startTime),
-							durationMicros: Number(row.durationMicros),
-							spanCount: Number(row.spanCount),
-							services: row.services.map((service) => decodeServiceName(service)),
-							rootSpanName: row.rootSpanName,
-							errorMessage: row.errorMessage,
-						})),
-					})
-				}),
-			)
-			.handle("errorRateByService", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.errorRateByService, tenant, payload)
-					return new ErrorRateByServiceResponse({
-						data: rows.map((row) => ({
-							serviceName: decodeServiceName(row.serviceName),
-							totalLogs: Number(row.totalLogs),
-							errorLogs: Number(row.errorLogs),
-							errorRate: Number(row.errorRate),
-						})),
-					})
-				}),
-			)
-			.handle("serviceOverview", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.serviceOverview, tenant, payload)
-					return new ServiceOverviewResponse({ data: rows })
-				}),
-			)
-			.handle("serviceHealthSnapshot", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.serviceHealthSnapshot, tenant, payload)
-					return new ServiceHealthSnapshotResponse({
-						data: rows.map((row) => ({
-							serviceName: decodeServiceName(row.serviceName),
-							environment: row.environment || "unknown",
-							requestCount: row.requestCount,
-							errorCount: row.errorCount,
-							p95LatencyMs: row.p95LatencyMs,
-						})),
-					})
-				}),
-			)
-			.handle("serviceHealthBaseline", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.serviceHealthBaseline, tenant, payload)
-					return new ServiceHealthBaselineResponse({
-						data: rows.map((row) => ({
-							serviceName: decodeServiceName(String(row.serviceName ?? "")),
-							serviceNamespace: String(row.serviceNamespace ?? ""),
-							environment: String(row.environment ?? "unknown"),
-							baselineP95LatencyMs: Number(row.baselineP95LatencyMs ?? 0),
-							baselineSpanCount: Number(row.baselineSpanCount ?? 0),
-						})),
-					})
-				}),
-			)
-			.handle("serviceApdex", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.serviceApdex, tenant, payload)
-					return new ServiceApdexResponse({
-						data: rows.map((row) => ({
-							bucket: String(row.bucket),
-							totalCount: Number(row.totalCount),
-							satisfiedCount: Number(row.satisfiedCount),
-							toleratingCount: Number(row.toleratingCount),
-							apdexScore: Number(row.apdexScore),
-						})),
-					})
-				}),
-			)
-			.handle("serviceCloudflareStats", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					// Counters (metrics_sum) + percentiles (metrics_gauge) run
-					// concurrently, then merge by ServiceName. Routed through the org's
-					// configured warehouse exactly like the metric explorer reads these
-					// same `cloudflare.*` metrics — no special ingest pin needed.
-					yield* warehouse.warmRoute(tenant)
-					const [counterRows, latencyRows] = yield* Effect.all(
-						[
-							runQuery(Queries.cloudflareServiceCounters, tenant, payload),
-							runQuery(Queries.cloudflareServiceLatency, tenant, payload),
-						],
-						{ concurrency: 2 },
-					)
-					const latencyByService = new Map(latencyRows.map((row) => [row.serviceName, row]))
-					const data = counterRows.map((row) => {
-						const latency = latencyByService.get(row.serviceName)
-						return {
-							serviceName: row.serviceName,
-							requests: row.requests,
-							errorCount: row.errorCount,
-							latencyP99Ms: latency?.latencyP99Ms ?? 0,
-							cpuP99Ms: latency?.cpuP99Ms ?? 0,
-						}
-					})
-					return new ServiceCloudflareStatsResponse({ data })
-				}),
-			)
-			.handle("servicePlanetScaleStats", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const byBranch = payload.database !== undefined
-					// Utilization gauges + the two-level connections rollup run
-					// concurrently, then merge by database(+branch). Routed through the
-					// org's configured warehouse like the metric explorer reads the same
-					// scraped `planetscale_*` metrics.
-					yield* warehouse.warmRoute(tenant)
-					const [gaugeRows, connectionRows, storageRows] = yield* Effect.all(
-						[
-							runQuery(Queries.planetscaleServiceGauges, tenant, payload),
-							runQuery(Queries.planetscaleServiceConnections, tenant, payload),
-							runQuery(Queries.planetscaleServiceStorage, tenant, payload),
-						],
-						{ concurrency: 3 },
-					)
-					const keyOf = (row: { database: string; branch?: string }) =>
-						byBranch ? `${row.database}\x00${row.branch ?? ""}` : row.database
-					const connectionsByKey = new Map(connectionRows.map((row) => [keyOf(row), row]))
-					const storageByKey = new Map(storageRows.map((row) => [keyOf(row), row]))
-					const seen = new Set<string>()
-					type MergedStatsRow = {
-						readonly database: string
-						readonly branch?: string
-						readonly cpuMaxPercent: number
-						readonly memMaxPercent: number
-						readonly replicaLagMaxSeconds: number
-						readonly connectionsAvg: number
-						readonly connectionsMax: number
-						readonly storageUsedPercent: number
-						/** 0 = the volume gauges never reported; the client must not render 0% used. */
-						readonly storageSamples: number
-					}
-					const storageFor = (key: string) => {
-						const storage = storageByKey.get(key)
-						return {
-							storageUsedPercent: storage?.storageUsedPercent ?? 0,
-							storageSamples: storage?.storageSamples ?? 0,
-						}
-					}
-					// The storage rollup is per-database or per-branch depending on the
-					// request; only the latter carries a branch to forward.
-					const branchOf = (
-						row:
-							| { readonly database: string }
-							| { readonly database: string; readonly branch: string },
-					): { readonly branch?: string } => ("branch" in row ? { branch: row.branch } : {})
-					const data: Array<MergedStatsRow> = gaugeRows.map((row) => {
-						const key = keyOf(row)
-						seen.add(key)
-						const connections = connectionsByKey.get(key)
-						return {
-							...row,
-							connectionsAvg: connections?.connectionsAvg ?? 0,
-							connectionsMax: connections?.connectionsMax ?? 0,
-							...storageFor(key),
-						}
-					})
-					// Databases with connection samples but no utilization gauges still
-					// deserve a row (e.g. filtered scrape sets).
-					for (const row of connectionRows) {
-						const key = keyOf(row)
-						if (seen.has(key)) continue
-						seen.add(key)
-						data.push({
-							...row,
-							cpuMaxPercent: 0,
-							memMaxPercent: 0,
-							replicaLagMaxSeconds: 0,
-							...storageFor(key),
+						const results = yield* runQueryEngineBatch({
+							requests: payload.requests,
+							execute: (request) =>
+								queryEngine
+									.execute(tenant, request)
+									.pipe(Effect.map((response) => response.result)),
 						})
-					}
-					// …and so do volumes reporting with no gauges or connections at all —
-					// an idle branch still filling its disk is exactly what to surface.
-					for (const row of storageRows) {
-						const key = keyOf(row)
-						if (seen.has(key)) continue
-						seen.add(key)
-						data.push({
-							database: row.database,
-							...branchOf(row),
-							cpuMaxPercent: 0,
-							memMaxPercent: 0,
-							replicaLagMaxSeconds: 0,
-							connectionsAvg: 0,
-							connectionsMax: 0,
-							storageUsedPercent: row.storageUsedPercent,
-							storageSamples: row.storageSamples,
-						})
-					}
-					return new ServicePlanetScaleStatsResponse({ data })
-				}),
-			)
-			.handle("planetscaleInfraTimeseries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.planetscaleInfraTimeseries, tenant, payload)
-					return new PlanetScaleInfraTimeseriesResponse({ data: rows.map((row) => ({ ...row })) })
-				}),
-			)
-			.handle("cloudflareInfraZones", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					// Counters (metrics_sum) + percentiles (metrics_gauge) run
-					// concurrently, then merge by ServiceName — same shape as
-					// serviceCloudflareStats above.
-					const filters = toCloudflareFilters(payload)
-					yield* warehouse.warmRoute(tenant)
-					const [counterRows, latencyRows] = yield* Effect.all(
-						[
-							runQuery(Queries.cloudflareInfraZoneCounters, tenant, payload),
-							runQuery(Queries.cloudflareInfraZoneLatency, tenant, payload),
-						],
-						{ concurrency: 2 },
-					)
-					const latencyByService = new Map(latencyRows.map((row) => [row.serviceName, row]))
-					const data = counterRows.map((row) => {
-						const latency = latencyByService.get(row.serviceName)
-						return {
-							serviceName: row.serviceName,
-							requests: row.requests,
-							errors5xx: row.errors5xx,
-							cacheHits: row.cacheHits,
-							bytes: row.bytes,
-							visits: row.visits,
-							ttfbP50Ms: latency?.ttfbP50Ms ?? 0,
-							ttfbP95Ms: latency?.ttfbP95Ms ?? 0,
-							ttfbP99Ms: latency?.ttfbP99Ms ?? 0,
-							originP50Ms: latency?.originP50Ms ?? 0,
-							originP95Ms: latency?.originP95Ms ?? 0,
-							originP99Ms: latency?.originP99Ms ?? 0,
-						}
-					})
-					return new CloudflareInfraZonesResponse({
-						data,
-						// The latency columns are zone-wide by construction, so a dimension filter
-						// narrows the counters but never the percentiles beside them.
-						ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
-							Integrations.CF_METRIC.requests,
-							Integrations.CF_METRIC.bytes,
-							Integrations.CF_METRIC.visits,
-						]),
-					})
-				}),
-			)
-			.handle("cloudflareInfraZoneTimeseries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const filters = toCloudflareFilters(payload)
-					const rows = yield* runQuery(Queries.cloudflareInfraZoneTimeseries, tenant, payload)
-					return new CloudflareInfraZoneTimeseriesResponse({
-						data: rows.map((row) => ({ ...row })),
-						ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
-							Integrations.CF_METRIC.requests,
-						]),
-					})
-				}),
-			)
-			.handle("cloudflareInfraZoneDetail", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const filters = toCloudflareFilters(payload)
-					yield* warehouse.warmRoute(tenant)
-					const [statusRows, cacheRows, latencyRows] = yield* Effect.all(
-						[
-							runQuery(Queries.cloudflareInfraZoneDetailStatus, tenant, payload),
-							runQuery(Queries.cloudflareInfraZoneDetailCache, tenant, payload),
-							runQuery(Queries.cloudflareInfraZoneDetailLatency, tenant, payload),
-						],
-						{ concurrency: 3 },
-					)
-					return new CloudflareInfraZoneDetailResponse({
-						statusBuckets: statusRows.map((row) => ({ ...row })),
-						cacheBuckets: cacheRows.map((row) => ({ ...row })),
-						latencyBuckets: latencyRows.map((row) => ({ ...row })),
-						ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
-							Integrations.CF_METRIC.requests,
-						]),
-						latencyIgnoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
-							Integrations.CF_METRIC.edgeTtfb,
-							Integrations.CF_METRIC.originDuration,
-						]),
-					})
-				}),
-			)
-			.handle("cloudflareInfraZoneSecurity", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const filters = toCloudflareFilters(payload)
-					yield* warehouse.warmRoute(tenant)
-					const [bucketRows, topRows] = yield* Effect.all(
-						[
-							runQuery(Queries.cloudflareInfraZoneFirewallTimeseries, tenant, payload),
-							runQuery(Queries.cloudflareInfraZoneFirewallTop, tenant, payload),
-						],
-						{ concurrency: 2 },
-					)
-					return new CloudflareInfraZoneSecurityResponse({
-						buckets: bucketRows.map((row) => ({ ...row })),
-						top: topRows.map((row) => ({ ...row })),
-						ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
-							Integrations.CF_METRIC.firewallEvents,
-						]),
-					})
-				}),
-			)
-			.handle("cloudflareInfraZoneDns", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const filters = toCloudflareFilters(payload)
-					yield* warehouse.warmRoute(tenant)
-					const [bucketRows, nameRows] = yield* Effect.all(
-						[
-							runQuery(Queries.cloudflareInfraZoneDnsTimeseries, tenant, payload),
-							runQuery(Queries.cloudflareInfraZoneDnsBreakdown, tenant, payload),
-						],
-						{ concurrency: 2 },
-					)
-					return new CloudflareInfraZoneDnsResponse({
-						buckets: bucketRows.map((row) => ({ ...row })),
-						names: nameRows.map((row) => ({ ...row })),
-						ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
-							Integrations.CF_METRIC.dnsQueries,
-						]),
-					})
-				}),
-			)
-			.handle("cloudflareInfraZoneBreakdown", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const filters = toCloudflareFilters(payload)
-					yield* warehouse.warmRoute(tenant)
-					const [totalRows, coverageRows, zoneRows] = yield* Effect.all(
-						[
-							runQuery(Queries.cloudflareInfraZoneBreakdownTotals, tenant, payload),
-							runQuery(Queries.cloudflareInfraZoneBreakdownCoverage, tenant, payload),
-							runQuery(Queries.cloudflareInfraZoneBreakdownZoneTotal, tenant, payload),
-						],
-						{ concurrency: 3 },
-					)
-					const topKeys = totalRows
-						.filter((row) => row.key !== Integrations.CLOUDFLARE_BREAKDOWN_OTHER_KEY)
-						.slice(0, Integrations.CLOUDFLARE_BREAKDOWN_SERIES_LIMIT)
-						.map((row) => row.key)
-					const bucketRows: ReadonlyArray<Integrations.CloudflareZoneBreakdownTimeseriesOutput> =
-						topKeys.length === 0
-							? []
-							: yield* runQuery(Queries.cloudflareInfraZoneBreakdownTimeseries, tenant, {
-									...payload,
-									topKeys,
+						return new QueryEngineExecuteBatchResponse({ results })
+					}),
+				)
+				.handle("spanHierarchy", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const nowMs = yield* Clock.currentTimeMillis
+						const rows = yield* queryEngine.cachedDirect(
+							tenant,
+							"spanHierarchy",
+							payload,
+							// Wrapped in cachedDirect's effect so the probe only fires on a
+							// cache miss. `trace_detail_spans` is partitioned by
+							// `toDate(Timestamp)`. Without a time predicate the hierarchy query
+							// seeks across every daily partition (~30) — p95 ~8.8s vs ~2.3s when
+							// pruned to one. When the caller has no timestamp (direct URL,
+							// shared link, AI link), resolve one via a cheap LIMIT-1 probe and
+							// derive a ±1h window so the main query can prune. The probe itself
+							// tries the recent window first (see PROBE_RECENT_WINDOW_MS).
+							Effect.gen(function* () {
+								let startTime = payload.startTime
+								let endTime = payload.endTime
+								if (startTime == null || endTime == null) {
+									const probe =
+										(yield* runQueryFirst(Queries.spanHierarchyProbeRecent, tenant, {
+											traceId: payload.traceId,
+											startTime: formatWarehouseDateTime(
+												nowMs - PROBE_RECENT_WINDOW_MS,
+											),
+										})) ??
+										(yield* runQueryFirst(Queries.spanHierarchyProbe, tenant, payload))
+									if (probe?.timestamp != null) {
+										const window = partitionWindowAround(probe.timestamp)
+										startTime = window.startTime
+										endTime = window.endTime
+									}
+								}
+								return yield* runQuery(Queries.spanHierarchy, tenant, {
+									traceId: payload.traceId,
+									spanId: payload.spanId,
+									startTime,
+									endTime,
 								})
-					const coverage = coverageRows[0]
-					const zoneRequests = zoneRows.find((row) => row.serviceName === payload.serviceName)
-					// Breakdown metrics are a per-window top-N fold of what Cloudflare returned, so
-					// they can only ever undercount the zone. Clamp rather than surface a negative.
-					const unattributed = Math.max(
-						0,
-						(zoneRequests?.requests ?? 0) - (coverage?.attributedRequests ?? 0),
-					)
-					return new CloudflareInfraZoneBreakdownResponse({
-						totals: totalRows.map((row) => ({ ...row })),
-						buckets: bucketRows.map((row) => ({ ...row })),
-						unattributed,
-						coverageStart:
-							coverage?.coverageStart != null && coverage.coverageStart !== ""
-								? coverage.coverageStart
-								: null,
-						ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(
-							filters,
-							Integrations.cloudflareBreakdownMetrics(payload.dimension),
-						),
-					})
-				}),
-			)
-			.handle("cloudflareInfraZoneFacets", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.cloudflareInfraZoneFacets, tenant, payload)
-					const buckets = {
-						hosts: [] as Array<{ name: string; count: number }>,
-						cacheStatuses: [] as Array<{ name: string; count: number }>,
-						statusClasses: [] as Array<{ name: string; count: number }>,
-						paths: [] as Array<{ name: string; count: number }>,
-						countries: [] as Array<{ name: string; count: number }>,
-						methods: [] as Array<{ name: string; count: number }>,
-						protocols: [] as Array<{ name: string; count: number }>,
-						deviceTypes: [] as Array<{ name: string; count: number }>,
-					}
-					for (const row of rows) {
-						// BYO-ClickHouse returns sum() as a JSON string; compileUnion has no
-						// rowSchema hook, so coerce here — same as podFacets.
-						const entry = { name: String(row.name), count: Number(row.count) || 0 }
-						switch (row.facetType) {
-							case "host":
-								buckets.hosts.push(entry)
-								break
-							case "cacheStatus":
-								buckets.cacheStatuses.push(entry)
-								break
-							case "statusClass":
-								buckets.statusClasses.push(entry)
-								break
-							case "path":
-								buckets.paths.push(entry)
-								break
-							case "country":
-								buckets.countries.push(entry)
-								break
-							case "method":
-								buckets.methods.push(entry)
-								break
-							case "protocol":
-								buckets.protocols.push(entry)
-								break
-							case "deviceType":
-								buckets.deviceTypes.push(entry)
-								break
-						}
-					}
-					return new CloudflareInfraZoneFacetsResponse({ data: buckets })
-				}),
-			)
-			.handle("cloudflareInfraPlatformResources", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					yield* warehouse.warmRoute(tenant)
-					const [queueRows, doRows] = yield* Effect.all(
-						[
-							runQuery(Queries.cloudflareInfraQueueGauges, tenant, payload),
-							runQuery(Queries.cloudflareInfraDurableObjects, tenant, payload),
-						],
-						{ concurrency: 2 },
-					)
-					return new CloudflareInfraPlatformResourcesResponse({
-						queues: queueRows.map((row) => ({ ...row })),
-						durableObjects: doRows.map((row) => ({ ...row })),
-					})
-				}),
-			)
-			.handle("cloudflareInfraWorkers", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					yield* warehouse.warmRoute(tenant)
-					const [counterRows, latencyRows] = yield* Effect.all(
-						[
-							runQuery(Queries.cloudflareInfraWorkerCounters, tenant, payload),
-							runQuery(Queries.cloudflareInfraWorkerLatency, tenant, payload),
-						],
-						{ concurrency: 2 },
-					)
-					const latencyByService = new Map(latencyRows.map((row) => [row.serviceName, row]))
-					const data = counterRows.map((row) => {
-						const latency = latencyByService.get(row.serviceName)
-						return {
-							serviceName: row.serviceName,
-							requests: row.requests,
-							errors: row.errors,
-							subrequests: row.subrequests,
-							cpuP50Ms: latency?.cpuP50Ms ?? 0,
-							cpuP99Ms: latency?.cpuP99Ms ?? 0,
-							durationP50Ms: latency?.durationP50Ms ?? 0,
-							durationP99Ms: latency?.durationP99Ms ?? 0,
-						}
-					})
-					return new CloudflareInfraWorkersResponse({ data })
-				}),
-			)
-			.handle("serviceDetailOverview", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					// One Worker invocation for the whole Overview tab: per-org config
-					// resolves once (the first sub-query warms the in-isolate memo) and
-					// the three queries run concurrently, replacing three separate
-					// browser->Worker round-trips. The primary chart keeps its own
-					// execute-path cache; releases is uncached (mirrors the standalone
-					// handler); environments is edge-cached on a service-scoped key.
-					yield* warehouse.warmRoute(tenant)
-					const [timeseries, releaseRows, environmentRows] = yield* Effect.all(
-						[
-							queryEngine.execute(tenant, payload.timeseries),
-							runQuery(Queries.serviceReleases, tenant, payload),
-							runQuery(Queries.serviceEnvironments, tenant, {
-								serviceName: payload.serviceName,
-								startTime: payload.startTime,
-								endTime: payload.endTime,
 							}),
-						],
-						{ concurrency: 3 },
-					)
-					return new ServiceDetailOverviewResponse({
-						timeseries,
-						releases: releaseRows.map((row) => ({
-							bucket: String(row.bucket),
-							commitSha: decodeCommitSha(row.commitSha),
-							count: Number(row.count),
-							errorCount: Number(row.errorCount),
-						})),
-						environments: environmentRows
-							.map((row) => String(row.environment ?? ""))
-							.filter((env) => env !== ""),
-					})
-				}),
-			)
-			.handle("serviceDependenciesBundle", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					// Dependencies tab in one Worker invocation: the three service-map
-					// edge queries run concurrently and share a single config
-					// resolution, replacing three independent round-trips.
-					yield* warehouse.warmRoute(tenant)
-					const [dependencyRows, dbEdgeRows, externalEdgeRows] = yield* Effect.all(
-						[
-							runQuery(Queries.serviceDependenciesForService, tenant, payload),
-							runQuery(Queries.serviceDbEdgesForService, tenant, payload),
-							runQuery(Queries.serviceExternalEdges, tenant, payload),
-						],
-						{ concurrency: 3 },
-					)
-					return new ServiceDependenciesBundleResponse({
-						dependencies: dependencyRows.map((row) => ({ ...row })),
-						dbEdges: dbEdgeRows.map((row) => ({ ...row })),
-						externalEdges: externalEdgeRows.map((row) => ({ ...row })),
-					})
-				}),
-			)
-			.handle("serviceMapBundle", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					// Resolve warehouse routing once before the fan-out.
-					yield* warehouse.warmRoute(tenant)
-					const [dependencyRows, overviewRows, dbEdgeRows, platformRows] = yield* Effect.all(
-						[
-							runQuery(Queries.serviceDependencies, tenant, payload),
-							runQuery(Queries.serviceOverview, tenant, payload),
-							runQuery(Queries.serviceDbEdges, tenant, payload),
-							runQuery(Queries.servicePlatforms, tenant, payload),
-						],
-						{ concurrency: 4 },
-					)
-
-					const services = new Set<string>()
-					for (const row of dependencyRows) {
-						services.add(String(row.sourceService ?? ""))
-						services.add(String(row.targetService ?? ""))
-					}
-					for (const row of overviewRows) services.add(String(row.serviceName ?? ""))
-					services.delete("")
-
-					const workloadRows =
-						services.size === 0
-							? []
-							: yield* runQuery(Queries.serviceWorkloads, tenant, {
-									startTime: payload.startTime,
-									endTime: payload.endTime,
-									services: Array.from(services)
-										.sort()
-										.map((name) => decodeServiceName(name)),
-								})
-
-					return new ServiceMapBundleResponse({
-						dependencies: dependencyRows.map((row) => ({ ...row })),
-						dbEdges: dbEdgeRows.map((row) => ({ ...row })),
-						overview: overviewRows.map((row) => ({ ...row })),
-						platforms: platformRows.map(toServicePlatformRow),
-						workloads: workloadRows.map(toServiceWorkloadRow),
-					})
-				}),
-			)
-			.handle("serviceDbQuerySummary", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-
-					yield* warehouse.warmRoute(tenant)
-					const [summary, timeseriesRows, topQueryRows] = yield* Effect.all(
-						[
-							runQueryFirst(Queries.serviceDbQuerySummary, tenant, payload),
-							runQuery(Queries.serviceDbQueryTimeseries, tenant, payload),
-							runQuery(Queries.serviceDbTopQueries, tenant, payload),
-						],
-						{ concurrency: 3 },
-					)
-
-					const toNumber = (value: unknown) => Number(value ?? 0)
-					return new ServiceDbQuerySummaryResponse({
-						summary:
-							summary && toNumber(summary.queryCount) > 0
+							traceCacheTtlSeconds(payload.endTime, nowMs),
+						)
+						const typedRows = rows.map((row) => ({
+							...row,
+							traceId: decodeTraceId(row.traceId),
+							spanId: decodeSpanId(row.spanId),
+							spanName: decodeSpanName(row.spanName),
+							serviceName: decodeServiceName(row.serviceName),
+							statusCode: coerceStatusCode(row.statusCode),
+						}))
+						return new SpanHierarchyResponse({ data: typedRows })
+					}),
+				)
+				.handle("spanDetail", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const row = yield* runQueryFirst(Queries.spanDetail, tenant, payload)
+						return new SpanDetailResponse({
+							data: row
 								? {
-										queryCount: toNumber(summary.queryCount),
-										estimatedQueryCount: toNumber(summary.estimatedQueryCount),
-										errorCount: toNumber(summary.errorCount),
-										estimatedErrorCount: toNumber(summary.estimatedErrorCount),
-										errorRate: toNumber(summary.errorRate),
-										avgDurationMs: toNumber(summary.avgDurationMs),
-										p50DurationMs: toNumber(summary.p50DurationMs),
-										p95DurationMs: toNumber(summary.p95DurationMs),
-										activeServiceCount: toNumber(summary.activeServiceCount),
+										...row,
+										traceId: decodeTraceId(row.traceId),
+										spanId: decodeSpanId(row.spanId),
 									}
 								: null,
-						timeseries: timeseriesRows.map((row) => ({
-							bucket: String(row.bucket),
-							queryCount: toNumber(row.queryCount),
-							estimatedQueryCount: toNumber(row.estimatedQueryCount),
-							errorCount: toNumber(row.errorCount),
-							errorRate: toNumber(row.errorRate),
-							avgDurationMs: toNumber(row.avgDurationMs),
-							p50DurationMs: toNumber(row.p50DurationMs),
-							p95DurationMs: toNumber(row.p95DurationMs),
-						})),
-						topQueries: topQueryRows.map((row) => ({
-							queryKey: String(row.queryKey),
-							queryLabel: String(row.queryLabel),
-							sampleStatement: String(row.sampleStatement),
-							sampleService: String(row.sampleService),
-							serviceCount: toNumber(row.serviceCount),
-							queryCount: toNumber(row.queryCount),
-							estimatedQueryCount: toNumber(row.estimatedQueryCount),
-							errorCount: toNumber(row.errorCount),
-							errorRate: toNumber(row.errorRate),
-							avgDurationMs: toNumber(row.avgDurationMs),
-							p50DurationMs: toNumber(row.p50DurationMs),
-							p95DurationMs: toNumber(row.p95DurationMs),
-							lastSeen: String(row.lastSeen),
-						})),
-					})
-				}),
-			)
-			.handle("serviceWorkloads", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					if (payload.services.length === 0) {
-						return new ServiceWorkloadsResponse({ data: [] })
-					}
-					const rows = yield* runQuery(Queries.serviceWorkloads, tenant, payload)
-					return new ServiceWorkloadsResponse({ data: rows.map(toServiceWorkloadRow) })
-				}),
-			)
-			.handle("serviceUsage", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.serviceUsage, tenant, payload)
-					return new ServiceUsageResponse({ data: rows })
-				}),
-			)
-			.handle("serviceOperations", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const toNumber = (value: unknown) => Number(value ?? 0)
-					const data = yield* queryEngine.cachedDirect(
-						tenant,
-						"serviceOperations",
-						payload,
-						Effect.gen(function* () {
-							// Both reads try `service_operations_minutely`/`_hourly` and
-							// degrade per-org on UNKNOWN_TABLE. The timeseries read repeats
-							// the probe rather than inheriting the summary's verdict: one
-							// extra failed query on a cluster that never applied migration
-							// 0008 is cheaper than the mutable flag this replaced.
-							const summaryRows = yield* mapExecError(
-								withServiceOperationsFallback(
-									(t, pl) => runQuery(Queries.serviceOperationsSummary, t, pl),
-									(t, pl) => runQuery(Queries.serviceOperationsSummaryRaw, t, pl),
-									tenant,
-									payload,
-								),
-								"serviceOperations query failed",
-							)
-							if (summaryRows.length === 0) {
-								return []
+						})
+					}),
+				)
+				.handle("errorsByType", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.errorsByType, tenant, payload)
+						return new ErrorsByTypeResponse({
+							data: rows.map((row) => ({
+								fingerprintHash: decodeFingerprintHash(row.fingerprintHash),
+								errorLabel: row.errorLabel,
+								sampleMessage: row.sampleMessage,
+								count: Number(row.count),
+								affectedServicesCount: Number(row.affectedServicesCount),
+								firstSeen: String(row.firstSeen),
+								lastSeen: String(row.lastSeen),
+							})),
+						})
+					}),
+				)
+				.handle("errorsTimeseries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.errorsTimeseries, tenant, payload)
+						return new ErrorsTimeseriesResponse({
+							data: rows.map((row) => ({
+								bucket: String(row.bucket),
+								count: Number(row.count),
+							})),
+						})
+					}),
+				)
+				.handle("errorsSpark", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.errorsSpark, tenant, payload)
+						return new ErrorsSparkResponse({
+							data: rows.map((row) => ({
+								fingerprintHash: decodeFingerprintHash(row.fingerprintHash),
+								bucket: String(row.bucket),
+								count: Number(row.count),
+							})),
+						})
+					}),
+				)
+				.handle("errorsSummary", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const row = yield* runQueryFirst(Queries.errorsSummary, tenant, payload)
+						return new ErrorsSummaryResponse({
+							data: row
+								? {
+										totalErrors: Number(row.totalErrors),
+										totalSpans: Number(row.totalSpans),
+										errorRate: Number(row.errorRate),
+										affectedServicesCount: Number(row.affectedServicesCount),
+										affectedTracesCount: Number(row.affectedTracesCount),
+									}
+								: null,
+						})
+					}),
+				)
+				.handle("errorDetailTraces", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.errorDetailTraces, tenant, payload)
+						return new ErrorDetailTracesResponse({
+							data: rows.map((row) => ({
+								traceId: decodeTraceId(row.traceId),
+								startTime: String(row.startTime),
+								durationMicros: Number(row.durationMicros),
+								spanCount: Number(row.spanCount),
+								services: row.services.map((service) => decodeServiceName(service)),
+								rootSpanName: row.rootSpanName,
+								errorMessage: row.errorMessage,
+							})),
+						})
+					}),
+				)
+				.handle("errorRateByService", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.errorRateByService, tenant, payload)
+						return new ErrorRateByServiceResponse({
+							data: rows.map((row) => ({
+								serviceName: decodeServiceName(row.serviceName),
+								totalLogs: Number(row.totalLogs),
+								errorLogs: Number(row.errorLogs),
+								errorRate: Number(row.errorRate),
+							})),
+						})
+					}),
+				)
+				.handle("serviceOverview", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.serviceOverview, tenant, payload)
+						return new ServiceOverviewResponse({ data: rows })
+					}),
+				)
+				.handle("serviceHealthSnapshot", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.serviceHealthSnapshot, tenant, payload)
+						return new ServiceHealthSnapshotResponse({
+							data: rows.map((row) => ({
+								serviceName: decodeServiceName(row.serviceName),
+								environment: row.environment || "unknown",
+								requestCount: row.requestCount,
+								errorCount: row.errorCount,
+								p95LatencyMs: row.p95LatencyMs,
+							})),
+						})
+					}),
+				)
+				.handle("serviceHealthBaseline", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.serviceHealthBaseline, tenant, payload)
+						return new ServiceHealthBaselineResponse({
+							data: rows.map((row) => ({
+								serviceName: decodeServiceName(String(row.serviceName ?? "")),
+								serviceNamespace: String(row.serviceNamespace ?? ""),
+								environment: String(row.environment ?? "unknown"),
+								baselineP95LatencyMs: Number(row.baselineP95LatencyMs ?? 0),
+								baselineSpanCount: Number(row.baselineSpanCount ?? 0),
+							})),
+						})
+					}),
+				)
+				.handle("serviceApdex", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.serviceApdex, tenant, payload)
+						return new ServiceApdexResponse({
+							data: rows.map((row) => ({
+								bucket: String(row.bucket),
+								totalCount: Number(row.totalCount),
+								satisfiedCount: Number(row.satisfiedCount),
+								toleratingCount: Number(row.toleratingCount),
+								apdexScore: Number(row.apdexScore),
+							})),
+						})
+					}),
+				)
+				.handle("serviceCloudflareStats", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						// Counters (metrics_sum) + percentiles (metrics_gauge) run
+						// concurrently, then merge by ServiceName. Routed through the org's
+						// configured warehouse exactly like the metric explorer reads these
+						// same `cloudflare.*` metrics — no special ingest pin needed.
+						yield* warehouse.warmRoute(tenant)
+						const [counterRows, latencyRows] = yield* Effect.all(
+							[
+								runQuery(Queries.cloudflareServiceCounters, tenant, payload),
+								runQuery(Queries.cloudflareServiceLatency, tenant, payload),
+							],
+							{ concurrency: 2 },
+						)
+						const latencyByService = new Map(latencyRows.map((row) => [row.serviceName, row]))
+						const data = counterRows.map((row) => {
+							const latency = latencyByService.get(row.serviceName)
+							return {
+								serviceName: row.serviceName,
+								requests: row.requests,
+								errorCount: row.errorCount,
+								latencyP99Ms: latency?.latencyP99Ms ?? 0,
+								cpuP99Ms: latency?.cpuP99Ms ?? 0,
 							}
-
-							const spanNames = summaryRows.map((row) => String(row.spanName))
-							// The rollup is minute-grain, so every sparkline interval must be
-							// a whole-minute multiple. Nearest-minute rounding keeps ~50 points.
-							const windowSeconds = Math.max(
-								0,
-								(Date.parse(`${payload.endTime.replace(" ", "T")}Z`) -
-									Date.parse(`${payload.startTime.replace(" ", "T")}Z`)) /
-									1000,
-							)
-							const requestedBucketSeconds = payload.bucketSeconds ?? windowSeconds / 50
-							const bucketSeconds = Math.max(1, Math.round(requestedBucketSeconds / 60)) * 60
-							const timeseriesInput = { ...payload, spanNames, bucketSeconds }
-							const timeseriesRows = yield* mapExecError(
-								withServiceOperationsFallback(
-									(t, pl) => runQuery(Queries.serviceOperationsTimeseries, t, pl),
-									(t, pl) => runQuery(Queries.serviceOperationsTimeseriesRaw, t, pl),
-									tenant,
-									timeseriesInput,
-								),
-								"serviceOperationsTimeseries query failed",
-							)
-
-							const sparklines = new Map<string, Array<{ bucket: string; count: number }>>()
-							for (const row of timeseriesRows) {
-								const key = String(row.spanName)
-								const points = sparklines.get(key) ?? []
-								points.push({ bucket: String(row.bucket), count: toNumber(row.count) })
-								sparklines.set(key, points)
+						})
+						return new ServiceCloudflareStatsResponse({ data })
+					}),
+				)
+				.handle("servicePlanetScaleStats", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const byBranch = payload.database !== undefined
+						// Utilization gauges + the two-level connections rollup run
+						// concurrently, then merge by database(+branch). Routed through the
+						// org's configured warehouse like the metric explorer reads the same
+						// scraped `planetscale_*` metrics.
+						yield* warehouse.warmRoute(tenant)
+						const [gaugeRows, connectionRows, storageRows] = yield* Effect.all(
+							[
+								runQuery(Queries.planetscaleServiceGauges, tenant, payload),
+								runQuery(Queries.planetscaleServiceConnections, tenant, payload),
+								runQuery(Queries.planetscaleServiceStorage, tenant, payload),
+							],
+							{ concurrency: 3 },
+						)
+						const keyOf = (row: { database: string; branch?: string }) =>
+							byBranch ? `${row.database}\x00${row.branch ?? ""}` : row.database
+						const connectionsByKey = new Map(connectionRows.map((row) => [keyOf(row), row]))
+						const storageByKey = new Map(storageRows.map((row) => [keyOf(row), row]))
+						const seen = new Set<string>()
+						type MergedStatsRow = {
+							readonly database: string
+							readonly branch?: string
+							readonly cpuMaxPercent: number
+							readonly memMaxPercent: number
+							readonly replicaLagMaxSeconds: number
+							readonly connectionsAvg: number
+							readonly connectionsMax: number
+							readonly storageUsedPercent: number
+							/** 0 = the volume gauges never reported; the client must not render 0% used. */
+							readonly storageSamples: number
+						}
+						const storageFor = (key: string) => {
+							const storage = storageByKey.get(key)
+							return {
+								storageUsedPercent: storage?.storageUsedPercent ?? 0,
+								storageSamples: storage?.storageSamples ?? 0,
 							}
+						}
+						// The storage rollup is per-database or per-branch depending on the
+						// request; only the latter carries a branch to forward.
+						const branchOf = (
+							row:
+								| { readonly database: string }
+								| { readonly database: string; readonly branch: string },
+						): { readonly branch?: string } => ("branch" in row ? { branch: row.branch } : {})
+						const data: Array<MergedStatsRow> = gaugeRows.map((row) => {
+							const key = keyOf(row)
+							seen.add(key)
+							const connections = connectionsByKey.get(key)
+							return {
+								...row,
+								connectionsAvg: connections?.connectionsAvg ?? 0,
+								connectionsMax: connections?.connectionsMax ?? 0,
+								...storageFor(key),
+							}
+						})
+						// Databases with connection samples but no utilization gauges still
+						// deserve a row (e.g. filtered scrape sets).
+						for (const row of connectionRows) {
+							const key = keyOf(row)
+							if (seen.has(key)) continue
+							seen.add(key)
+							data.push({
+								...row,
+								cpuMaxPercent: 0,
+								memMaxPercent: 0,
+								replicaLagMaxSeconds: 0,
+								...storageFor(key),
+							})
+						}
+						// …and so do volumes reporting with no gauges or connections at all —
+						// an idle branch still filling its disk is exactly what to surface.
+						for (const row of storageRows) {
+							const key = keyOf(row)
+							if (seen.has(key)) continue
+							seen.add(key)
+							data.push({
+								database: row.database,
+								...branchOf(row),
+								cpuMaxPercent: 0,
+								memMaxPercent: 0,
+								replicaLagMaxSeconds: 0,
+								connectionsAvg: 0,
+								connectionsMax: 0,
+								storageUsedPercent: row.storageUsedPercent,
+								storageSamples: row.storageSamples,
+							})
+						}
+						return new ServicePlanetScaleStatsResponse({ data })
+					}),
+				)
+				.handle("planetscaleInfraTimeseries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.planetscaleInfraTimeseries, tenant, payload)
+						return new PlanetScaleInfraTimeseriesResponse({
+							data: rows.map((row) => ({ ...row })),
+						})
+					}),
+				)
+				.handle("cloudflareInfraZones", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						// Counters (metrics_sum) + percentiles (metrics_gauge) run
+						// concurrently, then merge by ServiceName — same shape as
+						// serviceCloudflareStats above.
+						const filters = toCloudflareFilters(payload)
+						yield* warehouse.warmRoute(tenant)
+						const [counterRows, latencyRows] = yield* Effect.all(
+							[
+								runQuery(Queries.cloudflareInfraZoneCounters, tenant, payload),
+								runQuery(Queries.cloudflareInfraZoneLatency, tenant, payload),
+							],
+							{ concurrency: 2 },
+						)
+						const latencyByService = new Map(latencyRows.map((row) => [row.serviceName, row]))
+						const data = counterRows.map((row) => {
+							const latency = latencyByService.get(row.serviceName)
+							return {
+								serviceName: row.serviceName,
+								requests: row.requests,
+								errors5xx: row.errors5xx,
+								cacheHits: row.cacheHits,
+								bytes: row.bytes,
+								visits: row.visits,
+								ttfbP50Ms: latency?.ttfbP50Ms ?? 0,
+								ttfbP95Ms: latency?.ttfbP95Ms ?? 0,
+								ttfbP99Ms: latency?.ttfbP99Ms ?? 0,
+								originP50Ms: latency?.originP50Ms ?? 0,
+								originP95Ms: latency?.originP95Ms ?? 0,
+								originP99Ms: latency?.originP99Ms ?? 0,
+							}
+						})
+						return new CloudflareInfraZonesResponse({
+							data,
+							// The latency columns are zone-wide by construction, so a dimension filter
+							// narrows the counters but never the percentiles beside them.
+							ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
+								Integrations.CF_METRIC.requests,
+								Integrations.CF_METRIC.bytes,
+								Integrations.CF_METRIC.visits,
+							]),
+						})
+					}),
+				)
+				.handle("cloudflareInfraZoneTimeseries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const filters = toCloudflareFilters(payload)
+						const rows = yield* runQuery(Queries.cloudflareInfraZoneTimeseries, tenant, payload)
+						return new CloudflareInfraZoneTimeseriesResponse({
+							data: rows.map((row) => ({ ...row })),
+							ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
+								Integrations.CF_METRIC.requests,
+							]),
+						})
+					}),
+				)
+				.handle("cloudflareInfraZoneDetail", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const filters = toCloudflareFilters(payload)
+						yield* warehouse.warmRoute(tenant)
+						const [statusRows, cacheRows, latencyRows] = yield* Effect.all(
+							[
+								runQuery(Queries.cloudflareInfraZoneDetailStatus, tenant, payload),
+								runQuery(Queries.cloudflareInfraZoneDetailCache, tenant, payload),
+								runQuery(Queries.cloudflareInfraZoneDetailLatency, tenant, payload),
+							],
+							{ concurrency: 3 },
+						)
+						return new CloudflareInfraZoneDetailResponse({
+							statusBuckets: statusRows.map((row) => ({ ...row })),
+							cacheBuckets: cacheRows.map((row) => ({ ...row })),
+							latencyBuckets: latencyRows.map((row) => ({ ...row })),
+							ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
+								Integrations.CF_METRIC.requests,
+							]),
+							latencyIgnoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
+								Integrations.CF_METRIC.edgeTtfb,
+								Integrations.CF_METRIC.originDuration,
+							]),
+						})
+					}),
+				)
+				.handle("cloudflareInfraZoneSecurity", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const filters = toCloudflareFilters(payload)
+						yield* warehouse.warmRoute(tenant)
+						const [bucketRows, topRows] = yield* Effect.all(
+							[
+								runQuery(Queries.cloudflareInfraZoneFirewallTimeseries, tenant, payload),
+								runQuery(Queries.cloudflareInfraZoneFirewallTop, tenant, payload),
+							],
+							{ concurrency: 2 },
+						)
+						return new CloudflareInfraZoneSecurityResponse({
+							buckets: bucketRows.map((row) => ({ ...row })),
+							top: topRows.map((row) => ({ ...row })),
+							ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
+								Integrations.CF_METRIC.firewallEvents,
+							]),
+						})
+					}),
+				)
+				.handle("cloudflareInfraZoneDns", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const filters = toCloudflareFilters(payload)
+						yield* warehouse.warmRoute(tenant)
+						const [bucketRows, nameRows] = yield* Effect.all(
+							[
+								runQuery(Queries.cloudflareInfraZoneDnsTimeseries, tenant, payload),
+								runQuery(Queries.cloudflareInfraZoneDnsBreakdown, tenant, payload),
+							],
+							{ concurrency: 2 },
+						)
+						return new CloudflareInfraZoneDnsResponse({
+							buckets: bucketRows.map((row) => ({ ...row })),
+							names: nameRows.map((row) => ({ ...row })),
+							ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(filters, [
+								Integrations.CF_METRIC.dnsQueries,
+							]),
+						})
+					}),
+				)
+				.handle("cloudflareInfraZoneBreakdown", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const filters = toCloudflareFilters(payload)
+						yield* warehouse.warmRoute(tenant)
+						const [totalRows, coverageRows, zoneRows] = yield* Effect.all(
+							[
+								runQuery(Queries.cloudflareInfraZoneBreakdownTotals, tenant, payload),
+								runQuery(Queries.cloudflareInfraZoneBreakdownCoverage, tenant, payload),
+								runQuery(Queries.cloudflareInfraZoneBreakdownZoneTotal, tenant, payload),
+							],
+							{ concurrency: 3 },
+						)
+						const topKeys = totalRows
+							.filter((row) => row.key !== Integrations.CLOUDFLARE_BREAKDOWN_OTHER_KEY)
+							.slice(0, Integrations.CLOUDFLARE_BREAKDOWN_SERIES_LIMIT)
+							.map((row) => row.key)
+						const bucketRows: ReadonlyArray<Integrations.CloudflareZoneBreakdownTimeseriesOutput> =
+							topKeys.length === 0
+								? []
+								: yield* runQuery(Queries.cloudflareInfraZoneBreakdownTimeseries, tenant, {
+										...payload,
+										topKeys,
+									})
+						const coverage = coverageRows[0]
+						const zoneRequests = zoneRows.find((row) => row.serviceName === payload.serviceName)
+						// Breakdown metrics are a per-window top-N fold of what Cloudflare returned, so
+						// they can only ever undercount the zone. Clamp rather than surface a negative.
+						const unattributed = Math.max(
+							0,
+							(zoneRequests?.requests ?? 0) - (coverage?.attributedRequests ?? 0),
+						)
+						return new CloudflareInfraZoneBreakdownResponse({
+							totals: totalRows.map((row) => ({ ...row })),
+							buckets: bucketRows.map((row) => ({ ...row })),
+							unattributed,
+							coverageStart:
+								coverage?.coverageStart != null && coverage.coverageStart !== ""
+									? coverage.coverageStart
+									: null,
+							ignoredFilters: Integrations.cloudflareIgnoredFiltersFor(
+								filters,
+								Integrations.cloudflareBreakdownMetrics(payload.dimension),
+							),
+						})
+					}),
+				)
+				.handle("cloudflareInfraZoneFacets", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.cloudflareInfraZoneFacets, tenant, payload)
+						const buckets = {
+							hosts: [] as Array<{ name: string; count: number }>,
+							cacheStatuses: [] as Array<{ name: string; count: number }>,
+							statusClasses: [] as Array<{ name: string; count: number }>,
+							paths: [] as Array<{ name: string; count: number }>,
+							countries: [] as Array<{ name: string; count: number }>,
+							methods: [] as Array<{ name: string; count: number }>,
+							protocols: [] as Array<{ name: string; count: number }>,
+							deviceTypes: [] as Array<{ name: string; count: number }>,
+						}
+						for (const row of rows) {
+							// BYO-ClickHouse returns sum() as a JSON string; compileUnion has no
+							// rowSchema hook, so coerce here — same as podFacets.
+							const entry = { name: String(row.name), count: Number(row.count) || 0 }
+							switch (row.facetType) {
+								case "host":
+									buckets.hosts.push(entry)
+									break
+								case "cacheStatus":
+									buckets.cacheStatuses.push(entry)
+									break
+								case "statusClass":
+									buckets.statusClasses.push(entry)
+									break
+								case "path":
+									buckets.paths.push(entry)
+									break
+								case "country":
+									buckets.countries.push(entry)
+									break
+								case "method":
+									buckets.methods.push(entry)
+									break
+								case "protocol":
+									buckets.protocols.push(entry)
+									break
+								case "deviceType":
+									buckets.deviceTypes.push(entry)
+									break
+							}
+						}
+						return new CloudflareInfraZoneFacetsResponse({ data: buckets })
+					}),
+				)
+				.handle("cloudflareInfraPlatformResources", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						yield* warehouse.warmRoute(tenant)
+						const [queueRows, doRows] = yield* Effect.all(
+							[
+								runQuery(Queries.cloudflareInfraQueueGauges, tenant, payload),
+								runQuery(Queries.cloudflareInfraDurableObjects, tenant, payload),
+							],
+							{ concurrency: 2 },
+						)
+						return new CloudflareInfraPlatformResourcesResponse({
+							queues: queueRows.map((row) => ({ ...row })),
+							durableObjects: doRows.map((row) => ({ ...row })),
+						})
+					}),
+				)
+				.handle("cloudflareInfraWorkers", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						yield* warehouse.warmRoute(tenant)
+						const [counterRows, latencyRows] = yield* Effect.all(
+							[
+								runQuery(Queries.cloudflareInfraWorkerCounters, tenant, payload),
+								runQuery(Queries.cloudflareInfraWorkerLatency, tenant, payload),
+							],
+							{ concurrency: 2 },
+						)
+						const latencyByService = new Map(latencyRows.map((row) => [row.serviceName, row]))
+						const data = counterRows.map((row) => {
+							const latency = latencyByService.get(row.serviceName)
+							return {
+								serviceName: row.serviceName,
+								requests: row.requests,
+								errors: row.errors,
+								subrequests: row.subrequests,
+								cpuP50Ms: latency?.cpuP50Ms ?? 0,
+								cpuP99Ms: latency?.cpuP99Ms ?? 0,
+								durationP50Ms: latency?.durationP50Ms ?? 0,
+								durationP99Ms: latency?.durationP99Ms ?? 0,
+							}
+						})
+						return new CloudflareInfraWorkersResponse({ data })
+					}),
+				)
+				.handle("serviceDetailOverview", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						// One Worker invocation for the whole Overview tab: per-org config
+						// resolves once (the first sub-query warms the in-isolate memo) and
+						// the three queries run concurrently, replacing three separate
+						// browser->Worker round-trips. The primary chart keeps its own
+						// execute-path cache; releases is uncached (mirrors the standalone
+						// handler); environments is edge-cached on a service-scoped key.
+						yield* warehouse.warmRoute(tenant)
+						const [timeseries, releaseRows, environmentRows] = yield* Effect.all(
+							[
+								queryEngine.execute(tenant, payload.timeseries),
+								runQuery(Queries.serviceReleases, tenant, payload),
+								runQuery(Queries.serviceEnvironments, tenant, {
+									serviceName: payload.serviceName,
+									startTime: payload.startTime,
+									endTime: payload.endTime,
+								}),
+							],
+							{ concurrency: 3 },
+						)
+						return new ServiceDetailOverviewResponse({
+							timeseries,
+							releases: releaseRows.map((row) => ({
+								bucket: String(row.bucket),
+								commitSha: decodeCommitSha(row.commitSha),
+								count: Number(row.count),
+								errorCount: Number(row.errorCount),
+							})),
+							environments: environmentRows
+								.map((row) => String(row.environment ?? ""))
+								.filter((env) => env !== ""),
+						})
+					}),
+				)
+				.handle("serviceDependenciesBundle", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						// Dependencies tab in one Worker invocation: the three service-map
+						// edge queries run concurrently and share a single config
+						// resolution, replacing three independent round-trips.
+						yield* warehouse.warmRoute(tenant)
+						const [dependencyRows, dbEdgeRows, externalEdgeRows] = yield* Effect.all(
+							[
+								runQuery(Queries.serviceDependenciesForService, tenant, payload),
+								runQuery(Queries.serviceDbEdgesForService, tenant, payload),
+								runQuery(Queries.serviceExternalEdges, tenant, payload),
+							],
+							{ concurrency: 3 },
+						)
+						return new ServiceDependenciesBundleResponse({
+							dependencies: dependencyRows.map((row) => ({ ...row })),
+							dbEdges: dbEdgeRows.map((row) => ({ ...row })),
+							externalEdges: externalEdgeRows.map((row) => ({ ...row })),
+						})
+					}),
+				)
+				.handle("serviceMapBundle", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						// Resolve warehouse routing once before the fan-out.
+						yield* warehouse.warmRoute(tenant)
+						const [dependencyRows, overviewRows, dbEdgeRows, platformRows] = yield* Effect.all(
+							[
+								runQuery(Queries.serviceDependencies, tenant, payload),
+								runQuery(Queries.serviceOverview, tenant, payload),
+								runQuery(Queries.serviceDbEdges, tenant, payload),
+								runQuery(Queries.servicePlatforms, tenant, payload),
+							],
+							{ concurrency: 4 },
+						)
 
-							return summaryRows.map((row) => ({
-								spanName: String(row.spanName),
-								spanCount: toNumber(row.spanCount),
-								estimatedSpanCount: toNumber(row.estimatedSpanCount),
+						const services = new Set<string>()
+						for (const row of dependencyRows) {
+							services.add(String(row.sourceService ?? ""))
+							services.add(String(row.targetService ?? ""))
+						}
+						for (const row of overviewRows) services.add(String(row.serviceName ?? ""))
+						services.delete("")
+
+						const workloadRows =
+							services.size === 0
+								? []
+								: yield* runQuery(Queries.serviceWorkloads, tenant, {
+										startTime: payload.startTime,
+										endTime: payload.endTime,
+										services: Array.from(services)
+											.sort()
+											.map((name) => decodeServiceName(name)),
+									})
+
+						return new ServiceMapBundleResponse({
+							dependencies: dependencyRows.map((row) => ({ ...row })),
+							dbEdges: dbEdgeRows.map((row) => ({ ...row })),
+							overview: overviewRows.map((row) => ({ ...row })),
+							platforms: platformRows.map(toServicePlatformRow),
+							workloads: workloadRows.map(toServiceWorkloadRow),
+						})
+					}),
+				)
+				.handle("serviceDbQuerySummary", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+
+						yield* warehouse.warmRoute(tenant)
+						const [summary, timeseriesRows, topQueryRows] = yield* Effect.all(
+							[
+								runQueryFirst(Queries.serviceDbQuerySummary, tenant, payload),
+								runQuery(Queries.serviceDbQueryTimeseries, tenant, payload),
+								runQuery(Queries.serviceDbTopQueries, tenant, payload),
+							],
+							{ concurrency: 3 },
+						)
+
+						const toNumber = (value: unknown) => Number(value ?? 0)
+						return new ServiceDbQuerySummaryResponse({
+							summary:
+								summary && toNumber(summary.queryCount) > 0
+									? {
+											queryCount: toNumber(summary.queryCount),
+											estimatedQueryCount: toNumber(summary.estimatedQueryCount),
+											errorCount: toNumber(summary.errorCount),
+											estimatedErrorCount: toNumber(summary.estimatedErrorCount),
+											errorRate: toNumber(summary.errorRate),
+											avgDurationMs: toNumber(summary.avgDurationMs),
+											p50DurationMs: toNumber(summary.p50DurationMs),
+											p95DurationMs: toNumber(summary.p95DurationMs),
+											activeServiceCount: toNumber(summary.activeServiceCount),
+										}
+									: null,
+							timeseries: timeseriesRows.map((row) => ({
+								bucket: String(row.bucket),
+								queryCount: toNumber(row.queryCount),
+								estimatedQueryCount: toNumber(row.estimatedQueryCount),
 								errorCount: toNumber(row.errorCount),
-								estimatedErrorCount: toNumber(row.estimatedErrorCount),
 								errorRate: toNumber(row.errorRate),
 								avgDurationMs: toNumber(row.avgDurationMs),
 								p50DurationMs: toNumber(row.p50DurationMs),
 								p95DurationMs: toNumber(row.p95DurationMs),
-								sparkline: sparklines.get(String(row.spanName)) ?? [],
-							}))
-						}),
-						30,
-					)
-					return new ServiceOperationsResponse({ data })
-				}),
-			)
-			.handle("listLogs", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.listLogs, tenant, payload)
-					return new ListLogsResponse({ data: rows })
-				}),
-			)
-			.handle("getLog", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.getLog, tenant, payload)
-					return new GetLogResponse({ data: rows })
-				}),
-			)
-			.handle("listMetrics", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.listMetrics, tenant, payload)
-					return new ListMetricsResponse({ data: rows })
-				}),
-			)
-			.handle("metricsSummary", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.metricsSummary, tenant, payload)
-					return new MetricsSummaryResponse({
-						data: rows.map((row) => ({
-							metricType: row.metricType,
-							metricCount: Number(row.metricCount),
-							dataPointCount: Number(row.dataPointCount),
-						})),
-					})
-				}),
-			)
-			.handle("listHosts", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.listHosts, tenant, payload)
-					return new ListHostsResponse({
-						data: rows.map((row) => ({
-							hostName: row.hostName,
-							osType: row.osType,
-							hostArch: row.hostArch,
-							cloudProvider: row.cloudProvider,
-							lastSeen: String(row.lastSeen),
-							cpuPct: Number(row.cpuPct) || 0,
-							memoryPct: Number(row.memoryPct) || 0,
-							diskPct: Number(row.diskPct) || 0,
-							load15: Number(row.load15) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("hostDetailSummary", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const row = yield* runQueryFirst(Queries.hostDetailSummary, tenant, payload)
-					return new HostDetailSummaryResponse({
-						data: row
-							? {
-									hostName: row.hostName,
-									osType: row.osType,
-									hostArch: row.hostArch,
-									cloudProvider: row.cloudProvider,
-									cloudRegion: row.cloudRegion,
-									firstSeen: String(row.firstSeen),
-									lastSeen: String(row.lastSeen),
-									cpuPct: Number(row.cpuPct) || 0,
-									memoryPct: Number(row.memoryPct) || 0,
-									diskPct: Number(row.diskPct) || 0,
-									load15: Number(row.load15) || 0,
+							})),
+							topQueries: topQueryRows.map((row) => ({
+								queryKey: String(row.queryKey),
+								queryLabel: String(row.queryLabel),
+								sampleStatement: String(row.sampleStatement),
+								sampleService: String(row.sampleService),
+								serviceCount: toNumber(row.serviceCount),
+								queryCount: toNumber(row.queryCount),
+								estimatedQueryCount: toNumber(row.estimatedQueryCount),
+								errorCount: toNumber(row.errorCount),
+								errorRate: toNumber(row.errorRate),
+								avgDurationMs: toNumber(row.avgDurationMs),
+								p50DurationMs: toNumber(row.p50DurationMs),
+								p95DurationMs: toNumber(row.p95DurationMs),
+								lastSeen: String(row.lastSeen),
+							})),
+						})
+					}),
+				)
+				.handle("serviceWorkloads", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						if (payload.services.length === 0) {
+							return new ServiceWorkloadsResponse({ data: [] })
+						}
+						const rows = yield* runQuery(Queries.serviceWorkloads, tenant, payload)
+						return new ServiceWorkloadsResponse({ data: rows.map(toServiceWorkloadRow) })
+					}),
+				)
+				.handle("serviceUsage", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.serviceUsage, tenant, payload)
+						return new ServiceUsageResponse({ data: rows })
+					}),
+				)
+				.handle("serviceOperations", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const toNumber = (value: unknown) => Number(value ?? 0)
+						const data = yield* queryEngine.cachedDirect(
+							tenant,
+							"serviceOperations",
+							payload,
+							Effect.gen(function* () {
+								// Both reads try `service_operations_minutely`/`_hourly` and
+								// degrade per-org on UNKNOWN_TABLE. The timeseries read repeats
+								// the probe rather than inheriting the summary's verdict: one
+								// extra failed query on a cluster that never applied migration
+								// 0008 is cheaper than the mutable flag this replaced.
+								const summaryRows = yield* mapExecError(
+									withServiceOperationsFallback(
+										(t, pl) => runQuery(Queries.serviceOperationsSummary, t, pl),
+										(t, pl) => runQuery(Queries.serviceOperationsSummaryRaw, t, pl),
+										tenant,
+										payload,
+									),
+									"serviceOperations query failed",
+								)
+								if (summaryRows.length === 0) {
+									return []
 								}
-							: null,
-					})
-				}),
-			)
-			.handle("fleetUtilizationTimeseries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.fleetUtilizationTimeseries, tenant, payload)
-					return new FleetUtilizationTimeseriesResponse({
-						data: rows.map((row) => ({
-							bucket: String(row.bucket),
-							avgCpu: Number(row.avgCpu) || 0,
-							avgMemory: Number(row.avgMemory) || 0,
-							activeHosts: Number(row.activeHosts) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("hostInfraTimeseries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const bucketSeconds = payload.bucketSeconds ?? 60
 
-					const spec = hostMetricSpec(payload.metric)
+								const spanNames = summaryRows.map((row) => String(row.spanName))
+								// The rollup is minute-grain, so every sparkline interval must be
+								// a whole-minute multiple. Nearest-minute rounding keeps ~50 points.
+								const windowSeconds = Math.max(
+									0,
+									(Date.parse(`${payload.endTime.replace(" ", "T")}Z`) -
+										Date.parse(`${payload.startTime.replace(" ", "T")}Z`)) /
+										1000,
+								)
+								const requestedBucketSeconds = payload.bucketSeconds ?? windowSeconds / 50
+								const bucketSeconds =
+									Math.max(1, Math.round(requestedBucketSeconds / 60)) * 60
+								const timeseriesInput = { ...payload, spanNames, bucketSeconds }
+								const timeseriesRows = yield* mapExecError(
+									withServiceOperationsFallback(
+										(t, pl) => runQuery(Queries.serviceOperationsTimeseries, t, pl),
+										(t, pl) => runQuery(Queries.serviceOperationsTimeseriesRaw, t, pl),
+										tenant,
+										timeseriesInput,
+									),
+									"serviceOperationsTimeseries query failed",
+								)
 
-					if (spec.isNetwork) {
-						const rows = yield* runQuery(Queries.hostInfraNetworkTimeseries, tenant, payload)
+								const sparklines = new Map<string, Array<{ bucket: string; count: number }>>()
+								for (const row of timeseriesRows) {
+									const key = String(row.spanName)
+									const points = sparklines.get(key) ?? []
+									points.push({ bucket: String(row.bucket), count: toNumber(row.count) })
+									sparklines.set(key, points)
+								}
+
+								return summaryRows.map((row) => ({
+									spanName: String(row.spanName),
+									spanCount: toNumber(row.spanCount),
+									estimatedSpanCount: toNumber(row.estimatedSpanCount),
+									errorCount: toNumber(row.errorCount),
+									estimatedErrorCount: toNumber(row.estimatedErrorCount),
+									errorRate: toNumber(row.errorRate),
+									avgDurationMs: toNumber(row.avgDurationMs),
+									p50DurationMs: toNumber(row.p50DurationMs),
+									p95DurationMs: toNumber(row.p95DurationMs),
+									sparkline: sparklines.get(String(row.spanName)) ?? [],
+								}))
+							}),
+							30,
+						)
+						return new ServiceOperationsResponse({ data })
+					}),
+				)
+				.handle("listLogs", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.listLogs, tenant, payload)
+						return new ListLogsResponse({ data: rows })
+					}),
+				)
+				.handle("getLog", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.getLog, tenant, payload)
+						return new GetLogResponse({ data: rows })
+					}),
+				)
+				.handle("listMetrics", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.listMetrics, tenant, payload)
+						return new ListMetricsResponse({ data: rows })
+					}),
+				)
+				.handle("metricsSummary", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.metricsSummary, tenant, payload)
+						return new MetricsSummaryResponse({
+							data: rows.map((row) => ({
+								metricType: row.metricType,
+								metricCount: Number(row.metricCount),
+								dataPointCount: Number(row.dataPointCount),
+							})),
+						})
+					}),
+				)
+				.handle("listHosts", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.listHosts, tenant, payload)
+						return new ListHostsResponse({
+							data: rows.map((row) => ({
+								hostName: row.hostName,
+								osType: row.osType,
+								hostArch: row.hostArch,
+								cloudProvider: row.cloudProvider,
+								lastSeen: String(row.lastSeen),
+								cpuPct: Number(row.cpuPct) || 0,
+								memoryPct: Number(row.memoryPct) || 0,
+								diskPct: Number(row.diskPct) || 0,
+								load15: Number(row.load15) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("hostDetailSummary", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const row = yield* runQueryFirst(Queries.hostDetailSummary, tenant, payload)
+						return new HostDetailSummaryResponse({
+							data: row
+								? {
+										hostName: row.hostName,
+										osType: row.osType,
+										hostArch: row.hostArch,
+										cloudProvider: row.cloudProvider,
+										cloudRegion: row.cloudRegion,
+										firstSeen: String(row.firstSeen),
+										lastSeen: String(row.lastSeen),
+										cpuPct: Number(row.cpuPct) || 0,
+										memoryPct: Number(row.memoryPct) || 0,
+										diskPct: Number(row.diskPct) || 0,
+										load15: Number(row.load15) || 0,
+									}
+								: null,
+						})
+					}),
+				)
+				.handle("fleetUtilizationTimeseries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.fleetUtilizationTimeseries, tenant, payload)
+						return new FleetUtilizationTimeseriesResponse({
+							data: rows.map((row) => ({
+								bucket: String(row.bucket),
+								avgCpu: Number(row.avgCpu) || 0,
+								avgMemory: Number(row.avgMemory) || 0,
+								activeHosts: Number(row.activeHosts) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("hostInfraTimeseries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const bucketSeconds = payload.bucketSeconds ?? 60
+
+						const spec = hostMetricSpec(payload.metric)
+
+						if (spec.isNetwork) {
+							const rows = yield* runQuery(Queries.hostInfraNetworkTimeseries, tenant, payload)
+							return new HostInfraTimeseriesResponse({
+								data: rows.map((row) => ({
+									bucket: String(row.bucket),
+									attributeValue: String(row.attributeValue ?? ""),
+									value: Number(row.sumValue) || 0,
+								})),
+								groupByAttributeKey: spec.groupByAttributeKey,
+								unit: spec.unit,
+							})
+						}
+
+						const rows = yield* runQuery(Queries.hostInfraGaugeTimeseries, tenant, payload)
 						return new HostInfraTimeseriesResponse({
 							data: rows.map((row) => ({
 								bucket: String(row.bucket),
 								attributeValue: String(row.attributeValue ?? ""),
-								value: Number(row.sumValue) || 0,
+								value: Number(row.avgValue) || 0,
 							})),
 							groupByAttributeKey: spec.groupByAttributeKey,
 							unit: spec.unit,
 						})
-					}
-
-					const rows = yield* runQuery(Queries.hostInfraGaugeTimeseries, tenant, payload)
-					return new HostInfraTimeseriesResponse({
-						data: rows.map((row) => ({
-							bucket: String(row.bucket),
-							attributeValue: String(row.attributeValue ?? ""),
-							value: Number(row.avgValue) || 0,
-						})),
-						groupByAttributeKey: spec.groupByAttributeKey,
-						unit: spec.unit,
-					})
-				}),
-			)
-			.handle("listPods", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					yield* warehouse.warmRoute(tenant)
-					const [rows, countRow] = yield* Effect.all(
-						[
-							runQuery(Queries.listPods, tenant, payload),
-							runQueryFirst(Queries.listPodsCount, tenant, payload),
-						],
-						{ concurrency: 2 },
-					)
-					return new ListPodsResponse({
-						data: rows.map((row) => ({
-							podName: row.podName,
-							namespace: row.namespace,
-							nodeName: row.nodeName,
-							clusterName: row.clusterName,
-							environment: row.environment,
-							deploymentName: row.deploymentName,
-							statefulsetName: row.statefulsetName,
-							daemonsetName: row.daemonsetName,
-							jobName: row.jobName,
-							qosClass: row.qosClass,
-							podUid: row.podUid,
-							computeType: row.computeType,
-							lastSeen: String(row.lastSeen),
-							cpuUsage: Number(row.cpuUsage) || 0,
-							cpuLimitPct: Number(row.cpuLimitPct) || 0,
-							memoryLimitPct: Number(row.memoryLimitPct) || 0,
-							cpuRequestPct: Number(row.cpuRequestPct) || 0,
-							memoryRequestPct: Number(row.memoryRequestPct) || 0,
-							cpuUsagePeak: Number(row.cpuUsagePeak) || 0,
-							cpuLimitPctPeak: Number(row.cpuLimitPctPeak) || 0,
-							memoryLimitPctPeak: Number(row.memoryLimitPctPeak) || 0,
-							saturation: Number(row.saturation) || 0,
-						})),
-						// The denominator has to match the predicate the list ran, or a scoped
-						// view reads "Top 17 of 541". The scope counts are already computed.
-						totalCount:
-							Number(
-								payload.scope === "saturated"
-									? countRow?.saturatedPods
-									: payload.scope === "elevated"
-										? countRow?.elevatedPods
-										: payload.scope === "unbounded"
-											? countRow?.unboundedPods
-											: payload.scope === "stale"
-												? countRow?.stalePods
-												: countRow?.totalPods,
-							) ||
-							// A failed count must not render as "0 of 0" under a list with rows.
-							rows.length,
-					})
-				}),
-			)
-			.handle("podsSummary", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const row = yield* runQueryFirst(Queries.podsSummary, tenant, payload)
-					return new PodsSummaryResponse({
-						totalPods: Number(row?.totalPods) || 0,
-						saturatedPods: Number(row?.saturatedPods) || 0,
-						elevatedPods: Number(row?.elevatedPods) || 0,
-						unboundedPods: Number(row?.unboundedPods) || 0,
-						stalePods: Number(row?.stalePods) || 0,
-					})
-				}),
-			)
-			.handle("podDetailSummary", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const row = yield* runQueryFirst(Queries.podDetailSummary, tenant, payload)
-					return new PodDetailSummaryResponse({
-						data: row
-							? {
-									podName: row.podName,
-									namespace: row.namespace,
-									nodeName: row.nodeName,
-									deploymentName: row.deploymentName,
-									statefulsetName: row.statefulsetName,
-									daemonsetName: row.daemonsetName,
-									qosClass: row.qosClass,
-									podUid: row.podUid,
-									computeType: row.computeType,
-									podStartTime: row.podStartTime,
-									firstSeen: String(row.firstSeen),
-									lastSeen: String(row.lastSeen),
-									cpuUsage: Number(row.cpuUsage) || 0,
-									cpuLimitPct: Number(row.cpuLimitPct) || 0,
-									memoryLimitPct: Number(row.memoryLimitPct) || 0,
-									cpuRequestPct: Number(row.cpuRequestPct) || 0,
-									memoryRequestPct: Number(row.memoryRequestPct) || 0,
-								}
-							: null,
-					})
-				}),
-			)
-			.handle("podInfraTimeseries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const spec = podMetricSpec(payload.metric)
-					const rows = yield* runQuery(Queries.podInfraTimeseries, tenant, payload)
-					return new PodInfraTimeseriesResponse({
-						data: rows.map((row) => ({
-							bucket: String(row.bucket),
-							attributeValue: String(row.attributeValue ?? ""),
-							value: Number(row.avgValue) || 0,
-						})),
-						unit: spec.unit,
-					})
-				}),
-			)
-			.handle("listNodes", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.listNodes, tenant, payload)
-					return new ListNodesResponse({
-						data: rows.map((row) => ({
-							nodeName: row.nodeName,
-							nodeUid: row.nodeUid,
-							clusterName: row.clusterName,
-							environment: row.environment,
-							kubeletVersion: row.kubeletVersion,
-							lastSeen: String(row.lastSeen),
-							cpuUsage: Number(row.cpuUsage) || 0,
-							uptime: Number(row.uptime) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("nodeDetailSummary", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const row = yield* runQueryFirst(Queries.nodeDetailSummary, tenant, payload)
-					return new NodeDetailSummaryResponse({
-						data: row
-							? {
-									nodeName: row.nodeName,
-									nodeUid: row.nodeUid,
-									kubeletVersion: row.kubeletVersion,
-									containerRuntime: row.containerRuntime,
-									firstSeen: String(row.firstSeen),
-									lastSeen: String(row.lastSeen),
-									cpuUsage: Number(row.cpuUsage) || 0,
-									uptime: Number(row.uptime) || 0,
-								}
-							: null,
-					})
-				}),
-			)
-			.handle("nodeInfraTimeseries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const spec = nodeMetricSpec(payload.metric)
-					const rows = yield* runQuery(Queries.nodeInfraTimeseries, tenant, payload)
-					return new NodeInfraTimeseriesResponse({
-						data: rows.map((row) => ({
-							bucket: String(row.bucket),
-							attributeValue: String(row.attributeValue ?? ""),
-							value: Number(row.avgValue) || 0,
-						})),
-						unit: spec.unit,
-					})
-				}),
-			)
-			.handle("listWorkloads", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.listWorkloads, tenant, payload)
-					return new ListWorkloadsResponse({
-						data: rows.map((row) => ({
-							workloadName: row.workloadName,
-							namespace: row.namespace,
-							clusterName: row.clusterName,
-							environment: row.environment,
-							podCount: Number(row.podCount) || 0,
-							lastSeen: String(row.lastSeen),
-							avgCpuLimitPct: Number(row.avgCpuLimitPct) || 0,
-							avgMemoryLimitPct: Number(row.avgMemoryLimitPct) || 0,
-							avgCpuUsage: Number(row.avgCpuUsage) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("workloadDetailSummary", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const row = yield* runQueryFirst(Queries.workloadDetailSummary, tenant, payload)
-					return new WorkloadDetailSummaryResponse({
-						data: row
-							? {
-									workloadName: row.workloadName,
-									kind: payload.kind,
-									namespace: row.namespace,
-									podCount: Number(row.podCount) || 0,
-									firstSeen: String(row.firstSeen),
-									lastSeen: String(row.lastSeen),
-									avgCpuLimitPct: Number(row.avgCpuLimitPct) || 0,
-									avgMemoryLimitPct: Number(row.avgMemoryLimitPct) || 0,
-									avgCpuUsage: Number(row.avgCpuUsage) || 0,
-								}
-							: null,
-					})
-				}),
-			)
-			.handle("workloadInfraTimeseries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const spec = workloadMetricSpec(payload.metric)
-					const rows = yield* runQuery(Queries.workloadInfraTimeseries, tenant, payload)
-					return new WorkloadInfraTimeseriesResponse({
-						data: rows.map((row) => ({
-							bucket: String(row.bucket),
-							attributeValue: String(row.attributeValue ?? ""),
-							value: Number(row.avgValue) || 0,
-						})),
-						unit: spec.unit,
-					})
-				}),
-			)
-			.handle("podFacets", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.podFacets, tenant, payload)
-					const buckets = {
-						pods: [] as Array<{ name: string; count: number }>,
-						namespaces: [] as Array<{ name: string; count: number }>,
-						nodes: [] as Array<{ name: string; count: number }>,
-						clusters: [] as Array<{ name: string; count: number }>,
-						deployments: [] as Array<{ name: string; count: number }>,
-						statefulsets: [] as Array<{ name: string; count: number }>,
-						daemonsets: [] as Array<{ name: string; count: number }>,
-						jobs: [] as Array<{ name: string; count: number }>,
-						environments: [] as Array<{ name: string; count: number }>,
-						computeTypes: [] as Array<{ name: string; count: number }>,
-					}
-					for (const row of rows) {
-						const entry = { name: String(row.name), count: Number(row.count) || 0 }
-						switch (row.facetType) {
-							case "pod":
-								buckets.pods.push(entry)
-								break
-							case "namespace":
-								buckets.namespaces.push(entry)
-								break
-							case "node":
-								buckets.nodes.push(entry)
-								break
-							case "cluster":
-								buckets.clusters.push(entry)
-								break
-							case "deployment":
-								buckets.deployments.push(entry)
-								break
-							case "statefulset":
-								buckets.statefulsets.push(entry)
-								break
-							case "daemonset":
-								buckets.daemonsets.push(entry)
-								break
-							case "job":
-								buckets.jobs.push(entry)
-								break
-							case "environment":
-								buckets.environments.push(entry)
-								break
-							case "computeType":
-								buckets.computeTypes.push(entry)
-								break
+					}),
+				)
+				.handle("listPods", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						yield* warehouse.warmRoute(tenant)
+						const [rows, countRow] = yield* Effect.all(
+							[
+								runQuery(Queries.listPods, tenant, payload),
+								runQueryFirst(Queries.listPodsCount, tenant, payload),
+							],
+							{ concurrency: 2 },
+						)
+						return new ListPodsResponse({
+							data: rows.map((row) => ({
+								podName: row.podName,
+								namespace: row.namespace,
+								nodeName: row.nodeName,
+								clusterName: row.clusterName,
+								environment: row.environment,
+								deploymentName: row.deploymentName,
+								statefulsetName: row.statefulsetName,
+								daemonsetName: row.daemonsetName,
+								jobName: row.jobName,
+								qosClass: row.qosClass,
+								podUid: row.podUid,
+								computeType: row.computeType,
+								lastSeen: String(row.lastSeen),
+								cpuUsage: Number(row.cpuUsage) || 0,
+								cpuLimitPct: Number(row.cpuLimitPct) || 0,
+								memoryLimitPct: Number(row.memoryLimitPct) || 0,
+								cpuRequestPct: Number(row.cpuRequestPct) || 0,
+								memoryRequestPct: Number(row.memoryRequestPct) || 0,
+								cpuUsagePeak: Number(row.cpuUsagePeak) || 0,
+								cpuLimitPctPeak: Number(row.cpuLimitPctPeak) || 0,
+								memoryLimitPctPeak: Number(row.memoryLimitPctPeak) || 0,
+								saturation: Number(row.saturation) || 0,
+							})),
+							// The denominator has to match the predicate the list ran, or a scoped
+							// view reads "Top 17 of 541". The scope counts are already computed.
+							totalCount:
+								Number(
+									payload.scope === "saturated"
+										? countRow?.saturatedPods
+										: payload.scope === "elevated"
+											? countRow?.elevatedPods
+											: payload.scope === "unbounded"
+												? countRow?.unboundedPods
+												: payload.scope === "stale"
+													? countRow?.stalePods
+													: countRow?.totalPods,
+								) ||
+								// A failed count must not render as "0 of 0" under a list with rows.
+								rows.length,
+						})
+					}),
+				)
+				.handle("podsSummary", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const row = yield* runQueryFirst(Queries.podsSummary, tenant, payload)
+						return new PodsSummaryResponse({
+							totalPods: Number(row?.totalPods) || 0,
+							saturatedPods: Number(row?.saturatedPods) || 0,
+							elevatedPods: Number(row?.elevatedPods) || 0,
+							unboundedPods: Number(row?.unboundedPods) || 0,
+							stalePods: Number(row?.stalePods) || 0,
+						})
+					}),
+				)
+				.handle("podDetailSummary", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const row = yield* runQueryFirst(Queries.podDetailSummary, tenant, payload)
+						return new PodDetailSummaryResponse({
+							data: row
+								? {
+										podName: row.podName,
+										namespace: row.namespace,
+										nodeName: row.nodeName,
+										deploymentName: row.deploymentName,
+										statefulsetName: row.statefulsetName,
+										daemonsetName: row.daemonsetName,
+										qosClass: row.qosClass,
+										podUid: row.podUid,
+										computeType: row.computeType,
+										podStartTime: row.podStartTime,
+										firstSeen: String(row.firstSeen),
+										lastSeen: String(row.lastSeen),
+										cpuUsage: Number(row.cpuUsage) || 0,
+										cpuLimitPct: Number(row.cpuLimitPct) || 0,
+										memoryLimitPct: Number(row.memoryLimitPct) || 0,
+										cpuRequestPct: Number(row.cpuRequestPct) || 0,
+										memoryRequestPct: Number(row.memoryRequestPct) || 0,
+									}
+								: null,
+						})
+					}),
+				)
+				.handle("podInfraTimeseries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const spec = podMetricSpec(payload.metric)
+						const rows = yield* runQuery(Queries.podInfraTimeseries, tenant, payload)
+						return new PodInfraTimeseriesResponse({
+							data: rows.map((row) => ({
+								bucket: String(row.bucket),
+								attributeValue: String(row.attributeValue ?? ""),
+								value: Number(row.avgValue) || 0,
+							})),
+							unit: spec.unit,
+						})
+					}),
+				)
+				.handle("listNodes", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.listNodes, tenant, payload)
+						return new ListNodesResponse({
+							data: rows.map((row) => ({
+								nodeName: row.nodeName,
+								nodeUid: row.nodeUid,
+								clusterName: row.clusterName,
+								environment: row.environment,
+								kubeletVersion: row.kubeletVersion,
+								lastSeen: String(row.lastSeen),
+								cpuUsage: Number(row.cpuUsage) || 0,
+								uptime: Number(row.uptime) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("nodeDetailSummary", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const row = yield* runQueryFirst(Queries.nodeDetailSummary, tenant, payload)
+						return new NodeDetailSummaryResponse({
+							data: row
+								? {
+										nodeName: row.nodeName,
+										nodeUid: row.nodeUid,
+										kubeletVersion: row.kubeletVersion,
+										containerRuntime: row.containerRuntime,
+										firstSeen: String(row.firstSeen),
+										lastSeen: String(row.lastSeen),
+										cpuUsage: Number(row.cpuUsage) || 0,
+										uptime: Number(row.uptime) || 0,
+									}
+								: null,
+						})
+					}),
+				)
+				.handle("nodeInfraTimeseries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const spec = nodeMetricSpec(payload.metric)
+						const rows = yield* runQuery(Queries.nodeInfraTimeseries, tenant, payload)
+						return new NodeInfraTimeseriesResponse({
+							data: rows.map((row) => ({
+								bucket: String(row.bucket),
+								attributeValue: String(row.attributeValue ?? ""),
+								value: Number(row.avgValue) || 0,
+							})),
+							unit: spec.unit,
+						})
+					}),
+				)
+				.handle("listWorkloads", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.listWorkloads, tenant, payload)
+						return new ListWorkloadsResponse({
+							data: rows.map((row) => ({
+								workloadName: row.workloadName,
+								namespace: row.namespace,
+								clusterName: row.clusterName,
+								environment: row.environment,
+								podCount: Number(row.podCount) || 0,
+								lastSeen: String(row.lastSeen),
+								avgCpuLimitPct: Number(row.avgCpuLimitPct) || 0,
+								avgMemoryLimitPct: Number(row.avgMemoryLimitPct) || 0,
+								avgCpuUsage: Number(row.avgCpuUsage) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("workloadDetailSummary", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const row = yield* runQueryFirst(Queries.workloadDetailSummary, tenant, payload)
+						return new WorkloadDetailSummaryResponse({
+							data: row
+								? {
+										workloadName: row.workloadName,
+										kind: payload.kind,
+										namespace: row.namespace,
+										podCount: Number(row.podCount) || 0,
+										firstSeen: String(row.firstSeen),
+										lastSeen: String(row.lastSeen),
+										avgCpuLimitPct: Number(row.avgCpuLimitPct) || 0,
+										avgMemoryLimitPct: Number(row.avgMemoryLimitPct) || 0,
+										avgCpuUsage: Number(row.avgCpuUsage) || 0,
+									}
+								: null,
+						})
+					}),
+				)
+				.handle("workloadInfraTimeseries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const spec = workloadMetricSpec(payload.metric)
+						const rows = yield* runQuery(Queries.workloadInfraTimeseries, tenant, payload)
+						return new WorkloadInfraTimeseriesResponse({
+							data: rows.map((row) => ({
+								bucket: String(row.bucket),
+								attributeValue: String(row.attributeValue ?? ""),
+								value: Number(row.avgValue) || 0,
+							})),
+							unit: spec.unit,
+						})
+					}),
+				)
+				.handle("podFacets", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.podFacets, tenant, payload)
+						const buckets = {
+							pods: [] as Array<{ name: string; count: number }>,
+							namespaces: [] as Array<{ name: string; count: number }>,
+							nodes: [] as Array<{ name: string; count: number }>,
+							clusters: [] as Array<{ name: string; count: number }>,
+							deployments: [] as Array<{ name: string; count: number }>,
+							statefulsets: [] as Array<{ name: string; count: number }>,
+							daemonsets: [] as Array<{ name: string; count: number }>,
+							jobs: [] as Array<{ name: string; count: number }>,
+							environments: [] as Array<{ name: string; count: number }>,
+							computeTypes: [] as Array<{ name: string; count: number }>,
 						}
-					}
-					return new PodFacetsResponse({ data: buckets })
-				}),
-			)
-			.handle("nodeFacets", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.nodeFacets, tenant, payload)
-					const buckets = {
-						nodes: [] as Array<{ name: string; count: number }>,
-						clusters: [] as Array<{ name: string; count: number }>,
-						environments: [] as Array<{ name: string; count: number }>,
-					}
-					for (const row of rows) {
-						const entry = { name: String(row.name), count: Number(row.count) || 0 }
-						switch (row.facetType) {
-							case "node":
-								buckets.nodes.push(entry)
-								break
-							case "cluster":
-								buckets.clusters.push(entry)
-								break
-							case "environment":
-								buckets.environments.push(entry)
-								break
+						for (const row of rows) {
+							const entry = { name: String(row.name), count: Number(row.count) || 0 }
+							switch (row.facetType) {
+								case "pod":
+									buckets.pods.push(entry)
+									break
+								case "namespace":
+									buckets.namespaces.push(entry)
+									break
+								case "node":
+									buckets.nodes.push(entry)
+									break
+								case "cluster":
+									buckets.clusters.push(entry)
+									break
+								case "deployment":
+									buckets.deployments.push(entry)
+									break
+								case "statefulset":
+									buckets.statefulsets.push(entry)
+									break
+								case "daemonset":
+									buckets.daemonsets.push(entry)
+									break
+								case "job":
+									buckets.jobs.push(entry)
+									break
+								case "environment":
+									buckets.environments.push(entry)
+									break
+								case "computeType":
+									buckets.computeTypes.push(entry)
+									break
+							}
 						}
-					}
-					return new NodeFacetsResponse({ data: buckets })
-				}),
-			)
-			.handle("workloadFacets", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.workloadFacets, tenant, payload)
-					const buckets = {
-						workloads: [] as Array<{ name: string; count: number }>,
-						namespaces: [] as Array<{ name: string; count: number }>,
-						clusters: [] as Array<{ name: string; count: number }>,
-						environments: [] as Array<{ name: string; count: number }>,
-						computeTypes: [] as Array<{ name: string; count: number }>,
-					}
-					for (const row of rows) {
-						const entry = { name: String(row.name), count: Number(row.count) || 0 }
-						switch (row.facetType) {
-							case "workload":
-								buckets.workloads.push(entry)
-								break
-							case "namespace":
-								buckets.namespaces.push(entry)
-								break
-							case "cluster":
-								buckets.clusters.push(entry)
-								break
-							case "environment":
-								buckets.environments.push(entry)
-								break
-							case "computeType":
-								buckets.computeTypes.push(entry)
-								break
+						return new PodFacetsResponse({ data: buckets })
+					}),
+				)
+				.handle("nodeFacets", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.nodeFacets, tenant, payload)
+						const buckets = {
+							nodes: [] as Array<{ name: string; count: number }>,
+							clusters: [] as Array<{ name: string; count: number }>,
+							environments: [] as Array<{ name: string; count: number }>,
 						}
-					}
-					return new WorkloadFacetsResponse({ data: buckets })
-				}),
-			)
-			.handle("webAnalyticsSummary", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const row = yield* withProductEventsFallback(
-						(t, pl) => runQueryFirst(Queries.webAnalyticsSummary, t, pl),
-						(t, pl) => runQueryFirst(Queries.webAnalyticsSummaryRaw, t, pl),
-						tenant,
-						payload,
-					)
-					// A window with no sessions returns no rows at all, not a row of
-					// zeroes — the page needs the zeroes to render its empty state.
-					return new WebAnalyticsSummaryResponse({
-						data: {
-							visitors: Number(row?.visitors) || 0,
-							sessions: Number(row?.sessions) || 0,
-							newSessions: Number(row?.newSessions) || 0,
-							bouncedSessions: Number(row?.bouncedSessions) || 0,
-							identifiedSessions: Number(row?.identifiedSessions) || 0,
-							avgDurationMs: Number(row?.avgDurationMs) || 0,
-						},
-					})
-				}),
-			)
-			.handle("webAnalyticsTimeseries", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* withProductEventsFallback(
-						(t, pl) => runQuery(Queries.webAnalyticsTimeseries, t, pl),
-						(t, pl) => runQuery(Queries.webAnalyticsTimeseriesRaw, t, pl),
-						tenant,
-						payload,
-					)
-					return new WebAnalyticsTimeseriesResponse({
-						data: rows.map((row) => ({
-							bucket: String(row.bucket),
-							visitors: Number(row.visitors) || 0,
-							sessions: Number(row.sessions) || 0,
-							newSessions: Number(row.newSessions) || 0,
-							bouncedSessions: Number(row.bouncedSessions) || 0,
-							identifiedSessions: Number(row.identifiedSessions) || 0,
-							avgDurationMs: Number(row.avgDurationMs) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("webAnalyticsPageviews", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* withProductEventsFallback(
-						(t, pl) => runQuery(Queries.webAnalyticsPageviews, t, pl),
-						(t, pl) => runQuery(Queries.webAnalyticsPageviewsRaw, t, pl),
-						tenant,
-						payload,
-					)
-					return new WebAnalyticsPageviewsResponse({
-						data: rows.map((row) => ({
-							bucket: String(row.bucket),
-							pageViews: Number(row.pageViews) || 0,
-							sessions: Number(row.sessions) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("webAnalyticsPages", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* withProductEventsFallback(
-						(t, pl) => runQuery(Queries.webAnalyticsPages, t, pl),
-						(t, pl) => runQuery(Queries.webAnalyticsPagesRaw, t, pl),
-						tenant,
-						payload,
-					)
-					return new WebAnalyticsPagesResponse({
-						data: rows.map((row) => ({
-							host: String(row.host),
-							pagePath: String(row.pagePath),
-							pageViews: Number(row.pageViews) || 0,
-							sessions: Number(row.sessions) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("webAnalyticsEvents", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* withProductEventsFallback(
-						(t, pl) => runQuery(Queries.webAnalyticsEvents, t, pl),
-						(t, pl) => runQuery(Queries.webAnalyticsEventsRaw, t, pl),
-						tenant,
-						payload,
-					)
-					return new WebAnalyticsEventsResponse({
-						data: rows.map((row) => ({
-							name: String(row.name),
-							events: Number(row.events) || 0,
-							sessions: Number(row.sessions) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("webAnalyticsBreakdowns", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* withProductEventsFallback(
-						(t, pl) => runQuery(Queries.webAnalyticsBreakdowns, t, pl),
-						(t, pl) => runQuery(Queries.webAnalyticsBreakdownsRaw, t, pl),
-						tenant,
-						payload,
-					)
-					const buckets = {
-						referrerHosts: [] as Array<{ name: string; count: number }>,
-						countries: [] as Array<{ name: string; count: number }>,
-						deviceTypes: [] as Array<{ name: string; count: number }>,
-						browsers: [] as Array<{ name: string; count: number }>,
-						operatingSystems: [] as Array<{ name: string; count: number }>,
-						languages: [] as Array<{ name: string; count: number }>,
-						utmSources: [] as Array<{ name: string; count: number }>,
-						utmMediums: [] as Array<{ name: string; count: number }>,
-						utmCampaigns: [] as Array<{ name: string; count: number }>,
-						entryPaths: [] as Array<{ name: string; count: number }>,
-						exitPaths: [] as Array<{ name: string; count: number }>,
-						hosts: [] as Array<{ name: string; count: number }>,
-					}
-					// facetType → response key. A table rather than a twelve-arm switch:
-					// the mapping is the whole content of this step, and the keys have to
-					// stay in step with WebAnalyticsFacetKey in the query builder.
-					const bucketOf: Record<string, keyof typeof buckets> = {
-						referrerHost: "referrerHosts",
-						country: "countries",
-						deviceType: "deviceTypes",
-						browserName: "browsers",
-						osName: "operatingSystems",
-						language: "languages",
-						utmSource: "utmSources",
-						utmMedium: "utmMediums",
-						utmCampaign: "utmCampaigns",
-						entryPath: "entryPaths",
-						exitPath: "exitPaths",
-						host: "hosts",
-					} satisfies Record<string, keyof typeof buckets>
-					for (const row of rows) {
-						const key = bucketOf[row.facetType]
-						if (key) buckets[key].push({ name: String(row.name), count: Number(row.count) || 0 })
-					}
-					return new WebAnalyticsBreakdownsResponse({ data: buckets })
-				}),
-			)
-			// Funnels have no raw-`session_events` fallback: server and mobile
-			// events exist only in `product_events`, so a cluster without the table
-			// surfaces the missing-table error instead of a silently smaller funnel.
-			.handle("productEventsFunnel", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					yield* validateFunnelDefinition(productEventsFunnelOpts(payload))
-					const rows = yield* runQuery(Queries.productEventsFunnel, tenant, payload)
-					return new ProductEventsFunnelResponse({
-						data: rows.map((row) => ({
-							step: Number(row.step) || 0,
-							count: Number(row.count) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("productEventsFunnelBreakdown", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					// The breakdown builder, not the plain one: `limit` is validated
-					// only there, and an unvalidated one throws inside `compile`.
-					yield* validateFunnelDefinition({
-						...productEventsFunnelOpts(payload),
-						breakdownBy: payload.breakdownBy,
-						limit: payload.limit,
-					})
-					const rows = yield* runQuery(Queries.productEventsFunnelBreakdown, tenant, payload)
-					return new ProductEventsFunnelBreakdownResponse({
-						data: rows.map((row) => ({
-							group: String(row.group),
-							step: Number(row.step) || 0,
-							count: Number(row.count) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("productEventNames", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
-					const rows = yield* runQuery(Queries.productEventNames, tenant, payload)
-					return new ProductEventNamesResponse({
-						data: rows.map((row) => ({
-							eventName: String(row.eventName),
-							kind: String(row.kind),
-							count: Number(row.count) || 0,
-							sessions: Number(row.sessions) || 0,
-							persons: Number(row.persons) || 0,
-						})),
-					})
-				}),
-			)
-			.handle("executeRawSql", ({ payload }) =>
-				Effect.gen(function* () {
-					const tenant = yield* CurrentTenant.Context
+						for (const row of rows) {
+							const entry = { name: String(row.name), count: Number(row.count) || 0 }
+							switch (row.facetType) {
+								case "node":
+									buckets.nodes.push(entry)
+									break
+								case "cluster":
+									buckets.clusters.push(entry)
+									break
+								case "environment":
+									buckets.environments.push(entry)
+									break
+							}
+						}
+						return new NodeFacetsResponse({ data: buckets })
+					}),
+				)
+				.handle("workloadFacets", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.workloadFacets, tenant, payload)
+						const buckets = {
+							workloads: [] as Array<{ name: string; count: number }>,
+							namespaces: [] as Array<{ name: string; count: number }>,
+							clusters: [] as Array<{ name: string; count: number }>,
+							environments: [] as Array<{ name: string; count: number }>,
+							computeTypes: [] as Array<{ name: string; count: number }>,
+						}
+						for (const row of rows) {
+							const entry = { name: String(row.name), count: Number(row.count) || 0 }
+							switch (row.facetType) {
+								case "workload":
+									buckets.workloads.push(entry)
+									break
+								case "namespace":
+									buckets.namespaces.push(entry)
+									break
+								case "cluster":
+									buckets.clusters.push(entry)
+									break
+								case "environment":
+									buckets.environments.push(entry)
+									break
+								case "computeType":
+									buckets.computeTypes.push(entry)
+									break
+							}
+						}
+						return new WorkloadFacetsResponse({ data: buckets })
+					}),
+				)
+				.handle("webAnalyticsSummary", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const row = yield* withProductEventsFallback(
+							(t, pl) => runQueryFirst(Queries.webAnalyticsSummary, t, pl),
+							(t, pl) => runQueryFirst(Queries.webAnalyticsSummaryRaw, t, pl),
+							tenant,
+							payload,
+						)
+						// A window with no sessions returns no rows at all, not a row of
+						// zeroes — the page needs the zeroes to render its empty state.
+						return new WebAnalyticsSummaryResponse({
+							data: {
+								visitors: Number(row?.visitors) || 0,
+								sessions: Number(row?.sessions) || 0,
+								newSessions: Number(row?.newSessions) || 0,
+								bouncedSessions: Number(row?.bouncedSessions) || 0,
+								identifiedSessions: Number(row?.identifiedSessions) || 0,
+								avgDurationMs: Number(row?.avgDurationMs) || 0,
+							},
+						})
+					}),
+				)
+				.handle("webAnalyticsTimeseries", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* withProductEventsFallback(
+							(t, pl) => runQuery(Queries.webAnalyticsTimeseries, t, pl),
+							(t, pl) => runQuery(Queries.webAnalyticsTimeseriesRaw, t, pl),
+							tenant,
+							payload,
+						)
+						return new WebAnalyticsTimeseriesResponse({
+							data: rows.map((row) => ({
+								bucket: String(row.bucket),
+								visitors: Number(row.visitors) || 0,
+								sessions: Number(row.sessions) || 0,
+								newSessions: Number(row.newSessions) || 0,
+								bouncedSessions: Number(row.bouncedSessions) || 0,
+								identifiedSessions: Number(row.identifiedSessions) || 0,
+								avgDurationMs: Number(row.avgDurationMs) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("webAnalyticsPageviews", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* withProductEventsFallback(
+							(t, pl) => runQuery(Queries.webAnalyticsPageviews, t, pl),
+							(t, pl) => runQuery(Queries.webAnalyticsPageviewsRaw, t, pl),
+							tenant,
+							payload,
+						)
+						return new WebAnalyticsPageviewsResponse({
+							data: rows.map((row) => ({
+								bucket: String(row.bucket),
+								pageViews: Number(row.pageViews) || 0,
+								sessions: Number(row.sessions) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("webAnalyticsPages", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* withProductEventsFallback(
+							(t, pl) => runQuery(Queries.webAnalyticsPages, t, pl),
+							(t, pl) => runQuery(Queries.webAnalyticsPagesRaw, t, pl),
+							tenant,
+							payload,
+						)
+						return new WebAnalyticsPagesResponse({
+							data: rows.map((row) => ({
+								host: String(row.host),
+								pagePath: String(row.pagePath),
+								pageViews: Number(row.pageViews) || 0,
+								sessions: Number(row.sessions) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("webAnalyticsEvents", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* withProductEventsFallback(
+							(t, pl) => runQuery(Queries.webAnalyticsEvents, t, pl),
+							(t, pl) => runQuery(Queries.webAnalyticsEventsRaw, t, pl),
+							tenant,
+							payload,
+						)
+						return new WebAnalyticsEventsResponse({
+							data: rows.map((row) => ({
+								name: String(row.name),
+								events: Number(row.events) || 0,
+								sessions: Number(row.sessions) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("webAnalyticsBreakdowns", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* withProductEventsFallback(
+							(t, pl) => runQuery(Queries.webAnalyticsBreakdowns, t, pl),
+							(t, pl) => runQuery(Queries.webAnalyticsBreakdownsRaw, t, pl),
+							tenant,
+							payload,
+						)
+						const buckets = {
+							referrerHosts: [] as Array<{ name: string; count: number }>,
+							countries: [] as Array<{ name: string; count: number }>,
+							deviceTypes: [] as Array<{ name: string; count: number }>,
+							browsers: [] as Array<{ name: string; count: number }>,
+							operatingSystems: [] as Array<{ name: string; count: number }>,
+							languages: [] as Array<{ name: string; count: number }>,
+							utmSources: [] as Array<{ name: string; count: number }>,
+							utmMediums: [] as Array<{ name: string; count: number }>,
+							utmCampaigns: [] as Array<{ name: string; count: number }>,
+							entryPaths: [] as Array<{ name: string; count: number }>,
+							exitPaths: [] as Array<{ name: string; count: number }>,
+							hosts: [] as Array<{ name: string; count: number }>,
+						}
+						// facetType → response key. A table rather than a twelve-arm switch:
+						// the mapping is the whole content of this step, and the keys have to
+						// stay in step with WebAnalyticsFacetKey in the query builder.
+						const bucketOf: Record<string, keyof typeof buckets> = {
+							referrerHost: "referrerHosts",
+							country: "countries",
+							deviceType: "deviceTypes",
+							browserName: "browsers",
+							osName: "operatingSystems",
+							language: "languages",
+							utmSource: "utmSources",
+							utmMedium: "utmMediums",
+							utmCampaign: "utmCampaigns",
+							entryPath: "entryPaths",
+							exitPath: "exitPaths",
+							host: "hosts",
+						} satisfies Record<string, keyof typeof buckets>
+						for (const row of rows) {
+							const key = bucketOf[row.facetType]
+							if (key)
+								buckets[key].push({ name: String(row.name), count: Number(row.count) || 0 })
+						}
+						return new WebAnalyticsBreakdownsResponse({ data: buckets })
+					}),
+				)
+				// Funnels have no raw-`session_events` fallback: server and mobile
+				// events exist only in `product_events`, so a cluster without the table
+				// surfaces the missing-table error instead of a silently smaller funnel.
+				.handle("productEventsFunnel", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						yield* validateFunnelDefinition(productEventsFunnelOpts(payload))
+						const rows = yield* runQuery(Queries.productEventsFunnel, tenant, payload)
+						return new ProductEventsFunnelResponse({
+							data: rows.map((row) => ({
+								step: Number(row.step) || 0,
+								count: Number(row.count) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("productEventsFunnelBreakdown", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						// The breakdown builder, not the plain one: `limit` is validated
+						// only there, and an unvalidated one throws inside `compile`.
+						yield* validateFunnelDefinition({
+							...productEventsFunnelOpts(payload),
+							breakdownBy: payload.breakdownBy,
+							limit: payload.limit,
+						})
+						const rows = yield* runQuery(Queries.productEventsFunnelBreakdown, tenant, payload)
+						return new ProductEventsFunnelBreakdownResponse({
+							data: rows.map((row) => ({
+								group: String(row.group),
+								step: Number(row.step) || 0,
+								count: Number(row.count) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("productEventNames", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						const rows = yield* runQuery(Queries.productEventNames, tenant, payload)
+						return new ProductEventNamesResponse({
+							data: rows.map((row) => ({
+								eventName: String(row.eventName),
+								kind: String(row.kind),
+								count: Number(row.count) || 0,
+								sessions: Number(row.sessions) || 0,
+								persons: Number(row.persons) || 0,
+							})),
+						})
+					}),
+				)
+				.handle("executeRawSql", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
 
-					const autoBucketSeconds = computeAutoBucketSeconds(payload.startTime, payload.endTime)
-					const granularitySeconds = payload.granularitySeconds ?? autoBucketSeconds
+						const autoBucketSeconds = computeAutoBucketSeconds(payload.startTime, payload.endTime)
+						const granularitySeconds = payload.granularitySeconds ?? autoBucketSeconds
 
-					const result = yield* mapExecError(
-						executeRawSql(tenant, {
-							sql: payload.sql,
-							orgId: tenant.orgId,
-							startTime: payload.startTime,
-							endTime: payload.endTime,
-							granularitySeconds,
-							workload: "interactive",
-							context: "rawSql",
-						}),
-						"rawSql query failed",
-					)
+						const result = yield* mapExecError(
+							executeRawSql(tenant, {
+								sql: payload.sql,
+								orgId: tenant.orgId,
+								startTime: payload.startTime,
+								endTime: payload.endTime,
+								granularitySeconds,
+								workload: "interactive",
+								context: "rawSql",
+							}),
+							"rawSql query failed",
+						)
 
-					return new RawSqlExecuteResponse({
-						data: result.rows,
-						meta: {
-							rowCount: result.rowCount,
-							columns: result.columns,
-							granularitySeconds: result.granularitySeconds,
-						},
-					})
-				}),
-			)
+						return new RawSqlExecuteResponse({
+							data: result.rows,
+							meta: {
+								rowCount: result.rowCount,
+								columns: result.columns,
+								granularitySeconds: result.granularitySeconds,
+							},
+						})
+					}),
+				)
+		)
 	}),
 )
 

--- a/apps/api/src/services/billing/DailySpendService.ts
+++ b/apps/api/src/services/billing/DailySpendService.ts
@@ -29,6 +29,8 @@ export const toUtcDateKey = (epochMs: number) => new Date(epochMs).toISOString()
 
 const startOfUtcDay = (epochMs: number) => Math.floor(epochMs / DAY_MS) * DAY_MS
 
+const noEventRows: ReadonlyArray<typeof Integrations.dailyProductEventCountRowSchema.Type> = []
+
 export interface DailySpendServiceApi {
 	readonly get: (
 		tenant: TenantContext,
@@ -97,6 +99,9 @@ export class DailySpendService extends Context.Service<DailySpendService, DailyS
 					})
 				}
 
+				// `product_events` is a newer table than the other two: a cluster that
+				// predates it has ingested no product events, so the honest series is
+				// all zeros — not a 502 that takes the whole spend chart down with it.
 				const eventRows = yield* warehouse
 					.compiledQuery(
 						tenant,
@@ -105,7 +110,17 @@ export class DailySpendService extends Context.Service<DailySpendService, DailyS
 						}),
 						{ profile: "list", context: "billingDailyProductEventCount" },
 					)
-					.pipe(Effect.mapError(toQueryError))
+					.pipe(
+						Effect.catchTag("@maple/http/errors/WarehouseConfigError", (error) =>
+							/product_events/i.test(error.message)
+								? Effect.as(
+										Effect.annotateCurrentSpan("query.rollup.fallback", true),
+										noEventRows,
+									)
+								: Effect.fail(error),
+						),
+						Effect.mapError(toQueryError),
+					)
 
 				const sessionsByDay = new Map<string, number>()
 				for (const row of sessionRows) {

--- a/apps/api/src/services/billing/DailySpendService.ts
+++ b/apps/api/src/services/billing/DailySpendService.ts
@@ -2,6 +2,7 @@ import { DailySpendResponse, DailyVolume, WarehouseQueryError } from "@maple/dom
 import { CH, parseWarehouseDateTime, formatWarehouseDateTime } from "@maple/query-engine"
 import { Context, Effect, Layer } from "effect"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
+import { isMissingProductEvents } from "@/services/warehouse/missing-table"
 import type { TenantContext } from "@/services/auth/AuthService"
 import * as Integrations from "@maple/query-engine-integrations"
 
@@ -99,9 +100,8 @@ export class DailySpendService extends Context.Service<DailySpendService, DailyS
 					})
 				}
 
-				// `product_events` is a newer table than the other two: a cluster that
-				// predates it has ingested no product events, so the honest series is
-				// all zeros — not a 502 that takes the whole spend chart down with it.
+				// A cluster without `product_events` has ingested no product events, so
+				// the honest series is all zeros — not a 502 for the whole chart.
 				const eventRows = yield* warehouse
 					.compiledQuery(
 						tenant,
@@ -111,14 +111,7 @@ export class DailySpendService extends Context.Service<DailySpendService, DailyS
 						{ profile: "list", context: "billingDailyProductEventCount" },
 					)
 					.pipe(
-						Effect.catchTag("@maple/http/errors/WarehouseConfigError", (error) =>
-							/product_events/i.test(error.message)
-								? Effect.as(
-										Effect.annotateCurrentSpan("query.rollup.fallback", true),
-										noEventRows,
-									)
-								: Effect.fail(error),
-						),
+						Effect.catchIf(isMissingProductEvents, () => Effect.succeed(noEventRows)),
 						Effect.mapError(toQueryError),
 					)
 

--- a/apps/api/src/services/org/ApiKeysService.test.ts
+++ b/apps/api/src/services/org/ApiKeysService.test.ts
@@ -229,8 +229,8 @@ describe("ApiKeysService.touchLastUsed", () => {
 				kind: "mcp",
 			})
 
-			// `resolveByBearer` forks the touch detached, so it is driven directly here to
-			// keep the assertions off that race.
+			// Driven directly rather than through `resolveByBearer` so the assertions
+			// stay on the memo and the SQL gate, not on key resolution.
 			yield* svc.touchLastUsed(created.id)
 			const afterFirst = yield* readLastUsed(testDb, created.id)
 			assert.isOk(afterFirst?.lastUsedAt, "the first touch stamps last_used_at")

--- a/apps/api/src/services/org/ApiKeysService.ts
+++ b/apps/api/src/services/org/ApiKeysService.ts
@@ -18,7 +18,6 @@ import { and, desc, eq, getTableColumns, isNull, lt, ne, or, sql } from "drizzle
 import { Clock, Effect, Layer, Option, Redacted, Schema, Context } from "effect"
 import { Database } from "@/platform/DatabaseLive"
 import { readTxid, txidColumn } from "@/platform/electric-txid"
-import { forkRequestScoped } from "@/platform/fork-request-scoped"
 import { Env } from "@/platform/Env"
 import { dateToMs, msToDate } from "@/platform/time"
 
@@ -658,9 +657,16 @@ export class ApiKeysService extends Context.Service<ApiKeysService>()("@maple/ap
 					"tenant.userId": resolved.value.userId,
 					"maple.api_key.id": resolved.value.keyId,
 				})
-				// Scoped, not detached: this write shares the request's single Postgres
-				// connection, and a detached fiber can outlive its release.
-				yield* forkRequestScoped(touchLastUsed(resolved.value.keyId).pipe(Effect.ignore))
+				// Awaited, not forked. A fork — even one started immediately and bound
+				// to the request scope — still lost the race on requests whose handler
+				// had no further async work (`GET /mcp`): the response went out, the
+				// Postgres scope closed, and the UPDATE died with CONNECTION_ENDED
+				// before it reached the socket, recorded as an error span on every
+				// such request. The memo and the SQL predicate already make this at
+				// most one cheap UPDATE per key per heartbeat on an already-dialed
+				// connection, so there is nothing worth racing for. Failure is
+				// still best-effort: a missed heartbeat must never fail auth.
+				yield* touchLastUsed(resolved.value.keyId).pipe(Effect.ignore)
 			}
 			return resolved
 		})

--- a/apps/api/src/services/warehouse/missing-table.ts
+++ b/apps/api/src/services/warehouse/missing-table.ts
@@ -1,0 +1,39 @@
+/**
+ * Detect "this table is missing on the org's cluster" so a caller can read a
+ * raw-source equivalent (or degrade) instead of 502ing.
+ *
+ * Rollup and newer tables (`product_events` since migration 0016, the
+ * `service_operations_*` rollups) ship in `requiredForIngest: false`
+ * migrations, which reach a BYO-ClickHouse cluster only when an org admin
+ * clicks Apply schema — nothing reconciles that, so the window where an org
+ * lacks one is unbounded, per-org, and invisible from here. The only correct
+ * response is to notice at query time.
+ *
+ * Matches the classified `WarehouseConfigError` (ClickHouse `UNKNOWN_TABLE`,
+ * or the Tinybird gateway's "Resource '<name>' not found", which the query
+ * engine classifies the same way) whose message names the table.
+ */
+const isMissingTable =
+	(table: RegExp) =>
+	(error: unknown): boolean => {
+		if (typeof error !== "object" || error === null) return false
+		const candidate = error as {
+			readonly _tag?: unknown
+			readonly clickhouseType?: unknown
+			readonly message?: unknown
+		}
+		return (
+			candidate._tag === "@maple/http/errors/WarehouseConfigError" &&
+			(candidate.clickhouseType === "UNKNOWN_TABLE" ||
+				(typeof candidate.message === "string" && table.test(candidate.message)))
+		)
+	}
+
+/**
+ * Only page-view queries may degrade on this one — raw `session_events` holds
+ * the same browser rows. Funnels have no raw counterpart (server and mobile
+ * rows exist only in `product_events`) and must surface the error.
+ */
+export const isMissingProductEvents = isMissingTable(/product_events/i)
+
+export const isMissingServiceOperationsRollup = isMissingTable(/service_operations_(?:minutely|hourly)/i)

--- a/apps/cli/src/commands/server-args.ts
+++ b/apps/cli/src/commands/server-args.ts
@@ -49,3 +49,24 @@ export const buildDetachedChildArgs = (options: DetachedChildArgs): string[] => 
 		...(options.offline ? ["--offline"] : []),
 	]
 }
+
+/** Liveness probe via signal 0 — a process primitive with no FileSystem
+ *  equivalent. Never throws (errors mean "not alive").
+ *
+ *  A PID file naming *this* process is stale by definition: the previous server
+ *  is the one that wrote it, so if its number is ours it has died and the OS
+ *  reused the PID. In a container that is the common case, not the edge case —
+ *  `maple start` is PID 1 on every restart, the file survives on the data
+ *  volume, and `kill(1, 0)` always succeeds, so without this check a container
+ *  whose server died once refuses to start forever ("already running (PID 1)").
+ *  Non-positive PIDs are rejected for the same reason: `kill(0, 0)` and
+ *  `kill(-n, 0)` signal process groups and "succeed" for a group that exists. */
+export const isProcessAlive = (pid: number): boolean => {
+	if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) return false
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch {
+		return false
+	}
+}

--- a/apps/cli/src/commands/server.ts
+++ b/apps/cli/src/commands/server.ts
@@ -29,6 +29,7 @@ import {
 	type DirtyStorePolicy,
 	hostedDashboardUrl,
 	hostedUiOrigin,
+	isProcessAlive,
 	resolveAdvertiseHost,
 	resolveBindHost,
 	serverProbeUrl,
@@ -153,17 +154,6 @@ const readPid = (fs: FileSystem, pidPath: string): Effect.Effect<Option.Option<n
 		}),
 		Effect.orElseSucceed(() => Option.none<number>()),
 	)
-
-/** Liveness probe via signal 0 — a process primitive with no FileSystem
- *  equivalent. Never throws (errors mean "not alive"). */
-const isProcessAlive = (pid: number): boolean => {
-	try {
-		process.kill(pid, 0)
-		return true
-	} catch {
-		return false
-	}
-}
 
 const port = Flag.integer("port").pipe(
 	Flag.withDescription("Port for OTLP/HTTP ingest, the query API, and the bundled UI"),

--- a/apps/cli/test/server-args.test.ts
+++ b/apps/cli/test/server-args.test.ts
@@ -5,6 +5,7 @@ import {
 	defaultLocalUrl,
 	hostedDashboardUrl,
 	hostedUiOrigin,
+	isProcessAlive,
 	type DirtyStorePolicy,
 	resolveAdvertiseHost,
 	resolveBindHost,
@@ -130,5 +131,26 @@ describe("buildDetachedChildArgs", () => {
 				"fail",
 			],
 		)
+	})
+})
+
+describe("isProcessAlive", () => {
+	it("treats a PID file naming this very process as stale", () => {
+		// A container restarts `maple start` as PID 1 every time, and the PID file
+		// survives on the data volume — `kill(1, 0)` succeeding must not read as
+		// "already running" or the container never starts again.
+		strictEqual(isProcessAlive(process.pid), false)
+	})
+
+	it("never treats a non-positive PID as alive", () => {
+		// kill(0, 0) / kill(-n, 0) signal process groups and succeed for our own.
+		strictEqual(isProcessAlive(0), false)
+		strictEqual(isProcessAlive(-1), false)
+		strictEqual(isProcessAlive(Number.NaN), false)
+	})
+
+	it("still reports a real foreign process as alive", () => {
+		// The parent shell/runner is the one live process whose PID we can know.
+		strictEqual(isProcessAlive(process.ppid), true)
 	})
 })

--- a/packages/query-engine/src/execution/errors.test.ts
+++ b/packages/query-engine/src/execution/errors.test.ts
@@ -171,6 +171,12 @@ describe("mapWarehouseError", () => {
 				WarehouseConfigError,
 			)
 		})
+
+		it("classifies the Tinybird gateway's missing-datasource message", () => {
+			expect(mapWarehouseError("p", "Resource 'product_events' not found")).toBeInstanceOf(
+				WarehouseConfigError,
+			)
+		})
 	})
 
 	describe("client", () => {

--- a/packages/query-engine/src/execution/errors.ts
+++ b/packages/query-engine/src/execution/errors.ts
@@ -139,8 +139,11 @@ const CLASSIFICATION_RULES: ReadonlyArray<ClassificationRule> = [
 	{
 		status: (s) => s === 404,
 		types: new Set(["UNKNOWN_DATABASE", "UNKNOWN_TABLE", "TABLE_IS_DROPPED", "UNKNOWN_SETTING"]),
+		// "Resource '<name>' not found" is the Tinybird gateway's phrasing of
+		// UNKNOWN_TABLE; without it a missing datasource fell through to the
+		// generic query error and the per-org missing-table fallbacks never fired.
 		pattern:
-			/Invalid URL|unknown database|unknown table|table .* does not exist|database .* does not exist/i,
+			/Invalid URL|unknown database|unknown table|table .* does not exist|database .* does not exist|Resource '[^']*' not found/i,
 		make: (base) => new WarehouseConfigError(base),
 	},
 	{


### PR DESCRIPTION
## Summary

Triage of the open error issues in Maple's own error tracking, fixing the ones that are code bugs:

- **cli** — `maple start` in a container crash-looped forever with "already running (PID 1)": the PID file survives on the data volume and `kill(1, 0)` always succeeds because PID 1 is the new `maple` itself. A PID file naming the current process (or a non-positive PID) is now treated as stale. ~26k events/day, the CLI's top error. Regression tests in `apps/cli/test/server-args.test.ts`.
- **query-engine** — the Tinybird gateway phrases a missing datasource as `Resource '<name>' not found`, which the classifier did not recognise, so it fell through to a generic `WarehouseQueryError` and the per-org `product_events → session_events` fallback in the query-engine routes never fired. Now classified as `WarehouseConfigError`.
- **billing** — `DailySpendService` treats a missing `product_events` table as an all-zero event series instead of 502ing the whole spend chart.
- **api** — `ApiKeysService.touchLastUsed` is awaited inline instead of forked. The request-scoped fork still lost the race on handlers with no further async work (`GET /mcp`), producing `CONNECTION_ENDED` error spans on every such request. The memo + SQL predicate already bound it to one UPDATE per key per 5 minutes on an already-dialed connection, so there is nothing to race for.

## Not fixed here (ops / transient / needs more data)

- `org_3BfZ…` on the managed Tinybird gateway has no `product_events` datasource — the code now degrades gracefully, but that workspace still needs the datasource deployed.
- alerting/api `DatabaseError` bursts 22:46–22:50 UTC on 2026-08-21 were a Postgres blip; not recurring.
- web `TypeError: Cannot read properties of undefined (reading 'component')` (route error) and `Illegal invocation` (unhandled rejection) ship without stacks; 3–4 events each.
- legacy `custom_timeseries` widget with a metrics source and no `metricName` (9 events, one burst).

## Test plan

- [x] `tsc --noEmit` for apps/api, apps/cli, packages/query-engine
- [x] `vitest` errors.test.ts, ApiKeysService.test.ts, fork-request-scoped.test.ts
- [x] `bun test` apps/cli/test/server-args.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789988691&installation_model_id=427786&pr_number=567&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F567&signature=305f07f11a238872cc79f882b7d838281476657c7a89cd0f7134152887a69e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->