### PR TITLE
ci(deploy): surface Cloudflare's error when the ingest validation record cannot be written

### DIFF
--- a/scripts/ingest-cert-validate.sh
+++ b/scripts/ingest-cert-validate.sh
@@ -54,9 +54,19 @@ record_name="${record_name%.}"
 record_value="${record_value%.}"
 
 cf() { curl -sS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" "$@"; }
-zone_id=$(cf "https://api.cloudflare.com/client/v4/zones?name=${zone_name}&status=active" | jq -r '.result[0].id // empty')
+# Fail loudly with Cloudflare's own error list (the token's DNS permission on the
+# zone is the usual culprit) instead of a bare non-zero from `jq -e`.
+cf_ok() {
+    local response; response=$(cat)
+    if ! jq -e '.success' >/dev/null <<<"$response"; then
+        echo "::error::Cloudflare API call failed: $(jq -c '.errors' <<<"$response")"
+        return 1
+    fi
+}
+zones_response=$(cf "https://api.cloudflare.com/client/v4/zones?name=${zone_name}&status=active")
+zone_id=$(jq -r '.result[0].id // empty' <<<"$zones_response")
 if [ -z "$zone_id" ]; then
-    echo "::error::Cloudflare zone ${zone_name} not visible to CLOUDFLARE_API_TOKEN"
+    echo "::error::Cloudflare zone ${zone_name} not visible to CLOUDFLARE_API_TOKEN: $(jq -c '{success, errors}' <<<"$zones_response")"
     exit 1
 fi
 
@@ -64,11 +74,11 @@ existing=$(cf "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records
 if [ -n "$existing" ]; then
     echo "validation CNAME already present (record ${existing}); updating content in case it rotated"
     cf -X PATCH "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records/${existing}" \
-        --data "$(jq -nc --arg c "$record_value" '{content:$c, ttl:1, proxied:false}')" | jq -e '.success' >/dev/null
+        --data "$(jq -nc --arg c "$record_value" '{content:$c, ttl:1, proxied:false}')" | cf_ok
 else
     echo "creating validation CNAME for ${INGEST_DOMAIN} in zone ${zone_name}"
     cf -X POST "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records" \
-        --data "$(jq -nc --arg n "$record_name" --arg c "$record_value" '{type:"CNAME", name:$n, content:$c, ttl:1, proxied:false, comment:"ACM validation for the ingest gateway (managed by deploy workflow)"}')" | jq -e '.success' >/dev/null
+        --data "$(jq -nc --arg n "$record_name" --arg c "$record_value" '{type:"CNAME", name:$n, content:$c, ttl:1, proxied:false, comment:"ACM validation for the ingest gateway (managed by deploy workflow)"}')" | cf_ok
 fi
 
 # ACM usually picks up a Cloudflare-hosted record within a few minutes. The


### PR DESCRIPTION
Follow-up to #586: the validation step's first prod run ([32598737906](https://github.com/MapleTechLabs/maple/actions/runs/32598737906)) failed at the Cloudflare record POST with only an exit code. Print the API's `errors` (and the zone-lookup response) so a token without `DNS:Edit` on `maple.dev` — the likely cause — says so.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790025154&installation_model_id=427786&pr_number=587&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F587&signature=dba8a08a3ab2c14833cad41002be3a945a40286b427e72afc17a0f70fe6ff00d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->