### PR TITLE
fix(web): keep synthetic fingerprints out of the errors sparkline query

### DIFF
--- a/apps/web/src/components/errors/errors-hub.tsx
+++ b/apps/web/src/components/errors/errors-hub.tsx
@@ -20,7 +20,12 @@ import {
 } from "@/lib/services/atoms/warehouse-query-atoms"
 import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { errorIssueFromV2 } from "@/lib/services/error-issues"
-import { buildErrorSignals, indexInvestigationsByIssue, type ErrorSignal } from "@/lib/models/error-signal"
+import {
+	buildErrorSignals,
+	indexInvestigationsByIssue,
+	sparkFingerprintHashes,
+	type ErrorSignal,
+} from "@/lib/models/error-signal"
 import {
 	clearedSelection,
 	type IssueSelectionMsg,
@@ -277,7 +282,7 @@ export function ErrorsHub(props: ErrorsHubProps) {
 
 	// The sparkline set follows the rows actually on screen, so a filtered view
 	// never pays for fingerprints it will not draw.
-	const fingerprintHashes = useMemo(() => issues.map((issue) => issue.fingerprintHash), [issues])
+	const fingerprintHashes = useMemo(() => sparkFingerprintHashes(issues), [issues])
 
 	const bucketSeconds = useMemo(() => {
 		const startMs = Date.parse(props.range.startTime.replace(" ", "T") + "Z")

--- a/apps/web/src/lib/models/error-signal.test.ts
+++ b/apps/web/src/lib/models/error-signal.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest"
 import type { WorkflowState } from "@maple/domain/http"
 import type { V2Investigation } from "@maple/domain/http/v2"
 
-import { densifySpark, resolveSignalState, surgeRatio } from "./error-signal"
+import { densifySpark, resolveSignalState, sparkFingerprintHashes, surgeRatio } from "./error-signal"
 
 const HOUR_MS = 3_600_000
 
@@ -45,6 +45,21 @@ describe("resolveSignalState", () => {
 	it("falls back to the workflow state when nothing is running", () => {
 		const state = resolveSignalState(issue({ workflowState: "in_review" }), undefined)
 		expect(state).toEqual({ kind: "workflow", state: "in_review" })
+	})
+})
+
+describe("sparkFingerprintHashes", () => {
+	it("keeps only the issues whose fingerprint the warehouse can parse", () => {
+		// Alert and integration issues reuse the fingerprint column for a
+		// synthetic key. Sending one to the batched spark query makes ClickHouse
+		// reject `toUInt64('alert:…')` and fails the sparklines for every row.
+		const hashes = sparkFingerprintHashes([
+			{ kind: "error", fingerprintHash: "753390793895937054" },
+			{ kind: "alert", fingerprintHash: "alert:550bb2c5-8fe0-4ab9-b2f8-e566674cb0a2:scraper" },
+			{ kind: "integration", fingerprintHash: "planetscale:maple:branch.out_of_memory" },
+			{ kind: "error", fingerprintHash: "1037926342141719040" },
+		])
+		expect(hashes).toEqual(["753390793895937054", "1037926342141719040"])
 	})
 })
 

--- a/apps/web/src/lib/models/error-signal.ts
+++ b/apps/web/src/lib/models/error-signal.ts
@@ -10,7 +10,13 @@
 //
 // An `ErrorSignal` is those three joined on the fingerprint hash.
 
-import type { ErrorIssueDocument, ErrorIssueId, IssueSeverity, WorkflowState } from "@maple/domain/http"
+import type {
+	ErrorIssueDocument,
+	ErrorIssueId,
+	IssueKind,
+	IssueSeverity,
+	WorkflowState,
+} from "@maple/domain/http"
 import type { V2Investigation } from "@maple/domain/http/v2"
 
 import type { ErrorByType } from "@/api/warehouse/errors"
@@ -124,6 +130,22 @@ export function resolveSignalState(
 		}
 	}
 	return { kind: "workflow", state: issue.workflowState }
+}
+
+/**
+ * The fingerprints a sparkline can actually be drawn for.
+ *
+ * Only `kind === "error"` issues carry a real ClickHouse fingerprint (a decimal
+ * UInt64 string). Alert and integration issues reuse the column for a synthetic
+ * key — `alert:{ruleId}:{groupKey}`, `planetscale:{database}:{event}` — which
+ * `toUInt64()` rejects, failing the whole batched spark query for every row on
+ * screen. `ErrorIssueReadModelsService.getIssue` skips the warehouse for the
+ * same reason.
+ */
+export function sparkFingerprintHashes(
+	issues: ReadonlyArray<{ readonly kind: IssueKind; readonly fingerprintHash: string }>,
+): ReadonlyArray<string> {
+	return issues.filter((issue) => issue.kind === "error").map((issue) => issue.fingerprintHash)
 }
 
 /**


### PR DESCRIPTION
## What broke

Loading `/errors` returned a 500 from `errorsSpark`:

```
Cannot parse string 'alert:550bb2c5-…:scraper' as UInt64: syntax error at begin of string
```

`error_issues.fingerprint_hash` is shared across three issue kinds:

| kind | fingerprint |
| --- | --- |
| `error` | decimal UInt64 string from ClickHouse |
| `alert` | `alert:{ruleId}:{groupKey}` |
| `integration` | `planetscale:{database}:{event}` |

The errors hub sent every visible issue's fingerprint to the batched sparkline
query, which lowers the list into `FingerprintHash IN (toUInt64('…'), …)`. A
single alert-backed issue on screen made ClickHouse reject the whole batch — so
the sparklines failed for every row in the list, not just that one.

Issue *detail* never hit this because `ErrorIssueReadModelsService.getIssue`
already skips the warehouse for non-error kinds.

## Fix

Apply the same guard before the round-trip, as `sparkFingerprintHashes()` in
`lib/models/error-signal.ts`. Alert and integration rows already degrade
correctly: `buildErrorSignals` falls back to an empty series, and
`getErrorsSpark` short-circuits an empty list, so a view holding only alert
issues skips the request altogether.

## Not covered here

`/internal/query-engine/errors-spark` still lowers a caller-supplied list
straight into `toUInt64()`, so a future caller passing a synthetic key gets a
500 rather than a 400. Tightening the shared `FingerprintHash` primitive to
decimal-only would be wrong — `parseFingerprintHashes` in the v2 issues route
legitimately filters Postgres by `alert:` values — so that hardening would need
to live at the warehouse-bound boundary specifically. Left out of this fix.

## Verification

- `bun run --cwd apps/web test src/lib/models/error-signal.test.ts` — 12 passed,
  including a new case built from the fingerprint in the failing trace
- `bun run --cwd apps/web typecheck` — clean

Not verified in a browser: reproducing needs an alert-backed issue in the hub
list, which local data does not have. The failing path is a data-selection
choice, covered by the unit test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789994750&installation_model_id=427786&pr_number=573&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F573&signature=cb67cd16f5aef7579d0248ef62ae0a067cbfb385f28610c03c737b11ee3ef9bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->