### PR TITLE
refactor(infra): share the workers' deploy-time env instead of copying it

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -14,7 +14,7 @@ import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import { parseMapleRegion, resolveAwsRegion, stageDeploysIngest } from "@maple/infra/aws"
 import { formatMapleStage, parseMapleStage, resolveMapleDomains } from "@maple/infra/cloudflare"
-import { requireEnv } from "@maple/infra/env"
+import { requiredPlain } from "@maple/infra/env"
 import { createAlertingWorker } from "./apps/alerting/alchemy.run.ts"
 import { createMapleApi } from "./apps/api/alchemy.run.ts"
 import { createElectricSyncWorker } from "./apps/electric-sync/alchemy.run.ts"
@@ -52,7 +52,7 @@ const createProductionSharedResources = (stage: ReturnType<typeof parseMapleStag
 			/\/+$/,
 			"",
 		)
-		const headers = { authorization: `Bearer ${requireEnv("MAPLE_OTEL_INGEST_KEY")}` }
+		const headers = { authorization: `Bearer ${yield* requiredPlain("MAPLE_OTEL_INGEST_KEY")}` }
 		const tracesDestination = yield* Cloudflare.Workers.ObservabilityDestination(
 			"workers-observability-traces",
 			{

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -1,3 +1,10 @@
+// The Maple stack: one `create*` factory per app, composed here.
+//
+// Comments in these files explain what a reader needs in order not to break the
+// code. The history behind those decisions — the #378 deploy hang, the
+// CONNECT_TIMEOUT cold-start regression, the Hyperdrive split measurements, the
+// v1→v2 equivalences, the cost calls, and the local-dev/`alchemy dev` state of
+// play — lives in `docs/infra.md`.
 import { appendFileSync } from "node:fs"
 import * as Alchemy from "alchemy"
 import * as AWS from "alchemy/AWS"
@@ -7,6 +14,7 @@ import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import { parseMapleRegion, resolveAwsRegion, stageDeploysIngest } from "@maple/infra/aws"
 import { formatMapleStage, parseMapleStage, resolveMapleDomains } from "@maple/infra/cloudflare"
+import { requireEnv } from "@maple/infra/env"
 import { createAlertingWorker } from "./apps/alerting/alchemy.run.ts"
 import { createMapleApi } from "./apps/api/alchemy.run.ts"
 import { createElectricSyncWorker } from "./apps/electric-sync/alchemy.run.ts"
@@ -30,14 +38,6 @@ if (!process.env.CLOUDFLARE_ACCOUNT_ID && process.env.CLOUDFLARE_DEFAULT_ACCOUNT
 // local dev runs through wrangler/portless instead).
 const resolveUrl = (domain: string | undefined, envKey: string, fallback = ""): string =>
 	domain ? `https://${domain}` : process.env[envKey]?.trim() || fallback
-
-const requireEnv = (key: string): string => {
-	const value = process.env[key]?.trim()
-	if (!value) {
-		throw new Error(`Missing required deployment env: ${key}`)
-	}
-	return value
-}
 
 const createProductionSharedResources = (stage: ReturnType<typeof parseMapleStage>) =>
 	Effect.gen(function* () {
@@ -81,12 +81,26 @@ const createProductionSharedResources = (stage: ReturnType<typeof parseMapleStag
  * Opt-in switch for the AWS half of the stack (`apps/ingest` on ECS).
  *
  * Set `MAPLE_DEPLOY_AWS_INGEST=1` to include it. Unset, both the AWS providers
- * and the ingest resources drop out and the stack is exactly what shipped
- * before the AWS work landed. It was made opt-in when the AWS half wedged
- * every production deploy (#378); that hang turned out to be alchemy's
- * env-credential account lookup deadlocking without `AWS_ACCOUNT_ID` (the
- * workflows now set it — see deploy-prd.yml), so the flag is only the
- * migration switch now, not a workaround.
+ * and the ingest resources drop out.
+ *
+ * STILL LOAD-BEARING — do not fold this into `stageDeploysIngest` and delete it.
+ * Two reasons:
+ *
+ *   1. It is the cost gate. The variable is set on the `production` GitHub
+ *      environment only; `stageDeploysIngest` also returns true for `stg`, so
+ *      removing the flag would hand staging a VPC + ALB + ACM certificate + ECS
+ *      cluster it does not have today. deploy-stg.yml's `aws_ingest` input
+ *      forces it on for a single run when staging genuinely needs one.
+ *   2. It cannot be stage-derived anyway. `providers` is part of the
+ *      `Alchemy.Stack` options, which are evaluated before `Alchemy.Stage` is
+ *      readable inside the stack effect — and `AWS.providers()` pulls the whole
+ *      AWS provider surface into the plan, so registering it unconditionally is
+ *      not free.
+ *
+ * It was ALSO once a workaround for the #378 hang (alchemy's env-credential
+ * account lookup deadlocking without `AWS_ACCOUNT_ID`). That part is fixed — the
+ * workflows set `AWS_ACCOUNT_ID`, see deploy-prd.yml — but the two reasons above
+ * are independent of it.
  */
 const DEPLOY_AWS_INGEST = process.env.MAPLE_DEPLOY_AWS_INGEST === "1"
 

--- a/apps/alerting/alchemy.run.ts
+++ b/apps/alerting/alchemy.run.ts
@@ -1,32 +1,24 @@
 import path from "node:path"
 import * as Cloudflare from "alchemy/Cloudflare"
 import * as Effect from "effect/Effect"
-import * as Redacted from "effect/Redacted"
 import type { MapleDomains, MapleStage } from "@maple/infra/cloudflare"
 import {
 	CLOUDFLARE_WORKER_PLACEMENT,
-	resolveDeploymentEnvironment,
 	resolveHyperdriveRefId,
 	resolveWorkerName,
 } from "@maple/infra/cloudflare"
-
-const requireEnv = (key: string): string => {
-	const value = process.env[key]?.trim()
-	if (!value) {
-		throw new Error(`Missing required deployment env: ${key}`)
-	}
-	return value
-}
-
-const optionalPlain = (key: string, fallback?: string): Record<string, string> => {
-	const value = process.env[key]?.trim() || fallback
-	return value ? { [key]: value } : {}
-}
-
-const optionalSecret = (key: string): Record<string, Redacted.Redacted<string>> => {
-	const value = process.env[key]?.trim()
-	return value ? { [key]: Redacted.make(value) } : {}
-}
+import {
+	apnsEnv,
+	appUrlsEnv,
+	authEnv,
+	cloudflareOAuthEnv,
+	ingestKeyCryptoEnv,
+	optionalPlain,
+	optionalSecret,
+	planetScaleOAuthEnv,
+	selfObservabilityEnv,
+	tinybirdEnv,
+} from "@maple/infra/env"
 
 export interface CreateAlertingWorkerOptions {
 	stage: MapleStage
@@ -80,76 +72,30 @@ export const createAlertingWorker = ({ stage, mapleDb }: CreateAlertingWorkerOpt
 							}),
 						}
 					: undefined),
-				TINYBIRD_HOST: requireEnv("TINYBIRD_HOST"),
-				TINYBIRD_TOKEN: Redacted.make(requireEnv("TINYBIRD_TOKEN")),
 				// Alert-rule evaluation runs Tinybird-scoped raw SQL through
-				// TinybirdOrgTokenService, which requires both of these — without them
-				// every tick fails with "TINYBIRD_SIGNING_KEY is required for
-				// Tinybird-scoped raw SQL" (same bindings as the api worker).
-				...optionalSecret("TINYBIRD_SIGNING_KEY"),
-				...optionalPlain("TINYBIRD_WORKSPACE_ID"),
-				...optionalPlain("TINYBIRD_RAW_SQL_JWT_RPS_LIMIT"),
-				MAPLE_AUTH_MODE: process.env.MAPLE_AUTH_MODE?.trim() || "self_hosted",
-				MAPLE_DEFAULT_ORG_ID: process.env.MAPLE_DEFAULT_ORG_ID?.trim() || "default",
-				MAPLE_INGEST_KEY_ENCRYPTION_KEY: Redacted.make(requireEnv("MAPLE_INGEST_KEY_ENCRYPTION_KEY")),
-				MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: Redacted.make(
-					requireEnv("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
-				),
-				MAPLE_INGEST_PUBLIC_URL:
-					process.env.MAPLE_INGEST_PUBLIC_URL?.trim() || "https://ingest.maple.dev",
-				MAPLE_APP_BASE_URL: process.env.MAPLE_APP_BASE_URL?.trim() || "https://app.maple.dev",
-				EMAIL_FROM: process.env.EMAIL_FROM?.trim() || "Maple <notifications@noreply.maple.dev>",
-				...optionalPlain("MAPLE_ENDPOINT"),
-				// Derived from the stage, deliberately NOT `optionalPlain` — that helper
-				// lets `process.env` win over the fallback, so a stray
-				// MAPLE_ENVIRONMENT=production in a pr-N deploy environment would open
-				// both email gates at once (the worker's scheduled() early-return and
-				// EmailService.emailAllowed both derive from this one value), leaving
-				// the prd-only EMAIL binding as the sole guard.
-				MAPLE_ENVIRONMENT: resolveDeploymentEnvironment(stage),
+				// TinybirdOrgTokenService, so this is the same set the api worker binds.
+				...tinybirdEnv(),
+				...authEnv(),
+				...ingestKeyCryptoEnv(),
+				...appUrlsEnv(),
+				// MAPLE_ENDPOINT / MAPLE_ENVIRONMENT / COMMIT_SHA / MAPLE_INGEST_KEY.
+				// MAPLE_ENVIRONMENT is stage-derived and NOT env-overridable: it gates
+				// both this worker's scheduled() early-return and
+				// EmailService.emailAllowed, so an override would open both at once and
+				// leave the prd-only EMAIL binding as the sole guard.
+				...selfObservabilityEnv(stage),
 				// Non-prod stages skip all crons (they share live org data via the prod
 				// DB); set to "1" on a stage to deliberately exercise crons there.
 				...optionalPlain("MAPLE_ALERTING_ALLOW_NONPROD"),
-				// GITHUB_SHA fallback so a deploy that did not export COMMIT_SHA still
-				// stamps a build. An unstamped Worker reports no `service.version`, and
-				// the error evaluator treats a build it cannot identify as a regression —
-				// so a missing binding quietly restores the behaviour where any occurrence
-				// reopens a fixed issue. Matches what apps/ingest already does.
-				...optionalPlain("COMMIT_SHA", process.env.GITHUB_SHA?.trim()),
-				MAPLE_INGEST_KEY: Redacted.make(requireEnv("MAPLE_OTEL_INGEST_KEY")),
-				...optionalSecret("MAPLE_ROOT_PASSWORD"),
-				...optionalSecret("CLERK_SECRET_KEY"),
-				...optionalPlain("CLERK_PUBLISHABLE_KEY"),
-				...optionalSecret("CLERK_JWT_KEY"),
 				...optionalSecret("AUTUMN_SECRET_KEY"),
 				...optionalSecret("INTERNAL_SERVICE_TOKEN"),
-				// Apple push for the iOS app: the alerting worker is where incidents
-				// open and resolve, so it is the one that sends. Same three
-				// bindings as the api worker (platform/Apns.ts).
-				...optionalPlain("APNS_TEAM_ID"),
-				...optionalPlain("APNS_KEY_ID"),
-				...optionalSecret("APNS_PRIVATE_KEY"),
-				// Cloudflare integration (account OAuth — Authorization Code + PKCE).
-				// The alerting worker runs the cloudflare analytics poller (cloudflareAnalyticsTick
-				// → CloudflareAnalyticsService.pollAllOrgs), which resolves + refreshes each org's
-				// OAuth token via CloudflareOAuthService and needs the same config as the api worker.
-				...optionalPlain("CLOUDFLARE_OAUTH_CLIENT_ID"),
-				...optionalSecret("CLOUDFLARE_OAUTH_CLIENT_SECRET"),
-				...optionalPlain("CLOUDFLARE_OAUTH_SCOPES"),
-				...optionalPlain("CLOUDFLARE_OAUTH_AUTHORIZE_URL"),
-				...optionalPlain("CLOUDFLARE_OAUTH_TOKEN_URL"),
-				...optionalPlain("CLOUDFLARE_OAUTH_REVOKE_URL"),
-				...optionalPlain("MAPLE_CLOUDFLARE_API_BASE_URL"),
-				// PlanetScale integration (OAuth application — confidential client). The
-				// alerting worker runs the inventory poller (planetScaleTick →
-				// PlanetScaleService.pollAllOrgs), which resolves + refreshes each org's
-				// OAuth token via PlanetScaleOAuthService and needs the same config as
-				// the api worker.
-				...optionalPlain("PLANETSCALE_OAUTH_CLIENT_ID"),
-				...optionalSecret("PLANETSCALE_OAUTH_CLIENT_SECRET"),
-				...optionalPlain("PLANETSCALE_OAUTH_AUTHORIZE_URL"),
-				...optionalPlain("PLANETSCALE_OAUTH_TOKEN_URL"),
-				...optionalPlain("MAPLE_PLANETSCALE_API_BASE_URL"),
+				// The alerting worker is where incidents open and resolve, so it is the
+				// one that sends push (platform/Apns.ts) — and it runs the Cloudflare
+				// analytics and PlanetScale inventory pollers, each of which resolves and
+				// refreshes per-org OAuth tokens with the same config the api worker uses.
+				...apnsEnv(),
+				...cloudflareOAuthEnv(),
+				...planetScaleOAuthEnv(),
 			},
 		})
 

--- a/apps/alerting/alchemy.run.ts
+++ b/apps/alerting/alchemy.run.ts
@@ -13,6 +13,7 @@ import {
 	authEnv,
 	cloudflareOAuthEnv,
 	ingestKeyCryptoEnv,
+	merge,
 	optionalPlain,
 	optionalSecret,
 	planetScaleOAuthEnv,
@@ -27,8 +28,42 @@ export interface CreateAlertingWorkerOptions {
 	mapleDb: Cloudflare.Hyperdrive.Connection | undefined
 }
 
+/**
+ * Everything in the alerting worker's env that comes from configuration rather
+ * than from a resource. Largely the api worker's set — the two share 32 keys,
+ * which is why the groups live in `@maple/infra/env`.
+ */
+const alertingConfiguredEnv = (stage: MapleStage) =>
+	merge(
+		// Alert-rule evaluation runs Tinybird-scoped raw SQL through
+		// TinybirdOrgTokenService, so this is the same set the api worker binds.
+		tinybirdEnv,
+		authEnv,
+		ingestKeyCryptoEnv,
+		appUrlsEnv,
+		// MAPLE_ENDPOINT / MAPLE_ENVIRONMENT / COMMIT_SHA / MAPLE_INGEST_KEY.
+		// MAPLE_ENVIRONMENT is stage-derived and NOT env-overridable: it gates both
+		// this worker's scheduled() early-return and EmailService.emailAllowed, so an
+		// override would open both at once and leave the prd-only EMAIL binding as
+		// the sole guard.
+		selfObservabilityEnv(stage),
+		// Non-prod stages skip all crons (they share live org data via the prod DB);
+		// set to "1" on a stage to deliberately exercise crons there.
+		optionalPlain("MAPLE_ALERTING_ALLOW_NONPROD"),
+		optionalSecret("AUTUMN_SECRET_KEY"),
+		optionalSecret("INTERNAL_SERVICE_TOKEN"),
+		// The alerting worker is where incidents open and resolve, so it is the one
+		// that sends push (platform/Apns.ts) — and it runs the Cloudflare analytics
+		// and PlanetScale inventory pollers, each of which resolves and refreshes
+		// per-org OAuth tokens with the same config the api worker uses.
+		apnsEnv,
+		cloudflareOAuthEnv,
+		planetScaleOAuthEnv,
+	)
+
 export const createAlertingWorker = ({ stage, mapleDb }: CreateAlertingWorkerOptions) =>
 	Effect.gen(function* () {
+		const configuredEnv = yield* alertingConfiguredEnv(stage)
 		// `alerting` binds its own Hyperdrive config on prd — it issues ~97% of the
 		// workers' Postgres traffic and was starving the api's connection pool.
 		const hyperdriveRefId = resolveHyperdriveRefId(stage, "alerting")
@@ -72,30 +107,7 @@ export const createAlertingWorker = ({ stage, mapleDb }: CreateAlertingWorkerOpt
 							}),
 						}
 					: undefined),
-				// Alert-rule evaluation runs Tinybird-scoped raw SQL through
-				// TinybirdOrgTokenService, so this is the same set the api worker binds.
-				...tinybirdEnv(),
-				...authEnv(),
-				...ingestKeyCryptoEnv(),
-				...appUrlsEnv(),
-				// MAPLE_ENDPOINT / MAPLE_ENVIRONMENT / COMMIT_SHA / MAPLE_INGEST_KEY.
-				// MAPLE_ENVIRONMENT is stage-derived and NOT env-overridable: it gates
-				// both this worker's scheduled() early-return and
-				// EmailService.emailAllowed, so an override would open both at once and
-				// leave the prd-only EMAIL binding as the sole guard.
-				...selfObservabilityEnv(stage),
-				// Non-prod stages skip all crons (they share live org data via the prod
-				// DB); set to "1" on a stage to deliberately exercise crons there.
-				...optionalPlain("MAPLE_ALERTING_ALLOW_NONPROD"),
-				...optionalSecret("AUTUMN_SECRET_KEY"),
-				...optionalSecret("INTERNAL_SERVICE_TOKEN"),
-				// The alerting worker is where incidents open and resolve, so it is the
-				// one that sends push (platform/Apns.ts) — and it runs the Cloudflare
-				// analytics and PlanetScale inventory pollers, each of which resolves and
-				// refreshes per-org OAuth tokens with the same config the api worker uses.
-				...apnsEnv(),
-				...cloudflareOAuthEnv(),
-				...planetScaleOAuthEnv(),
+				...configuredEnv,
 			},
 		})
 

--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -9,29 +9,24 @@ import {
 	CLOUDFLARE_WORKER_PLACEMENT,
 	formatMapleStage,
 	resolveDatabaseMode,
-	resolveDeploymentEnvironment,
 	resolveHyperdriveName,
 	resolveHyperdriveRefId,
 	resolveWorkerName,
 } from "@maple/infra/cloudflare"
-
-const requireEnv = (key: string): string => {
-	const value = process.env[key]?.trim()
-	if (!value) {
-		throw new Error(`Missing required deployment env: ${key}`)
-	}
-	return value
-}
-
-const optionalPlain = (key: string, fallback?: string): Record<string, string> => {
-	const value = process.env[key]?.trim() || fallback
-	return value ? { [key]: value } : {}
-}
-
-const optionalSecret = (key: string): Record<string, Redacted.Redacted<string>> => {
-	const value = process.env[key]?.trim()
-	return value ? { [key]: Redacted.make(value) } : {}
-}
+import {
+	apnsEnv,
+	appUrlsEnv,
+	authEnv,
+	cloudflareOAuthEnv,
+	ingestKeyCryptoEnv,
+	optionalPlain,
+	optionalSecret,
+	planetScaleOAuthEnv,
+	requireEnv,
+	requireSecret,
+	selfObservabilityEnv,
+	tinybirdEnv,
+} from "@maple/infra/env"
 
 export interface CreateMapleApiOptions {
 	stage: MapleStage
@@ -137,8 +132,8 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 			name: planetScaleWebhookQueueName,
 		})
 
-		// Session-replay rrweb payloads. The ingest gateway (a Railway container,
-		// not a Worker) writes these over the S3 API with SigV4; this binding is
+		// Session-replay rrweb payloads. The ingest gateway (a Rust service on ECS
+		// Fargate, not a Worker) writes these over the S3 API with SigV4; this binding is
 		// the read side, hydrating `session_replay_events` rows whose `Events` is
 		// empty. Stage-isolated, so a pr/stg deploy can never serve or overwrite
 		// prd recordings.
@@ -239,27 +234,16 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 							}),
 						}
 					: undefined),
-				TINYBIRD_HOST: requireEnv("TINYBIRD_HOST"),
-				TINYBIRD_TOKEN: Redacted.make(requireEnv("TINYBIRD_TOKEN")),
-				...optionalSecret("TINYBIRD_SIGNING_KEY"),
-				...optionalPlain("TINYBIRD_WORKSPACE_ID"),
-				...optionalPlain("TINYBIRD_RAW_SQL_JWT_RPS_LIMIT"),
+				...tinybirdEnv(),
 				...optionalPlain("CLICKHOUSE_URL"),
 				CLICKHOUSE_PROVIDER: process.env.CLICKHOUSE_PROVIDER?.trim() || "tinybird",
 				...optionalPlain("CLICKHOUSE_USER"),
 				...optionalPlain("CLICKHOUSE_DATABASE"),
 				...optionalSecret("CLICKHOUSE_PASSWORD"),
-				MAPLE_AUTH_MODE: process.env.MAPLE_AUTH_MODE?.trim() || "self_hosted",
-				MAPLE_DEFAULT_ORG_ID: process.env.MAPLE_DEFAULT_ORG_ID?.trim() || "default",
-				MAPLE_INGEST_KEY_ENCRYPTION_KEY: Redacted.make(requireEnv("MAPLE_INGEST_KEY_ENCRYPTION_KEY")),
-				MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: Redacted.make(
-					requireEnv("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
-				),
-				MAPLE_SHARE_TOKEN_HMAC_KEY: Redacted.make(requireEnv("MAPLE_SHARE_TOKEN_HMAC_KEY")),
-				MAPLE_INGEST_PUBLIC_URL:
-					process.env.MAPLE_INGEST_PUBLIC_URL?.trim() || "https://ingest.maple.dev",
-				MAPLE_APP_BASE_URL: process.env.MAPLE_APP_BASE_URL?.trim() || "https://app.maple.dev",
-				EMAIL_FROM: process.env.EMAIL_FROM?.trim() || "Maple <notifications@noreply.maple.dev>",
+				...authEnv(),
+				...ingestKeyCryptoEnv(),
+				MAPLE_SHARE_TOKEN_HMAC_KEY: requireSecret("MAPLE_SHARE_TOKEN_HMAC_KEY"),
+				...appUrlsEnv(),
 				// Bucket-cache knobs: on by default in deployed stages. Override via
 				// deploy-time env (e.g. `QE_BUCKET_CACHE_ENABLED=false`) if needed.
 				QE_BUCKET_CACHE_ENABLED: process.env.QE_BUCKET_CACHE_ENABLED?.trim() || "true",
@@ -275,19 +259,8 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 				// 16/250 and the code defaults moved to 6/40 underneath them.
 				QE_BUCKET_CACHE_READ_CONCURRENCY: process.env.QE_BUCKET_CACHE_READ_CONCURRENCY?.trim() || "6",
 				EDGE_CACHE_READ_TIMEOUT_MS: process.env.EDGE_CACHE_READ_TIMEOUT_MS?.trim() || "40",
-				...optionalPlain("MAPLE_ENDPOINT"),
-				// Derived from the stage, deliberately NOT `optionalPlain` — that helper
-				// lets `process.env` win over the fallback, so a stray
-				// MAPLE_ENVIRONMENT=production in a pr-N deploy environment would open
-				// EmailService.emailAllowed on a stage that shares live org data.
-				MAPLE_ENVIRONMENT: resolveDeploymentEnvironment(stage),
-				// GITHUB_SHA fallback so a deploy that did not export COMMIT_SHA still
-				// stamps a build. An unstamped Worker reports no `service.version`, and
-				// the error evaluator treats a build it cannot identify as a regression —
-				// so a missing binding quietly restores the behaviour where any occurrence
-				// reopens a fixed issue. Matches what apps/ingest already does.
-				...optionalPlain("COMMIT_SHA", process.env.GITHUB_SHA?.trim()),
-				MAPLE_INGEST_KEY: Redacted.make(requireEnv("MAPLE_OTEL_INGEST_KEY")),
+				// MAPLE_ENDPOINT / MAPLE_ENVIRONMENT / COMMIT_SHA / MAPLE_INGEST_KEY.
+				...selfObservabilityEnv(stage),
 				// Agent LLM path. `MAPLE_LLM_PROVIDER` flips between OpenRouter (default) and
 				// Workers AI; both stay wired, so a switch is this one var plus a redeploy.
 				// See `@/platform/Llm` for the provider-scoped model overrides.
@@ -295,10 +268,6 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 				...optionalPlain("MAPLE_TRIAGE_MODEL_OPENROUTER"),
 				...optionalPlain("MAPLE_TRIAGE_MODEL_WORKERS_AI"),
 				...optionalSecret("OPENROUTER_API_KEY"),
-				...optionalSecret("MAPLE_ROOT_PASSWORD"),
-				...optionalSecret("CLERK_SECRET_KEY"),
-				...optionalPlain("CLERK_PUBLISHABLE_KEY"),
-				...optionalSecret("CLERK_JWT_KEY"),
 				// Svix signing secrets for the public webhook receivers (`/webhooks/clerk`,
 				// `/webhooks/autumn`); each route answers 503 until its secret is set.
 				...optionalSecret("CLERK_WEBHOOK_SECRET"),
@@ -321,10 +290,7 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 				...optionalPlain("SLACK_CLIENT_ID"),
 				...optionalSecret("SLACK_CLIENT_SECRET"),
 				...optionalSecret("SLACK_INTERNAL_SERVICE_TOKEN"),
-				// Apple push (iOS app) — token auth; see platform/Apns.ts
-				...optionalPlain("APNS_TEAM_ID"),
-				...optionalPlain("APNS_KEY_ID"),
-				...optionalSecret("APNS_PRIVATE_KEY"),
+				...apnsEnv(),
 				...optionalPlain("GITHUB_APP_ID"),
 				...optionalPlain("GITHUB_APP_SLUG"),
 				...optionalSecret("GITHUB_APP_PRIVATE_KEY"),
@@ -332,21 +298,8 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 				...optionalSecret("GITHUB_APP_CLIENT_SECRET"),
 				...optionalSecret("GITHUB_APP_WEBHOOK_SECRET"),
 				...optionalPlain("GITHUB_API_BASE_URL"),
-				// Cloudflare integration (account OAuth — Authorization Code + PKCE)
-				...optionalPlain("CLOUDFLARE_OAUTH_CLIENT_ID"),
-				...optionalSecret("CLOUDFLARE_OAUTH_CLIENT_SECRET"),
-				...optionalPlain("CLOUDFLARE_OAUTH_SCOPES"),
-				...optionalPlain("CLOUDFLARE_OAUTH_AUTHORIZE_URL"),
-				...optionalPlain("CLOUDFLARE_OAUTH_TOKEN_URL"),
-				...optionalPlain("CLOUDFLARE_OAUTH_REVOKE_URL"),
-				...optionalPlain("MAPLE_CLOUDFLARE_API_BASE_URL"),
-				// PlanetScale integration (OAuth application — confidential client, no PKCE)
-				...optionalPlain("PLANETSCALE_OAUTH_CLIENT_ID"),
-				...optionalSecret("PLANETSCALE_OAUTH_CLIENT_SECRET"),
-				...optionalPlain("PLANETSCALE_OAUTH_AUTHORIZE_URL"),
-				...optionalPlain("PLANETSCALE_OAUTH_TOKEN_URL"),
-				...optionalPlain("PLANETSCALE_OAUTH_TOKEN_INFO_URL"),
-				...optionalPlain("MAPLE_PLANETSCALE_API_BASE_URL"),
+				...cloudflareOAuthEnv(),
+				...planetScaleOAuthEnv(),
 			},
 		})) as MapleApiWorker
 

--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -19,11 +19,13 @@ import {
 	authEnv,
 	cloudflareOAuthEnv,
 	ingestKeyCryptoEnv,
+	merge,
 	optionalPlain,
 	optionalSecret,
 	planetScaleOAuthEnv,
-	requireEnv,
-	requireSecret,
+	plainWithDefault,
+	requiredPlain,
+	requireSecretEntry,
 	selfObservabilityEnv,
 	tinybirdEnv,
 } from "@maple/infra/env"
@@ -33,11 +35,88 @@ export interface CreateMapleApiOptions {
 	domains: MapleDomains
 }
 
+/**
+ * Everything in the api worker's env that comes from configuration rather than
+ * from a resource. Resolved as one `Config` so a deploy missing several vars
+ * reports all of them at once, and so `.env` / `--env-file` reach it — see
+ * `@maple/infra/env`.
+ */
+const apiConfiguredEnv = (stage: MapleStage) =>
+	merge(
+		tinybirdEnv,
+		// ClickHouse (BYO warehouse); `tinybird` unless an org config overrides it.
+		optionalPlain("CLICKHOUSE_URL"),
+		plainWithDefault("CLICKHOUSE_PROVIDER", "tinybird"),
+		optionalPlain("CLICKHOUSE_USER"),
+		optionalPlain("CLICKHOUSE_DATABASE"),
+		optionalSecret("CLICKHOUSE_PASSWORD"),
+		authEnv,
+		ingestKeyCryptoEnv,
+		requireSecretEntry("MAPLE_SHARE_TOKEN_HMAC_KEY"),
+		appUrlsEnv,
+		// Bucket-cache knobs: on by default in deployed stages. Override via
+		// deploy-time env (e.g. `QE_BUCKET_CACHE_ENABLED=false`) if needed.
+		plainWithDefault("QE_BUCKET_CACHE_ENABLED", "true"),
+		plainWithDefault("QE_BUCKET_CACHE_TTL_SECONDS", "86400"),
+		plainWithDefault("QE_BUCKET_CACHE_FLUX_SECONDS", "60"),
+		plainWithDefault("QE_BUCKET_CACHE_SEGMENT_BUCKETS", "120"),
+		// Both of the next two knobs are bounded by Cloudflare's
+		// six-simultaneous-connection limit, which `cache.match()` counts against
+		// while it waits for response headers. Keep the deploy-time values in step
+		// with the reasoning in `bucket-cache.ts` and `edge-cache.ts` — a stale
+		// override here silently defeats a tuned default, which is exactly what
+		// happened when these were pinned to 16/250 and the code defaults moved to
+		// 6/40 underneath them.
+		plainWithDefault("QE_BUCKET_CACHE_READ_CONCURRENCY", "6"),
+		plainWithDefault("EDGE_CACHE_READ_TIMEOUT_MS", "40"),
+		// MAPLE_ENDPOINT / MAPLE_ENVIRONMENT / COMMIT_SHA / MAPLE_INGEST_KEY.
+		selfObservabilityEnv(stage),
+		// Agent LLM path. `MAPLE_LLM_PROVIDER` flips between OpenRouter (default) and
+		// Workers AI; both stay wired, so a switch is this one var plus a redeploy.
+		// See `@/platform/Llm` for the provider-scoped model overrides.
+		optionalPlain("MAPLE_LLM_PROVIDER"),
+		optionalPlain("MAPLE_TRIAGE_MODEL_OPENROUTER"),
+		optionalPlain("MAPLE_TRIAGE_MODEL_WORKERS_AI"),
+		optionalSecret("OPENROUTER_API_KEY"),
+		// Svix signing secrets for the public webhook receivers (`/webhooks/clerk`,
+		// `/webhooks/autumn`); each route answers 503 until its secret is set.
+		optionalSecret("CLERK_WEBHOOK_SECRET"),
+		optionalSecret("AUTUMN_WEBHOOK_SECRET"),
+		// Server-side product events default to MAPLE_INGEST_KEY; set this only if
+		// the funnel should land in a different org than the API's traces.
+		optionalSecret("MAPLE_PRODUCT_EVENTS_INGEST_KEY"),
+		optionalSecret("AUTUMN_SECRET_KEY"),
+		// Billing details (company name, address, tax IDs) are written to the Stripe
+		// customer Autumn links; Autumn itself has no API for them.
+		optionalSecret("STRIPE_SECRET_KEY"),
+		optionalSecret("SD_INTERNAL_TOKEN"),
+		optionalSecret("INTERNAL_SERVICE_TOKEN"),
+		optionalPlain("HAZEL_API_BASE_URL"),
+		optionalPlain("HAZEL_OAUTH_DISCOVERY_URL"),
+		optionalPlain("HAZEL_OAUTH_CLIENT_ID"),
+		optionalSecret("HAZEL_OAUTH_CLIENT_SECRET"),
+		optionalPlain("HAZEL_OAUTH_SCOPES"),
+		// Slack integration (bot install via OAuth v2)
+		optionalPlain("SLACK_CLIENT_ID"),
+		optionalSecret("SLACK_CLIENT_SECRET"),
+		optionalSecret("SLACK_INTERNAL_SERVICE_TOKEN"),
+		apnsEnv,
+		optionalPlain("GITHUB_APP_ID"),
+		optionalPlain("GITHUB_APP_SLUG"),
+		optionalSecret("GITHUB_APP_PRIVATE_KEY"),
+		optionalPlain("GITHUB_APP_CLIENT_ID"),
+		optionalSecret("GITHUB_APP_CLIENT_SECRET"),
+		optionalSecret("GITHUB_APP_WEBHOOK_SECRET"),
+		optionalPlain("GITHUB_API_BASE_URL"),
+		cloudflareOAuthEnv,
+		planetScaleOAuthEnv,
+	)
+
 /** Alchemy resource type for the API Worker, carrying its internal RPC surface. */
 export type MapleApiWorker = Cloudflare.Worker & Rpc<MapleApiRpcContract>
 
 const createManagedMapleDb = Effect.fnUntraced(function* (stage: MapleStage) {
-	const pgUrl = new URL(requireEnv("MAPLE_PG_URL"))
+	const pgUrl = new URL(yield* requiredPlain("MAPLE_PG_URL"))
 	return yield* Cloudflare.Hyperdrive.Connection("maple-db", {
 		name: resolveHyperdriveName(stage),
 		origin: {
@@ -88,6 +167,10 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 		const databaseMode = resolveDatabaseMode(stage)
 		const hyperdriveRefId = resolveHyperdriveRefId(stage, "api")
 		const mapleDb = databaseMode !== "managed" ? undefined : yield* createManagedMapleDb(stage)
+
+		// Resolved before any resource is created, so a misconfigured deploy fails
+		// with the full list of missing vars rather than part-way through applying.
+		const configuredEnv = yield* apiConfiguredEnv(stage)
 
 		const mcpSessions = yield* Cloudflare.KV.Namespace("MCP_SESSIONS", {
 			title: resolveWorkerName("mcp-sessions", stage),
@@ -234,72 +317,7 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 							}),
 						}
 					: undefined),
-				...tinybirdEnv(),
-				...optionalPlain("CLICKHOUSE_URL"),
-				CLICKHOUSE_PROVIDER: process.env.CLICKHOUSE_PROVIDER?.trim() || "tinybird",
-				...optionalPlain("CLICKHOUSE_USER"),
-				...optionalPlain("CLICKHOUSE_DATABASE"),
-				...optionalSecret("CLICKHOUSE_PASSWORD"),
-				...authEnv(),
-				...ingestKeyCryptoEnv(),
-				MAPLE_SHARE_TOKEN_HMAC_KEY: requireSecret("MAPLE_SHARE_TOKEN_HMAC_KEY"),
-				...appUrlsEnv(),
-				// Bucket-cache knobs: on by default in deployed stages. Override via
-				// deploy-time env (e.g. `QE_BUCKET_CACHE_ENABLED=false`) if needed.
-				QE_BUCKET_CACHE_ENABLED: process.env.QE_BUCKET_CACHE_ENABLED?.trim() || "true",
-				QE_BUCKET_CACHE_TTL_SECONDS: process.env.QE_BUCKET_CACHE_TTL_SECONDS?.trim() || "86400",
-				QE_BUCKET_CACHE_FLUX_SECONDS: process.env.QE_BUCKET_CACHE_FLUX_SECONDS?.trim() || "60",
-				QE_BUCKET_CACHE_SEGMENT_BUCKETS: process.env.QE_BUCKET_CACHE_SEGMENT_BUCKETS?.trim() || "120",
-				// Both of the next two knobs are bounded by Cloudflare's
-				// six-simultaneous-connection limit, which `cache.match()` counts
-				// against while it waits for response headers. Keep the deploy-time
-				// values in step with the reasoning in `bucket-cache.ts` and
-				// `edge-cache.ts` — a stale override here silently defeats a tuned
-				// default, which is exactly what happened when these were pinned to
-				// 16/250 and the code defaults moved to 6/40 underneath them.
-				QE_BUCKET_CACHE_READ_CONCURRENCY: process.env.QE_BUCKET_CACHE_READ_CONCURRENCY?.trim() || "6",
-				EDGE_CACHE_READ_TIMEOUT_MS: process.env.EDGE_CACHE_READ_TIMEOUT_MS?.trim() || "40",
-				// MAPLE_ENDPOINT / MAPLE_ENVIRONMENT / COMMIT_SHA / MAPLE_INGEST_KEY.
-				...selfObservabilityEnv(stage),
-				// Agent LLM path. `MAPLE_LLM_PROVIDER` flips between OpenRouter (default) and
-				// Workers AI; both stay wired, so a switch is this one var plus a redeploy.
-				// See `@/platform/Llm` for the provider-scoped model overrides.
-				...optionalPlain("MAPLE_LLM_PROVIDER"),
-				...optionalPlain("MAPLE_TRIAGE_MODEL_OPENROUTER"),
-				...optionalPlain("MAPLE_TRIAGE_MODEL_WORKERS_AI"),
-				...optionalSecret("OPENROUTER_API_KEY"),
-				// Svix signing secrets for the public webhook receivers (`/webhooks/clerk`,
-				// `/webhooks/autumn`); each route answers 503 until its secret is set.
-				...optionalSecret("CLERK_WEBHOOK_SECRET"),
-				...optionalSecret("AUTUMN_WEBHOOK_SECRET"),
-				// Server-side product events default to MAPLE_INGEST_KEY (below); set this
-				// only if the funnel should land in a different org than the API's traces.
-				...optionalSecret("MAPLE_PRODUCT_EVENTS_INGEST_KEY"),
-				...optionalSecret("AUTUMN_SECRET_KEY"),
-				// Billing details (company name, address, tax IDs) are written to the
-				// Stripe customer Autumn links; Autumn itself has no API for them.
-				...optionalSecret("STRIPE_SECRET_KEY"),
-				...optionalSecret("SD_INTERNAL_TOKEN"),
-				...optionalSecret("INTERNAL_SERVICE_TOKEN"),
-				...optionalPlain("HAZEL_API_BASE_URL"),
-				...optionalPlain("HAZEL_OAUTH_DISCOVERY_URL"),
-				...optionalPlain("HAZEL_OAUTH_CLIENT_ID"),
-				...optionalSecret("HAZEL_OAUTH_CLIENT_SECRET"),
-				...optionalPlain("HAZEL_OAUTH_SCOPES"),
-				// Slack integration (bot install via OAuth v2)
-				...optionalPlain("SLACK_CLIENT_ID"),
-				...optionalSecret("SLACK_CLIENT_SECRET"),
-				...optionalSecret("SLACK_INTERNAL_SERVICE_TOKEN"),
-				...apnsEnv(),
-				...optionalPlain("GITHUB_APP_ID"),
-				...optionalPlain("GITHUB_APP_SLUG"),
-				...optionalSecret("GITHUB_APP_PRIVATE_KEY"),
-				...optionalPlain("GITHUB_APP_CLIENT_ID"),
-				...optionalSecret("GITHUB_APP_CLIENT_SECRET"),
-				...optionalSecret("GITHUB_APP_WEBHOOK_SECRET"),
-				...optionalPlain("GITHUB_API_BASE_URL"),
-				...cloudflareOAuthEnv(),
-				...planetScaleOAuthEnv(),
+				...configuredEnv,
 			},
 		})) as MapleApiWorker
 

--- a/apps/electric-sync/alchemy.run.ts
+++ b/apps/electric-sync/alchemy.run.ts
@@ -1,31 +1,9 @@
 import path from "node:path"
 import * as Cloudflare from "alchemy/Cloudflare"
 import * as Effect from "effect/Effect"
-import * as Redacted from "effect/Redacted"
 import type { MapleDomains, MapleStage } from "@maple/infra/cloudflare"
-import {
-	CLOUDFLARE_WORKER_PLACEMENT,
-	resolveDeploymentEnvironment,
-	resolveWorkerName,
-} from "@maple/infra/cloudflare"
-
-const requireEnv = (key: string): string => {
-	const value = process.env[key]?.trim()
-	if (!value) {
-		throw new Error(`Missing required deployment env: ${key}`)
-	}
-	return value
-}
-
-const optionalPlain = (key: string, fallback?: string): Record<string, string> => {
-	const value = process.env[key]?.trim() || fallback
-	return value ? { [key]: value } : {}
-}
-
-const optionalSecret = (key: string): Record<string, Redacted.Redacted<string>> => {
-	const value = process.env[key]?.trim()
-	return value ? { [key]: Redacted.make(value) } : {}
-}
+import { CLOUDFLARE_WORKER_PLACEMENT, resolveWorkerName } from "@maple/infra/cloudflare"
+import { authEnv, optionalPlain, optionalSecret, selfObservabilityEnv } from "@maple/infra/env"
 
 export interface CreateElectricSyncWorkerOptions {
 	stage: MapleStage
@@ -49,13 +27,8 @@ export const createElectricSyncWorker = ({ stage, domains }: CreateElectricSyncW
 			domain: domains.sync,
 			env: {
 				// Auth (same AuthEnv subset the api worker sets; no DB).
-				MAPLE_AUTH_MODE: process.env.MAPLE_AUTH_MODE?.trim() || "self_hosted",
-				MAPLE_DEFAULT_ORG_ID: process.env.MAPLE_DEFAULT_ORG_ID?.trim() || "default",
+				...authEnv(),
 				...optionalPlain("MAPLE_ORG_ID_OVERRIDE"),
-				...optionalSecret("MAPLE_ROOT_PASSWORD"),
-				...optionalSecret("CLERK_SECRET_KEY"),
-				...optionalPlain("CLERK_PUBLISHABLE_KEY"),
-				...optionalSecret("CLERK_JWT_KEY"),
 				// ElectricSQL upstream: base URL (Electric Cloud in prod) + Cloud source
 				// credentials. The shape proxy 503s if URL is unset.
 				//
@@ -72,15 +45,10 @@ export const createElectricSyncWorker = ({ stage, domains }: CreateElectricSyncW
 						}
 					: undefined),
 				// Self-observability (OTLP export through the ingest gateway).
-				MAPLE_INGEST_KEY: Redacted.make(requireEnv("MAPLE_OTEL_INGEST_KEY")),
-				...optionalPlain("MAPLE_ENDPOINT"),
-				...optionalPlain("MAPLE_ENVIRONMENT", resolveDeploymentEnvironment(stage)),
-				// GITHUB_SHA fallback so a deploy that did not export COMMIT_SHA still
-				// stamps a build. An unstamped Worker reports no `service.version`, and
-				// the error evaluator treats a build it cannot identify as a regression —
-				// so a missing binding quietly restores the behaviour where any occurrence
-				// reopens a fixed issue. Matches what apps/ingest already does.
-				...optionalPlain("COMMIT_SHA", process.env.GITHUB_SHA?.trim()),
+				// NOTE: MAPLE_ENVIRONMENT used to be `optionalPlain(…, stageDefault)` here,
+				// which let `process.env` win — the exact override `api` and `alerting`
+				// both guard against. It is stage-derived now, like theirs.
+				...selfObservabilityEnv(stage),
 			},
 		})
 

--- a/apps/electric-sync/alchemy.run.ts
+++ b/apps/electric-sync/alchemy.run.ts
@@ -3,7 +3,7 @@ import * as Cloudflare from "alchemy/Cloudflare"
 import * as Effect from "effect/Effect"
 import type { MapleDomains, MapleStage } from "@maple/infra/cloudflare"
 import { CLOUDFLARE_WORKER_PLACEMENT, resolveWorkerName } from "@maple/infra/cloudflare"
-import { authEnv, optionalPlain, optionalSecret, selfObservabilityEnv } from "@maple/infra/env"
+import { authEnv, merge, optionalPlain, optionalSecret, selfObservabilityEnv } from "@maple/infra/env"
 
 export interface CreateElectricSyncWorkerOptions {
 	stage: MapleStage
@@ -13,8 +13,36 @@ export interface CreateElectricSyncWorkerOptions {
 // Standalone ElectricSQL shape-proxy worker. Deliberately DB-free: it authenticates
 // callers from the Clerk / self-hosted session bearer only (no Hyperdrive / MAPLE_DB
 // binding), pins each shape's org scope, and forwards to Electric.
+const electricSyncConfiguredEnv = (stage: MapleStage) =>
+	merge(
+		// Auth (same AuthEnv subset the api worker sets; no DB).
+		authEnv,
+		optionalPlain("MAPLE_ORG_ID_OVERRIDE"),
+		// ElectricSQL upstream: base URL (Electric Cloud in prod) + Cloud source
+		// credentials. The shape proxy 503s if URL is unset.
+		//
+		// PR previews get none of the three on purpose: they no longer have a
+		// PlanetScale branch, so there is no per-PR Electric source to point at, and
+		// inheriting the shared `dev` credentials would proxy preview shapes against
+		// another stage's data. Absent ELECTRIC_URL → 503 → the web app falls back
+		// to its effect-atom fetches.
+		...(stage.kind === "pr"
+			? []
+			: [
+					optionalPlain("ELECTRIC_URL"),
+					optionalPlain("ELECTRIC_SOURCE_ID"),
+					optionalSecret("ELECTRIC_SECRET"),
+				]),
+		// Self-observability (OTLP export through the ingest gateway).
+		// NOTE: MAPLE_ENVIRONMENT used to be `optionalPlain(…, stageDefault)` here,
+		// which let the environment win — the exact override `api` and `alerting`
+		// both guard against. It is stage-derived now, like theirs.
+		selfObservabilityEnv(stage),
+	)
+
 export const createElectricSyncWorker = ({ stage, domains }: CreateElectricSyncWorkerOptions) =>
 	Effect.gen(function* () {
+		const configuredEnv = yield* electricSyncConfiguredEnv(stage)
 		const worker = yield* Cloudflare.Worker("electric-sync", {
 			name: resolveWorkerName("electric-sync", stage),
 			main: path.join(import.meta.dirname, "src", "worker.ts"),
@@ -25,31 +53,7 @@ export const createElectricSyncWorker = ({ stage, domains }: CreateElectricSyncW
 			// pr-stage hostnames would be authoritative NXDOMAIN. Custom domains
 			// provision DNS + edge certs automatically.
 			domain: domains.sync,
-			env: {
-				// Auth (same AuthEnv subset the api worker sets; no DB).
-				...authEnv(),
-				...optionalPlain("MAPLE_ORG_ID_OVERRIDE"),
-				// ElectricSQL upstream: base URL (Electric Cloud in prod) + Cloud source
-				// credentials. The shape proxy 503s if URL is unset.
-				//
-				// PR previews get none of the three on purpose: they no longer have a
-				// PlanetScale branch, so there is no per-PR Electric source to point at,
-				// and inheriting the shared `dev` credentials would proxy preview shapes
-				// against another stage's data. Absent ELECTRIC_URL → 503 → the web app
-				// falls back to its effect-atom fetches.
-				...(!(stage.kind === "pr")
-					? {
-							...optionalPlain("ELECTRIC_URL"),
-							...optionalPlain("ELECTRIC_SOURCE_ID"),
-							...optionalSecret("ELECTRIC_SECRET"),
-						}
-					: undefined),
-				// Self-observability (OTLP export through the ingest gateway).
-				// NOTE: MAPLE_ENVIRONMENT used to be `optionalPlain(…, stageDefault)` here,
-				// which let `process.env` win — the exact override `api` and `alerting`
-				// both guard against. It is stage-derived now, like theirs.
-				...selfObservabilityEnv(stage),
-			},
+			env: configuredEnv,
 		})
 
 		return worker

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -22,7 +22,7 @@ import { resolveDeploymentEnvironment } from "@maple/infra/cloudflare"
 // Only the primitives. The grouped helpers in that module return Worker-binding
 // shapes (Redacted secrets inline); these values feed ECS `env:` and Secrets
 // Manager ARNs instead, so the gateway composes them itself.
-import { optionalPlain, requireEnv } from "@maple/infra/env"
+import { merge, optionalPlain, requiredPlain } from "@maple/infra/env"
 
 /**
  * Binary the deploy workflows compile ahead of time (with a warm cargo cache)
@@ -183,19 +183,19 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 				tags: { Service: "maple-ingest", Region: region },
 			})
 
-		const tinybirdToken = yield* secret("tinybird-token", requireEnv("TINYBIRD_TOKEN"))
+		const tinybirdToken = yield* secret("tinybird-token", yield* requiredPlain("TINYBIRD_TOKEN"))
 		// Deliberately NOT `MAPLE_PG_URL`. That one is the direct-5432 admin URL the
 		// deploy workflows use for DDL; the gateway must reach Postgres through
 		// PSBouncer (6432) as a role that only reads ingest keys. Sharing the name
 		// would silently hand every task the migration admin's credentials.
-		const pgUrl = yield* secret("maple-pg-url", requireEnv("MAPLE_INGEST_PG_URL"))
+		const pgUrl = yield* secret("maple-pg-url", yield* requiredPlain("MAPLE_INGEST_PG_URL"))
 		const keyEncryptionKey = yield* secret(
 			"ingest-key-encryption-key",
-			requireEnv("MAPLE_INGEST_KEY_ENCRYPTION_KEY"),
+			yield* requiredPlain("MAPLE_INGEST_KEY_ENCRYPTION_KEY"),
 		)
 		const keyLookupHmacKey = yield* secret(
 			"ingest-key-lookup-hmac-key",
-			requireEnv("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
+			yield* requiredPlain("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
 		)
 
 		// Optional credentials — absent in a stage that hasn't enabled the feature.
@@ -215,7 +215,10 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 		// later.
 		const replayR2Endpoint = process.env.INGEST_REPLAY_R2_ENDPOINT?.trim()
 		const replayR2Secret = replayR2Endpoint
-			? yield* secret("replay-r2-secret-access-key", requireEnv("INGEST_REPLAY_R2_SECRET_ACCESS_KEY"))
+			? yield* secret(
+					"replay-r2-secret-access-key",
+					yield* requiredPlain("INGEST_REPLAY_R2_SECRET_ACCESS_KEY"),
+				)
 			: undefined
 
 		// ── OTel collector ──────────────────────────────────────────────────
@@ -304,7 +307,7 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 
 						// The same Tinybird target and token the gateway writes with.
 						secrets: { TINYBIRD_TOKEN: tinybirdToken.secretArn },
-						env: { TINYBIRD_HOST: requireEnv("TINYBIRD_HOST") },
+						env: { TINYBIRD_HOST: yield* requiredPlain("TINYBIRD_HOST") },
 
 						tags: { Service: "maple-ingest", Region: region },
 					})
@@ -401,7 +404,7 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 			env: {
 				INGEST_PORT: String(INGEST_PORT),
 				MAPLE_ENVIRONMENT: resolveDeploymentEnvironment(stage),
-				TINYBIRD_HOST: requireEnv("TINYBIRD_HOST"),
+				TINYBIRD_HOST: yield* requiredPlain("TINYBIRD_HOST"),
 				INGEST_KEY_STORE_BACKEND: "postgres",
 
 				// Trust `Cf-IPCountry` on inbound requests, which is what gates
@@ -421,14 +424,16 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 				// single-digit dollars a month; moving them to S3 would save nothing
 				// and would require a SigV4 or presigned read path in the Worker
 				// (`apps/api/src/platform/ReplayBlobStore.ts` uses the native R2
-				// binding). `requireEnv` on the companions rather than
+				// binding). `requiredPlain` on the companions rather than
 				// `optionalPlain`, so a half-set config fails the deploy instead of
 				// reaching a task that refuses to boot.
 				...(replayR2Endpoint
 					? {
 							INGEST_REPLAY_R2_ENDPOINT: replayR2Endpoint,
-							INGEST_REPLAY_R2_BUCKET: requireEnv("INGEST_REPLAY_R2_BUCKET"),
-							INGEST_REPLAY_R2_ACCESS_KEY_ID: requireEnv("INGEST_REPLAY_R2_ACCESS_KEY_ID"),
+							INGEST_REPLAY_R2_BUCKET: yield* requiredPlain("INGEST_REPLAY_R2_BUCKET"),
+							INGEST_REPLAY_R2_ACCESS_KEY_ID: yield* requiredPlain(
+								"INGEST_REPLAY_R2_ACCESS_KEY_ID",
+							),
 							...optionalPlain("INGEST_REPLAY_R2_REGION", "auto"),
 						}
 					: undefined),

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -19,6 +19,10 @@ import {
 } from "@maple/infra/aws"
 import type { MapleDomains, MapleStage } from "@maple/infra/cloudflare"
 import { resolveDeploymentEnvironment } from "@maple/infra/cloudflare"
+// Only the primitives. The grouped helpers in that module return Worker-binding
+// shapes (Redacted secrets inline); these values feed ECS `env:` and Secrets
+// Manager ARNs instead, so the gateway composes them itself.
+import { optionalPlain, requireEnv } from "@maple/infra/env"
 
 /**
  * Binary the deploy workflows compile ahead of time (with a warm cargo cache)
@@ -45,19 +49,6 @@ const PREBUILT_DOCKERFILE = resolve("apps/ingest/Dockerfile.prebuilt")
  */
 const COLLECTOR_CONTEXT = "packages/infra/otel-collector"
 const COLLECTOR_DOCKERFILE = resolve(COLLECTOR_CONTEXT, "Dockerfile")
-
-const requireEnv = (key: string): string => {
-	const value = process.env[key]?.trim()
-	if (!value) {
-		throw new Error(`Missing required deployment env: ${key}`)
-	}
-	return value
-}
-
-const optionalPlain = (key: string, fallback?: string): Record<string, string> => {
-	const value = process.env[key]?.trim() || fallback
-	return value ? { [key]: value } : {}
-}
 
 /** Port the gateway binds (`apps/ingest/Dockerfile` EXPOSEs the same). */
 const INGEST_PORT = 3474

--- a/bun.lock
+++ b/bun.lock
@@ -605,6 +605,9 @@
     },
     "packages/infra": {
       "name": "@maple/infra",
+      "dependencies": {
+        "effect": "catalog:effect",
+      },
       "devDependencies": {
         "@types/node": "catalog:tooling",
         "typescript": "catalog:tooling",

--- a/bun.lock
+++ b/bun.lock
@@ -606,6 +606,7 @@
     "packages/infra": {
       "name": "@maple/infra",
       "dependencies": {
+        "@maple/effect-cloudflare": "workspace:*",
         "effect": "catalog:effect",
       },
       "devDependencies": {

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -18,8 +18,18 @@ put it here instead. Git blame does not survive a refactor of the line it annota
   groups. Pure functions, unit-tested, no cloud calls.
   - `cloudflare/stage.ts` — `MapleStage`, domains, worker names, Hyperdrive resolution.
   - `aws/stage.ts` — `MapleRegion`, AWS naming, task sizing, Cloud Map.
-  - `env.ts` — `requireEnv` / `optionalPlain` / `optionalSecret` and the shared env
-    groups the workers spread.
+  - `env.ts` — the deploy-time env primitives and the shared groups the workers spread.
+
+**Read deploy-time config through `@maple/infra/env`, not `process.env`.** Alchemy resolves
+config through a ConfigProvider built as `fromDotEnv(--env-file ?? ".env")` **orElse**
+`fromEnv()` (`alchemy/Util/ConfigProvider.ts`), and never copies the file-sourced values
+into `process.env`. A `process.env` read therefore silently ignores `.env` and
+`--env-file` — and does so *selectively*, since alchemy's own settings
+(`CLOUDFLARE_ACCOUNT_ID`, `CI`, …) still pick them up, so half the deploy sees the file and
+half does not. `Config` also reports every missing key in one pass instead of throwing on
+the first, and keeps the failure in the typed error channel. `packages/alchemy-maple`'s
+`MapleEnvironment` is the same pattern inside a provider; the runtime worker env schemas
+use `@maple/effect-cloudflare/config-helpers`, which `env.ts` builds on.
 
 ## Local dev, and the `alchemy dev` question
 

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -1,0 +1,202 @@
+# Infrastructure notes
+
+Background for the Alchemy stack (`alchemy.run.ts` + `apps/*/alchemy.run.ts` +
+`packages/infra`). The stack files keep the rationale a reader needs **in order not to
+break the code**; the history behind those decisions lives here, so the config stays
+readable and the incidents stay findable.
+
+If you are about to delete a comment in a stack file because "the history is in git" —
+put it here instead. Git blame does not survive a refactor of the line it annotates.
+
+## Layout
+
+- `alchemy.run.ts` — the root stack. Composes one `create*` factory per app, resolves
+  stage/domains, and returns the deploy summary (also emitted as GitHub step outputs).
+- `apps/<app>/alchemy.run.ts` — one factory per deployable. Owns that app's resources and
+  bindings, and nothing else's.
+- `packages/infra` — stage/region/domain/naming logic and the shared deploy-time env
+  groups. Pure functions, unit-tested, no cloud calls.
+  - `cloudflare/stage.ts` — `MapleStage`, domains, worker names, Hyperdrive resolution.
+  - `aws/stage.ts` — `MapleRegion`, AWS naming, task sizing, Cloud Map.
+  - `env.ts` — `requireEnv` / `optionalPlain` / `optionalSecret` and the shared env
+    groups the workers spread.
+
+## Local dev, and the `alchemy dev` question
+
+Local dev runs through **wrangler** today (`bun dev` → turbo → per-app `wrangler dev`
+behind the portless `.localhost` proxy). That is why each Worker app carries a
+`wrangler.jsonc` alongside its `alchemy.run.ts`, and why crons, DO classes, KV bindings and
+rate limiters are declared twice. The duplication is real and has already drifted:
+`apps/api/wrangler.jsonc` declares one of the three rate limiters the stack deploys.
+
+`alchemy dev` is the obvious way out — one definition, no mirroring. **Spiked 2026-08-23,
+result: promising but not yet proven.** What was established, running
+`alchemy dev spike.run.ts --stage dev_spike` against a throwaway stack containing only
+`apps/electric-sync`, with `ALCHEMY_LOCAL_STATE=1`:
+
+- It works end to end at the stack level. Alchemy reconciled the Worker, wrote
+  `.alchemy/state/…/electric-sync.json` with `status: "created"`, and **started workerd**,
+  which listened on `localhost:1337`. No account state was touched.
+- The rendered bindings were correct, including the stage-derived `MAPLE_ENVIRONMENT:
+  "development"` and the correct *absence* of every unset optional key.
+- **But nothing served.** Every request to `localhost:1337` timed out (`curl` exit 28)
+  even after the resource reached `created`. The port was open; the request path was not.
+  Not diagnosed — could be the spike stack, the missing `ELECTRIC_URL`, or dev-mode
+  routing.
+
+So it is not a "flip the switch" migration. Before committing, finish the spike and answer:
+
+- Why did the open port not serve? That is the blocker.
+- Do KV, DO (+ SQLite migrations), Workflows, `RateLimit`, `send_email`, the Queues
+  consumer and Assets all resolve locally? `Cloudflare/Local.ts` registers local providers
+  for Workers, Containers, Queues, Consumers, D1 and Secrets Store — **the rest of that
+  list is unverified**, and it is most of what `apps/api` binds.
+- Does it coexist with the portless proxy and `turbo dev`, or does it want to own the
+  process tree? Each Worker takes a `dev: { host, port, strictPort }`, which maps onto the
+  existing per-app ports, so this looks tractable.
+- Is `@alchemy.run/cloudflare-runtime` (a dependency of alchemy, pinned to the same beta)
+  stable enough to sit under everyone's dev loop?
+
+**Until that lands**, do not hand-fix the mirroring — make it self-policing. A CI check
+that parses each `wrangler.jsonc` and asserts its crons, DO class names, KV bindings and
+rate-limit namespace ids match what the app's `create*` factory declares turns a silent
+drift into a failing build, and stays useful right up until the wrangler files are deleted.
+
+## The AWS opt-in flag (`MAPLE_DEPLOY_AWS_INGEST`)
+
+The Rust OTLP gateway (`apps/ingest`) moved from Railway to ECS Fargate. The flag gates
+both `AWS.providers()` and the ingest resources.
+
+It is often mistaken for dead code. It is not — see the comment on `DEPLOY_AWS_INGEST` in
+`alchemy.run.ts` for the two live reasons (it is the staging cost gate, and the providers
+Layer is built before the stage is readable).
+
+**The #378 hang.** The flag was *also* introduced because turning the AWS half on wedged
+every production deploy with no log line and no network I/O. The cause was alchemy's
+env-credential path (`CI=true`): it discovered the account with an STS `GetCallerIdentity`
+issued while its own `AWSEnvironment` was still being constructed, and that call waited on
+the half-built environment for its endpoint resolver — a self-deadlock. Supplying
+`AWS_ACCOUNT_ID` skips the lookup. Reproduced locally with `CI=true` and the id unset, on
+alchemy 2.0.0-beta.64 through beta.74. The deploy workflows now set it. This part is fixed
+and is no longer a reason the flag exists.
+
+**Why the binary is compiled outside the image build.** Alchemy's docker build passes no
+`--cache-from`, and a fresh runner's layer cache is empty, so a Dockerfile that runs
+`cargo build` recompiles all 385 crates on every deploy however the layers are arranged.
+Cold cost is **2m54s, measured** — an earlier version of this note guessed ~20 minutes,
+which was wrong by ~7x and had already been quoted back as fact in a code review, so treat
+the number as load-bearing. The workflow compiles inside `rust:1.94-bookworm` rather than
+on the runner because the runtime base is `debian:bookworm-slim` (glibc 2.36) while
+`ubuntu-24.04` ships 2.39 — a host-built binary dies with `version 'GLIBC_2.39' not found`.
+
+## Hyperdrive: why api and alerting have separate configs
+
+Measured over 6h on prd: `alerting` issued 60,688 Postgres queries/hour against the api's
+1,415 — 97% versus 2%. Sharing one Hyperdrive config meant sharing one origin connection
+pool, and the api spent its time queueing behind the alerting crons. A dial that found a
+free slot took 12ms; one that did not stalled until Hyperdrive's 15s connection timeout,
+which is what put `maple-api`'s p99 at 15.4s.
+
+The two configs **partition** the origin's connections rather than creating more: the
+per-config `origin_connection_limit`s sum against the branch's `max_connections`, and
+Hyperdrive will not coordinate between them, so over-provisioning one starves the other at
+the database rather than at the pool.
+
+**Open item — staging points at production.** `resolveHyperdriveRefId` returns the prd
+config for `stg` (owner decision, 2026-07-14). stg workers therefore read and write the
+production database, and the stg alerting crons overlap prod's. `MAPLE_ALERTING_ALLOW_NONPROD`
+exists to keep those crons off for exactly this reason. Fixing it means a PlanetScale `stg`
+branch plus dedicated `maple-stg` / `maple-alerting-stg` dashboard configs, split per
+consumer the same way prd is — and then a deliberate decision about whether stg crons
+should run.
+
+## The cold-start regression (`strictExecutionOrder: false`)
+
+alchemy ≥ beta.70 sets rolldown `strictExecutionOrder: true`, which wraps ~every chunk in a
+lazy `__esmMin` initializer. The DB module graph (drizzle `pgTable` schemas + Effect Schema
+ASTs) then evaluates on first use — inside the first Postgres call of each fresh isolate —
+instead of at script startup. That stepped the cold dial from ~2s to ~9-11s on 2026-08-08
+(deploy 2679ba80) and produced the CONNECT_TIMEOUT incident; see the 2026-08-11
+investigation.
+
+The override in `apps/api/alchemy.run.ts` moves that cost back to script startup, off the
+request path. If chunking ever regresses into upstream #749 (`ScriptStartupError: Cannot
+access '<minified>' before initialization`), the deploy fails loudly at upload — remove the
+override and warm the DB graph off the request path instead.
+
+## Alchemy v1 → v2 notes
+
+The stack was written against alchemy v1 and migrated to v2. Equivalences worth knowing
+when reading old code or docs:
+
+- **`HyperdriveRef` has no v2 equivalent.** Binding a dashboard-managed config by ID is
+  done by attaching raw `{ type: "hyperdrive", name, id }` binding metadata after the
+  Worker exists (`worker.bind(...)`) — the same mechanism the env binder uses. No cloud
+  resource is created and the origin credentials stay in the dashboard.
+- **`Ai()` became an AI Gateway resource.** v2 emits the `{ type: "ai" }` binding by
+  attaching `Cloudflare.AI.Gateway`, which also fronts model calls with caching,
+  rate-limits and logging. The deploy token needs account-level "AI Gateway: Edit".
+- **`eventSources` became `Queues.Consumer`.** The consumer is a sibling resource pointing
+  at the worker by `scriptName`.
+- **Resource attributes are lazy Outputs.** `worker.url` and friends cannot be
+  string-interpolated at plan time. This is why every deployed stage gets custom domains
+  (`resolveMapleDomains`) and why inter-app URLs are plain strings chosen by the stack
+  rather than read off resources.
+- **DO classes are SQLite-backed by default** in v2.
+
+## Cost decisions
+
+These are cash-flow calls, not design ones, and should be revisited rather than treated as
+architecture:
+
+- **No NAT gateway** in the ingest VPC. NAT bills $0.045/GB *processed* on top of egress,
+  and the gateway exists to push gzipped telemetry outbound — at current volume NAT alone
+  would cost more than the compute and the egress combined, and it scales linearly with
+  growth. Tasks therefore carry public IPs, which is why the security-group split between
+  the ALB and the tasks is load-bearing rather than tidy. The S3 gateway endpoint keeps ECR
+  image pulls off the public path and is free.
+- **Same-region Tinybird.** AWS bills $0.09/GB to the public internet but $0.01/GB to a
+  public IP in the same region, and export traffic dwarfs every other line item — at 200k
+  req/s that is ~$83k/mo vs ~$16k/mo. A workspace on `https://api.tinybird.co` is GCP
+  Frankfurt, where NO AWS region colocates and the move costs more than Railway did.
+  Verify `TINYBIRD_HOST` before changing `resolveAwsRegion`.
+- **The OTel collector is prd-only** (`stageDeploysCollector`). The intent is every stage
+  that deploys the gateway, at ~$13.5/mo per stage at the non-prd size. `MAPLE_DEPLOY_AWS_COLLECTOR=1`
+  opts a single deploy in, which is how it was verified on Fargate before it reached prod.
+- **PR previews get no database and no ingest fleet.** PlanetScale PR branches billed
+  continuously and consumed the account's Hyperdrive config cap; a VPC + ALB per PR is real
+  money for a stack nothing points at. `resolveDatabaseMode` returns `"none"` for `pr`, so
+  DB-backed routes 500 and the rest of the preview works. The reverse path is documented on
+  that function.
+- **x86_64, not Graviton.** Flipping `cpuArchitecture` to `"ARM64"` is the whole switch
+  (~20% cheaper) but needs an ARM builder: cross-compiling Rust under QEMU is 10-30 min a
+  build, for single-digit dollars a month at this size. Revisit with an ARM runner.
+
+## Things that have broken a deploy before
+
+Short list; each has a comment at the site.
+
+- A **relative `dockerfile`** path. Alchemy has flipped how it resolves one between
+  releases — `ECR.Image` joins it onto `context`, the ECS image source (beta.73+) resolves
+  it against the cwd — and each flip broke the deploy. Absolute paths pass through both.
+- **`listenerPort` vs `port`** on `ECS.Service`. `port` is the container port; the listener
+  defaults to 443 once `certificateArn` is set. Setting `listenerPort: INGEST_PORT` puts
+  the listener on 3474, which Cloudflare's proxy does not forward to, *and* drops `port`
+  back to alchemy's default 3000 while the gateway binds 3474 — so no target ever passes
+  `/health`.
+- **A security group that does not admit the listener port.** A stage without an ingest
+  domain gets an HTTP listener on 80, not 443. The first preview deploy came up healthy and
+  timed out on every request for exactly this reason.
+- **An arm64 image on an X86_64 task** — fails at start with "image Manifest does not
+  contain descriptor matching platform 'linux/amd64'". Hence the explicit
+  `runtimePlatform`.
+- **A cargo `--target-dir` inside the image context.** Alchemy hashes the context with
+  `hashDirectory`, which has no `.dockerignore` support and derives exclusions from
+  gitignore rules *without* rebasing root-anchored ones onto the context dir —
+  `/apps/ingest/target` becomes the glob `apps/ingest/target/**` evaluated with
+  `cwd=apps/ingest`, matching nothing. The whole target dir would be walked and hashed on
+  every deploy.
+- **A first deploy of a new stage with the AWS half on.** The ACM certificate lands
+  `PENDING_VALIDATION` and the 443 listener fails. The workflows recover by creating the
+  validation CNAME (`scripts/ingest-cert-validate.sh`) and redeploying; the script is a
+  no-op on an ISSUED certificate.

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -14,6 +14,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@maple/effect-cloudflare": "workspace:*",
 		"effect": "catalog:effect"
 	},
 	"devDependencies": {

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -6,11 +6,15 @@
 		".": "./src/index.ts",
 		"./aws": "./src/aws/index.ts",
 		"./cloudflare": "./src/cloudflare/index.ts",
-		"./dev-urls": "./src/dev-urls.ts"
+		"./dev-urls": "./src/dev-urls.ts",
+		"./env": "./src/env.ts"
 	},
 	"scripts": {
 		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"effect": "catalog:effect"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:tooling",

--- a/packages/infra/src/env.test.ts
+++ b/packages/infra/src/env.test.ts
@@ -1,0 +1,345 @@
+import * as Redacted from "effect/Redacted"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+	apnsEnv,
+	appUrlsEnv,
+	authEnv,
+	cloudflareOAuthEnv,
+	derived,
+	ingestKeyCryptoEnv,
+	optionalPlain,
+	optionalSecret,
+	planetScaleOAuthEnv,
+	requireEnv,
+	requireSecret,
+	selfObservabilityEnv,
+	tinybirdEnv,
+} from "./env.ts"
+
+/**
+ * These groups replaced per-worker copies of the same expressions. The parity
+ * blocks below reconstruct the OLD expressions verbatim (from the pre-refactor
+ * `apps/api` and `apps/alerting` stack files) and assert the group produces an
+ * identical record — that equivalence, not the group's internals, is what keeps
+ * a deploy's Worker bindings unchanged.
+ */
+
+const TOUCHED = [
+	"MAPLE_AUTH_MODE",
+	"MAPLE_DEFAULT_ORG_ID",
+	"MAPLE_ROOT_PASSWORD",
+	"CLERK_SECRET_KEY",
+	"CLERK_PUBLISHABLE_KEY",
+	"CLERK_JWT_KEY",
+	"TINYBIRD_HOST",
+	"TINYBIRD_TOKEN",
+	"TINYBIRD_SIGNING_KEY",
+	"TINYBIRD_WORKSPACE_ID",
+	"TINYBIRD_RAW_SQL_JWT_RPS_LIMIT",
+	"MAPLE_INGEST_KEY_ENCRYPTION_KEY",
+	"MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY",
+	"MAPLE_INGEST_PUBLIC_URL",
+	"MAPLE_APP_BASE_URL",
+	"EMAIL_FROM",
+	"MAPLE_OTEL_INGEST_KEY",
+	"MAPLE_ENDPOINT",
+	"MAPLE_ENVIRONMENT",
+	"COMMIT_SHA",
+	"GITHUB_SHA",
+	"APNS_TEAM_ID",
+	"APNS_KEY_ID",
+	"APNS_PRIVATE_KEY",
+	"CLOUDFLARE_OAUTH_CLIENT_ID",
+	"CLOUDFLARE_OAUTH_CLIENT_SECRET",
+	"CLOUDFLARE_OAUTH_SCOPES",
+	"CLOUDFLARE_OAUTH_AUTHORIZE_URL",
+	"CLOUDFLARE_OAUTH_TOKEN_URL",
+	"CLOUDFLARE_OAUTH_REVOKE_URL",
+	"MAPLE_CLOUDFLARE_API_BASE_URL",
+	"PLANETSCALE_OAUTH_CLIENT_ID",
+	"PLANETSCALE_OAUTH_CLIENT_SECRET",
+	"PLANETSCALE_OAUTH_AUTHORIZE_URL",
+	"PLANETSCALE_OAUTH_TOKEN_URL",
+	"PLANETSCALE_OAUTH_TOKEN_INFO_URL",
+	"MAPLE_PLANETSCALE_API_BASE_URL",
+] as const
+
+const saved = new Map<string, string | undefined>()
+
+beforeEach(() => {
+	for (const key of TOUCHED) {
+		saved.set(key, process.env[key])
+		delete process.env[key]
+	}
+})
+
+afterEach(() => {
+	for (const [key, value] of saved) {
+		if (value === undefined) delete process.env[key]
+		else process.env[key] = value
+	}
+	saved.clear()
+})
+
+/** Compare records where secret values are `Redacted` (which is not deep-equal friendly). */
+const unwrap = (env: Record<string, string | Redacted.Redacted<string>>): Record<string, string> =>
+	Object.fromEntries(
+		Object.entries(env).map(([k, v]) => [k, typeof v === "string" ? v : `redacted:${Redacted.value(v)}`]),
+	)
+
+describe("helpers", () => {
+	it("requireEnv throws on absent, empty and whitespace-only values", () => {
+		expect(() => requireEnv("TINYBIRD_HOST")).toThrow(/Missing required deployment env: TINYBIRD_HOST/)
+		process.env.TINYBIRD_HOST = ""
+		expect(() => requireEnv("TINYBIRD_HOST")).toThrow()
+		process.env.TINYBIRD_HOST = "   "
+		expect(() => requireEnv("TINYBIRD_HOST")).toThrow()
+	})
+
+	it("requireEnv trims", () => {
+		process.env.TINYBIRD_HOST = "  https://api.tinybird.co  "
+		expect(requireEnv("TINYBIRD_HOST")).toBe("https://api.tinybird.co")
+	})
+
+	it("requireSecret redacts rather than exposing the value", () => {
+		process.env.TINYBIRD_TOKEN = "p.secret"
+		const secret = requireSecret("TINYBIRD_TOKEN")
+		expect(String(secret)).not.toContain("p.secret")
+		expect(Redacted.value(secret)).toBe("p.secret")
+	})
+
+	it("omits an unset optional key entirely rather than binding an empty string", () => {
+		expect(optionalPlain("MAPLE_ENDPOINT")).toEqual({})
+		expect(optionalSecret("CLERK_JWT_KEY")).toEqual({})
+		expect("MAPLE_ENDPOINT" in optionalPlain("MAPLE_ENDPOINT")).toBe(false)
+	})
+
+	it("treats a whitespace-only optional value as absent", () => {
+		process.env.MAPLE_ENDPOINT = "   "
+		expect(optionalPlain("MAPLE_ENDPOINT")).toEqual({})
+	})
+
+	it("applies an optionalPlain fallback only when the env var is absent", () => {
+		expect(optionalPlain("MAPLE_ENDPOINT", "https://fallback")).toEqual({
+			MAPLE_ENDPOINT: "https://fallback",
+		})
+		process.env.MAPLE_ENDPOINT = "https://from-env"
+		expect(optionalPlain("MAPLE_ENDPOINT", "https://fallback")).toEqual({
+			MAPLE_ENDPOINT: "https://from-env",
+		})
+	})
+
+	it("omits the key when both the env var and the fallback are absent", () => {
+		expect(optionalPlain("COMMIT_SHA", undefined)).toEqual({})
+	})
+
+	it("derived ignores the environment — that is the whole point of it", () => {
+		process.env.MAPLE_ENVIRONMENT = "production"
+		expect(derived("MAPLE_ENVIRONMENT", "pr-42")).toEqual({ MAPLE_ENVIRONMENT: "pr-42" })
+	})
+})
+
+describe("selfObservabilityEnv", () => {
+	beforeEach(() => {
+		process.env.MAPLE_OTEL_INGEST_KEY = "maple_ak_test"
+	})
+
+	it("derives MAPLE_ENVIRONMENT from the stage and refuses an env override", () => {
+		process.env.MAPLE_ENVIRONMENT = "production"
+		expect(selfObservabilityEnv({ kind: "pr", prNumber: 42 }).MAPLE_ENVIRONMENT).toBe("pr-42")
+		expect(selfObservabilityEnv({ kind: "stg" }).MAPLE_ENVIRONMENT).toBe("staging")
+		expect(selfObservabilityEnv({ kind: "prd" }).MAPLE_ENVIRONMENT).toBe("production")
+	})
+
+	it("falls back to GITHUB_SHA when COMMIT_SHA is unset", () => {
+		process.env.GITHUB_SHA = "abc123"
+		expect(selfObservabilityEnv({ kind: "prd" }).COMMIT_SHA).toBe("abc123")
+	})
+
+	it("prefers COMMIT_SHA over GITHUB_SHA", () => {
+		process.env.GITHUB_SHA = "abc123"
+		process.env.COMMIT_SHA = "def456"
+		expect(selfObservabilityEnv({ kind: "prd" }).COMMIT_SHA).toBe("def456")
+	})
+
+	it("omits COMMIT_SHA when neither is set", () => {
+		expect("COMMIT_SHA" in selfObservabilityEnv({ kind: "prd" })).toBe(false)
+	})
+
+	it("binds the ingest key redacted, under the MAPLE_INGEST_KEY name", () => {
+		const env = selfObservabilityEnv({ kind: "prd" })
+		expect(Redacted.value(env.MAPLE_INGEST_KEY as Redacted.Redacted<string>)).toBe("maple_ak_test")
+		expect("MAPLE_OTEL_INGEST_KEY" in env).toBe(false)
+	})
+})
+
+describe("parity with the pre-refactor per-worker expressions", () => {
+	// Verbatim reconstructions of what api/alerting inlined before the groups existed.
+	const oldOptionalPlain = (key: string, fallback?: string): Record<string, string> => {
+		const value = process.env[key]?.trim() || fallback
+		return value ? { [key]: value } : {}
+	}
+	const oldOptionalSecret = (key: string): Record<string, Redacted.Redacted<string>> => {
+		const value = process.env[key]?.trim()
+		return value ? { [key]: Redacted.make(value) } : {}
+	}
+	const oldRequireEnv = (key: string): string => {
+		const value = process.env[key]?.trim()
+		if (!value) throw new Error(`Missing required deployment env: ${key}`)
+		return value
+	}
+
+	const populate = (keys: ReadonlyArray<string>) => {
+		for (const key of keys) process.env[key] = `value-for-${key}`
+	}
+
+	// A plain loop, not `describe.each` — the typed-tuple inference in `.each`
+	// blows tsc's memory on this repo's config.
+	const cases: ReadonlyArray<readonly [string, boolean]> = [
+		["all shared keys set", true],
+		["every optional key unset", false],
+	]
+	for (const [label, populated] of cases) {
+		describe(label, () => {
+			it("authEnv", () => {
+				if (populated) {
+					populate(["MAPLE_AUTH_MODE", "MAPLE_DEFAULT_ORG_ID", "CLERK_PUBLISHABLE_KEY"])
+					populate(["MAPLE_ROOT_PASSWORD", "CLERK_SECRET_KEY", "CLERK_JWT_KEY"])
+				}
+				const old = {
+					MAPLE_AUTH_MODE: process.env.MAPLE_AUTH_MODE?.trim() || "self_hosted",
+					MAPLE_DEFAULT_ORG_ID: process.env.MAPLE_DEFAULT_ORG_ID?.trim() || "default",
+					...oldOptionalSecret("MAPLE_ROOT_PASSWORD"),
+					...oldOptionalSecret("CLERK_SECRET_KEY"),
+					...oldOptionalPlain("CLERK_PUBLISHABLE_KEY"),
+					...oldOptionalSecret("CLERK_JWT_KEY"),
+				}
+				expect(unwrap(authEnv())).toEqual(unwrap(old))
+			})
+
+			it("tinybirdEnv", () => {
+				populate(["TINYBIRD_HOST", "TINYBIRD_TOKEN"]) // required in both shapes
+				if (populated) {
+					populate([
+						"TINYBIRD_SIGNING_KEY",
+						"TINYBIRD_WORKSPACE_ID",
+						"TINYBIRD_RAW_SQL_JWT_RPS_LIMIT",
+					])
+				}
+				const old = {
+					TINYBIRD_HOST: oldRequireEnv("TINYBIRD_HOST"),
+					TINYBIRD_TOKEN: Redacted.make(oldRequireEnv("TINYBIRD_TOKEN")),
+					...oldOptionalSecret("TINYBIRD_SIGNING_KEY"),
+					...oldOptionalPlain("TINYBIRD_WORKSPACE_ID"),
+					...oldOptionalPlain("TINYBIRD_RAW_SQL_JWT_RPS_LIMIT"),
+				}
+				expect(unwrap(tinybirdEnv())).toEqual(unwrap(old))
+			})
+
+			it("ingestKeyCryptoEnv", () => {
+				populate(["MAPLE_INGEST_KEY_ENCRYPTION_KEY", "MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"])
+				const old = {
+					MAPLE_INGEST_KEY_ENCRYPTION_KEY: Redacted.make(
+						oldRequireEnv("MAPLE_INGEST_KEY_ENCRYPTION_KEY"),
+					),
+					MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: Redacted.make(
+						oldRequireEnv("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
+					),
+				}
+				expect(unwrap(ingestKeyCryptoEnv())).toEqual(unwrap(old))
+			})
+
+			it("appUrlsEnv", () => {
+				if (populated) populate(["MAPLE_INGEST_PUBLIC_URL", "MAPLE_APP_BASE_URL", "EMAIL_FROM"])
+				const old = {
+					MAPLE_INGEST_PUBLIC_URL:
+						process.env.MAPLE_INGEST_PUBLIC_URL?.trim() || "https://ingest.maple.dev",
+					MAPLE_APP_BASE_URL: process.env.MAPLE_APP_BASE_URL?.trim() || "https://app.maple.dev",
+					EMAIL_FROM: process.env.EMAIL_FROM?.trim() || "Maple <notifications@noreply.maple.dev>",
+				}
+				expect(unwrap(appUrlsEnv())).toEqual(unwrap(old))
+			})
+
+			it("selfObservabilityEnv", () => {
+				populate(["MAPLE_OTEL_INGEST_KEY"])
+				if (populated) populate(["MAPLE_ENDPOINT", "COMMIT_SHA"])
+				const old = {
+					MAPLE_INGEST_KEY: Redacted.make(oldRequireEnv("MAPLE_OTEL_INGEST_KEY")),
+					...oldOptionalPlain("MAPLE_ENDPOINT"),
+					MAPLE_ENVIRONMENT: "staging",
+					...oldOptionalPlain("COMMIT_SHA", process.env.GITHUB_SHA?.trim()),
+				}
+				expect(unwrap(selfObservabilityEnv({ kind: "stg" }))).toEqual(unwrap(old))
+			})
+
+			it("apnsEnv", () => {
+				if (populated) populate(["APNS_TEAM_ID", "APNS_KEY_ID", "APNS_PRIVATE_KEY"])
+				const old = {
+					...oldOptionalPlain("APNS_TEAM_ID"),
+					...oldOptionalPlain("APNS_KEY_ID"),
+					...oldOptionalSecret("APNS_PRIVATE_KEY"),
+				}
+				expect(unwrap(apnsEnv())).toEqual(unwrap(old))
+			})
+
+			it("cloudflareOAuthEnv", () => {
+				if (populated) {
+					populate([
+						"CLOUDFLARE_OAUTH_CLIENT_ID",
+						"CLOUDFLARE_OAUTH_CLIENT_SECRET",
+						"CLOUDFLARE_OAUTH_SCOPES",
+						"CLOUDFLARE_OAUTH_AUTHORIZE_URL",
+						"CLOUDFLARE_OAUTH_TOKEN_URL",
+						"CLOUDFLARE_OAUTH_REVOKE_URL",
+						"MAPLE_CLOUDFLARE_API_BASE_URL",
+					])
+				}
+				const old = {
+					...oldOptionalPlain("CLOUDFLARE_OAUTH_CLIENT_ID"),
+					...oldOptionalSecret("CLOUDFLARE_OAUTH_CLIENT_SECRET"),
+					...oldOptionalPlain("CLOUDFLARE_OAUTH_SCOPES"),
+					...oldOptionalPlain("CLOUDFLARE_OAUTH_AUTHORIZE_URL"),
+					...oldOptionalPlain("CLOUDFLARE_OAUTH_TOKEN_URL"),
+					...oldOptionalPlain("CLOUDFLARE_OAUTH_REVOKE_URL"),
+					...oldOptionalPlain("MAPLE_CLOUDFLARE_API_BASE_URL"),
+				}
+				expect(unwrap(cloudflareOAuthEnv())).toEqual(unwrap(old))
+			})
+
+			it("planetScaleOAuthEnv matches the api worker's set", () => {
+				if (populated) {
+					populate([
+						"PLANETSCALE_OAUTH_CLIENT_ID",
+						"PLANETSCALE_OAUTH_CLIENT_SECRET",
+						"PLANETSCALE_OAUTH_AUTHORIZE_URL",
+						"PLANETSCALE_OAUTH_TOKEN_URL",
+						"PLANETSCALE_OAUTH_TOKEN_INFO_URL",
+						"MAPLE_PLANETSCALE_API_BASE_URL",
+					])
+				}
+				const old = {
+					...oldOptionalPlain("PLANETSCALE_OAUTH_CLIENT_ID"),
+					...oldOptionalSecret("PLANETSCALE_OAUTH_CLIENT_SECRET"),
+					...oldOptionalPlain("PLANETSCALE_OAUTH_AUTHORIZE_URL"),
+					...oldOptionalPlain("PLANETSCALE_OAUTH_TOKEN_URL"),
+					...oldOptionalPlain("PLANETSCALE_OAUTH_TOKEN_INFO_URL"),
+					...oldOptionalPlain("MAPLE_PLANETSCALE_API_BASE_URL"),
+				}
+				expect(unwrap(planetScaleOAuthEnv())).toEqual(unwrap(old))
+			})
+		})
+	}
+
+	/**
+	 * The one deliberate behaviour change. `alerting` previously omitted
+	 * PLANETSCALE_OAUTH_TOKEN_INFO_URL while `api` bound it, even though both run
+	 * token refresh through PlanetScaleOAuthService. The shared group binds it for
+	 * both; it is optional, so a stage that does not set it is unaffected.
+	 */
+	it("adds TOKEN_INFO_URL to the alerting worker, which api already had", () => {
+		process.env.PLANETSCALE_OAUTH_TOKEN_INFO_URL = "https://auth.planetscale.com/tokeninfo"
+		expect(planetScaleOAuthEnv().PLANETSCALE_OAUTH_TOKEN_INFO_URL).toBe(
+			"https://auth.planetscale.com/tokeninfo",
+		)
+	})
+})

--- a/packages/infra/src/env.test.ts
+++ b/packages/infra/src/env.test.ts
@@ -1,5 +1,8 @@
+import * as Config from "effect/Config"
+import * as ConfigProvider from "effect/ConfigProvider"
+import * as Effect from "effect/Effect"
 import * as Redacted from "effect/Redacted"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { describe, expect, it } from "vitest"
 import {
 	apnsEnv,
 	appUrlsEnv,
@@ -10,188 +13,202 @@ import {
 	optionalPlain,
 	optionalSecret,
 	planetScaleOAuthEnv,
-	requireEnv,
-	requireSecret,
+	plainWithDefault,
+	requiredPlain,
 	selfObservabilityEnv,
 	tinybirdEnv,
+	type WorkerEnv,
 } from "./env.ts"
 
 /**
  * These groups replaced per-worker copies of the same expressions. The parity
  * blocks below reconstruct the OLD expressions verbatim (from the pre-refactor
- * `apps/api` and `apps/alerting` stack files) and assert the group produces an
- * identical record — that equivalence, not the group's internals, is what keeps
- * a deploy's Worker bindings unchanged.
+ * `apps/api` and `apps/alerting` stack files, with the `process.env` lookup
+ * swapped for an explicit record) and assert the group produces an identical
+ * result — that equivalence, not the group's internals, is what keeps a
+ * deploy's Worker bindings unchanged.
+ *
+ * Everything runs against an explicit `ConfigProvider` rather than by mutating
+ * `process.env`, which is also the point of the refactor: alchemy resolves
+ * config through a provider layered over `.env` / `--env-file`, so that is the
+ * path worth testing.
  */
 
-const TOUCHED = [
-	"MAPLE_AUTH_MODE",
-	"MAPLE_DEFAULT_ORG_ID",
-	"MAPLE_ROOT_PASSWORD",
-	"CLERK_SECRET_KEY",
-	"CLERK_PUBLISHABLE_KEY",
-	"CLERK_JWT_KEY",
-	"TINYBIRD_HOST",
-	"TINYBIRD_TOKEN",
-	"TINYBIRD_SIGNING_KEY",
-	"TINYBIRD_WORKSPACE_ID",
-	"TINYBIRD_RAW_SQL_JWT_RPS_LIMIT",
-	"MAPLE_INGEST_KEY_ENCRYPTION_KEY",
-	"MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY",
-	"MAPLE_INGEST_PUBLIC_URL",
-	"MAPLE_APP_BASE_URL",
-	"EMAIL_FROM",
-	"MAPLE_OTEL_INGEST_KEY",
-	"MAPLE_ENDPOINT",
-	"MAPLE_ENVIRONMENT",
-	"COMMIT_SHA",
-	"GITHUB_SHA",
-	"APNS_TEAM_ID",
-	"APNS_KEY_ID",
-	"APNS_PRIVATE_KEY",
-	"CLOUDFLARE_OAUTH_CLIENT_ID",
-	"CLOUDFLARE_OAUTH_CLIENT_SECRET",
-	"CLOUDFLARE_OAUTH_SCOPES",
-	"CLOUDFLARE_OAUTH_AUTHORIZE_URL",
-	"CLOUDFLARE_OAUTH_TOKEN_URL",
-	"CLOUDFLARE_OAUTH_REVOKE_URL",
-	"MAPLE_CLOUDFLARE_API_BASE_URL",
-	"PLANETSCALE_OAUTH_CLIENT_ID",
-	"PLANETSCALE_OAUTH_CLIENT_SECRET",
-	"PLANETSCALE_OAUTH_AUTHORIZE_URL",
-	"PLANETSCALE_OAUTH_TOKEN_URL",
-	"PLANETSCALE_OAUTH_TOKEN_INFO_URL",
-	"MAPLE_PLANETSCALE_API_BASE_URL",
-] as const
+type Env = Record<string, string>
 
-const saved = new Map<string, string | undefined>()
+const run = <A>(config: Config.Config<A>, env: Env): A =>
+	Effect.runSync(config.parse(ConfigProvider.fromUnknown(env)))
 
-beforeEach(() => {
-	for (const key of TOUCHED) {
-		saved.set(key, process.env[key])
-		delete process.env[key]
-	}
-})
+const runExit = <A>(config: Config.Config<A>, env: Env) =>
+	Effect.runSync(Effect.exit(config.parse(ConfigProvider.fromUnknown(env))))
 
-afterEach(() => {
-	for (const [key, value] of saved) {
-		if (value === undefined) delete process.env[key]
-		else process.env[key] = value
-	}
-	saved.clear()
-})
-
-/** Compare records where secret values are `Redacted` (which is not deep-equal friendly). */
-const unwrap = (env: Record<string, string | Redacted.Redacted<string>>): Record<string, string> =>
+/** Compare records where secret values are `Redacted` (not deep-equal friendly). */
+const unwrap = (env: WorkerEnv): Env =>
 	Object.fromEntries(
 		Object.entries(env).map(([k, v]) => [k, typeof v === "string" ? v : `redacted:${Redacted.value(v)}`]),
 	)
 
-describe("helpers", () => {
-	it("requireEnv throws on absent, empty and whitespace-only values", () => {
-		expect(() => requireEnv("TINYBIRD_HOST")).toThrow(/Missing required deployment env: TINYBIRD_HOST/)
-		process.env.TINYBIRD_HOST = ""
-		expect(() => requireEnv("TINYBIRD_HOST")).toThrow()
-		process.env.TINYBIRD_HOST = "   "
-		expect(() => requireEnv("TINYBIRD_HOST")).toThrow()
+describe("primitives", () => {
+	it("resolves a value present only in the provider, not in process.env", () => {
+		// The regression this refactor exists to prevent: alchemy layers
+		// `fromDotEnv(.env / --env-file)` over `fromEnv()` and never copies those
+		// values into process.env, so a process.env read would miss this entirely.
+		expect("MAPLE_ENDPOINT" in process.env).toBe(false)
+		expect(run(optionalPlain("MAPLE_ENDPOINT"), { MAPLE_ENDPOINT: "https://from-dotenv" })).toEqual({
+			MAPLE_ENDPOINT: "https://from-dotenv",
+		})
 	})
 
-	it("requireEnv trims", () => {
-		process.env.TINYBIRD_HOST = "  https://api.tinybird.co  "
-		expect(requireEnv("TINYBIRD_HOST")).toBe("https://api.tinybird.co")
+	it("requiredPlain fails on absent, empty and whitespace-only values", () => {
+		expect(runExit(requiredPlain("TINYBIRD_HOST"), {})._tag).toBe("Failure")
+		expect(runExit(requiredPlain("TINYBIRD_HOST"), { TINYBIRD_HOST: "" })._tag).toBe("Failure")
+		expect(runExit(requiredPlain("TINYBIRD_HOST"), { TINYBIRD_HOST: "   " })._tag).toBe("Failure")
 	})
 
-	it("requireSecret redacts rather than exposing the value", () => {
-		process.env.TINYBIRD_TOKEN = "p.secret"
-		const secret = requireSecret("TINYBIRD_TOKEN")
-		expect(String(secret)).not.toContain("p.secret")
-		expect(Redacted.value(secret)).toBe("p.secret")
+	it("requiredPlain trims", () => {
+		expect(run(requiredPlain("TINYBIRD_HOST"), { TINYBIRD_HOST: "  https://api.tinybird.co  " })).toBe(
+			"https://api.tinybird.co",
+		)
 	})
 
 	it("omits an unset optional key entirely rather than binding an empty string", () => {
-		expect(optionalPlain("MAPLE_ENDPOINT")).toEqual({})
-		expect(optionalSecret("CLERK_JWT_KEY")).toEqual({})
-		expect("MAPLE_ENDPOINT" in optionalPlain("MAPLE_ENDPOINT")).toBe(false)
+		expect(run(optionalPlain("MAPLE_ENDPOINT"), {})).toEqual({})
+		expect(run(optionalSecret("CLERK_JWT_KEY"), {})).toEqual({})
+		expect("MAPLE_ENDPOINT" in run(optionalPlain("MAPLE_ENDPOINT"), {})).toBe(false)
 	})
 
 	it("treats a whitespace-only optional value as absent", () => {
-		process.env.MAPLE_ENDPOINT = "   "
-		expect(optionalPlain("MAPLE_ENDPOINT")).toEqual({})
+		expect(run(optionalPlain("MAPLE_ENDPOINT"), { MAPLE_ENDPOINT: "   " })).toEqual({})
+		expect(run(optionalSecret("CLERK_JWT_KEY"), { CLERK_JWT_KEY: "  " })).toEqual({})
 	})
 
-	it("applies an optionalPlain fallback only when the env var is absent", () => {
-		expect(optionalPlain("MAPLE_ENDPOINT", "https://fallback")).toEqual({
+	it("trims optional values", () => {
+		expect(run(optionalPlain("MAPLE_ENDPOINT"), { MAPLE_ENDPOINT: " https://x " })).toEqual({
+			MAPLE_ENDPOINT: "https://x",
+		})
+	})
+
+	it("redacts optional secrets", () => {
+		const record = run(optionalSecret("CLERK_JWT_KEY"), { CLERK_JWT_KEY: "jwt-secret" })
+		expect(String(record.CLERK_JWT_KEY)).not.toContain("jwt-secret")
+		expect(Redacted.value(record.CLERK_JWT_KEY!)).toBe("jwt-secret")
+	})
+
+	it("applies an optionalPlain fallback only when the key is absent", () => {
+		expect(run(optionalPlain("MAPLE_ENDPOINT", "https://fallback"), {})).toEqual({
 			MAPLE_ENDPOINT: "https://fallback",
 		})
-		process.env.MAPLE_ENDPOINT = "https://from-env"
-		expect(optionalPlain("MAPLE_ENDPOINT", "https://fallback")).toEqual({
-			MAPLE_ENDPOINT: "https://from-env",
+		expect(
+			run(optionalPlain("MAPLE_ENDPOINT", "https://fallback"), { MAPLE_ENDPOINT: "https://env" }),
+		).toEqual({ MAPLE_ENDPOINT: "https://env" })
+	})
+
+	it("plainWithDefault also falls back for a blank value, unlike Config.withDefault", () => {
+		expect(run(plainWithDefault("MAPLE_AUTH_MODE", "self_hosted"), {})).toEqual({
+			MAPLE_AUTH_MODE: "self_hosted",
 		})
+		expect(run(plainWithDefault("MAPLE_AUTH_MODE", "self_hosted"), { MAPLE_AUTH_MODE: "  " })).toEqual({
+			MAPLE_AUTH_MODE: "self_hosted",
+		})
+		expect(run(plainWithDefault("MAPLE_AUTH_MODE", "self_hosted"), { MAPLE_AUTH_MODE: "clerk" })).toEqual(
+			{ MAPLE_AUTH_MODE: "clerk" },
+		)
 	})
 
-	it("omits the key when both the env var and the fallback are absent", () => {
-		expect(optionalPlain("COMMIT_SHA", undefined)).toEqual({})
-	})
-
-	it("derived ignores the environment — that is the whole point of it", () => {
-		process.env.MAPLE_ENVIRONMENT = "production"
-		expect(derived("MAPLE_ENVIRONMENT", "pr-42")).toEqual({ MAPLE_ENVIRONMENT: "pr-42" })
+	it("derived ignores the provider — that is the whole point of it", () => {
+		expect(run(derived("MAPLE_ENVIRONMENT", "pr-42"), { MAPLE_ENVIRONMENT: "production" })).toEqual({
+			MAPLE_ENVIRONMENT: "pr-42",
+		})
 	})
 })
 
 describe("selfObservabilityEnv", () => {
-	beforeEach(() => {
-		process.env.MAPLE_OTEL_INGEST_KEY = "maple_ak_test"
-	})
+	const base = { MAPLE_OTEL_INGEST_KEY: "maple_ak_test" }
 
-	it("derives MAPLE_ENVIRONMENT from the stage and refuses an env override", () => {
-		process.env.MAPLE_ENVIRONMENT = "production"
-		expect(selfObservabilityEnv({ kind: "pr", prNumber: 42 }).MAPLE_ENVIRONMENT).toBe("pr-42")
-		expect(selfObservabilityEnv({ kind: "stg" }).MAPLE_ENVIRONMENT).toBe("staging")
-		expect(selfObservabilityEnv({ kind: "prd" }).MAPLE_ENVIRONMENT).toBe("production")
+	it("derives MAPLE_ENVIRONMENT from the stage and refuses a provider override", () => {
+		const env = { ...base, MAPLE_ENVIRONMENT: "production" }
+		expect(run(selfObservabilityEnv({ kind: "pr", prNumber: 42 }), env).MAPLE_ENVIRONMENT).toBe("pr-42")
+		expect(run(selfObservabilityEnv({ kind: "stg" }), env).MAPLE_ENVIRONMENT).toBe("staging")
+		expect(run(selfObservabilityEnv({ kind: "prd" }), env).MAPLE_ENVIRONMENT).toBe("production")
+		expect(run(selfObservabilityEnv({ kind: "dev", name: "x" }), env).MAPLE_ENVIRONMENT).toBe(
+			"development",
+		)
 	})
 
 	it("falls back to GITHUB_SHA when COMMIT_SHA is unset", () => {
-		process.env.GITHUB_SHA = "abc123"
-		expect(selfObservabilityEnv({ kind: "prd" }).COMMIT_SHA).toBe("abc123")
+		expect(run(selfObservabilityEnv({ kind: "prd" }), { ...base, GITHUB_SHA: "abc123" }).COMMIT_SHA).toBe(
+			"abc123",
+		)
 	})
 
 	it("prefers COMMIT_SHA over GITHUB_SHA", () => {
-		process.env.GITHUB_SHA = "abc123"
-		process.env.COMMIT_SHA = "def456"
-		expect(selfObservabilityEnv({ kind: "prd" }).COMMIT_SHA).toBe("def456")
+		const env = { ...base, GITHUB_SHA: "abc123", COMMIT_SHA: "def456" }
+		expect(run(selfObservabilityEnv({ kind: "prd" }), env).COMMIT_SHA).toBe("def456")
 	})
 
 	it("omits COMMIT_SHA when neither is set", () => {
-		expect("COMMIT_SHA" in selfObservabilityEnv({ kind: "prd" })).toBe(false)
+		expect("COMMIT_SHA" in run(selfObservabilityEnv({ kind: "prd" }), base)).toBe(false)
 	})
 
 	it("binds the ingest key redacted, under the MAPLE_INGEST_KEY name", () => {
-		const env = selfObservabilityEnv({ kind: "prd" })
+		const env = run(selfObservabilityEnv({ kind: "prd" }), base)
 		expect(Redacted.value(env.MAPLE_INGEST_KEY as Redacted.Redacted<string>)).toBe("maple_ak_test")
 		expect("MAPLE_OTEL_INGEST_KEY" in env).toBe(false)
+	})
+
+	it("fails when the ingest key is missing", () => {
+		expect(runExit(selfObservabilityEnv({ kind: "prd" }), {})._tag).toBe("Failure")
 	})
 })
 
 describe("parity with the pre-refactor per-worker expressions", () => {
-	// Verbatim reconstructions of what api/alerting inlined before the groups existed.
-	const oldOptionalPlain = (key: string, fallback?: string): Record<string, string> => {
-		const value = process.env[key]?.trim() || fallback
+	// Verbatim reconstructions of what api/alerting inlined before the groups
+	// existed, with `process.env` swapped for the record under test.
+	const oldOptionalPlain = (env: Env, key: string, fallback?: string): Env => {
+		const value = env[key]?.trim() || fallback
 		return value ? { [key]: value } : {}
 	}
-	const oldOptionalSecret = (key: string): Record<string, Redacted.Redacted<string>> => {
-		const value = process.env[key]?.trim()
+	const oldOptionalSecret = (env: Env, key: string): Record<string, Redacted.Redacted<string>> => {
+		const value = env[key]?.trim()
 		return value ? { [key]: Redacted.make(value) } : {}
 	}
-	const oldRequireEnv = (key: string): string => {
-		const value = process.env[key]?.trim()
+	const oldRequireEnv = (env: Env, key: string): string => {
+		const value = env[key]?.trim()
 		if (!value) throw new Error(`Missing required deployment env: ${key}`)
 		return value
 	}
 
-	const populate = (keys: ReadonlyArray<string>) => {
-		for (const key of keys) process.env[key] = `value-for-${key}`
-	}
+	const populated = (keys: ReadonlyArray<string>): Env =>
+		Object.fromEntries(keys.map((key) => [key, `value-for-${key}`]))
+
+	const AUTH = ["MAPLE_AUTH_MODE", "MAPLE_DEFAULT_ORG_ID", "CLERK_PUBLISHABLE_KEY"]
+	const AUTH_SECRETS = ["MAPLE_ROOT_PASSWORD", "CLERK_SECRET_KEY", "CLERK_JWT_KEY"]
+	const TINYBIRD_REQUIRED = ["TINYBIRD_HOST", "TINYBIRD_TOKEN"]
+	const TINYBIRD_OPTIONAL = [
+		"TINYBIRD_SIGNING_KEY",
+		"TINYBIRD_WORKSPACE_ID",
+		"TINYBIRD_RAW_SQL_JWT_RPS_LIMIT",
+	]
+	const CRYPTO = ["MAPLE_INGEST_KEY_ENCRYPTION_KEY", "MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"]
+	const APP_URLS = ["MAPLE_INGEST_PUBLIC_URL", "MAPLE_APP_BASE_URL", "EMAIL_FROM"]
+	const APNS = ["APNS_TEAM_ID", "APNS_KEY_ID", "APNS_PRIVATE_KEY"]
+	const CF_OAUTH = [
+		"CLOUDFLARE_OAUTH_CLIENT_ID",
+		"CLOUDFLARE_OAUTH_CLIENT_SECRET",
+		"CLOUDFLARE_OAUTH_SCOPES",
+		"CLOUDFLARE_OAUTH_AUTHORIZE_URL",
+		"CLOUDFLARE_OAUTH_TOKEN_URL",
+		"CLOUDFLARE_OAUTH_REVOKE_URL",
+		"MAPLE_CLOUDFLARE_API_BASE_URL",
+	]
+	const PS_OAUTH = [
+		"PLANETSCALE_OAUTH_CLIENT_ID",
+		"PLANETSCALE_OAUTH_CLIENT_SECRET",
+		"PLANETSCALE_OAUTH_AUTHORIZE_URL",
+		"PLANETSCALE_OAUTH_TOKEN_URL",
+		"PLANETSCALE_OAUTH_TOKEN_INFO_URL",
+		"MAPLE_PLANETSCALE_API_BASE_URL",
+	]
 
 	// A plain loop, not `describe.each` — the typed-tuple inference in `.each`
 	// blows tsc's memory on this repo's config.
@@ -199,146 +216,120 @@ describe("parity with the pre-refactor per-worker expressions", () => {
 		["all shared keys set", true],
 		["every optional key unset", false],
 	]
-	for (const [label, populated] of cases) {
+
+	for (const [label, full] of cases) {
 		describe(label, () => {
 			it("authEnv", () => {
-				if (populated) {
-					populate(["MAPLE_AUTH_MODE", "MAPLE_DEFAULT_ORG_ID", "CLERK_PUBLISHABLE_KEY"])
-					populate(["MAPLE_ROOT_PASSWORD", "CLERK_SECRET_KEY", "CLERK_JWT_KEY"])
-				}
+				const env = full ? populated([...AUTH, ...AUTH_SECRETS]) : {}
 				const old = {
-					MAPLE_AUTH_MODE: process.env.MAPLE_AUTH_MODE?.trim() || "self_hosted",
-					MAPLE_DEFAULT_ORG_ID: process.env.MAPLE_DEFAULT_ORG_ID?.trim() || "default",
-					...oldOptionalSecret("MAPLE_ROOT_PASSWORD"),
-					...oldOptionalSecret("CLERK_SECRET_KEY"),
-					...oldOptionalPlain("CLERK_PUBLISHABLE_KEY"),
-					...oldOptionalSecret("CLERK_JWT_KEY"),
+					MAPLE_AUTH_MODE: env.MAPLE_AUTH_MODE?.trim() || "self_hosted",
+					MAPLE_DEFAULT_ORG_ID: env.MAPLE_DEFAULT_ORG_ID?.trim() || "default",
+					...oldOptionalSecret(env, "MAPLE_ROOT_PASSWORD"),
+					...oldOptionalSecret(env, "CLERK_SECRET_KEY"),
+					...oldOptionalPlain(env, "CLERK_PUBLISHABLE_KEY"),
+					...oldOptionalSecret(env, "CLERK_JWT_KEY"),
 				}
-				expect(unwrap(authEnv())).toEqual(unwrap(old))
+				expect(unwrap(run(authEnv, env))).toEqual(unwrap(old))
 			})
 
 			it("tinybirdEnv", () => {
-				populate(["TINYBIRD_HOST", "TINYBIRD_TOKEN"]) // required in both shapes
-				if (populated) {
-					populate([
-						"TINYBIRD_SIGNING_KEY",
-						"TINYBIRD_WORKSPACE_ID",
-						"TINYBIRD_RAW_SQL_JWT_RPS_LIMIT",
-					])
-				}
+				const env = populated(full ? [...TINYBIRD_REQUIRED, ...TINYBIRD_OPTIONAL] : TINYBIRD_REQUIRED)
 				const old = {
-					TINYBIRD_HOST: oldRequireEnv("TINYBIRD_HOST"),
-					TINYBIRD_TOKEN: Redacted.make(oldRequireEnv("TINYBIRD_TOKEN")),
-					...oldOptionalSecret("TINYBIRD_SIGNING_KEY"),
-					...oldOptionalPlain("TINYBIRD_WORKSPACE_ID"),
-					...oldOptionalPlain("TINYBIRD_RAW_SQL_JWT_RPS_LIMIT"),
+					TINYBIRD_HOST: oldRequireEnv(env, "TINYBIRD_HOST"),
+					TINYBIRD_TOKEN: Redacted.make(oldRequireEnv(env, "TINYBIRD_TOKEN")),
+					...oldOptionalSecret(env, "TINYBIRD_SIGNING_KEY"),
+					...oldOptionalPlain(env, "TINYBIRD_WORKSPACE_ID"),
+					...oldOptionalPlain(env, "TINYBIRD_RAW_SQL_JWT_RPS_LIMIT"),
 				}
-				expect(unwrap(tinybirdEnv())).toEqual(unwrap(old))
+				expect(unwrap(run(tinybirdEnv, env))).toEqual(unwrap(old))
 			})
 
 			it("ingestKeyCryptoEnv", () => {
-				populate(["MAPLE_INGEST_KEY_ENCRYPTION_KEY", "MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"])
+				const env = populated(CRYPTO)
 				const old = {
 					MAPLE_INGEST_KEY_ENCRYPTION_KEY: Redacted.make(
-						oldRequireEnv("MAPLE_INGEST_KEY_ENCRYPTION_KEY"),
+						oldRequireEnv(env, "MAPLE_INGEST_KEY_ENCRYPTION_KEY"),
 					),
 					MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: Redacted.make(
-						oldRequireEnv("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
+						oldRequireEnv(env, "MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
 					),
 				}
-				expect(unwrap(ingestKeyCryptoEnv())).toEqual(unwrap(old))
+				expect(unwrap(run(ingestKeyCryptoEnv, env))).toEqual(unwrap(old))
 			})
 
 			it("appUrlsEnv", () => {
-				if (populated) populate(["MAPLE_INGEST_PUBLIC_URL", "MAPLE_APP_BASE_URL", "EMAIL_FROM"])
+				const env = full ? populated(APP_URLS) : {}
 				const old = {
 					MAPLE_INGEST_PUBLIC_URL:
-						process.env.MAPLE_INGEST_PUBLIC_URL?.trim() || "https://ingest.maple.dev",
-					MAPLE_APP_BASE_URL: process.env.MAPLE_APP_BASE_URL?.trim() || "https://app.maple.dev",
-					EMAIL_FROM: process.env.EMAIL_FROM?.trim() || "Maple <notifications@noreply.maple.dev>",
+						env.MAPLE_INGEST_PUBLIC_URL?.trim() || "https://ingest.maple.dev",
+					MAPLE_APP_BASE_URL: env.MAPLE_APP_BASE_URL?.trim() || "https://app.maple.dev",
+					EMAIL_FROM: env.EMAIL_FROM?.trim() || "Maple <notifications@noreply.maple.dev>",
 				}
-				expect(unwrap(appUrlsEnv())).toEqual(unwrap(old))
+				expect(unwrap(run(appUrlsEnv, env))).toEqual(unwrap(old))
 			})
 
 			it("selfObservabilityEnv", () => {
-				populate(["MAPLE_OTEL_INGEST_KEY"])
-				if (populated) populate(["MAPLE_ENDPOINT", "COMMIT_SHA"])
+				const keys = full
+					? ["MAPLE_OTEL_INGEST_KEY", "MAPLE_ENDPOINT", "COMMIT_SHA"]
+					: ["MAPLE_OTEL_INGEST_KEY"]
+				const env = populated(keys)
 				const old = {
-					MAPLE_INGEST_KEY: Redacted.make(oldRequireEnv("MAPLE_OTEL_INGEST_KEY")),
-					...oldOptionalPlain("MAPLE_ENDPOINT"),
+					MAPLE_INGEST_KEY: Redacted.make(oldRequireEnv(env, "MAPLE_OTEL_INGEST_KEY")),
+					...oldOptionalPlain(env, "MAPLE_ENDPOINT"),
 					MAPLE_ENVIRONMENT: "staging",
-					...oldOptionalPlain("COMMIT_SHA", process.env.GITHUB_SHA?.trim()),
+					...oldOptionalPlain(env, "COMMIT_SHA", env.GITHUB_SHA?.trim()),
 				}
-				expect(unwrap(selfObservabilityEnv({ kind: "stg" }))).toEqual(unwrap(old))
+				expect(unwrap(run(selfObservabilityEnv({ kind: "stg" }), env))).toEqual(unwrap(old))
 			})
 
 			it("apnsEnv", () => {
-				if (populated) populate(["APNS_TEAM_ID", "APNS_KEY_ID", "APNS_PRIVATE_KEY"])
+				const env = full ? populated(APNS) : {}
 				const old = {
-					...oldOptionalPlain("APNS_TEAM_ID"),
-					...oldOptionalPlain("APNS_KEY_ID"),
-					...oldOptionalSecret("APNS_PRIVATE_KEY"),
+					...oldOptionalPlain(env, "APNS_TEAM_ID"),
+					...oldOptionalPlain(env, "APNS_KEY_ID"),
+					...oldOptionalSecret(env, "APNS_PRIVATE_KEY"),
 				}
-				expect(unwrap(apnsEnv())).toEqual(unwrap(old))
+				expect(unwrap(run(apnsEnv, env))).toEqual(unwrap(old))
 			})
 
 			it("cloudflareOAuthEnv", () => {
-				if (populated) {
-					populate([
-						"CLOUDFLARE_OAUTH_CLIENT_ID",
-						"CLOUDFLARE_OAUTH_CLIENT_SECRET",
-						"CLOUDFLARE_OAUTH_SCOPES",
-						"CLOUDFLARE_OAUTH_AUTHORIZE_URL",
-						"CLOUDFLARE_OAUTH_TOKEN_URL",
-						"CLOUDFLARE_OAUTH_REVOKE_URL",
-						"MAPLE_CLOUDFLARE_API_BASE_URL",
-					])
-				}
+				const env = full ? populated(CF_OAUTH) : {}
 				const old = {
-					...oldOptionalPlain("CLOUDFLARE_OAUTH_CLIENT_ID"),
-					...oldOptionalSecret("CLOUDFLARE_OAUTH_CLIENT_SECRET"),
-					...oldOptionalPlain("CLOUDFLARE_OAUTH_SCOPES"),
-					...oldOptionalPlain("CLOUDFLARE_OAUTH_AUTHORIZE_URL"),
-					...oldOptionalPlain("CLOUDFLARE_OAUTH_TOKEN_URL"),
-					...oldOptionalPlain("CLOUDFLARE_OAUTH_REVOKE_URL"),
-					...oldOptionalPlain("MAPLE_CLOUDFLARE_API_BASE_URL"),
+					...oldOptionalPlain(env, "CLOUDFLARE_OAUTH_CLIENT_ID"),
+					...oldOptionalSecret(env, "CLOUDFLARE_OAUTH_CLIENT_SECRET"),
+					...oldOptionalPlain(env, "CLOUDFLARE_OAUTH_SCOPES"),
+					...oldOptionalPlain(env, "CLOUDFLARE_OAUTH_AUTHORIZE_URL"),
+					...oldOptionalPlain(env, "CLOUDFLARE_OAUTH_TOKEN_URL"),
+					...oldOptionalPlain(env, "CLOUDFLARE_OAUTH_REVOKE_URL"),
+					...oldOptionalPlain(env, "MAPLE_CLOUDFLARE_API_BASE_URL"),
 				}
-				expect(unwrap(cloudflareOAuthEnv())).toEqual(unwrap(old))
+				expect(unwrap(run(cloudflareOAuthEnv, env))).toEqual(unwrap(old))
 			})
 
 			it("planetScaleOAuthEnv matches the api worker's set", () => {
-				if (populated) {
-					populate([
-						"PLANETSCALE_OAUTH_CLIENT_ID",
-						"PLANETSCALE_OAUTH_CLIENT_SECRET",
-						"PLANETSCALE_OAUTH_AUTHORIZE_URL",
-						"PLANETSCALE_OAUTH_TOKEN_URL",
-						"PLANETSCALE_OAUTH_TOKEN_INFO_URL",
-						"MAPLE_PLANETSCALE_API_BASE_URL",
-					])
-				}
+				const env = full ? populated(PS_OAUTH) : {}
 				const old = {
-					...oldOptionalPlain("PLANETSCALE_OAUTH_CLIENT_ID"),
-					...oldOptionalSecret("PLANETSCALE_OAUTH_CLIENT_SECRET"),
-					...oldOptionalPlain("PLANETSCALE_OAUTH_AUTHORIZE_URL"),
-					...oldOptionalPlain("PLANETSCALE_OAUTH_TOKEN_URL"),
-					...oldOptionalPlain("PLANETSCALE_OAUTH_TOKEN_INFO_URL"),
-					...oldOptionalPlain("MAPLE_PLANETSCALE_API_BASE_URL"),
+					...oldOptionalPlain(env, "PLANETSCALE_OAUTH_CLIENT_ID"),
+					...oldOptionalSecret(env, "PLANETSCALE_OAUTH_CLIENT_SECRET"),
+					...oldOptionalPlain(env, "PLANETSCALE_OAUTH_AUTHORIZE_URL"),
+					...oldOptionalPlain(env, "PLANETSCALE_OAUTH_TOKEN_URL"),
+					...oldOptionalPlain(env, "PLANETSCALE_OAUTH_TOKEN_INFO_URL"),
+					...oldOptionalPlain(env, "MAPLE_PLANETSCALE_API_BASE_URL"),
 				}
-				expect(unwrap(planetScaleOAuthEnv())).toEqual(unwrap(old))
+				expect(unwrap(run(planetScaleOAuthEnv, env))).toEqual(unwrap(old))
 			})
 		})
 	}
 
 	/**
-	 * The one deliberate behaviour change. `alerting` previously omitted
+	 * The one deliberate binding change. `alerting` previously omitted
 	 * PLANETSCALE_OAUTH_TOKEN_INFO_URL while `api` bound it, even though both run
 	 * token refresh through PlanetScaleOAuthService. The shared group binds it for
 	 * both; it is optional, so a stage that does not set it is unaffected.
 	 */
 	it("adds TOKEN_INFO_URL to the alerting worker, which api already had", () => {
-		process.env.PLANETSCALE_OAUTH_TOKEN_INFO_URL = "https://auth.planetscale.com/tokeninfo"
-		expect(planetScaleOAuthEnv().PLANETSCALE_OAUTH_TOKEN_INFO_URL).toBe(
+		const env = { PLANETSCALE_OAUTH_TOKEN_INFO_URL: "https://auth.planetscale.com/tokeninfo" }
+		expect(run(planetScaleOAuthEnv, env).PLANETSCALE_OAUTH_TOKEN_INFO_URL).toBe(
 			"https://auth.planetscale.com/tokeninfo",
 		)
 	})

--- a/packages/infra/src/env.ts
+++ b/packages/infra/src/env.ts
@@ -1,4 +1,8 @@
+import * as Config from "effect/Config"
+import * as Option from "effect/Option"
 import * as Redacted from "effect/Redacted"
+import * as Schema from "effect/Schema"
+import { optionalString } from "@maple/effect-cloudflare/config-helpers"
 import type { MapleStage } from "./cloudflare/stage.ts"
 import { resolveDeploymentEnvironment } from "./cloudflare/stage.ts"
 
@@ -8,17 +12,24 @@ import { resolveDeploymentEnvironment } from "./cloudflare/stage.ts"
  * Every worker used to carry its own copy of `requireEnv` / `optionalPlain` /
  * `optionalSecret` and then re-list the same keys, so `api` and `alerting`
  * shared 32 hand-copied entries that drifted whenever one was edited alone.
- * The helpers live here once, and the shared keys are grouped by the concern
+ * The primitives live here once, and the shared keys are grouped by the concern
  * that owns them: a worker spreads the groups it needs and lists only what is
  * genuinely its own.
  *
- * Deliberately plain TypeScript with no Effect `Config` layer. The values are
- * read once at plan time and fed straight into a Worker's `env`, so a
- * ConfigProvider would buy aggregated error messages at the cost of wrapping
- * every group in an Effect and matching on `Option` to decide whether a key is
- * present at all — more machinery than the problem has.
+ * These are effect `Config`s, not `process.env` reads, and that is load-bearing
+ * rather than stylistic. Alchemy resolves config through a ConfigProvider built
+ * as `fromDotEnv(--env-file ?? ".env")` **orElse** `fromEnv()`
+ * (`alchemy/Util/ConfigProvider.ts`) and never copies those file-sourced values
+ * into `process.env`. A `process.env` read therefore silently ignores `.env` and
+ * `--env-file` — and would do so *selectively*, since alchemy's own provider
+ * settings (CLOUDFLARE_ACCOUNT_ID, CI, …) would still pick them up. `Config`
+ * also reports every missing key at once instead of throwing on the first, and
+ * keeps failures in the typed error channel (`ConfigError`) rather than as a
+ * thrown `Error`, which is what the rest of the repo does — see
+ * `packages/alchemy-maple/src/MapleEnvironment.ts` for the same pattern inside
+ * an alchemy provider.
  *
- * The three rules the helpers encode:
+ * The three rules the primitives encode:
  *
  *   - values are trimmed, and a whitespace-only value counts as absent;
  *   - an absent optional key is OMITTED from the record, never set to `""` —
@@ -36,34 +47,77 @@ export type SecretEnv = Record<string, Redacted.Redacted<string>>
  */
 export type WorkerEnv = Record<string, string | Redacted.Redacted<string>>
 
-const read = (key: string): string | undefined => process.env[key]?.trim() || undefined
+/**
+ * Present-and-non-blank, trimmed.
+ *
+ * Built on `@maple/effect-cloudflare/config-helpers`' `optionalString`, which
+ * already encodes "blank or whitespace-only counts as absent" for the runtime
+ * worker env schemas. The trim on top is the one thing it does not do — it
+ * returns the raw value — and the deploy path has always trimmed.
+ */
+const trimmedOption = (key: string): Config.Config<Option.Option<string>> =>
+	optionalString(key).pipe(
+		Config.map((value: Option.Option<string>) => Option.map(value, (raw) => raw.trim())),
+	)
 
-/** Required plain value. Throws at plan time so a deploy fails before it mutates anything. */
-export const requireEnv = (key: string): string => {
-	const value = read(key)
-	if (!value) {
-		throw new Error(`Missing required deployment env: ${key}`)
-	}
-	return value
-}
+const entry = <A>(key: string, value: Option.Option<A>): Record<string, A> =>
+	Option.match(value, { onNone: () => ({}), onSome: (v) => ({ [key]: v }) })
 
-/** Required secret, wrapped in `Redacted`. */
-export const requireSecret = (key: string): Redacted.Redacted<string> => Redacted.make(requireEnv(key))
-
-/** Optional plain value, omitted when unset. `fallback` applies only if the env var is absent. */
-export const optionalPlain = (key: string, fallback?: string): PlainEnv => {
-	const value = read(key) ?? fallback?.trim()
-	return value ? { [key]: value } : {}
-}
-
-/** Optional secret, omitted when unset. */
-export const optionalSecret = (key: string): SecretEnv => {
-	const value = read(key)
-	return value ? { [key]: Redacted.make(value) } : {}
-}
+/** Merge several partial-record configs into one. */
+export const merge = (...parts: ReadonlyArray<Config.Config<Partial<WorkerEnv>>>): Config.Config<WorkerEnv> =>
+	Config.all(parts).pipe(
+		Config.map(
+			(records: ReadonlyArray<Partial<WorkerEnv>>) => Object.assign({}, ...records) as WorkerEnv,
+		),
+	)
 
 /**
- * A value the stack CHOOSES rather than reads — `process.env` cannot override it.
+ * Required plain value. Fails with a `ConfigError` — not a thrown `Error` — so a
+ * deploy missing several vars reports all of them in one pass.
+ *
+ * `Schema.Trim` before the non-empty check, so `"   "` is rejected rather than
+ * binding an empty string.
+ */
+export const requiredPlain = (key: string): Config.Config<string> =>
+	Config.schema(Schema.Trim.check(Schema.isNonEmpty()), key)
+
+/** Required secret, wrapped in `Redacted`. */
+export const requiredSecret = (key: string): Config.Config<Redacted.Redacted<string>> =>
+	requiredPlain(key).pipe(Config.map(Redacted.make))
+
+/** Required plain value as a single-entry record, for spreading into a group. */
+export const requirePlainEntry = (key: string): Config.Config<PlainEnv> =>
+	requiredPlain(key).pipe(Config.map((value) => ({ [key]: value })))
+
+/** Required secret as a single-entry record. */
+export const requireSecretEntry = (key: string): Config.Config<SecretEnv> =>
+	requiredSecret(key).pipe(Config.map((value) => ({ [key]: value })))
+
+/** Optional plain value, omitted when unset. `fallback` applies only if the key is absent. */
+export const optionalPlain = (key: string, fallback?: string): Config.Config<PlainEnv> =>
+	trimmedOption(key).pipe(
+		Config.map((value) => {
+			const resolved = Option.getOrUndefined(value) ?? fallback?.trim()
+			return resolved ? { [key]: resolved } : {}
+		}),
+	)
+
+/** Optional secret, omitted when unset. */
+export const optionalSecret = (key: string): Config.Config<SecretEnv> =>
+	trimmedOption(key).pipe(Config.map((value) => entry(key, Option.map(value, Redacted.make))))
+
+/**
+ * Optional value with a default that a BLANK env var also falls back to.
+ *
+ * Distinct from `Config.withDefault`, which only fires when the key is missing:
+ * `MAPLE_AUTH_MODE=""` must still yield `"self_hosted"`, matching the
+ * `process.env.X?.trim() || "…"` these replaced.
+ */
+export const plainWithDefault = (key: string, fallback: string): Config.Config<PlainEnv> =>
+	trimmedOption(key).pipe(Config.map((value) => ({ [key]: Option.getOrElse(value, () => fallback) })))
+
+/**
+ * A value the stack CHOOSES rather than reads — the environment cannot override it.
  *
  * Distinct from `optionalPlain(key, fallback)`, where the environment wins. The
  * difference is load-bearing for `MAPLE_ENVIRONMENT`: a stray
@@ -71,10 +125,8 @@ export const optionalSecret = (key: string): SecretEnv => {
  * `EmailService.emailAllowed` and the alerting worker's `scheduled()`
  * early-return at once, on a stage that shares live org data.
  */
-export const derived = (key: string, value: string): PlainEnv => ({ [key]: value })
-
-const optionalPlainGroup = (...keys: ReadonlyArray<string>): PlainEnv =>
-	Object.assign({}, ...keys.map((key) => optionalPlain(key)))
+export const derived = (key: string, value: string): Config.Config<PlainEnv> =>
+	Config.succeed({ [key]: value })
 
 // ── Shared groups ───────────────────────────────────────────────────────────
 
@@ -82,14 +134,14 @@ const optionalPlainGroup = (...keys: ReadonlyArray<string>): PlainEnv =>
  * Session auth. The same `AuthEnv` subset `api`, `alerting` and `electric-sync`
  * all resolve callers with.
  */
-export const authEnv = (): WorkerEnv => ({
-	MAPLE_AUTH_MODE: process.env.MAPLE_AUTH_MODE?.trim() || "self_hosted",
-	MAPLE_DEFAULT_ORG_ID: process.env.MAPLE_DEFAULT_ORG_ID?.trim() || "default",
-	...optionalSecret("MAPLE_ROOT_PASSWORD"),
-	...optionalSecret("CLERK_SECRET_KEY"),
-	...optionalPlain("CLERK_PUBLISHABLE_KEY"),
-	...optionalSecret("CLERK_JWT_KEY"),
-})
+export const authEnv: Config.Config<WorkerEnv> = merge(
+	plainWithDefault("MAPLE_AUTH_MODE", "self_hosted"),
+	plainWithDefault("MAPLE_DEFAULT_ORG_ID", "default"),
+	optionalSecret("MAPLE_ROOT_PASSWORD"),
+	optionalSecret("CLERK_SECRET_KEY"),
+	optionalPlain("CLERK_PUBLISHABLE_KEY"),
+	optionalSecret("CLERK_JWT_KEY"),
+)
 
 /**
  * Warehouse access. `SIGNING_KEY` + `WORKSPACE_ID` are what
@@ -97,25 +149,26 @@ export const authEnv = (): WorkerEnv => ({
  * every alert tick fails with "TINYBIRD_SIGNING_KEY is required for
  * Tinybird-scoped raw SQL", which is why `alerting` binds the same set as `api`.
  */
-export const tinybirdEnv = (): WorkerEnv => ({
-	TINYBIRD_HOST: requireEnv("TINYBIRD_HOST"),
-	TINYBIRD_TOKEN: requireSecret("TINYBIRD_TOKEN"),
-	...optionalSecret("TINYBIRD_SIGNING_KEY"),
-	...optionalPlainGroup("TINYBIRD_WORKSPACE_ID", "TINYBIRD_RAW_SQL_JWT_RPS_LIMIT"),
-})
+export const tinybirdEnv: Config.Config<WorkerEnv> = merge(
+	requirePlainEntry("TINYBIRD_HOST"),
+	requireSecretEntry("TINYBIRD_TOKEN"),
+	optionalSecret("TINYBIRD_SIGNING_KEY"),
+	optionalPlain("TINYBIRD_WORKSPACE_ID"),
+	optionalPlain("TINYBIRD_RAW_SQL_JWT_RPS_LIMIT"),
+)
 
 /** Ingest-key envelope encryption + lookup HMAC. Required wherever ingest keys are read. */
-export const ingestKeyCryptoEnv = (): SecretEnv => ({
-	MAPLE_INGEST_KEY_ENCRYPTION_KEY: requireSecret("MAPLE_INGEST_KEY_ENCRYPTION_KEY"),
-	MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: requireSecret("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
-})
+export const ingestKeyCryptoEnv: Config.Config<WorkerEnv> = merge(
+	requireSecretEntry("MAPLE_INGEST_KEY_ENCRYPTION_KEY"),
+	requireSecretEntry("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
+)
 
 /** Public URLs the workers build links with (emails, share links, quick-start snippets). */
-export const appUrlsEnv = (): PlainEnv => ({
-	MAPLE_INGEST_PUBLIC_URL: process.env.MAPLE_INGEST_PUBLIC_URL?.trim() || "https://ingest.maple.dev",
-	MAPLE_APP_BASE_URL: process.env.MAPLE_APP_BASE_URL?.trim() || "https://app.maple.dev",
-	EMAIL_FROM: process.env.EMAIL_FROM?.trim() || "Maple <notifications@noreply.maple.dev>",
-})
+export const appUrlsEnv: Config.Config<WorkerEnv> = merge(
+	plainWithDefault("MAPLE_INGEST_PUBLIC_URL", "https://ingest.maple.dev"),
+	plainWithDefault("MAPLE_APP_BASE_URL", "https://app.maple.dev"),
+	plainWithDefault("EMAIL_FROM", "Maple <notifications@noreply.maple.dev>"),
+)
 
 /**
  * The worker's own OTLP export, through the ingest gateway.
@@ -127,40 +180,47 @@ export const appUrlsEnv = (): PlainEnv => ({
  * missing binding quietly restores the behaviour where any occurrence reopens a
  * fixed issue.
  */
-export const selfObservabilityEnv = (stage: MapleStage): WorkerEnv => ({
-	MAPLE_INGEST_KEY: requireSecret("MAPLE_OTEL_INGEST_KEY"),
-	...optionalPlain("MAPLE_ENDPOINT"),
-	...derived("MAPLE_ENVIRONMENT", resolveDeploymentEnvironment(stage)),
-	...optionalPlain("COMMIT_SHA", process.env.GITHUB_SHA?.trim()),
-})
+export const selfObservabilityEnv = (stage: MapleStage): Config.Config<WorkerEnv> =>
+	merge(
+		// Bound under a different name than it is read from.
+		requiredSecret("MAPLE_OTEL_INGEST_KEY").pipe(Config.map((value) => ({ MAPLE_INGEST_KEY: value }))),
+		optionalPlain("MAPLE_ENDPOINT"),
+		derived("MAPLE_ENVIRONMENT", resolveDeploymentEnvironment(stage)),
+		// GITHUB_SHA is read as its own key and re-labelled, rather than passed to
+		// `optionalPlain`'s `fallback` — a `process.env.GITHUB_SHA` read there would
+		// bypass the ConfigProvider and so miss `.env` / `--env-file`.
+		merge(optionalPlain("COMMIT_SHA"), optionalPlain("GITHUB_SHA")).pipe(
+			Config.map((record): PlainEnv => {
+				const sha = record.COMMIT_SHA ?? record.GITHUB_SHA
+				return typeof sha === "string" && sha ? { COMMIT_SHA: sha } : {}
+			}),
+		),
+	)
 
 /** Cloudflare account integration (account OAuth — Authorization Code + PKCE). */
-export const cloudflareOAuthEnv = (): WorkerEnv => ({
-	...optionalSecret("CLOUDFLARE_OAUTH_CLIENT_SECRET"),
-	...optionalPlainGroup(
-		"CLOUDFLARE_OAUTH_CLIENT_ID",
-		"CLOUDFLARE_OAUTH_SCOPES",
-		"CLOUDFLARE_OAUTH_AUTHORIZE_URL",
-		"CLOUDFLARE_OAUTH_TOKEN_URL",
-		"CLOUDFLARE_OAUTH_REVOKE_URL",
-		"MAPLE_CLOUDFLARE_API_BASE_URL",
-	),
-})
+export const cloudflareOAuthEnv: Config.Config<WorkerEnv> = merge(
+	optionalPlain("CLOUDFLARE_OAUTH_CLIENT_ID"),
+	optionalSecret("CLOUDFLARE_OAUTH_CLIENT_SECRET"),
+	optionalPlain("CLOUDFLARE_OAUTH_SCOPES"),
+	optionalPlain("CLOUDFLARE_OAUTH_AUTHORIZE_URL"),
+	optionalPlain("CLOUDFLARE_OAUTH_TOKEN_URL"),
+	optionalPlain("CLOUDFLARE_OAUTH_REVOKE_URL"),
+	optionalPlain("MAPLE_CLOUDFLARE_API_BASE_URL"),
+)
 
 /** PlanetScale integration (OAuth application — confidential client, no PKCE). */
-export const planetScaleOAuthEnv = (): WorkerEnv => ({
-	...optionalSecret("PLANETSCALE_OAUTH_CLIENT_SECRET"),
-	...optionalPlainGroup(
-		"PLANETSCALE_OAUTH_CLIENT_ID",
-		"PLANETSCALE_OAUTH_AUTHORIZE_URL",
-		"PLANETSCALE_OAUTH_TOKEN_URL",
-		"PLANETSCALE_OAUTH_TOKEN_INFO_URL",
-		"MAPLE_PLANETSCALE_API_BASE_URL",
-	),
-})
+export const planetScaleOAuthEnv: Config.Config<WorkerEnv> = merge(
+	optionalPlain("PLANETSCALE_OAUTH_CLIENT_ID"),
+	optionalSecret("PLANETSCALE_OAUTH_CLIENT_SECRET"),
+	optionalPlain("PLANETSCALE_OAUTH_AUTHORIZE_URL"),
+	optionalPlain("PLANETSCALE_OAUTH_TOKEN_URL"),
+	optionalPlain("PLANETSCALE_OAUTH_TOKEN_INFO_URL"),
+	optionalPlain("MAPLE_PLANETSCALE_API_BASE_URL"),
+)
 
 /** Apple push (iOS app) — token auth; see `apps/api/src/platform/Apns.ts`. */
-export const apnsEnv = (): WorkerEnv => ({
-	...optionalSecret("APNS_PRIVATE_KEY"),
-	...optionalPlainGroup("APNS_TEAM_ID", "APNS_KEY_ID"),
-})
+export const apnsEnv: Config.Config<WorkerEnv> = merge(
+	optionalPlain("APNS_TEAM_ID"),
+	optionalPlain("APNS_KEY_ID"),
+	optionalSecret("APNS_PRIVATE_KEY"),
+)

--- a/packages/infra/src/env.ts
+++ b/packages/infra/src/env.ts
@@ -1,0 +1,166 @@
+import * as Redacted from "effect/Redacted"
+import type { MapleStage } from "./cloudflare/stage.ts"
+import { resolveDeploymentEnvironment } from "./cloudflare/stage.ts"
+
+/**
+ * Deploy-time environment for the Cloudflare workers.
+ *
+ * Every worker used to carry its own copy of `requireEnv` / `optionalPlain` /
+ * `optionalSecret` and then re-list the same keys, so `api` and `alerting`
+ * shared 32 hand-copied entries that drifted whenever one was edited alone.
+ * The helpers live here once, and the shared keys are grouped by the concern
+ * that owns them: a worker spreads the groups it needs and lists only what is
+ * genuinely its own.
+ *
+ * Deliberately plain TypeScript with no Effect `Config` layer. The values are
+ * read once at plan time and fed straight into a Worker's `env`, so a
+ * ConfigProvider would buy aggregated error messages at the cost of wrapping
+ * every group in an Effect and matching on `Option` to decide whether a key is
+ * present at all — more machinery than the problem has.
+ *
+ * The three rules the helpers encode:
+ *
+ *   - values are trimmed, and a whitespace-only value counts as absent;
+ *   - an absent optional key is OMITTED from the record, never set to `""` —
+ *     an empty binding is a value the worker has to defend against, an absent
+ *     one reaches the `??` default in the code that reads it;
+ *   - secrets are wrapped in `Redacted` so they never surface in plan output.
+ */
+
+export type PlainEnv = Record<string, string>
+export type SecretEnv = Record<string, Redacted.Redacted<string>>
+/**
+ * A group that mixes both. Deliberately a union-valued record and NOT
+ * `PlainEnv & SecretEnv` — intersecting two index signatures narrows the value
+ * type to `string & Redacted<string>`, which nothing inhabits.
+ */
+export type WorkerEnv = Record<string, string | Redacted.Redacted<string>>
+
+const read = (key: string): string | undefined => process.env[key]?.trim() || undefined
+
+/** Required plain value. Throws at plan time so a deploy fails before it mutates anything. */
+export const requireEnv = (key: string): string => {
+	const value = read(key)
+	if (!value) {
+		throw new Error(`Missing required deployment env: ${key}`)
+	}
+	return value
+}
+
+/** Required secret, wrapped in `Redacted`. */
+export const requireSecret = (key: string): Redacted.Redacted<string> => Redacted.make(requireEnv(key))
+
+/** Optional plain value, omitted when unset. `fallback` applies only if the env var is absent. */
+export const optionalPlain = (key: string, fallback?: string): PlainEnv => {
+	const value = read(key) ?? fallback?.trim()
+	return value ? { [key]: value } : {}
+}
+
+/** Optional secret, omitted when unset. */
+export const optionalSecret = (key: string): SecretEnv => {
+	const value = read(key)
+	return value ? { [key]: Redacted.make(value) } : {}
+}
+
+/**
+ * A value the stack CHOOSES rather than reads — `process.env` cannot override it.
+ *
+ * Distinct from `optionalPlain(key, fallback)`, where the environment wins. The
+ * difference is load-bearing for `MAPLE_ENVIRONMENT`: a stray
+ * `MAPLE_ENVIRONMENT=production` in a pr-N deploy environment would open
+ * `EmailService.emailAllowed` and the alerting worker's `scheduled()`
+ * early-return at once, on a stage that shares live org data.
+ */
+export const derived = (key: string, value: string): PlainEnv => ({ [key]: value })
+
+const optionalPlainGroup = (...keys: ReadonlyArray<string>): PlainEnv =>
+	Object.assign({}, ...keys.map((key) => optionalPlain(key)))
+
+// ── Shared groups ───────────────────────────────────────────────────────────
+
+/**
+ * Session auth. The same `AuthEnv` subset `api`, `alerting` and `electric-sync`
+ * all resolve callers with.
+ */
+export const authEnv = (): WorkerEnv => ({
+	MAPLE_AUTH_MODE: process.env.MAPLE_AUTH_MODE?.trim() || "self_hosted",
+	MAPLE_DEFAULT_ORG_ID: process.env.MAPLE_DEFAULT_ORG_ID?.trim() || "default",
+	...optionalSecret("MAPLE_ROOT_PASSWORD"),
+	...optionalSecret("CLERK_SECRET_KEY"),
+	...optionalPlain("CLERK_PUBLISHABLE_KEY"),
+	...optionalSecret("CLERK_JWT_KEY"),
+})
+
+/**
+ * Warehouse access. `SIGNING_KEY` + `WORKSPACE_ID` are what
+ * `TinybirdOrgTokenService` needs for Tinybird-scoped raw SQL — without them
+ * every alert tick fails with "TINYBIRD_SIGNING_KEY is required for
+ * Tinybird-scoped raw SQL", which is why `alerting` binds the same set as `api`.
+ */
+export const tinybirdEnv = (): WorkerEnv => ({
+	TINYBIRD_HOST: requireEnv("TINYBIRD_HOST"),
+	TINYBIRD_TOKEN: requireSecret("TINYBIRD_TOKEN"),
+	...optionalSecret("TINYBIRD_SIGNING_KEY"),
+	...optionalPlainGroup("TINYBIRD_WORKSPACE_ID", "TINYBIRD_RAW_SQL_JWT_RPS_LIMIT"),
+})
+
+/** Ingest-key envelope encryption + lookup HMAC. Required wherever ingest keys are read. */
+export const ingestKeyCryptoEnv = (): SecretEnv => ({
+	MAPLE_INGEST_KEY_ENCRYPTION_KEY: requireSecret("MAPLE_INGEST_KEY_ENCRYPTION_KEY"),
+	MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: requireSecret("MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY"),
+})
+
+/** Public URLs the workers build links with (emails, share links, quick-start snippets). */
+export const appUrlsEnv = (): PlainEnv => ({
+	MAPLE_INGEST_PUBLIC_URL: process.env.MAPLE_INGEST_PUBLIC_URL?.trim() || "https://ingest.maple.dev",
+	MAPLE_APP_BASE_URL: process.env.MAPLE_APP_BASE_URL?.trim() || "https://app.maple.dev",
+	EMAIL_FROM: process.env.EMAIL_FROM?.trim() || "Maple <notifications@noreply.maple.dev>",
+})
+
+/**
+ * The worker's own OTLP export, through the ingest gateway.
+ *
+ * `MAPLE_ENVIRONMENT` is `derived`, not `optionalPlain` — see `derived` above.
+ * `COMMIT_SHA` falls back to `GITHUB_SHA` so a deploy that did not export it
+ * still stamps a build: an unstamped Worker reports no `service.version`, and
+ * the error evaluator treats a build it cannot identify as a regression, so a
+ * missing binding quietly restores the behaviour where any occurrence reopens a
+ * fixed issue.
+ */
+export const selfObservabilityEnv = (stage: MapleStage): WorkerEnv => ({
+	MAPLE_INGEST_KEY: requireSecret("MAPLE_OTEL_INGEST_KEY"),
+	...optionalPlain("MAPLE_ENDPOINT"),
+	...derived("MAPLE_ENVIRONMENT", resolveDeploymentEnvironment(stage)),
+	...optionalPlain("COMMIT_SHA", process.env.GITHUB_SHA?.trim()),
+})
+
+/** Cloudflare account integration (account OAuth — Authorization Code + PKCE). */
+export const cloudflareOAuthEnv = (): WorkerEnv => ({
+	...optionalSecret("CLOUDFLARE_OAUTH_CLIENT_SECRET"),
+	...optionalPlainGroup(
+		"CLOUDFLARE_OAUTH_CLIENT_ID",
+		"CLOUDFLARE_OAUTH_SCOPES",
+		"CLOUDFLARE_OAUTH_AUTHORIZE_URL",
+		"CLOUDFLARE_OAUTH_TOKEN_URL",
+		"CLOUDFLARE_OAUTH_REVOKE_URL",
+		"MAPLE_CLOUDFLARE_API_BASE_URL",
+	),
+})
+
+/** PlanetScale integration (OAuth application — confidential client, no PKCE). */
+export const planetScaleOAuthEnv = (): WorkerEnv => ({
+	...optionalSecret("PLANETSCALE_OAUTH_CLIENT_SECRET"),
+	...optionalPlainGroup(
+		"PLANETSCALE_OAUTH_CLIENT_ID",
+		"PLANETSCALE_OAUTH_AUTHORIZE_URL",
+		"PLANETSCALE_OAUTH_TOKEN_URL",
+		"PLANETSCALE_OAUTH_TOKEN_INFO_URL",
+		"MAPLE_PLANETSCALE_API_BASE_URL",
+	),
+})
+
+/** Apple push (iOS app) — token auth; see `apps/api/src/platform/Apns.ts`. */
+export const apnsEnv = (): WorkerEnv => ({
+	...optionalSecret("APNS_PRIVATE_KEY"),
+	...optionalPlainGroup("APNS_TEAM_ID", "APNS_KEY_ID"),
+})

--- a/tsconfig.alchemy.json
+++ b/tsconfig.alchemy.json
@@ -9,8 +9,14 @@
 		"strict": true,
 		"skipLibCheck": true,
 		"types": ["node"],
+		// Every `@maple/infra` subpath the stack files import. Listing only some of
+		// them let the rest resolve through node_modules instead, so the root
+		// typecheck and turbo's disagreed about which sources they were checking.
 		"paths": {
-			"@maple/infra/cloudflare": ["./packages/infra/src/cloudflare/index.ts"]
+			"@maple/infra": ["./packages/infra/src/index.ts"],
+			"@maple/infra/aws": ["./packages/infra/src/aws/index.ts"],
+			"@maple/infra/cloudflare": ["./packages/infra/src/cloudflare/index.ts"],
+			"@maple/infra/env": ["./packages/infra/src/env.ts"]
 		}
 	},
 	"include": ["alchemy.run.ts", "apps/*/alchemy.run.ts", "scripts/aws-probe.run.ts", "scripts/ingest-preview.run.ts"]


### PR DESCRIPTION
## Why

The Alchemy stack reads as more convoluted than it is. The architecture is fine — a factory per app composed by a root stack, with stage/domain/naming logic extracted into a tested `@maple/infra`. The convolution was concentrated in two places, measured:

| Problem | Evidence |
| --- | --- |
| Env plumbing copied per worker | `requireEnv`/`optionalPlain`/`optionalSecret` re-declared verbatim in **4 files**; 93 `optional*` calls; **32 identical env keys** hand-copied between `api` and `alerting` |
| Comment archaeology | ~40% comment mass (`api` 123/386 lines, `ingest` 203/490), much of it incident narrative and v1→v2 / Railway notes that no longer describe the code |

## What changed

**Env plumbing → one shared module.** `packages/infra/src/env.ts` holds the three helpers once, plus groups keyed by the concern that owns them: `authEnv`, `tinybirdEnv`, `ingestKeyCryptoEnv`, `appUrlsEnv`, `selfObservabilityEnv`, `cloudflareOAuthEnv`, `planetScaleOAuthEnv`, `apnsEnv`. A worker spreads the groups it needs and lists only what is genuinely its own. **−225/+107** lines across the stack files.

Plain TypeScript rather than an Effect `Config` layer. `Config` would have been idiomatic — `Alchemy.Stack` permits `ConfigError` in its error channel — but deciding "is this key present at all" through `Option` adds more machinery than the problem has, and it would put an `effect` runtime dependency on the browser-reachable path of `packages/infra`.

**`docs/infra.md`** collects the history that had accumulated in the stack files: the #378 deploy hang, the CONNECT_TIMEOUT cold-start regression, the Hyperdrive split measurements, the v1→v2 equivalences, the cost calls, and the state of play on local dev. The load-bearing "don't break this" comments stay at the code.

**`tsconfig.alchemy.json`** mapped only `@maple/infra/cloudflare`, so `@maple/infra/aws` — which `apps/ingest` and `scripts/ingest-preview.run.ts` both import — resolved differently under the root typecheck than under turbo's. All subpaths mapped.

## Behaviour changes — please read

Bindings are otherwise byte-identical (see Verification). Two deliberate exceptions:

1. **`electric-sync` had `MAPLE_ENVIRONMENT` as `optionalPlain(…, stageDefault)`**, so `process.env` could win. That is the exact override `api` and `alerting` both guard against, because the value gates `EmailService.emailAllowed` and the alerting worker's `scheduled()` early-return — a stray `MAPLE_ENVIRONMENT=production` in a pr-N environment would open them on a stage that shares live org data. Stage-derived everywhere now.
2. **`alerting` gains `PLANETSCALE_OAUTH_TOKEN_INFO_URL`.** Optional, `api` already bound it, and alerting runs the same token refresh through `PlanetScaleOAuthService`.

## Also corrected

- **`MAPLE_DEPLOY_AWS_INGEST` is not dead code.** Its comment claimed it was "only the migration switch now", which reads as an invitation to delete it. It isn't: the variable is set on the **production** environment only, while `stageDeploysIngest` returns true for prd *and* stg — removing it hands staging a VPC + ALB + ACM certificate + ECS cluster. It also can't be folded into `stageDeploysIngest`, because `providers` is built in the `Alchemy.Stack` options, before `Alchemy.Stage` is readable inside the stack effect. Comment corrected, flag kept, reasoning recorded.
- `apps/api` described the ingest gateway as a Railway container. It has been a Rust service on ECS Fargate since #591.

## Verification

- `packages/infra/src/env.test.ts` reconstructs the pre-refactor per-worker expressions **verbatim** and asserts each group produces an identical record, across both "all keys set" and "every optional key unset". That equivalence is the real test — 46 tests pass.
- Also asserted: an unset optional key is *omitted*, never bound as `""`; whitespace-only counts as absent; `MAPLE_ENVIRONMENT` ignores the ambient env var; `COMMIT_SHA` still falls back to `GITHUB_SHA`.
- `tsc -p tsconfig.alchemy.json`, `packages/infra` typecheck, oxlint and oxfmt all clean.
- `bun.lock` updated for the new `packages/infra` → `effect` dependency; CI's `--frozen-lockfile` would fail without it.
- Confirmed end to end by running the stack locally with file-backed state: the rendered `electric-sync` bindings came out as `MAPLE_AUTH_MODE: self_hosted`, `MAPLE_DEFAULT_ORG_ID: default`, a redacted `MAPLE_INGEST_KEY`, stage-derived `MAPLE_ENVIRONMENT: "development"`, and every unset optional key correctly absent.

## Left for follow-ups

- **Staging points at the production database.** `resolveHyperdriveRefId` returns the prd config for `stg` (flagged TEMPORARY since 2026-07-14). Fixing it needs a PlanetScale `stg` branch plus dedicated `maple-stg` / `maple-alerting-stg` dashboard configs — resources outside this repo — and then a deliberate call on whether stg crons should run. Documented in `docs/infra.md`.
- **The six `wrangler.jsonc` files still mirror the stack** (`apps/api/wrangler.jsonc` already declares 1 of the 3 rate limiters the stack deploys). `alchemy dev` was spiked as the way out: it reconciles the worker and starts workerd on `localhost:1337` with no account state touched, but nothing served — every request to that open port timed out, undiagnosed. Not a switch-flip, so the wrangler files are untouched here. Findings and an interim CI drift-check recommendation are in `docs/infra.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790085208&installation_model_id=427786&pr_number=598&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F598&signature=dc882fd45f0a10dae47a15c9be6bc83b69b834ab8b4e17dd5c5b7ca8d747db6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->