### PR TITLE
ci(deploy): a deploy recovered by the certificate retry is a green run

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -135,8 +135,11 @@ jobs:
             # log line. That was the "AWS ingest deploy hang" (#378). With the id
             # supplied, the lookup is skipped. Reproduced locally with CI=true and
             # the id unset on alchemy 2.0.0-beta.64 through beta.74.
+            # continue-on-error so the certificate step below can finish the job;
+            # the last step turns an unrecovered failure back into a red run.
             - name: Deploy PRD stack with Alchemy
               id: deploy
+              continue-on-error: true
               run: bun run alchemy:deploy:prd
               env:
                   AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
@@ -148,10 +151,17 @@ jobs:
             # deploy that failed for any other reason reaches this too: the script
             # is a no-op on an ISSUED certificate and the retry fails the same way.
             - name: Validate the ingest certificate and retry the deploy
-              if: ${{ failure() && steps.deploy.outcome == 'failure' && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
+              id: retry
+              if: ${{ steps.deploy.outcome == 'failure' && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
               env:
                   INGEST_DOMAIN: ingest.maple.dev
                   AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
               run: |
                   bash scripts/ingest-cert-validate.sh
                   bun run alchemy:deploy:prd
+
+            - name: Fail the run if the deploy did not succeed
+              if: ${{ steps.deploy.outcome == 'failure' && steps.retry.outcome != 'success' }}
+              run: |
+                  echo "::error::alchemy deploy failed and the certificate-validation retry did not recover it (retry outcome: ${{ steps.retry.outcome }})"
+                  exit 1

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -120,8 +120,11 @@ jobs:
               run: DATABASE_URL="$MAPLE_PG_URL" bun run --cwd packages/db db:migrate
 
             # AWS_ACCOUNT_ID: see the note in deploy-prd.yml.
+            # continue-on-error so the certificate step below can finish the job;
+            # the last step turns an unrecovered failure back into a red run.
             - name: Deploy STG stack with Alchemy
               id: deploy
+              continue-on-error: true
               run: bun run alchemy:deploy:stg
               env:
                   AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
@@ -133,10 +136,17 @@ jobs:
             # deploy that failed for any other reason reaches this too: the script
             # is a no-op on an ISSUED certificate and the retry fails the same way.
             - name: Validate the ingest certificate and retry the deploy
-              if: ${{ failure() && steps.deploy.outcome == 'failure' && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
+              id: retry
+              if: ${{ steps.deploy.outcome == 'failure' && env.MAPLE_DEPLOY_AWS_INGEST == '1' }}
               env:
                   INGEST_DOMAIN: ingest-staging.maple.dev
                   AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
               run: |
                   bash scripts/ingest-cert-validate.sh
                   bun run alchemy:deploy:stg
+
+            - name: Fail the run if the deploy did not succeed
+              if: ${{ steps.deploy.outcome == 'failure' && steps.retry.outcome != 'success' }}
+              run: |
+                  echo "::error::alchemy deploy failed and the certificate-validation retry did not recover it (retry outcome: ${{ steps.retry.outcome }})"
+                  exit 1


### PR DESCRIPTION
[Run 32599719981](https://github.com/MapleTechLabs/maple/actions/runs/32599719981) validated the `ingest.maple.dev` certificate and redeployed successfully — the ingest service is live — yet showed as failed because the initial deploy step had failed before the retry. The deploy step now continues on error and a final step fails the run only when neither it nor the retry succeeded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790027030&installation_model_id=427786&pr_number=589&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F589&signature=f9df1eeaa05fd855bd9a65165a327bf41f6dd3358dfa0d8d622b07a255d497ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->