### PR TITLE
fix: point maple repo links at the MapleTechLabs org

### DIFF
--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -45,7 +45,7 @@ import { Cause, Effect, Layer, Match } from "effect"
 const telemetry = MapleCloudflareSDK.make({
 	serviceName: "alerting",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
 })
 

--- a/apps/api/src/chat/turn-runner.ts
+++ b/apps/api/src/chat/turn-runner.ts
@@ -36,7 +36,7 @@ import { summarizeCause } from "@/platform/describe-cause"
 const telemetry = MapleCloudflareSDK.make({
 	serviceName: "maple-api",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS, ...MCP_ANTICIPATED_ERROR_IDENTIFIERS],
 })
 

--- a/apps/api/src/planetscale-webhook-runtime.ts
+++ b/apps/api/src/planetscale-webhook-runtime.ts
@@ -17,7 +17,7 @@ import { PlanetScaleWebhookJob } from "./services/integrations/planetscale/Plane
 const telemetry = MapleCloudflareSDK.make({
 	serviceName: "maple-api",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
 })
 

--- a/apps/api/src/slack-reconcile-runtime.ts
+++ b/apps/api/src/slack-reconcile-runtime.ts
@@ -26,7 +26,7 @@ import { SlackIntegrationService } from "./services/integrations/SlackIntegratio
 const telemetry = MapleCloudflareSDK.make({
 	serviceName: "maple-api",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
 })
 

--- a/apps/api/src/vcs-sync-runtime.ts
+++ b/apps/api/src/vcs-sync-runtime.ts
@@ -27,7 +27,7 @@ import { summarizeCause } from "@/platform/describe-cause"
 const telemetry = MapleCloudflareSDK.make({
 	serviceName: "maple-api",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
 })
 

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -59,7 +59,7 @@ const WorkerPlatformLive = Layer.mergeAll(
 const telemetry = MapleCloudflareSDK.make({
 	serviceName: "maple-api",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	dropSpanNames: ["McpServer/Notifications."],
 	// Expected 4xx outcomes (validation, not-found, unauthorized, …) record as
 	// Ok spans instead of errors — see @maple/domain/anticipated-errors.

--- a/apps/api/src/workflows/ClickHouseSchemaApplyWorkflow.run.ts
+++ b/apps/api/src/workflows/ClickHouseSchemaApplyWorkflow.run.ts
@@ -82,7 +82,7 @@ const bustRuntimeConfigCache = (orgId: OrgId): Promise<void> =>
 const schemaApplyTelemetry = MapleCloudflareSDK.make({
 	serviceName: "maple-api",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
 })
 

--- a/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
+++ b/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
@@ -166,7 +166,7 @@ const PERSIST_STEP = { retries: { limit: 5, delay: "2 seconds", backoff: "expone
 const fanoutTelemetry = MapleCloudflareSDK.make({
 	serviceName: "maple-api",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS, ...MCP_ANTICIPATED_ERROR_IDENTIFIERS],
 })
 

--- a/apps/cli/src/core/telemetry.ts
+++ b/apps/cli/src/core/telemetry.ts
@@ -46,7 +46,7 @@ export const TelemetryLayer = Maple.layer({
 	serviceNamespace: "backend",
 	serviceVersion: MAPLE_VERSION,
 	environment: resolveEnvironment(),
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	ingestKey: process.env.MAPLE_INGEST_KEY ?? DEFAULT_INGEST_KEY,
 	shutdownTimeout: "3 seconds",
 	// NOTE: expected user outcomes ("maple is already running", `--help`) no

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -31,7 +31,7 @@ export class UpdateError extends Schema.TaggedError<UpdateError>()("@maple/cli/U
 	message: Schema.String,
 }) {}
 
-const REPO = "Makisuo/maple"
+const REPO = "MapleTechLabs/maple"
 const LATEST_API = `https://api.github.com/repos/${REPO}/releases/latest`
 /** Throttle window for the startup check — hit GitHub at most once per day. */
 export const CHECK_TTL_MS = 24 * 60 * 60 * 1000

--- a/apps/electric-sync/src/worker.ts
+++ b/apps/electric-sync/src/worker.ts
@@ -46,7 +46,7 @@ const WorkerPlatformLive = Layer.mergeAll(
 const telemetry = MapleCloudflareSDK.make({
 	serviceName: "electric-sync",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
 })
 

--- a/apps/ingest/src/otel.rs
+++ b/apps/ingest/src/otel.rs
@@ -40,7 +40,7 @@ pub fn build_resource(cfg: ResourceConfig) -> Resource {
     attrs.push(KeyValue::new(
         "vcs.repository.url.full",
         env::var("VCS_REPOSITORY_URL")
-            .unwrap_or_else(|_| "https://github.com/Makisuo/maple".to_owned()),
+            .unwrap_or_else(|_| "https://github.com/MapleTechLabs/maple".to_owned()),
     ));
     if let Some(revision) = detect_head_revision() {
         attrs.push(KeyValue::new("vcs.ref.head.revision", revision));

--- a/apps/landing/src/components/BottomCTA.astro
+++ b/apps/landing/src/components/BottomCTA.astro
@@ -24,7 +24,7 @@ import * as m from "../paraglide/messages.js";
             <a href="https://app.maple.dev" data-track="cta_click" data-track-location="bottom" class="inline-flex h-9 items-center justify-center rounded-lg bg-primary px-3 text-xs font-medium text-primary-foreground transition-all hover:bg-primary/80">
                 {m.cta_get_started()}
             </a>
-            <a href="https://github.com/Makisuo/maple" target="_blank" rel="noopener noreferrer" class="inline-flex h-9 items-center justify-center rounded-lg border border-input bg-input/30 px-3 text-xs font-medium text-fg transition-all hover:bg-input/50">
+            <a href="https://github.com/MapleTechLabs/maple" target="_blank" rel="noopener noreferrer" class="inline-flex h-9 items-center justify-center rounded-lg border border-input bg-input/30 px-3 text-xs font-medium text-fg transition-all hover:bg-input/50">
                 {m.cta_github()}
             </a>
         </div>

--- a/apps/landing/src/components/FeatureHero.astro
+++ b/apps/landing/src/components/FeatureHero.astro
@@ -43,7 +43,7 @@ const { label, title, subtitle } = Astro.props;
         <!-- Dual CTAs -->
         <div class="mt-8 flex flex-wrap items-center gap-3">
             <HeroCta client:load className={buttonVariants({ size: "default" })} />
-            <a href="https://github.com/Makisuo/maple" target="_blank" rel="noopener noreferrer" class={buttonVariants({ variant: "outline", size: "default" })}>
+            <a href="https://github.com/MapleTechLabs/maple" target="_blank" rel="noopener noreferrer" class={buttonVariants({ variant: "outline", size: "default" })}>
                 {m.cta_github()}
             </a>
         </div>

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -95,7 +95,7 @@ const stars = await getGitHubStars();
                     <!-- GitHub keeps its text row for the star count; X and
                          Discord move to icons in the bottom bar, so they aren't
                          listed twice. -->
-                    <li><a href="https://github.com/Makisuo/maple" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-fg-muted text-xs hover:text-foreground transition-colors">{m.footer_github()}{stars != null && <span class="tabular-nums">{formatStars(stars)}</span>}</a></li>
+                    <li><a href="https://github.com/MapleTechLabs/maple" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-fg-muted text-xs hover:text-foreground transition-colors">{m.footer_github()}{stars != null && <span class="tabular-nums">{formatStars(stars)}</span>}</a></li>
                     <li><a href="https://opentelemetry.io" target="_blank" rel="noopener noreferrer" class="text-fg-muted text-xs hover:text-foreground transition-colors">{m.footer_opentelemetry()}</a></li>
                 </ul>
 
@@ -126,7 +126,7 @@ const stars = await getGitHubStars();
                 <a href="/brand" class="text-fg-muted text-[10px] hover:text-foreground transition-colors">{m.footer_brand()}</a>
                 <LanguageSwitcher />
                 <div class="flex items-center gap-3 border-l border-border pl-4">
-                    <a href="https://github.com/Makisuo/maple" target="_blank" rel="noopener noreferrer" aria-label={m.footer_github()} class="text-fg-muted hover:text-foreground transition-colors">
+                    <a href="https://github.com/MapleTechLabs/maple" target="_blank" rel="noopener noreferrer" aria-label={m.footer_github()} class="text-fg-muted hover:text-foreground transition-colors">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg>
                     </a>
                     <a href="https://x.com/Mapledotdev" target="_blank" rel="noopener noreferrer" aria-label={m.footer_twitter()} class="text-fg-muted hover:text-foreground transition-colors">

--- a/apps/landing/src/components/GithubStarButton.tsx
+++ b/apps/landing/src/components/GithubStarButton.tsx
@@ -1,6 +1,6 @@
 import { formatStars } from "../lib/github-stars"
 
-const REPO_URL = "https://github.com/Makisuo/maple"
+const REPO_URL = "https://github.com/MapleTechLabs/maple"
 
 /** GitHub "octocat" mark. Inherits color via `currentColor`. */
 export function Octocat({ className }: { className?: string }) {

--- a/apps/landing/src/components/NavBar.tsx
+++ b/apps/landing/src/components/NavBar.tsx
@@ -365,7 +365,7 @@ function NavBarInner({ locale = "en", stars }: { locale?: string; stars?: number
 
 						<div className="pt-6 flex flex-col gap-4">
 							<a
-								href="https://github.com/Makisuo/maple"
+								href="https://github.com/MapleTechLabs/maple"
 								target="_blank"
 								rel="noopener noreferrer"
 								className="flex items-center justify-between text-xs text-fg-muted hover:text-fg transition-colors"

--- a/apps/landing/src/components/SeoHead.astro
+++ b/apps/landing/src/components/SeoHead.astro
@@ -93,7 +93,7 @@ const organizationJsonLd = includeOrganization ? {
         "addressCountry": "US",
     },
     "sameAs": [
-        "https://github.com/Makisuo/maple",
+        "https://github.com/MapleTechLabs/maple",
         "https://x.com/Mapledotdev",
         "https://discord.gg/BnXjKuwJqP",
     ],

--- a/apps/landing/src/components/Sovereignty.astro
+++ b/apps/landing/src/components/Sovereignty.astro
@@ -55,7 +55,7 @@ const pillars = [
 		</dl>
 
 		<div class="mt-12 flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
-			<a href="https://github.com/Makisuo/maple" target="_blank" rel="noopener noreferrer" class="ink-link">
+			<a href="https://github.com/MapleTechLabs/maple" target="_blank" rel="noopener noreferrer" class="ink-link">
 				{m.sov_link_source()}
 			</a>
 			<a href="/opentelemetry" class="ink-link">

--- a/apps/landing/src/components/docs/AvailableSdks.astro
+++ b/apps/landing/src/components/docs/AvailableSdks.astro
@@ -60,6 +60,6 @@ const sdks: Sdk[] = [
         })}
     </div>
     <p class="text-[10px] text-fg-muted/70 mt-3 leading-relaxed">
-        Need a language we don't cover? <a href="https://github.com/Makisuo/maple/issues" target="_blank" rel="noopener" class="text-fg-muted hover:text-primary underline underline-offset-2 transition-colors">Open an issue</a>.
+        Need a language we don't cover? <a href="https://github.com/MapleTechLabs/maple/issues" target="_blank" rel="noopener" class="text-fg-muted hover:text-primary underline underline-offset-2 transition-colors">Open an issue</a>.
     </p>
 </div>

--- a/apps/landing/src/components/home/FinalCta.astro
+++ b/apps/landing/src/components/home/FinalCta.astro
@@ -30,7 +30,7 @@ import * as m from "../../paraglide/messages.js";
 				{m.cta_bookend_primary()}
 			</a>
 			<a
-				href="https://github.com/Makisuo/maple"
+				href="https://github.com/MapleTechLabs/maple"
 				target="_blank"
 				rel="noopener noreferrer"
 				class="inline-flex h-11 items-center justify-center rounded-lg border border-current/40 px-5 text-sm font-medium transition-colors hover:bg-current/10"

--- a/apps/landing/src/components/home/HomeHero.astro
+++ b/apps/landing/src/components/home/HomeHero.astro
@@ -22,7 +22,7 @@ const stars = await getGitHubStars();
 // Two slots, both live numbers we can point at: the GitHub star count (a
 // build-time fetch) and the volume we've ingested.
 const stats = [
-	stars !== null && { value: formatStars(stars), label: m.stat_github(), star: true, href: "https://github.com/Makisuo/maple" },
+	stars !== null && { value: formatStars(stars), label: m.stat_github(), star: true, href: "https://github.com/MapleTechLabs/maple" },
 	{ value: `${formatDataPoints(DATA_POINTS_INGESTED)}+`, label: m.ingest_stats_label() },
 ].filter(Boolean) as { value: string; label: string; star?: boolean; href?: string }[];
 ---
@@ -75,7 +75,7 @@ const stats = [
 		<div class="mt-10 flex flex-wrap items-center gap-3">
 			<HeroCta client:load className={buttonVariants({ size: "xl" })} />
 			<a
-				href="https://github.com/Makisuo/maple"
+				href="https://github.com/MapleTechLabs/maple"
 				target="_blank"
 				rel="noopener noreferrer"
 				class={buttonVariants({ variant: "outline", size: "xl" })}

--- a/apps/landing/src/components/home/KubernetesSection.astro
+++ b/apps/landing/src/components/home/KubernetesSection.astro
@@ -86,7 +86,7 @@ const points = [
 						{m.k8s_link_feature()}
 					</a>
 					<a
-						href="https://github.com/Makisuo/maple/tree/main/deploy/k8s-infra"
+						href="https://github.com/MapleTechLabs/maple/tree/main/deploy/k8s-infra"
 						target="_blank"
 						rel="noopener noreferrer"
 						class="text-fg-muted transition-colors hover:text-fg"

--- a/apps/landing/src/components/home/LocalSection.astro
+++ b/apps/landing/src/components/home/LocalSection.astro
@@ -65,7 +65,7 @@ const stars = await getGitHubStars();
 						{m.local_link_docs()}
 					</a>
 					<a
-						href="https://github.com/Makisuo/maple"
+						href="https://github.com/MapleTechLabs/maple"
 						target="_blank"
 						rel="noopener noreferrer"
 						class="inline-flex items-center gap-2 text-fg-muted transition-colors hover:text-fg"

--- a/apps/landing/src/components/local/LocalProductHero.astro
+++ b/apps/landing/src/components/local/LocalProductHero.astro
@@ -84,7 +84,7 @@ const stats = [
 				<!-- CTAs -->
 				<div class="lph-rise mt-6 flex flex-wrap items-center gap-3" style="--d:300ms">
 					<a
-						href="https://github.com/Makisuo/maple"
+						href="https://github.com/MapleTechLabs/maple"
 						target="_blank"
 						rel="noopener noreferrer"
 						class="inline-flex h-9 items-center justify-center rounded-lg border border-input bg-input/30 px-3 text-xs font-medium text-fg transition-all hover:bg-input/50"

--- a/apps/landing/src/components/page/PageCta.astro
+++ b/apps/landing/src/components/page/PageCta.astro
@@ -36,7 +36,7 @@ const { title, lede } = Astro.props;
 				{m.cta_bookend_primary()}
 			</a>
 			<a
-				href="https://github.com/Makisuo/maple"
+				href="https://github.com/MapleTechLabs/maple"
 				target="_blank"
 				rel="noopener noreferrer"
 				class="inline-flex h-11 items-center justify-center rounded-lg border border-current/40 px-5 text-sm font-medium transition-colors hover:bg-current/10"

--- a/apps/landing/src/components/page/PageHero.astro
+++ b/apps/landing/src/components/page/PageHero.astro
@@ -67,7 +67,7 @@ const { eyebrow, title, lede, breadcrumb, signal } = Astro.props;
 			<div class="mt-10 flex flex-wrap items-center gap-3">
 				<HeroCta client:load className={buttonVariants({ size: "xl" })} />
 				<a
-					href="https://github.com/Makisuo/maple"
+					href="https://github.com/MapleTechLabs/maple"
 					target="_blank"
 					rel="noopener noreferrer"
 					class={buttonVariants({ variant: "outline", size: "xl" })}

--- a/apps/landing/src/content/docs/concepts/otel-conventions.md
+++ b/apps/landing/src/content/docs/concepts/otel-conventions.md
@@ -9,7 +9,7 @@ Maple is fully compatible with the OpenTelemetry Protocol (OTLP). This document 
 
 Maple stores every OTel attribute you send verbatim, but a curated set get special treatment — pre-extracted into fast columns at ingest, exposed as short filter aliases, rendered as colored badges, used to draw the service map, or scored higher in the attribute chip strip. Most of these follow the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/) — if your SDK emits standard attributes you usually don't need to do anything extra.
 
-> **Audit with Claude Code:** `maple-audit` reviews an existing setup against these conventions — per service, with severities — and fixes the gaps. See the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Audit with Claude Code:** `maple-audit` reviews an existing setup against these conventions — per service, with severities — and fixes the gaps. See the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Ingest Endpoints
 

--- a/apps/landing/src/content/docs/getting-started/introduction.md
+++ b/apps/landing/src/content/docs/getting-started/introduction.md
@@ -39,7 +39,7 @@ The fastest path: run **`maple-onboard`** in Claude Code (or Codex / Cursor with
 maple-onboard
 ```
 
-Already instrumented? Run **`maple-audit`** instead — it reviews an existing OpenTelemetry setup against Maple's conventions, reports gaps per service, and fixes them. See the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+Already instrumented? Run **`maple-audit`** instead — it reviews an existing OpenTelemetry setup against Maple's conventions, reports gaps per service, and fixes them. See the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 Or set up by hand. The recommended shape is to **inline the endpoint and ingest key in your bootstrap source** -- the ingest key is project-scoped and write-only (Sentry-DSN-shaped), so source-level configuration removes a class of "OTel didn't start because env vars weren't set" deploy failures. See the per-language guides for exact code.
 

--- a/apps/landing/src/content/docs/guides/instrumentation-csharp.md
+++ b/apps/landing/src/content/docs/guides/instrumentation-csharp.md
@@ -8,7 +8,7 @@ sdk: "csharp"
 
 This guide covers instrumenting a .NET (C#) application to send traces and logs to Maple using the OpenTelemetry SDK.
 
-> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/Makisuo/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Prerequisites
 

--- a/apps/landing/src/content/docs/guides/instrumentation-go.md
+++ b/apps/landing/src/content/docs/guides/instrumentation-go.md
@@ -8,7 +8,7 @@ sdk: "go"
 
 This guide covers instrumenting a Go application to send traces and logs to Maple using the OpenTelemetry SDK.
 
-> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/Makisuo/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Prerequisites
 

--- a/apps/landing/src/content/docs/guides/instrumentation-java.md
+++ b/apps/landing/src/content/docs/guides/instrumentation-java.md
@@ -8,7 +8,7 @@ sdk: "java"
 
 This guide covers instrumenting a Java application to send traces and logs to Maple. The fastest path on the JVM is the OpenTelemetry Java agent, which auto-instruments most popular libraries with zero code changes.
 
-> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/Makisuo/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Prerequisites
 

--- a/apps/landing/src/content/docs/guides/instrumentation-kotlin.md
+++ b/apps/landing/src/content/docs/guides/instrumentation-kotlin.md
@@ -8,7 +8,7 @@ sdk: "kotlin"
 
 This guide covers instrumenting a Kotlin JVM application (Ktor, Spring Boot, generic JVM) to send traces and logs to Maple. For Android, see the [opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android) project.
 
-> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/Makisuo/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Prerequisites
 

--- a/apps/landing/src/content/docs/guides/instrumentation-laravel.md
+++ b/apps/landing/src/content/docs/guides/instrumentation-laravel.md
@@ -8,7 +8,7 @@ sdk: "laravel"
 
 This guide covers instrumenting a Laravel application to send traces and logs to Maple using the [`keepsuit/laravel-opentelemetry`](https://github.com/keepsuit/laravel-opentelemetry) package, which wires OpenTelemetry into Laravel's HTTP kernel, database, queue, and logging internals so you get useful spans out of the box.
 
-> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/Makisuo/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Prerequisites
 

--- a/apps/landing/src/content/docs/guides/instrumentation-nextjs.md
+++ b/apps/landing/src/content/docs/guides/instrumentation-nextjs.md
@@ -8,7 +8,7 @@ sdk: "nextjs"
 
 This guide covers instrumenting a Next.js application -- App Router, Pages Router, route handlers, and middleware -- using `@vercel/otel` and shipping traces and logs to Maple.
 
-> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/Makisuo/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Prerequisites
 

--- a/apps/landing/src/content/docs/guides/instrumentation-nodejs.md
+++ b/apps/landing/src/content/docs/guides/instrumentation-nodejs.md
@@ -8,7 +8,7 @@ sdk: "node"
 
 This guide covers instrumenting a Node.js application to send traces and logs to Maple using the OpenTelemetry SDK.
 
-> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/Makisuo/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Prerequisites
 

--- a/apps/landing/src/content/docs/guides/instrumentation-python.md
+++ b/apps/landing/src/content/docs/guides/instrumentation-python.md
@@ -8,7 +8,7 @@ sdk: "python"
 
 This guide covers instrumenting a Python application to send traces and logs to Maple using the OpenTelemetry SDK.
 
-> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/Makisuo/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Prerequisites
 

--- a/apps/landing/src/content/docs/guides/instrumentation-rust.md
+++ b/apps/landing/src/content/docs/guides/instrumentation-rust.md
@@ -8,7 +8,7 @@ sdk: "rust"
 
 This guide covers instrumenting a Rust application to send traces and logs to Maple using the OpenTelemetry SDK and the `tracing` ecosystem.
 
-> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/Makisuo/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/Makisuo/maple/tree/main/skills/maple-audit).
+> **Run this with Claude Code:** `maple-onboard` walks every service in the repo, installs OpenTelemetry, and verifies the bootstrap end-to-end. See the [maple-onboard skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-onboard). Already instrumented? `maple-audit` reviews the existing setup against Maple's conventions and fixes gaps — see the [maple-audit skill](https://github.com/MapleTechLabs/maple/tree/main/skills/maple-audit).
 
 ## Prerequisites
 

--- a/apps/landing/src/content/docs/guides/kubernetes-infrastructure.md
+++ b/apps/landing/src/content/docs/guides/kubernetes-infrastructure.md
@@ -25,7 +25,7 @@ All signals are exported over OTLP HTTP to Maple's ingest gateway. The collector
 The fastest path is the install script, which creates the namespace + ingest-key Secret and runs Helm for you. It prints your active `kubectl` context and asks for confirmation first (set `MAPLE_INSTALL_YES=1` to skip):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Makisuo/maple/main/deploy/k8s-infra/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/MapleTechLabs/maple/main/deploy/k8s-infra/install.sh | \
   MAPLE_INGEST_KEY=YOUR_MAPLE_INGEST_KEY \
   MAPLE_CLUSTER_NAME=production \
   bash

--- a/apps/landing/src/content/docs/local-mode.mdx
+++ b/apps/landing/src/content/docs/local-mode.mdx
@@ -20,7 +20,7 @@ Pick your package manager. Homebrew is the easiest path on macOS and Linux; the 
 
 <InstallTabs />
 
-> Prefer to do it by hand? Download a release bundle (both `maple` + `libchdb`) from [GitHub Releases](https://github.com/Makisuo/maple/releases), or read [`scripts/install.sh`](https://github.com/Makisuo/maple/blob/main/scripts/install.sh) first before piping it to a shell.
+> Prefer to do it by hand? Download a release bundle (both `maple` + `libchdb`) from [GitHub Releases](https://github.com/MapleTechLabs/maple/releases), or read [`scripts/install.sh`](https://github.com/MapleTechLabs/maple/blob/main/scripts/install.sh) first before piping it to a shell.
 
 ## Start the server
 
@@ -82,4 +82,4 @@ The same CLI talks to either your local server or a hosted Maple workspace. The 
 
 ## How it works
 
-One Bun-compiled binary is both the CLI and the server, talking to ClickHouse in-process via `bun:ffi` → `libchdb` (no subprocess, no second language). For the architecture, the `/local/query` contract, the UI-origin model, and the release bundle, see the [local-mode design doc](https://github.com/Makisuo/maple/blob/main/docs/local-mode.md).
+One Bun-compiled binary is both the CLI and the server, talking to ClickHouse in-process via `bun:ffi` → `libchdb` (no subprocess, no second language). For the architecture, the `/local/query` contract, the UI-origin model, and the release bundle, see the [local-mode design doc](https://github.com/MapleTechLabs/maple/blob/main/docs/local-mode.md).

--- a/apps/landing/src/lib/agent-resources.ts
+++ b/apps/landing/src/lib/agent-resources.ts
@@ -8,7 +8,7 @@
  */
 
 export const API_ORIGIN = "https://api.maple.dev"
-export const GITHUB_URL = "https://github.com/Makisuo/maple"
+export const GITHUB_URL = "https://github.com/MapleTechLabs/maple"
 export const DISCORD_URL = "https://discord.gg/BnXjKuwJqP"
 export const X_URL = "https://x.com/maple_dev"
 

--- a/apps/landing/src/lib/company.ts
+++ b/apps/landing/src/lib/company.ts
@@ -56,7 +56,7 @@ export const aboutPage: CompanyPage = {
 		{
 			heading: "Open source",
 			paragraphs: [
-				`The source code is public at [github.com/Makisuo/maple](${GITHUB_URL}) under the Functional Source License (FSL-1.1); each release converts to Apache 2.0 two years after publication. You can read every line, self-host the whole platform, or use the hosted service at maple.dev. Maple Local packages the same platform — ingest, query engine, and UI — as a single binary with an embedded ClickHouse for laptops and CI.`,
+				`The source code is public at [github.com/MapleTechLabs/maple](${GITHUB_URL}) under the Functional Source License (FSL-1.1); each release converts to Apache 2.0 two years after publication. You can read every line, self-host the whole platform, or use the hosted service at maple.dev. Maple Local packages the same platform — ingest, query engine, and UI — as a single binary with an embedded ClickHouse for laptops and CI.`,
 			],
 		},
 		{

--- a/apps/landing/src/lib/github-stars.ts
+++ b/apps/landing/src/lib/github-stars.ts
@@ -1,4 +1,4 @@
-const REPO = "Makisuo/maple"
+const REPO = "MapleTechLabs/maple"
 
 let cached: Promise<number | null> | undefined
 

--- a/apps/landing/src/pages/docs/index.astro
+++ b/apps/landing/src/pages/docs/index.astro
@@ -249,7 +249,7 @@ const renderTree = (i: number, last: number) => (i === last ? "└──" : "├
         <footer class="docs-index__rail">
             <span class="text-fg-muted/70" aria-hidden="true">───</span>
             <span class="text-fg-muted">looking for something specific?</span>
-            <a href="https://github.com/Makisuo/maple" class="docs-index__rail-link">github</a>
+            <a href="https://github.com/MapleTechLabs/maple" class="docs-index__rail-link">github</a>
             <span class="text-fg-muted/40" aria-hidden="true">·</span>
             <a href="https://app.maple.dev" class="docs-index__rail-link">open the app <span aria-hidden="true">→</span></a>
         </footer>

--- a/apps/landing/src/pages/local.astro
+++ b/apps/landing/src/pages/local.astro
@@ -212,7 +212,7 @@ const valueProps = [
                             Read the docs
                         </a>
                         <a
-                            href="https://github.com/Makisuo/maple/releases"
+                            href="https://github.com/MapleTechLabs/maple/releases"
                             target="_blank"
                             rel="noopener noreferrer"
                             class="inline-flex h-9 items-center justify-center rounded-lg border border-input bg-input/30 px-3 text-xs font-medium text-fg transition-all hover:bg-input/50"

--- a/apps/scraper/src/main.ts
+++ b/apps/scraper/src/main.ts
@@ -21,7 +21,7 @@ import { ScrapeScheduler } from "./ScrapeScheduler"
 const TelemetryLayer = Maple.layer({
 	serviceName: "scraper",
 	serviceNamespace: "backend",
-	repositoryUrl: "https://github.com/Makisuo/maple",
+	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	shutdownTimeout: "3 seconds",
 })
 

--- a/apps/slack-agent/agent/instrumentation.ts
+++ b/apps/slack-agent/agent/instrumentation.ts
@@ -56,7 +56,7 @@ export function buildResourceAttributes(input: ResourceAttributeInput = {}): Rec
 		"service.instance.id": randomUUID(),
 		"service.version": input.serviceVersion?.trim() || "development",
 		"maple.sdk.type": "eve",
-		"vcs.repository.url.full": "https://github.com/Makisuo/maple",
+		"vcs.repository.url.full": "https://github.com/MapleTechLabs/maple",
 	} satisfies Record<string, string>
 	if (input.commitSha?.trim()) {
 		attributes["deployment.commit_sha"] = input.commitSha.trim()

--- a/apps/web/src/components/header/connect-button.tsx
+++ b/apps/web/src/components/header/connect-button.tsx
@@ -18,7 +18,7 @@ import { useIngestConnection } from "@/components/ingest/use-ingest-connection"
 import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { mcpUrl } from "@/lib/services/common/mcp-url"
 
-const ONBOARD_SKILL_COMMAND = "bunx skills add Makisuo/maple/skills/maple-onboard"
+const ONBOARD_SKILL_COMMAND = "bunx skills add MapleTechLabs/maple/skills/maple-onboard"
 const MCP_ENDPOINT = `${mcpUrl}/mcp`
 
 export function ConnectButton() {

--- a/apps/web/src/lib/services/common/otel-layer.ts
+++ b/apps/web/src/lib/services/common/otel-layer.ts
@@ -20,7 +20,7 @@ const telemetry = MapleFlush.make({
 	serviceVersion: import.meta.env.VITE_COMMIT_SHA,
 	attributes: {
 		"service.namespace": "client",
-		"vcs.repository.url.full": "https://github.com/Makisuo/maple",
+		"vcs.repository.url.full": "https://github.com/MapleTechLabs/maple",
 		...(import.meta.env.VITE_COMMIT_SHA
 			? { "vcs.ref.head.revision": import.meta.env.VITE_COMMIT_SHA }
 			: undefined),

--- a/deploy/k8s-infra/Chart.yaml
+++ b/deploy/k8s-infra/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
     - observability
     - opentelemetry
     - kubernetes
-home: https://github.com/makisuo/maple
+home: https://github.com/MapleTechLabs/maple
 sources:
     - https://github.com/open-telemetry/opentelemetry-collector-contrib
     - https://github.com/open-telemetry/opentelemetry-operator

--- a/deploy/k8s-infra/Dockerfile.otel-collector-maple
+++ b/deploy/k8s-infra/Dockerfile.otel-collector-maple
@@ -48,7 +48,7 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 # OCI labels — `org.opencontainers.image.source` is what GHCR uses to link
 # the package back to the source repo for visibility / permissions.
-LABEL org.opencontainers.image.source="https://github.com/Makisuo/maple"
+LABEL org.opencontainers.image.source="https://github.com/MapleTechLabs/maple"
 LABEL org.opencontainers.image.description="OpenTelemetry Collector with Maple ClickHouse exporter"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/deploy/k8s-infra/README.md
+++ b/deploy/k8s-infra/README.md
@@ -16,7 +16,7 @@ The chart defaults to Maple's hosted ingest gateway (`https://ingest.maple.dev`)
 The chart is published to GHCR. The easiest install path is:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Makisuo/maple/main/deploy/k8s-infra/install.sh | \
+curl -fsSL https://raw.githubusercontent.com/MapleTechLabs/maple/main/deploy/k8s-infra/install.sh | \
   MAPLE_INGEST_KEY=YOUR_MAPLE_INGEST_KEY \
   MAPLE_CLUSTER_NAME=production \
   bash

--- a/deploy/maple-otel/Chart.yaml
+++ b/deploy/maple-otel/Chart.yaml
@@ -19,6 +19,6 @@ keywords:
     - observability
     - opentelemetry
     - clickhouse
-home: https://github.com/makisuo/maple
+home: https://github.com/MapleTechLabs/maple
 sources:
-    - https://github.com/makisuo/maple
+    - https://github.com/MapleTechLabs/maple

--- a/docs/local-mode.md
+++ b/docs/local-mode.md
@@ -30,7 +30,7 @@ curl -fsSL https://maple.dev/cli/install | sh
 
 (`maple.dev/cli/install` is [scripts/install.sh](../scripts/install.sh) served by
 `apps/landing` — the build copies it to `public/cli/install`. The raw GitHub URL
-`https://raw.githubusercontent.com/Makisuo/maple/main/scripts/install.sh` works too.)
+`https://raw.githubusercontent.com/MapleTechLabs/maple/main/scripts/install.sh` works too.)
 
 The manual installer detects your OS/arch, downloads the matching bundle from
 the latest GitHub release, verifies its checksum, installs the two files into

--- a/packages/domain/src/mcp-manifest.ts
+++ b/packages/domain/src/mcp-manifest.ts
@@ -47,7 +47,7 @@ export const mapleMcpServerManifest = ({
 		version: MAPLE_MCP_SERVER_VERSION,
 		websiteUrl: `${site}/features/ai-mcp-integration`,
 		repository: {
-			url: "https://github.com/Makisuo/maple",
+			url: "https://github.com/MapleTechLabs/maple",
 			source: "github",
 			subfolder: "apps/api",
 		},

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@
 #   curl -fsSL https://maple.dev/cli/install | sh
 #
 # (maple.dev/cli/install is this same file, served by apps/landing. The raw
-#  GitHub URL — raw.githubusercontent.com/Makisuo/maple/main/scripts/install.sh —
+#  GitHub URL — raw.githubusercontent.com/MapleTechLabs/maple/main/scripts/install.sh —
 #  works too.)
 #
 # Downloads the platform bundle from the latest GitHub release, verifies its
@@ -29,7 +29,7 @@
 #   MAPLE_SKIP_CHECKSUM  set to 1 to skip SHA-256 verification (not recommended)
 set -eu
 
-REPO="Makisuo/maple"
+REPO="MapleTechLabs/maple"
 INSTALL_DIR="${MAPLE_INSTALL_DIR:-$HOME/.maple/bin}"
 
 say() { printf '%s\n' "$*"; }


### PR DESCRIPTION
The repo lives at `github.com/MapleTechLabs/maple`. Package metadata and the CI OIDC subjects already used that owner, but docs, landing pages, telemetry attributes and the install/update scripts still pointed at the old one.

## What changed

56 files, 61 replacements — every one a 1:1 `Makisuo` → `MapleTechLabs` swap.

- **Repo URLs** — landing pages and components, docs, Helm `Chart.yaml` `home:` fields, the OCI image `source` label, and the `repositoryUrl` OTel resource attribute across ~12 service runtimes.
- **`raw.githubusercontent.com`** paths in the k8s install guide and `scripts/install.sh`.
- **Bare repo slugs used against the GitHub API.** These are functional rather than cosmetic, and a plain URL search misses them:
  - `scripts/install.sh` — release-bundle downloads
  - `apps/cli/src/core/update.ts` — CLI self-update check
  - `apps/landing/src/lib/github-stars.ts` — stargazer count
  - `apps/web/src/components/header/connect-button.tsx` — the `bunx skills add` command

`apps/landing/public/cli/install` is gitignored and generated from `scripts/install.sh`, so it picks the change up on the next build.

## Left alone deliberately

- **`ghcr.io/makisuo/*`** image and Helm chart coordinates, plus the `publish-*-chart.sh` `OWNER` default — rewriting these breaks self-host pulls until the packages are republished under the new owner.
- **`Makisuo/tap`** Homebrew tap — a separate repo, bumped by hand.
- **Go module paths** under `packages/otel-collector-maple-exporter` — build identifiers resolved through a local `replace`, not links.
- **`Makisuo, Inc.`** as the legal entity in LICENSEs and copyright strings.
- **`docs/sst-fork-workflow.md`** — refers to a fork of a different upstream repo.

## Verification

Every added line confirmed to contain `MapleTechLabs` (61 insertions, 61 deletions, no stray edits). No test asserts these URLs; the one test touching `Makisuo` asserts the entity name, which is unchanged.

Follow-up worth a look: the schema.org author in `apps/landing/src/pages/guides/api-latency.astro` is `{"@type": "Person", name: "Makisuo"}` and renders a visible "By Makisuo" byline. That is public-facing attribution rather than a link, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789989147&installation_model_id=427786&pr_number=569&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F569&signature=6a835fdf41fdb78e3c72ec169e1bc5fd5999aa3592e7040a61a33d18b5f7d57c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->