### PR TITLE
fix(api): raise the scrape upstream timeout ceiling to 60s

### DIFF
--- a/apps/api/src/services/integrations/ScrapeTargetsService.ts
+++ b/apps/api/src/services/integrations/ScrapeTargetsService.ts
@@ -1153,8 +1153,12 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 				} else {
 					headers = yield* authHeadersForRow(row.value)
 				}
+				// The ceiling is 60s, not 10s: slow upstreams (PlanetScale metrics under
+				// load) were being cut off at exactly 10s and surfacing as a 502 to the
+				// collector. The scrape interval still bounds it, so a scrape can never
+				// overlap the next one.
 				const timeoutMs = Math.min(
-					10_000,
+					60_000,
 					Math.max(1_000, (row.value.scrapeIntervalSeconds - 1) * 1000),
 				)
 


### PR DESCRIPTION
`ScrapeTargetsService.fetchUpstream` capped its per-scrape timeout at 10s. Slow upstreams hit that ceiling exactly, the fetch was interrupted, and the internal `prometheus-scrape` route returned a 502 to the collector.

Trace `362efc37ed177c5bf9fdf7d0eeb068e0` (prod, commit `e018bd1f`):

- `ScrapeTargetsService.fetchUpstream` — 10.00s, `Error`, "Scrape target request timed out"
- `ScrapeTargetsService.scrapeForCollector` — 10.08s, `Error`
- `GET /api/internal/prometheus-scrape` — 10.08s, HTTP 502
- `scraper.scrape_target` — 10.18s, "target returned HTTP 502"

Everything else in the trace is fast (target row 13ms, PlanetScale discovery 69ms) — the whole 10s is the upstream fetch being cut off.

## Change

The `Math.min` ceiling goes from `10_000` to `60_000`. The interval-derived bound is untouched, so the timeout stays `min(60s, max(1s, (interval - 1) * 1000))` and a scrape still can never overlap the next one.

## Worth knowing before merge

- **The ceiling only binds long-interval targets.** With the default 15s interval the effective timeout goes 10s → 14s; only targets with an interval above 61s actually get 60s. If the intent is "always allow 60s", the interval bound needs to change too — that is a separate decision, since it would let scrapes overlap.
- **The scraper caps every API round-trip at 30s** (`REQUEST_TIMEOUT` in `apps/scraper/src/ApiClient.ts:55`). An API-side timeout above ~30s can never be observed: the collector aborts first. Left alone here deliberately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789992570&installation_model_id=427786&pr_number=570&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F570&signature=efdba2c06ba00f2cf5edd06dfe5e9aad35fb4a2990c86d81d93bbf78bb69d249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->