### PR TITLE
fix(web): stop dropping v3 data sources from the create-alert chart param

### DIFF
--- a/apps/web/src/lib/alerts/widget-chart-param.test.ts
+++ b/apps/web/src/lib/alerts/widget-chart-param.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
 
+import { makeQueryDataSource, makeRawSqlDataSource } from "@maple/widgets/dashboard"
+
 import { defaultRuleForm } from "@/lib/alerts/form-utils"
 import { toBase64Url } from "@/lib/base64url"
 import {
@@ -90,6 +92,77 @@ describe("encodeAlertChartToSearchParam / decodeAlertChartFromSearchParam", () =
 		expect(viaParam.form.queryBuilderDraft.whereClause).toBe(
 			'service.name = "café/checkout+v2" AND attr.note = "a=b"',
 		)
+	})
+
+	// The builder has written v3 data sources (`{ kind: "query" | "raw_sql" }`)
+	// since the schema flip; the param schema still described the v2
+	// `{ endpoint, params }` shape, and Effect Schema drops excess properties on
+	// decode — so every real "Create alert" navigation arrived with an empty data
+	// source and painted a blank form. Built with the real constructors so the
+	// test follows the stored shape rather than a copy of it.
+	it("round-trips a v3 query-set widget instead of stripping it to a blank form", () => {
+		const ctx: AlertChartContext = {
+			dashboardId: "dash-1",
+			widget: {
+				id: "w3",
+				visualization: "timeseries",
+				dataSource: makeQueryDataSource({
+					resultShape: "timeseries",
+					queries: [
+						{
+							id: "query-a",
+							name: "A",
+							enabled: true,
+							hidden: false,
+							dataSource: "traces",
+							aggregation: "count",
+							whereClause: 'service.name = "checkout"',
+							addOns: {
+								groupBy: false,
+								having: false,
+								orderBy: false,
+								limit: false,
+								legend: false,
+							},
+							groupBy: ["none"],
+						},
+					],
+				}),
+				display: { title: "v3 traffic" },
+			},
+		}
+
+		const decoded = decodeAlertChartFromSearchParam(encodeAlertChartToSearchParam(ctx)!)
+		expect(decoded?.widget.dataSource).toEqual(ctx.widget.dataSource)
+
+		const prefill = createWidgetAlertPrefill(decoded!.widget, defaultRuleForm())
+		expect(prefill.form.signalType).toBe("builder_query")
+		expect(prefill.form.name).toBe("Alert - v3 traffic")
+		expect(prefill.form.queryBuilderDraft.whereClause).toBe('service.name = "checkout"')
+		expect(prefill.notices).toEqual([])
+	})
+
+	it("round-trips a v3 raw SQL widget with its reducer transform", () => {
+		const sql = "SELECT max(Duration) AS value FROM traces WHERE $__orgFilter"
+		const ctx: AlertChartContext = {
+			dashboardId: "dash-1",
+			widget: {
+				id: "w4",
+				dataSource: makeRawSqlDataSource({
+					sql,
+					transform: { reduceToValue: { field: "value", aggregate: "max" } },
+				}),
+				display: { title: "Slowest" },
+			},
+		}
+
+		const decoded = decodeAlertChartFromSearchParam(encodeAlertChartToSearchParam(ctx)!)
+		expect(decoded?.widget.dataSource).toEqual(ctx.widget.dataSource)
+
+		const prefill = createWidgetAlertPrefill(decoded!.widget, defaultRuleForm())
+		expect(prefill.form.signalType).toBe("raw_query")
+		expect(prefill.form.rawQuerySql).toBe(sql)
+		expect(prefill.form.rawQueryReducer).toBe("max")
 	})
 
 	it("round-trips a raw SQL widget keeping the SQL intact", () => {

--- a/apps/web/src/lib/alerts/widget-chart-param.ts
+++ b/apps/web/src/lib/alerts/widget-chart-param.ts
@@ -15,13 +15,19 @@ import { fromBase64Url, toBase64Url } from "@/lib/base64url"
 const AlertChartWidgetSchema = Schema.Struct({
 	id: Schema.String,
 	visualization: Schema.optional(Schema.String),
-	dataSource: Schema.optional(
-		Schema.Struct({
-			endpoint: Schema.optional(Schema.String),
-			params: Schema.optional(Schema.Unknown),
-			transform: Schema.optional(Schema.Unknown),
-		}),
-	),
+	/**
+	 * Deliberately opaque.
+	 *
+	 * This used to be `Struct({ endpoint, params, transform })` — the v2 shape —
+	 * and Effect Schema drops excess properties on decode, so once the builder
+	 * started writing v3 data sources (`{ kind: "query" | "raw_sql", ... }`) every
+	 * snapshot decoded to `{}` and the alert page fell back to a blank form. The
+	 * prefill reads this through the version-agnostic accessors in
+	 * `@maple/widgets/dashboard`, which take `unknown` and narrow themselves, so
+	 * restating the data-source shape here buys nothing and silently truncates
+	 * whatever arm it does not know about.
+	 */
+	dataSource: Schema.optional(Schema.Unknown),
 	display: Schema.optional(Schema.Struct({ title: Schema.optional(Schema.String) })),
 })
 

--- a/apps/web/src/lib/alerts/widget-prefill.ts
+++ b/apps/web/src/lib/alerts/widget-prefill.ts
@@ -18,11 +18,12 @@ export type WidgetAlertPrefillResult = {
 type AlertableDashboardWidget = {
 	id: string
 	visualization?: string
-	dataSource?: {
-		endpoint?: string
-		params?: unknown
-		transform?: unknown
-	}
+	/**
+	 * Read only through the version-agnostic accessors below, which narrow
+	 * `unknown` themselves — so this stays opaque rather than restating one
+	 * schema version's field list and quietly excluding the others.
+	 */
+	dataSource?: unknown
 	display?: { title?: string }
 }
 


### PR DESCRIPTION
## Symptom

"Create alert" on a chart lands on a blank `/alerts/create` form instead of one
prefilled with the chart's query. Reproduces from every entry point that builds
the `chart` search param:

- the dashboard widget menu (`widget-actions-context.tsx`)
- the metrics explorer's "Create alert" (`metric-graduation-actions.tsx`)
- the PlanetScale "Alert on this" menu (`planetscale-alert-menu.tsx`)

Both query-builder charts and raw-SQL charts are affected.

## Root cause

`AlertChartWidgetSchema` in `apps/web/src/lib/alerts/widget-chart-param.ts`
described the widget's `dataSource` as the **v2** shape:

```ts
dataSource: Schema.optional(
  Schema.Struct({ endpoint, params, transform }),
)
```

Effect Schema drops excess properties on decode. Since the dashboard schema
flipped to v3, the builder writes discriminated-union data sources
(`{ kind: "query", resultShape, queries }` / `{ kind: "raw_sql", sql }`) via
`makeQueryDataSource` / `makeRawSqlDataSource`, so decoding the param stripped
every field and yielded `dataSource: {}` (or `{ transform }`). The
version-agnostic accessors then found neither a query set nor raw SQL, and
`createWidgetAlertPrefill` returned the blank base form with a
"not a query-driven chart" notice.

Encoding was fine (`JSON.stringify`, no schema encode) — the loss happened
entirely on decode, on the alert page.

The gap was invisible because `widget-chart-param.test.ts` and
`widget-prefill.test.ts` only ever fed the v2 `{ endpoint, params }` shape, and
`planetscale-alert-menu.test.tsx` asserts `search.chart` is truthy without
decoding it. It also type-checked: a v3 data source has an optional `transform`,
so TypeScript's weak-type check saw an overlapping property and accepted the
assignment.

## Fix

Carry the data source opaquely (`Schema.optional(Schema.Unknown)`) and type
`AlertableDashboardWidget["dataSource"]` as `unknown`. The prefill already reads
it exclusively through the `unknown`-in accessors in `@maple/widgets/dashboard`
(`dataSourceQuerySet`, `dataSourceRawSql`, `dataSourceTransform`), which narrow
both stored versions themselves — restating one version's field list in the
param schema bought nothing and truncated the rest.

## Verification

Two regression tests in `widget-chart-param.test.ts` round-trip a v3 query-set
widget and a v3 raw-SQL widget (built with the real constructors, so they follow
the stored shape rather than a copy of it) and assert the resulting prefill.
Both fail on `main`:

```
AssertionError: expected { transform: { …(1) } } to deeply equal { kind: 'raw_sql', …(2) }
Tests  2 failed | 7 passed (9)
```

After the fix:

- `bun run --cwd apps/web test -- src/lib/alerts/ src/components/alerts/ src/components/infra/planetscale/planetscale-alert-menu.test.tsx` — 11 files, 106 tests passed
- `bun typecheck` — 40/40 tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790001990&installation_model_id=427786&pr_number=578&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F578&signature=417a8ce9b56b218684a1860ebb08a8df83d9ab675f96a022c1b8fafa22b0a7b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->