### PR TITLE
ci(deploy): print the ingest certificate's validation CNAME after each deploy

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -139,3 +139,19 @@ jobs:
               run: bun run alchemy:deploy:prd
               env:
                   AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
+
+            # The ACM certificate for the ingest domain validates over DNS, and the
+            # stack does not manage the Cloudflare zone: print the validation CNAME
+            # (and status) after every deploy so the first pass of a stage — which
+            # fails at the 443 listener until the record exists — tells you exactly
+            # what to add. alchemy's own output snapshots the options before ACM has
+            # populated them, so this asks ACM directly.
+            - name: Ingest certificate validation records
+              if: ${{ always() && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
+              run: |
+                  for arn in $(aws acm list-certificates --region us-east-1 \
+                      --query "CertificateSummaryList[?starts_with(DomainName, 'ingest')].CertificateArn" --output text); do
+                      aws acm describe-certificate --region us-east-1 --certificate-arn "$arn" \
+                          --query 'Certificate.{Domain:DomainName,Status:Status,Validation:DomainValidationOptions[].{Status:ValidationStatus,Record:ResourceRecord}}' \
+                          --output json
+                  done

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -124,3 +124,19 @@ jobs:
               run: bun run alchemy:deploy:stg
               env:
                   AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
+
+            # The ACM certificate for the ingest domain validates over DNS, and the
+            # stack does not manage the Cloudflare zone: print the validation CNAME
+            # (and status) after every deploy so the first pass of a stage — which
+            # fails at the 443 listener until the record exists — tells you exactly
+            # what to add. alchemy's own output snapshots the options before ACM has
+            # populated them, so this asks ACM directly.
+            - name: Ingest certificate validation records
+              if: ${{ always() && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
+              run: |
+                  for arn in $(aws acm list-certificates --region us-east-1 \
+                      --query "CertificateSummaryList[?starts_with(DomainName, 'ingest')].CertificateArn" --output text); do
+                      aws acm describe-certificate --region us-east-1 --certificate-arn "$arn" \
+                          --query 'Certificate.{Domain:DomainName,Status:Status,Validation:DomainValidationOptions[].{Status:ValidationStatus,Record:ResourceRecord}}' \
+                          --output json
+                  done


### PR DESCRIPTION
First prod deploy with the AWS half on ([run 32597775947](https://github.com/MapleTechLabs/maple/actions/runs/32597775947)) created the `ingest.maple.dev` certificate and, as designed, failed at the 443 listener until it is validated — but nothing printed the validation record (alchemy snapshots `domainValidationOptions` before ACM fills them in). This step asks ACM directly after every deploy, `if: always()`, so the first pass of any stage says exactly which CNAME to add.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790024064&installation_model_id=427786&pr_number=585&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F585&signature=b4c03b27c18382ae526e3ffbce4876edd724277b89825be91f887755a65f6663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->