### PR TITLE
fix(web): show the stored raw SQL query when re-editing a widget

### DIFF
--- a/apps/web/src/components/dashboard-builder/config/widget-query-builder-page.test.tsx
+++ b/apps/web/src/components/dashboard-builder/config/widget-query-builder-page.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { makeQueryDataSource, makeRawSqlDataSource } from "@maple/widgets/dashboard"
+
+import { DashboardTimeRangeWrapper } from "@/components/dashboard-builder/dashboard-providers"
+import { WidgetBuilderProvider } from "@/components/dashboard-builder/config/widget-builder-provider"
+import { WidgetQueryBuilderPage } from "@/components/dashboard-builder/config/widget-query-builder-page"
+import type { DashboardWidget } from "@/components/dashboard-builder/types"
+
+afterEach(cleanup)
+
+const STORED_SQL = "SELECT bucket, count() AS spans FROM traces WHERE $__orgFilter"
+
+const widgetWith = (dataSource: DashboardWidget["dataSource"]): DashboardWidget =>
+	({
+		id: "w1",
+		visualization: "chart",
+		dataSource,
+		display: { title: "Spans", chartId: "query-builder-line" },
+		layout: { x: 0, y: 0, w: 6, h: 6 },
+	}) as DashboardWidget
+
+const rawSqlWidget = (sql: string) => widgetWith(makeRawSqlDataSource({ sql, displayType: "line" }))
+
+const builderWidget = () => widgetWith(makeQueryDataSource({ resultShape: "timeseries", queries: [] }))
+
+const editor = (widget: DashboardWidget) => (
+	<DashboardTimeRangeWrapper initialTimeRange={{ type: "relative", value: "1h" }}>
+		<WidgetBuilderProvider widget={widget}>
+			<WidgetQueryBuilderPage widget={widget} onApply={vi.fn()} />
+		</WidgetBuilderProvider>
+	</DashboardTimeRangeWrapper>
+)
+
+const sqlEditor = () => screen.queryByLabelText("SQL query") as HTMLTextAreaElement | null
+
+// The widget prop is not fixed for the life of the editor: the dashboard row can
+// reach it after the first render, or be replaced by a later sync. Seeding the
+// SQL draft and the Source toggle from the first render alone left a re-opened
+// raw-SQL widget showing the Query Builder tab and a template, while the preview
+// and the canvas tile drew the stored SQL.
+describe("WidgetQueryBuilderPage raw SQL rehydration", () => {
+	it("shows the stored SQL when the widget arrives after the first render", () => {
+		const { rerender } = render(editor(builderWidget()))
+		expect(sqlEditor()).toBeNull()
+
+		rerender(editor(rawSqlWidget(STORED_SQL)))
+
+		expect(sqlEditor()?.value).toBe(STORED_SQL)
+	})
+
+	it("follows the widget when its stored SQL changes under an untouched draft", () => {
+		const { rerender } = render(editor(rawSqlWidget(STORED_SQL)))
+		expect(sqlEditor()?.value).toBe(STORED_SQL)
+
+		const updated = `${STORED_SQL} AND SpanKind = 'Server'`
+		rerender(editor(rawSqlWidget(updated)))
+
+		expect(sqlEditor()?.value).toBe(updated)
+	})
+
+	it("keeps what the user typed when the widget prop is replaced", () => {
+		const { rerender } = render(editor(rawSqlWidget(STORED_SQL)))
+
+		const typed = `${STORED_SQL} AND ServiceName = 'ingest'`
+		const textarea = sqlEditor()
+		if (!textarea) throw new Error("SQL editor not rendered")
+		fireEvent.change(textarea, { target: { value: typed } })
+
+		// A dashboard-level write (a time-range sync, another tile's layout) hands
+		// the editor a fresh widget object carrying the same stored SQL.
+		rerender(editor(rawSqlWidget(STORED_SQL)))
+
+		expect(sqlEditor()?.value).toBe(typed)
+	})
+})

--- a/apps/web/src/components/dashboard-builder/config/widget-query-builder-page.tsx
+++ b/apps/web/src/components/dashboard-builder/config/widget-query-builder-page.tsx
@@ -96,6 +96,9 @@ function readRawSqlDraftFromWidget(widget: DashboardWidget): RawSqlDraft {
 	return { sql: RAW_SQL_TEMPLATES[displayType], granularitySeconds: null }
 }
 
+const sameRawSqlDraft = (a: RawSqlDraft, b: RawSqlDraft): boolean =>
+	a.sql === b.sql && a.granularitySeconds === b.granularitySeconds
+
 /**
  * Build the `raw_sql_chart` data source for the type currently selected in the
  * editor — NOT the saved widget's type. Reading `widget.*` here meant the Type
@@ -197,6 +200,36 @@ export function WidgetQueryBuilderPage({
 	// only updates when the user clicks Run Preview — typing in the textarea
 	// shouldn't refire the SQL on every keystroke.
 	const [rawSqlPreviewDraft, setRawSqlPreviewDraft] = React.useState<RawSqlDraft>(initialRawSqlDraft)
+
+	// The widget prop is not fixed for the life of the editor: the dashboard row
+	// can reach it after the first render, or be replaced by a later sync. Seeding
+	// the SQL draft and the Source toggle only from the first render left a
+	// re-opened raw-SQL widget on the Query Builder tab with a template in the
+	// editor, while the preview and the canvas tile drew the stored SQL — the
+	// widget prop had the query all along.
+	//
+	// Re-seeded during render (React's "adjust state when a prop changes"), and
+	// only while the draft is still the one seeded: whatever the user typed wins.
+	const seededRawSqlRef = React.useRef<RawSqlDraft>(initialRawSqlDraft)
+	if (
+		!sameRawSqlDraft(initialRawSqlDraft, seededRawSqlRef.current) &&
+		sameRawSqlDraft(rawSqlDraft, seededRawSqlRef.current)
+	) {
+		seededRawSqlRef.current = initialRawSqlDraft
+		// The dirty baseline follows too, or the unsaved-changes blocker fires on
+		// an edit the user never made.
+		initialRawSqlSnapshotRef.current = initialRawSqlDraft
+		setRawSqlDraft(initialRawSqlDraft)
+		setRawSqlPreviewDraft(initialRawSqlDraft)
+	}
+	// Same for the Source toggle — a widget that arrives as raw SQL after the
+	// first render leaves the editor on Query Builder otherwise. `initialModeRef`
+	// is also the dirty baseline, so it follows either way; the toggle itself only
+	// moves while the user has not chosen a tab of their own.
+	if (initialMode !== initialModeRef.current) {
+		if (mode === initialModeRef.current) setMode(initialMode)
+		initialModeRef.current = initialMode
+	}
 
 	const previewWidget = React.useMemo(() => {
 		// The override applies live from the editing state — it costs nothing to


### PR DESCRIPTION
## Symptom

Re-opening the editor of a raw-SQL dashboard widget can show an empty SQL editor (or the Query Builder tab) instead of the stored query, while the tile and the editor preview keep rendering that same query correctly.

## Root cause

`WidgetQueryBuilderPage` seeds three pieces of local state from the `widget` prop on the first render only:

- `mode` (the Source toggle) — `useState(initialMode)`
- `rawSqlDraft` / `rawSqlPreviewDraft` — `useState(initialRawSqlDraft)`
- the dirty baselines `initialModeRef` / `initialRawSqlSnapshotRef`

`initialRawSqlDraft` is a `useMemo` over `[widget]`, so it recomputes when the widget prop changes, but nothing ever fed it back into state. The prop is not fixed for the life of the editor — the dashboard row can reach the page after the first render, or be replaced by a later sync — so an editor whose first render saw a widget without the stored raw-SQL data source keeps the Query Builder tab and the seeded template for the rest of the visit. Everything else in the page (the preview, `applyChanges`' target, the canvas tile) reads the widget prop directly, which is why the chart stays correct while the editor does not.

## Fix

Re-seed the draft and the Source toggle during render (React's "adjust state when a prop changes") when the widget's stored raw SQL changes, and only while the draft is still the one seeded — anything the user typed wins. The dirty baselines follow, so the unsaved-changes blocker does not fire on an edit nobody made.

## Verification

- New `apps/web/src/components/dashboard-builder/config/widget-query-builder-page.test.tsx` renders the real editor and covers: widget arrives after the first render, stored SQL changes under an untouched draft, and a widget-prop replacement while the user has typed. Two of the three fail on `main` and pass with this change.
- `bun run --cwd apps/web test` — 1767 passing; the 4 failures (`use-timezone-preference`, `use-recently-used-times`) are pre-existing on `main` and come from jsdom having no `window.localStorage`.
- `bun typecheck` — 40/40 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790002417&installation_model_id=427786&pr_number=579&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F579&signature=8d1f57ad070a6cfd4f003f43927289bf33b695acaf2c596ed39f5327c2045e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->