### PR TITLE
fix(web): clear removed advanced filters from the traces URL

### DIFF
--- a/apps/web/src/lib/traces/advanced-filter-sync.test.ts
+++ b/apps/web/src/lib/traces/advanced-filter-sync.test.ts
@@ -493,3 +493,100 @@ describe("applyWhereClause", () => {
 		expect(result.excludedServices).toBeUndefined()
 	})
 })
+
+describe("applyWhereClause removals", () => {
+	it("clears named-field params the previous clause set but the new one drops", () => {
+		const result = applyWhereClause(
+			{
+				whereClause: 'service.name = "checkout" AND span.name = "GET /orders"',
+				services: ["checkout"],
+				spanNames: ["GET /orders"],
+				startTime: "2026-02-01 00:00:00",
+			},
+			'span.name = "GET /orders"',
+		)
+
+		expect(result.services).toBeUndefined()
+		expect(result.spanNames).toEqual(["GET /orders"])
+		expect(result.startTime).toBe("2026-02-01 00:00:00")
+	})
+
+	it("clears boolean and duration params the previous clause set", () => {
+		const result = applyWhereClause(
+			{
+				whereClause:
+					'service.name = "checkout" AND has_error = true AND min_duration_ms = 100 AND max_duration_ms = 900 AND root_only = false',
+				services: ["checkout"],
+				hasError: true,
+				minDurationMs: 100,
+				maxDurationMs: 900,
+				rootOnly: false,
+			},
+			'service.name = "checkout"',
+		)
+
+		expect(result.hasError).toBeUndefined()
+		expect(result.minDurationMs).toBeUndefined()
+		expect(result.maxDurationMs).toBeUndefined()
+		expect(result.rootOnly).toBeUndefined()
+		expect(result.services).toEqual(["checkout"])
+	})
+
+	it("clears attribute filters the previous clause set", () => {
+		const result = applyWhereClause(
+			{
+				whereClause: 'attr.http.route = "/api" AND resource.service.version = "1.2.3"',
+				attributeFilters: [{ key: "http.route", value: "/api" }],
+				resourceAttributeFilters: [{ key: "service.version", value: "1.2.3" }],
+			},
+			'attr.http.route = "/api"',
+		)
+
+		expect(result.attributeFilters).toEqual([{ key: "http.route", value: "/api", matchMode: undefined }])
+		expect(result.resourceAttributeFilters).toBeUndefined()
+	})
+
+	it("clears excluded* params the previous clause set", () => {
+		const result = applyWhereClause(
+			{
+				whereClause: 'service.name != "checkout" AND span.name != "GET /health"',
+				excludedServices: ["checkout"],
+				excludedSpanNames: ["GET /health"],
+			},
+			'span.name != "GET /health"',
+		)
+
+		expect(result.excludedServices).toBeUndefined()
+		expect(result.excludedSpanNames).toEqual(["GET /health"])
+	})
+
+	it("clears a match mode the previous clause set", () => {
+		const result = applyWhereClause(
+			{
+				whereClause: 'service.name contains "check"',
+				services: ["check"],
+				serviceMatchMode: "contains",
+			},
+			'service.name = "checkout"',
+		)
+
+		expect(result.services).toEqual(["checkout"])
+		expect(result.serviceMatchMode).toBeUndefined()
+	})
+
+	it("keeps params the previous clause never set", () => {
+		const result = applyWhereClause(
+			{
+				whereClause: 'span.name = "GET /orders"',
+				spanNames: ["GET /orders"],
+				services: ["billing"],
+				hasError: true,
+			},
+			'span.name = "POST /pay"',
+		)
+
+		expect(result.spanNames).toEqual(["POST /pay"])
+		expect(result.services).toEqual(["billing"])
+		expect(result.hasError).toBe(true)
+	})
+})

--- a/apps/web/src/lib/traces/advanced-filter-sync.ts
+++ b/apps/web/src/lib/traces/advanced-filter-sync.ts
@@ -289,10 +289,60 @@ export function toWhereClause(filters: ParsedWhereClauseFilters): string | undef
 	return clauses.join(" AND ")
 }
 
+type ClauseFields = Omit<TracesSearchLike, "startTime" | "endTime" | "whereClause">
+
+/**
+ * The search params a clause owns, containing only the keys it actually sets.
+ * The key set is what tells `applyWhereClause` which params to drop when a
+ * later edit of the clause no longer produces them.
+ */
+function clauseFields(filters: ParsedWhereClauseFilters): ClauseFields {
+	const modes = filters.matchModes ?? {}
+	const fields: ClauseFields = {}
+
+	if (filters.service) {
+		fields.services = [filters.service]
+		fields.serviceMatchMode = modes.service
+	}
+	if (filters.spanName) {
+		fields.spanNames = [filters.spanName]
+		fields.spanNameMatchMode = modes.spanName
+	}
+	if (filters.deploymentEnv) {
+		fields.deploymentEnvs = [filters.deploymentEnv]
+		fields.deploymentEnvMatchMode = modes.deploymentEnv
+	}
+	if (filters.httpMethod) fields.httpMethods = [filters.httpMethod]
+	if (filters.httpStatusCode) fields.httpStatusCodes = [filters.httpStatusCode]
+	if (filters.hasError !== undefined) fields.hasError = filters.hasError
+	if (filters.rootOnly !== undefined) fields.rootOnly = filters.rootOnly
+	if (filters.minDurationMs !== undefined) fields.minDurationMs = filters.minDurationMs
+	if (filters.maxDurationMs !== undefined) fields.maxDurationMs = filters.maxDurationMs
+	if (filters.attributeFilters.length > 0) fields.attributeFilters = filters.attributeFilters
+	if (filters.resourceAttributeFilters.length > 0) {
+		fields.resourceAttributeFilters = filters.resourceAttributeFilters
+	}
+	if (filters.excludedServices?.length) fields.excludedServices = filters.excludedServices
+	if (filters.excludedSpanNames?.length) fields.excludedSpanNames = filters.excludedSpanNames
+	if (filters.excludedDeploymentEnvs?.length) {
+		fields.excludedDeploymentEnvs = filters.excludedDeploymentEnvs
+	}
+	if (filters.excludedHttpMethods?.length) fields.excludedHttpMethods = filters.excludedHttpMethods
+	if (filters.excludedHttpStatusCodes?.length) {
+		fields.excludedHttpStatusCodes = filters.excludedHttpStatusCodes
+	}
+
+	return fields
+}
+
 /**
  * One-way transform: parses a where clause string and merges the parsed
  * filter values into the search params. Does NOT reverse-sync checkboxes
  * back into whereClause text.
+ *
+ * Params the previous clause contributed are dropped first, so removing a
+ * clause removes its filter from the URL instead of leaving it stuck there.
+ * Params the previous clause never set (sidebar selections) are kept.
  */
 export function applyWhereClause(search: TracesSearchLike, whereClause: string): TracesSearchLike {
 	const trimmed = whereClause.trim()
@@ -323,44 +373,16 @@ export function applyWhereClause(search: TracesSearchLike, whereClause: string):
 		}
 	}
 
-	const { filters } = parseWhereClause(trimmed)
-	const modes = filters.matchModes ?? {}
+	const carried: TracesSearchLike = { ...search }
+	if (search.whereClause) {
+		for (const key of Object.keys(clauseFields(parseWhereClause(search.whereClause).filters))) {
+			delete carried[key as keyof ClauseFields]
+		}
+	}
 
 	return {
-		...search,
+		...carried,
+		...clauseFields(parseWhereClause(trimmed).filters),
 		whereClause: trimmed,
-		services: filters.service ? [filters.service] : search.services,
-		spanNames: filters.spanName ? [filters.spanName] : search.spanNames,
-		hasError: filters.hasError ?? search.hasError,
-		minDurationMs: filters.minDurationMs ?? search.minDurationMs,
-		maxDurationMs: filters.maxDurationMs ?? search.maxDurationMs,
-		httpMethods: filters.httpMethod ? [filters.httpMethod] : search.httpMethods,
-		httpStatusCodes: filters.httpStatusCode ? [filters.httpStatusCode] : search.httpStatusCodes,
-		deploymentEnvs: filters.deploymentEnv ? [filters.deploymentEnv] : search.deploymentEnvs,
-		rootOnly: filters.rootOnly ?? search.rootOnly,
-		attributeFilters:
-			filters.attributeFilters.length > 0 ? filters.attributeFilters : search.attributeFilters,
-		resourceAttributeFilters:
-			filters.resourceAttributeFilters.length > 0
-				? filters.resourceAttributeFilters
-				: search.resourceAttributeFilters,
-		serviceMatchMode: filters.service ? modes.service : search.serviceMatchMode,
-		spanNameMatchMode: filters.spanName ? modes.spanName : search.spanNameMatchMode,
-		deploymentEnvMatchMode: filters.deploymentEnv ? modes.deploymentEnv : search.deploymentEnvMatchMode,
-		excludedServices: filters.excludedServices?.length
-			? filters.excludedServices
-			: search.excludedServices,
-		excludedSpanNames: filters.excludedSpanNames?.length
-			? filters.excludedSpanNames
-			: search.excludedSpanNames,
-		excludedDeploymentEnvs: filters.excludedDeploymentEnvs?.length
-			? filters.excludedDeploymentEnvs
-			: search.excludedDeploymentEnvs,
-		excludedHttpMethods: filters.excludedHttpMethods?.length
-			? filters.excludedHttpMethods
-			: search.excludedHttpMethods,
-		excludedHttpStatusCodes: filters.excludedHttpStatusCodes?.length
-			? filters.excludedHttpStatusCodes
-			: search.excludedHttpStatusCodes,
 	}
 }


### PR DESCRIPTION
## What was wrong

On the traces page, removing a condition from the Advanced Filters dialog left its search param in the URL. Editing `service.name = "checkout" AND span.name = "GET /orders"` down to just the span clause kept `services=checkout` in the URL, so the list stayed filtered by a condition that was no longer in the text.

## Root cause

`applyWhereClause` in `apps/web/src/lib/traces/advanced-filter-sync.ts` merged the newly parsed clause over the existing search params, falling back to the current value for every field the clause did not produce (`services: filters.service ? [filters.service] : search.services`, and the same shape for span names, envs, HTTP method/status, durations, `hasError`, `rootOnly`, attribute filters and the `excluded*` lists). A field the previous clause had written was therefore re-adopted from the URL instead of being cleared.

The empty-clause path (Clear Filter, and removing the last condition) already reset everything explicitly, which is why only partial removals were affected.

## Fix

A clause now declares the params it owns via `clauseFields()`, which returns only the keys it actually sets. `applyWhereClause` drops the previous clause's keys before merging the new clause's keys, so:

- a condition removed from the clause loses its search param;
- params the previous clause never set (sidebar facet selections) are still carried through;
- the empty-clause reset path is unchanged.

## Verification

- Six new cases in `advanced-filter-sync.test.ts` covering removal of named fields, booleans/durations, attribute + resource attribute filters, `excluded*` lists, match modes, and the sidebar-preservation case. Four failed before the change.
- `bun run --cwd apps/web test -- src/lib/traces src/components/traces src/routes/traces` — 73 passed.
- `bun typecheck` — 40/40 tasks successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790001261&installation_model_id=427786&pr_number=575&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F575&signature=138186911828ec2840f45d7c1f4629f7e494ab70b42420635e080afe1570d948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->