### PR TITLE
feat(web): selectable preview timeframe on the alert rule form

### DIFF
--- a/apps/web/src/components/alerts/alert-create-form-surface.tsx
+++ b/apps/web/src/components/alerts/alert-create-form-surface.tsx
@@ -17,8 +17,10 @@ import { ScopeSection } from "@/components/alerts/scope-section"
 import { SignalAndThresholdSection } from "@/components/alerts/signal-and-threshold-section"
 import { WidgetPrefillNoticeBanner } from "@/components/alerts/widget-prefill-notice-banner"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import type { TimeRange } from "@/components/time-range-picker/types"
 import { trackProduct } from "@/lib/analytics"
 import { useAlertRulePreview } from "@/hooks/use-alert-rule-preview"
+import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useAutocompleteValuesContext } from "@/hooks/use-autocomplete-values"
 import {
 	buildRuleCreateParamsV2,
@@ -35,6 +37,9 @@ import type { WidgetAlertPrefillNotice } from "@/lib/alerts/widget-prefill"
 import { Result, useAtomSet } from "@/lib/effect-atom"
 import { MapleApiV2AtomClient } from "@/lib/services/common/v2-atom-client"
 import { useAlertRulesList } from "@/hooks/use-alerts-list"
+
+/** Preview lookback the form opens on — the rule detail page's default too. */
+const DEFAULT_PREVIEW_PRESET = "24h"
 
 export function AlertCreateFormSurface({
 	initialForm,
@@ -86,7 +91,19 @@ export function AlertCreateFormSurface({
 	// entry with no pre-fills.
 	const [templatesOpen, setTemplatesOpen] = useState(() => showTemplatesInitially)
 
-	const { preview, previewLoading, previewError } = useAlertRulePreview(ruleForm)
+	// Preview-only lookback. Deliberately component-local: it tunes what the
+	// chart shows while authoring and is never part of the rule that gets saved,
+	// so it stays out of the URL and out of `ruleForm`.
+	const [previewTimeRange, setPreviewTimeRange] = useState<TimeRange>({
+		presetValue: DEFAULT_PREVIEW_PRESET,
+	})
+	const previewRange = useEffectiveTimeRange(
+		previewTimeRange.startTime,
+		previewTimeRange.endTime,
+		previewTimeRange.presetValue ?? DEFAULT_PREVIEW_PRESET,
+	)
+
+	const { preview, previewLoading, previewError } = useAlertRulePreview(ruleForm, previewRange)
 
 	const validationIssues = useMemo(
 		() => deriveValidationIssues(ruleForm, destinations),
@@ -190,6 +207,9 @@ export function AlertCreateFormSurface({
 								onTestRule={() => runTest(false)}
 								testing={previewingRule}
 								previewResult={freshPreviewResult}
+								range={previewRange}
+								timeRange={previewTimeRange}
+								onTimeRangeChange={setPreviewTimeRange}
 							/>
 							<div className="grid gap-4 lg:grid-cols-[1.6fr_1fr]">
 								<SignalAndThresholdSection

--- a/apps/web/src/components/alerts/rule-live-chart-hero.test.tsx
+++ b/apps/web/src/components/alerts/rule-live-chart-hero.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { RuleLiveChartHero } from "./rule-live-chart-hero"
+import { defaultRuleForm } from "@/lib/alerts/form-utils"
+
+afterEach(() => {
+	cleanup()
+})
+
+function renderHero(timeRange: Parameters<typeof RuleLiveChartHero>[0]["timeRange"]) {
+	return render(
+		<RuleLiveChartHero
+			form={defaultRuleForm()}
+			preview={null}
+			previewLoading={false}
+			previewError={null}
+			onTestRule={vi.fn()}
+			testing={false}
+			previewResult={null}
+			range={{ startTime: "2026-08-01 00:00:00", endTime: "2026-08-02 00:00:00" }}
+			timeRange={timeRange}
+			onTimeRangeChange={vi.fn()}
+		/>,
+	)
+}
+
+describe("RuleLiveChartHero", () => {
+	it("labels the preview picker with the selected preset", () => {
+		renderHero({ presetValue: "24h" })
+		expect(screen.getByText("Last 24 hours")).toBeTruthy()
+	})
+
+	it("labels the preview picker with a custom range's bounds", () => {
+		// Bounds are rendered in the viewer's timezone, so assert the shape
+		// rather than the exact day/hour.
+		renderHero({ startTime: "2026-08-01 12:00:00", endTime: "2026-08-02 12:00:00" })
+		expect(screen.getByText(/^Aug \d+, \d{2}:\d{2} - Aug \d+, \d{2}:\d{2}$/)).toBeTruthy()
+	})
+})

--- a/apps/web/src/components/alerts/rule-live-chart-hero.tsx
+++ b/apps/web/src/components/alerts/rule-live-chart-hero.tsx
@@ -11,7 +11,8 @@ import { AlertStatusBadge } from "@/components/alerts/alert-status-badge"
 import { CheckIcon, EyeIcon, FireIcon, LoaderIcon } from "@/components/icons"
 import { breachStatsFromPreview, formatBreachDuration, type BreachStats } from "@/lib/alerts/breach-stats"
 import { normalizeTimestampInput } from "@/lib/timezone-format"
-import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { TimeRangePicker } from "@/components/time-range-picker/time-range-picker"
+import type { TimeRange } from "@/components/time-range-picker/types"
 import {
 	formThresholdToDomain,
 	formatSignalValue,
@@ -31,15 +32,20 @@ interface RuleLiveChartHeroProps {
 		status: "breached" | "healthy" | "skipped"
 		value: number | null
 	} | null
+	/** Resolved absolute window the preview was evaluated over. */
+	range: { startTime: string; endTime: string }
+	/** The picker's own (unresolved) selection — preset or custom bounds. */
+	timeRange: TimeRange
+	onTimeRangeChange: (range: TimeRange) => void
 }
 
 /**
  * Hero block sitting above the form: the SAME chart the rule detail page
- * renders, fed by the evaluator's own preview over the last 24h — threshold
- * line, per-window observations, and shaded "would have fired" spans. The
- * would-have-fired count is folded into the header strip as a compact pill so
- * the entire hero stays inside one short card. Raw-SQL rules get a real
- * preview too (the endpoint replays the SQL per evaluation window).
+ * renders, fed by the evaluator's own preview over a user-picked lookback —
+ * threshold line, per-window observations, and shaded "would have fired"
+ * spans. The would-have-fired count is folded into the header strip as a
+ * compact pill so the entire hero stays inside one short card. Raw-SQL rules
+ * get a real preview too (the endpoint replays the SQL per evaluation window).
  */
 export function RuleLiveChartHero({
 	form,
@@ -49,6 +55,9 @@ export function RuleLiveChartHero({
 	onTestRule,
 	testing,
 	previewResult,
+	range,
+	timeRange,
+	onTimeRangeChange,
 }: RuleLiveChartHeroProps) {
 	// The preview plots observed signal data in domain units (error_rate as a
 	// 0–1 ratio), so the threshold line must be converted from the form's percent
@@ -59,14 +68,14 @@ export function RuleLiveChartHero({
 			? formThresholdToDomain(form.signalType, form.thresholdUpper)
 			: null
 
-	// Same canned 24h window `useAlertRulePreview` uses when no range is passed.
-	const { startTime, endTime } = useEffectiveTimeRange(undefined, undefined, "24h")
+	// The chart's domain is the exact window the preview query ran over, so the
+	// axis, threshold line, and would-fire bands stay in step with the picker.
 	const window = useMemo(
 		() => ({
-			min: new Date(normalizeTimestampInput(startTime)).getTime(),
-			max: new Date(normalizeTimestampInput(endTime)).getTime(),
+			min: new Date(normalizeTimestampInput(range.startTime)).getTime(),
+			max: new Date(normalizeTimestampInput(range.endTime)).getTime(),
 		}),
-		[startTime, endTime],
+		[range.startTime, range.endTime],
 	)
 
 	const stats = useMemo(() => breachStatsFromPreview(preview), [preview])
@@ -81,7 +90,6 @@ export function RuleLiveChartHero({
 					<Badge variant="outline" className="font-mono text-xs">
 						{signalLabels[form.signalType]}
 					</Badge>
-					<span className="text-muted-foreground text-xs">Live · last 24h</span>
 					{groupBySummary && (
 						<span className="hidden max-w-[360px] truncate text-muted-foreground text-xs md:inline">
 							Grouped by {groupBySummary}
@@ -89,7 +97,9 @@ export function RuleLiveChartHero({
 					)}
 					<BreachPill stats={stats} />
 				</div>
-				<div className="flex items-center gap-2">
+				{/* shrink-0: a custom range's long label must squeeze the left-hand
+				    summary, not the controls. */}
+				<div className="flex shrink-0 items-center gap-2">
 					{previewResult && (
 						<PreviewBadge
 							status={previewResult.status}
@@ -97,6 +107,14 @@ export function RuleLiveChartHero({
 							signalType={form.signalType}
 						/>
 					)}
+					{/* Preview-only lookback: it re-runs the preview query, never the
+					    rule being saved. */}
+					<TimeRangePicker
+						startTime={timeRange.startTime}
+						endTime={timeRange.endTime}
+						presetValue={timeRange.presetValue}
+						onChange={onTimeRangeChange}
+					/>
 					<Button variant="outline" size="sm" onClick={onTestRule} disabled={testing}>
 						{testing ? <LoaderIcon size={14} className="animate-spin" /> : <EyeIcon size={14} />}
 						Test rule
@@ -137,7 +155,7 @@ function BreachPill({ stats }: { stats: BreachStats }) {
 		return (
 			<span className="hidden items-center gap-1 text-xs text-success-foreground sm:inline-flex">
 				<CheckIcon size={12} />
-				No breaches in 24h
+				No breaches in this window
 			</span>
 		)
 	}

--- a/apps/web/src/hooks/use-alert-rule-preview.ts
+++ b/apps/web/src/hooks/use-alert-rule-preview.ts
@@ -55,8 +55,9 @@ export function useAlertRulePreview(
 	form: RuleFormState | null,
 	range?: { startTime: string; endTime: string },
 ): AlertRulePreviewState {
-	// Callers that own a page-level time window (the rule detail page) pass it in;
-	// the create form + live hero pass nothing and keep the canned last-24h window.
+	// Callers own their window: the rule detail page passes its page-level range,
+	// the create/edit form passes the lookback picked next to the preview chart.
+	// Only callers with no window at all fall back to the canned last 24h.
 	const fallback = useEffectiveTimeRange(undefined, undefined, "24h")
 	const startTime = range?.startTime ?? fallback.startTime
 	const endTime = range?.endTime ?? fallback.endTime


### PR DESCRIPTION
The alert create/edit form's preview chart was pinned to a canned last-24h lookback, so there was no way to check a candidate rule against a shorter spike or a longer stretch of history before saving it.

## What changed

- `RuleLiveChartHero` renders the standard `TimeRangePicker` (default preset set, 5m–1mo) in its header strip, next to "Test rule". The static "Live · last 24h" label is gone — the picker's trigger carries the window.
- The picked window drives `useAlertRulePreview` (which already accepted a range for the rule detail page) and the chart domain, so the axis, threshold line, and would-fire bands all follow it.
- Selection is component-local state in `AlertCreateFormSurface`: not in the URL, not persisted, and never part of the rule payload that gets saved. Default stays `24h`, matching the rule detail page.
- The edit page reaches the same surface via `/alerts/create?ruleId=`, so it gets the control for free.
- The breach pill no longer hardcodes "No breaches in 24h".

The server caps a preview at 200 evaluation buckets and reports `truncated_to_start`, so a long window degrades rather than failing.

## Verification

- `bun typecheck` — 40/40 tasks pass.
- `bun run --cwd apps/web test -- src/components/alerts` — 5 files / 40 tests pass, including a new `rule-live-chart-hero.test.tsx` covering the picker label for a preset and for a custom range.
- Not verified in a browser: no web dev server was running locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790001353&installation_model_id=427786&pr_number=576&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F576&signature=5bb7d353bfa7003aad4352bc0adfd0af220215d6119b9b0c9d2f55abe3e8548c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->