### PR TITLE
ci(deploy): validate the ingest certificate in Cloudflare and retry the deploy

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -136,22 +136,22 @@ jobs:
             # supplied, the lookup is skipped. Reproduced locally with CI=true and
             # the id unset on alchemy 2.0.0-beta.64 through beta.74.
             - name: Deploy PRD stack with Alchemy
+              id: deploy
               run: bun run alchemy:deploy:prd
               env:
                   AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
 
-            # The ACM certificate for the ingest domain validates over DNS, and the
-            # stack does not manage the Cloudflare zone: print the validation CNAME
-            # (and status) after every deploy so the first pass of a stage — which
-            # fails at the 443 listener until the record exists — tells you exactly
-            # what to add. alchemy's own output snapshots the options before ACM has
-            # populated them, so this asks ACM directly.
-            - name: Ingest certificate validation records
-              if: ${{ always() && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
+            # First pass of a stage with the AWS half on: the ingest ACM certificate
+            # is created PENDING_VALIDATION and the 443 listener fails. Finish the
+            # job here — create the validation CNAME in the Cloudflare zone with the
+            # token Infisical already provides, wait for ISSUED, deploy again. A
+            # deploy that failed for any other reason reaches this too: the script
+            # is a no-op on an ISSUED certificate and the retry fails the same way.
+            - name: Validate the ingest certificate and retry the deploy
+              if: ${{ failure() && steps.deploy.outcome == 'failure' && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
+              env:
+                  INGEST_DOMAIN: ingest.maple.dev
+                  AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
               run: |
-                  for arn in $(aws acm list-certificates --region us-east-1 \
-                      --query "CertificateSummaryList[?starts_with(DomainName, 'ingest')].CertificateArn" --output text); do
-                      aws acm describe-certificate --region us-east-1 --certificate-arn "$arn" \
-                          --query 'Certificate.{Domain:DomainName,Status:Status,Validation:DomainValidationOptions[].{Status:ValidationStatus,Record:ResourceRecord}}' \
-                          --output json
-                  done
+                  bash scripts/ingest-cert-validate.sh
+                  bun run alchemy:deploy:prd

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -121,22 +121,22 @@ jobs:
 
             # AWS_ACCOUNT_ID: see the note in deploy-prd.yml.
             - name: Deploy STG stack with Alchemy
+              id: deploy
               run: bun run alchemy:deploy:stg
               env:
                   AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
 
-            # The ACM certificate for the ingest domain validates over DNS, and the
-            # stack does not manage the Cloudflare zone: print the validation CNAME
-            # (and status) after every deploy so the first pass of a stage — which
-            # fails at the 443 listener until the record exists — tells you exactly
-            # what to add. alchemy's own output snapshots the options before ACM has
-            # populated them, so this asks ACM directly.
-            - name: Ingest certificate validation records
-              if: ${{ always() && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
+            # First pass of a stage with the AWS half on: the ingest ACM certificate
+            # is created PENDING_VALIDATION and the 443 listener fails. Finish the
+            # job here — create the validation CNAME in the Cloudflare zone with the
+            # token Infisical already provides, wait for ISSUED, deploy again. A
+            # deploy that failed for any other reason reaches this too: the script
+            # is a no-op on an ISSUED certificate and the retry fails the same way.
+            - name: Validate the ingest certificate and retry the deploy
+              if: ${{ failure() && steps.deploy.outcome == 'failure' && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
+              env:
+                  INGEST_DOMAIN: ingest-staging.maple.dev
+                  AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
               run: |
-                  for arn in $(aws acm list-certificates --region us-east-1 \
-                      --query "CertificateSummaryList[?starts_with(DomainName, 'ingest')].CertificateArn" --output text); do
-                      aws acm describe-certificate --region us-east-1 --certificate-arn "$arn" \
-                          --query 'Certificate.{Domain:DomainName,Status:Status,Validation:DomainValidationOptions[].{Status:ValidationStatus,Record:ResourceRecord}}' \
-                          --output json
-                  done
+                  bash scripts/ingest-cert-validate.sh
+                  bun run alchemy:deploy:stg

--- a/scripts/ingest-cert-validate.sh
+++ b/scripts/ingest-cert-validate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Validate the ingest ACM certificate for $INGEST_DOMAIN by creating its DNS
+# validation CNAME in the Cloudflare zone, then wait until ACM reports ISSUED.
+#
+# Why this exists: the ingest stack requests a DNS-validated ACM certificate
+# but deliberately does not manage the Cloudflare zone, so the first deploy of
+# a stage fails at the 443 listener ("certificate must have a fully-qualified
+# domain name…" = still PENDING_VALIDATION). alchemy's own output snapshots
+# DomainValidationOptions before ACM fills them in, and GitHub masks digits in
+# the log, so "print it and add it by hand" was not workable either. The deploy
+# workflows run this after a failed deploy and then retry the deploy once.
+#
+# Needs: aws cli with the deploy role, CLOUDFLARE_API_TOKEN (Infisical),
+# INGEST_DOMAIN (e.g. ingest.maple.dev), optional AWS_REGION (default us-east-1).
+# Idempotent: an ISSUED certificate or an existing record is a no-op.
+set -euo pipefail
+
+: "${INGEST_DOMAIN:?INGEST_DOMAIN is required}"
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+region="${AWS_REGION:-us-east-1}"
+zone_name="${INGEST_DOMAIN#*.}"   # ingest.maple.dev -> maple.dev ; ingest-staging.maple.dev -> maple.dev
+
+arn=$(aws acm list-certificates --region "$region" \
+    --query "CertificateSummaryList[?DomainName=='${INGEST_DOMAIN}'].CertificateArn | [0]" --output text)
+if [ -z "$arn" ] || [ "$arn" = "None" ]; then
+    echo "no ACM certificate for ${INGEST_DOMAIN} in ${region} — nothing to validate"
+    exit 0
+fi
+
+status=$(aws acm describe-certificate --region "$region" --certificate-arn "$arn" --query 'Certificate.Status' --output text)
+echo "certificate for ${INGEST_DOMAIN}: ${status}"
+if [ "$status" = "ISSUED" ]; then
+    exit 0
+fi
+if [ "$status" != "PENDING_VALIDATION" ]; then
+    echo "::error::certificate for ${INGEST_DOMAIN} is ${status}; not something a DNS record fixes"
+    exit 1
+fi
+
+# ACM fills the validation options a few seconds after CreateCertificate.
+for _ in $(seq 1 30); do
+    record_name=$(aws acm describe-certificate --region "$region" --certificate-arn "$arn" \
+        --query 'Certificate.DomainValidationOptions[0].ResourceRecord.Name' --output text)
+    record_value=$(aws acm describe-certificate --region "$region" --certificate-arn "$arn" \
+        --query 'Certificate.DomainValidationOptions[0].ResourceRecord.Value' --output text)
+    [ -n "$record_name" ] && [ "$record_name" != "None" ] && break
+    sleep 5
+done
+if [ -z "${record_name:-}" ] || [ "$record_name" = "None" ]; then
+    echo "::error::ACM never returned a validation record for ${arn}"
+    exit 1
+fi
+record_name="${record_name%.}"
+record_value="${record_value%.}"
+
+cf() { curl -sS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" "$@"; }
+zone_id=$(cf "https://api.cloudflare.com/client/v4/zones?name=${zone_name}&status=active" | jq -r '.result[0].id // empty')
+if [ -z "$zone_id" ]; then
+    echo "::error::Cloudflare zone ${zone_name} not visible to CLOUDFLARE_API_TOKEN"
+    exit 1
+fi
+
+existing=$(cf "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records?type=CNAME&name=${record_name}" | jq -r '.result[0].id // empty')
+if [ -n "$existing" ]; then
+    echo "validation CNAME already present (record ${existing}); updating content in case it rotated"
+    cf -X PATCH "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records/${existing}" \
+        --data "$(jq -nc --arg c "$record_value" '{content:$c, ttl:1, proxied:false}')" | jq -e '.success' >/dev/null
+else
+    echo "creating validation CNAME for ${INGEST_DOMAIN} in zone ${zone_name}"
+    cf -X POST "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records" \
+        --data "$(jq -nc --arg n "$record_name" --arg c "$record_value" '{type:"CNAME", name:$n, content:$c, ttl:1, proxied:false, comment:"ACM validation for the ingest gateway (managed by deploy workflow)"}')" | jq -e '.success' >/dev/null
+fi
+
+# ACM usually picks up a Cloudflare-hosted record within a few minutes. The
+# built-in waiter gives up after 5 attempts; loop it to about 20 minutes.
+for _ in $(seq 1 4); do
+    if aws acm wait certificate-validated --region "$region" --certificate-arn "$arn"; then
+        echo "certificate for ${INGEST_DOMAIN}: ISSUED"
+        exit 0
+    fi
+done
+echo "::error::certificate for ${INGEST_DOMAIN} still not ISSUED after ~20 minutes — check the validation CNAME in Cloudflare"
+exit 1


### PR DESCRIPTION
First prod pass with the AWS half on fails at the 443 listener until the `ingest.maple.dev` ACM certificate is validated (#585 tried to print the record; GitHub masks every digit `1` in the log, so it was unreadable). The deploy already receives `CLOUDFLARE_API_TOKEN` from Infisical: after a failed deploy the workflow now upserts the validation CNAME (DNS-only) in the `maple.dev` zone, waits for `ISSUED`, and runs the deploy once more. Idempotent — no-op on an issued certificate, so unrelated failures just fail again the same way. Same for staging with `ingest-staging.maple.dev`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790024795&installation_model_id=427786&pr_number=586&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F586&signature=ec3f7664126b907d00831b98741fc867e79caf920e2fa1a3e04263f6f4745d26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->