### PR TITLE
ci(deploy): name the Cloudflare token when the ingest validation record is refused

### DIFF
--- a/scripts/ingest-cert-validate.sh
+++ b/scripts/ingest-cert-validate.sh
@@ -60,6 +60,12 @@ cf_ok() {
     local response; response=$(cat)
     if ! jq -e '.success' >/dev/null <<<"$response"; then
         echo "::error::Cloudflare API call failed: $(jq -c '.errors' <<<"$response")"
+        # Name the token so the right one gets the permission (id + status only;
+        # GitHub masks digits, so also print the id with separators between
+        # characters, which survives the masker).
+        local verify; verify=$(cf "https://api.cloudflare.com/client/v4/user/tokens/verify")
+        local token_id; token_id=$(jq -r '.result.id // "unknown"' <<<"$verify")
+        echo "token in use: id=${token_id} status=$(jq -r '.result.status // "unknown"' <<<"$verify") (id spaced: $(sed 's/./& /g' <<<"$token_id"))"
         return 1
     fi
 }


### PR DESCRIPTION
DNS:Edit was granted to a token and [run 32599419538](https://github.com/MapleTechLabs/maple/actions/runs/32599419538) still got `Authentication error` writing the validation record while zone reads succeed — so the permission landed on a different token (or a different zone scope). Print the id + status of the token the deploy actually holds (`/user/tokens/verify`, id only, also spaced so GitHub's digit masking can't hide it).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790026024&installation_model_id=427786&pr_number=588&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F588&signature=74358cc2194145e1c000c259a6b6b872bd233e0627297899a7b07184609eef2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->