### PR TITLE
fix(ingest): default log level to warn

### DIFF
--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -1596,7 +1596,7 @@ fn init_tracing(
     service_instance_id: &str,
 ) -> Option<TelemetryProviders> {
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| "maple_ingest=info,tower_http=info".into());
+        .unwrap_or_else(|_| "maple_ingest=warn,tower_http=warn".into());
 
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_target(false)
@@ -3676,7 +3676,7 @@ async fn handle_cloudflare_logpush(
             span_handle.record("maple.cloudflare.is_validation", is_validation);
             metrics::request_completed("logs", "ok", "none", duration.as_secs_f64());
             metrics::cloudflare_batch("http_requests", is_validation);
-            info!(
+            debug!(
                 status = status_code,
                 duration_ms = duration_millis(duration),
                 item_count,


### PR DESCRIPTION
## Summary

- Default ingest tracing filter `maple_ingest=info,tower_http=info` → `maple_ingest=warn,tower_http=warn` (`RUST_LOG` still overrides). A per-request `info!` on the ingest hot path was recently picked up in production and generated a large volume of log traffic; with `warn` as the default, an accidental `info!` in a hot path no longer ships per-request logs.
- Demote the remaining per-request `info!` (Cloudflare Logpush "request processed") to `debug!`.

Startup, Postgres-probe, WAL-replay and Autumn logs stay at `info` but are no longer emitted by default; set `RUST_LOG=maple_ingest=info` to see them.

## Test plan
- [x] `cargo check` on `apps/ingest`
- [ ] Confirm prod ingest log volume drops after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790003595&installation_model_id=427786&pr_number=581&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F581&signature=6bfa74b50da981915e26f6bdf2de2fd7cd867f5d7f9e751f69e2cff3f04c0c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->