### PR TITLE
fix(web): fold severity case variants in the log volume histogram

### DIFF
--- a/apps/web/src/components/logs/logs-volume-chart.tsx
+++ b/apps/web/src/components/logs/logs-volume-chart.tsx
@@ -352,10 +352,17 @@ export function LogsVolumeChart({ filters, onTimeRangeSelect }: LogsVolumeChartP
 			const points = response.data
 			if (points.length === 0) return null
 
+			// Severity is grouped by the RAW `SeverityText`, and SDKs disagree on
+			// its case — one org ships `INFO`, `Info` and `info` side by side. They
+			// are one severity to the reader, so fold them into one series here.
+			// Leaving them apart produced three tooltip rows all labelled "INFO",
+			// and three identical React keys: on every hover re-render React then
+			// leaked the stale rows instead of replacing them, and the tooltip grew
+			// a row per bucket crossed.
 			const seriesKeysSet = new Set<string>()
 			for (const point of points) {
 				for (const key of Object.keys(point.series)) {
-					seriesKeysSet.add(key)
+					seriesKeysSet.add(key.toUpperCase())
 				}
 			}
 
@@ -368,10 +375,15 @@ export function LogsVolumeChart({ filters, onTimeRangeSelect }: LogsVolumeChartP
 				}
 			}
 
-			const chartData = points.map((point) => ({
-				bucket: point.bucket,
-				...point.series,
-			}))
+			const chartData = points.map((point) => {
+				const bySeverity = new Map<string, number>()
+				for (const [key, value] of Object.entries(point.series)) {
+					if (typeof value !== "number") continue
+					const canonical = key.toUpperCase()
+					bySeverity.set(canonical, (bySeverity.get(canonical) ?? 0) + value)
+				}
+				return { bucket: point.bucket, ...Object.fromEntries(bySeverity) }
+			})
 
 			const totalCount = points.reduce((sum, point) => {
 				return (

--- a/packages/ui/src/components/plot/plot-tooltip.tsx
+++ b/packages/ui/src/components/plot/plot-tooltip.tsx
@@ -253,12 +253,15 @@ export function PlotTooltipBody<TDatum>({
 				{heading(datum)}
 			</div>
 			<div className="grid gap-1.5">
-				{series.map((spec) => {
+				{series.map((spec, index) => {
 					const value = spec.value(datum)
 					if (value == null) return null
 					return (
 						<div
-							key={spec.label}
+							// Position-qualified: two series CAN share a label (a chart
+							// that folds case variants imperfectly, say), and duplicate
+							// keys make React leak stale rows across re-renders.
+							key={`${index}:${spec.label}`}
 							className={
 								spec.label === highlightLabel
 									? "flex w-full items-center gap-2 [&_*]:font-semibold"


### PR DESCRIPTION
## Problem

Hovering the logs volume histogram could produce a tooltip with dozens of rows — INFO/WARN/ERROR repeated over and over with values from many different buckets.

## Cause

The histogram groups by the raw `SeverityText`. Some orgs emit `INFO`, `Info` and `info` (and the same for WARN/ERROR) side by side, so the chart built three series that it labelled identically. `PlotTooltipBody` keyed its rows on that label; React's handling of duplicate keys leaks stale rows on every re-render, so each hover across a bucket left the previous rows behind and the tooltip grew unbounded.

## Fix

- `logs-volume-chart.tsx`: fold case variants into one canonical upper-cased series per bucket (summing counts) before building the chart.
- `plot-tooltip.tsx`: qualify tooltip row keys by position so two series sharing a label can never collide again.

Verified locally: histogram + tooltip render unchanged at 12h/7d; `packages/ui` plot tests pass; lint/typecheck clean on the touched files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789994228&installation_model_id=427786&pr_number=572&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F572&signature=b04416efefd9ac085fbbbd48d0aff66a94fdd35268718029034843aa5273b899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->