### PR TITLE
fix(ingest): Cloudflare-only ALB ingress + origin token for the proxied gateway

### DIFF
--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -232,6 +232,25 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 		const autumnKey = process.env.AUTUMN_SECRET_KEY?.trim()
 		const autumnSecret = autumnKey ? yield* secret("autumn-secret-key", autumnKey) : undefined
 
+		// Origin token: proves a request came through OUR Cloudflare zone, which
+		// the Cloudflare IP allow-list on the ALB cannot (those ranges are shared
+		// by every tenant, so a Worker elsewhere can dial the origin from them and
+		// forge Cf-IPCountry). The gateway rejects every non-health request
+		// without a matching `X-Maple-Origin-Token` once this is set.
+		//
+		// Rollout ORDER matters, because enabling it before the header exists
+		// blackholes ingest:
+		//   1. Cloudflare → maple.dev → Rules → Transform Rules → Modify Request
+		//      Header: for hostname `ingest.<domain>` set `X-Maple-Origin-Token`
+		//      to the value (use a long random string).
+		//   2. Add MAPLE_INGEST_ORIGIN_TOKEN with that value to the stage's
+		//      Infisical environment.
+		//   3. Deploy. Verify: requests via the domain succeed, requests straight
+		//      at the ALB hostname get 403.
+		// Unset (PR previews, or before step 2) the gateway stays open.
+		const originToken = process.env.MAPLE_INGEST_ORIGIN_TOKEN?.trim()
+		const originTokenSecret = originToken ? yield* secret("ingest-origin-token", originToken) : undefined
+
 		// Replay blob storage keys off the ENDPOINT, matching the gateway's own
 		// switch (`Config::from_env` in `apps/ingest/src/main.rs` treats
 		// INGEST_REPLAY_R2_ENDPOINT as the enable flag and `required()`s the rest).
@@ -425,6 +444,7 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 				MAPLE_INGEST_KEY_ENCRYPTION_KEY: keyEncryptionKey.secretArn,
 				MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: keyLookupHmacKey.secretArn,
 				...(autumnSecret ? { AUTUMN_SECRET_KEY: autumnSecret.secretArn } : undefined),
+				...(originTokenSecret ? { MAPLE_INGEST_ORIGIN_TOKEN: originTokenSecret.secretArn } : undefined),
 				...(replayR2Secret
 					? { INGEST_REPLAY_R2_SECRET_ACCESS_KEY: replayR2Secret.secretArn }
 					: undefined),
@@ -438,13 +458,15 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 
 				// Trust `Cf-IPCountry` on inbound requests, which is what gates
 				// `derive_country` in `apps/ingest/src/main.rs` and therefore whether
-				// `session_replays.Country` is ever non-empty. Safe on proxied stages
-				// because the ALB security group admits only Cloudflare's published
-				// ranges (`albIngress` above), so the header cannot be client-supplied.
-				// A PR preview is open and unproxied, so there the value is only as
-				// honest as the caller — acceptable for a test stack. Left unset until now, which is why every session
-				// recorded before this deploy has `Country = ''` — the gateway never
-				// stores a client IP, so there is nothing to backfill from.
+				// `session_replays.Country` is ever non-empty. Honest on proxied
+				// stages once MAPLE_INGEST_ORIGIN_TOKEN is enforced (see below): the
+				// ALB's Cloudflare-only ingress keeps the open internet out, and the
+				// origin token keeps other Cloudflare tenants out. A PR preview is
+				// open and unproxied, so there the value is only as honest as the
+				// caller — acceptable for a test stack. Left unset until 2026-08,
+				// which is why every session recorded before then has `Country = ''`
+				// — the gateway never stores a client IP, so there is nothing to
+				// backfill from.
 				MAPLE_INGEST_TRUST_PROXY_GEO: "true",
 
 				INGEST_QUEUE_MAX_BYTES: String(WAL_MAX_BYTES),

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -5,6 +5,8 @@ import * as Effect from "effect/Effect"
 import * as Redacted from "effect/Redacted"
 import type { MapleRegion } from "@maple/infra/aws"
 import {
+	CLOUDFLARE_IPV4_RANGES,
+	CLOUDFLARE_IPV6_RANGES,
 	COLLECTOR_DNS_LABEL,
 	COLLECTOR_OTLP_HTTP_PORT,
 	resolveAwsRegion,
@@ -133,23 +135,50 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 		// alchemy's default HTTP listener on 80, and the group has to admit THAT
 		// port or the load balancer is unreachable (the first preview deploy came
 		// up healthy and timed out on every request for exactly this reason).
-		const listenerPort = domains.ingest ? 443 : 80
+		//
+		// WHO may reach it also follows the domain. A stage with an ingest domain
+		// is proxied by Cloudflare, which terminates the public TLS, rate-limits,
+		// and stamps `Cf-IPCountry` — a header the gateway trusts
+		// (MAPLE_INGEST_TRUST_PROXY_GEO below). So only Cloudflare's published
+		// egress ranges may dial the ALB; anything else would bypass the proxy and
+		// be free to forge that header. A PR preview has no domain and is hit
+		// directly, so it stays open.
+		const proxiedByCloudflare = Boolean(domains.ingest)
+		const listenerPort = proxiedByCloudflare ? 443 : 80
+		const listenerDescription = proxiedByCloudflare ? "OTLP over HTTPS from Cloudflare" : "OTLP over HTTP (no ingest domain, no certificate)"
+		const albIngress = proxiedByCloudflare
+			? [
+					...CLOUDFLARE_IPV4_RANGES.map((cidrIpv4) => ({
+						ipProtocol: "tcp" as const,
+						fromPort: listenerPort,
+						toPort: listenerPort,
+						cidrIpv4,
+						description: listenerDescription,
+					})),
+					...CLOUDFLARE_IPV6_RANGES.map((cidrIpv6) => ({
+						ipProtocol: "tcp" as const,
+						fromPort: listenerPort,
+						toPort: listenerPort,
+						cidrIpv6,
+						description: listenerDescription,
+					})),
+				]
+			: [
+					{
+						ipProtocol: "tcp" as const,
+						fromPort: listenerPort,
+						toPort: listenerPort,
+						cidrIpv4: "0.0.0.0/0",
+						description: listenerDescription,
+					},
+				]
 		const albSecurityGroup = yield* AWS.EC2.SecurityGroup("ingest-alb-sg", {
 			vpcId: network.vpcId,
 			groupName: name("ingest-alb"),
-			description: `Maple OTLP ingest - public ${listenerPort === 443 ? "HTTPS" : "HTTP"} to the load balancer`,
-			ingress: [
-				{
-					ipProtocol: "tcp",
-					fromPort: listenerPort,
-					toPort: listenerPort,
-					cidrIpv4: "0.0.0.0/0",
-					description:
-						listenerPort === 443
-							? "OTLP over HTTPS"
-							: "OTLP over HTTP (no ingest domain, no certificate)",
-				},
-			],
+			description: proxiedByCloudflare
+				? "Maple OTLP ingest - HTTPS to the load balancer from Cloudflare only"
+				: "Maple OTLP ingest - public HTTP to the load balancer",
+			ingress: albIngress,
 		})
 
 		const taskSecurityGroup = yield* AWS.EC2.SecurityGroup("ingest-sg", {
@@ -409,10 +438,11 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 
 				// Trust `Cf-IPCountry` on inbound requests, which is what gates
 				// `derive_country` in `apps/ingest/src/main.rs` and therefore whether
-				// `session_replays.Country` is ever non-empty. Safe here specifically
-				// because the ALB security group only admits Cloudflare's proxy ranges
-				// (see `albSecurityGroup` above), so the header cannot be
-				// client-supplied. Left unset until now, which is why every session
+				// `session_replays.Country` is ever non-empty. Safe on proxied stages
+				// because the ALB security group admits only Cloudflare's published
+				// ranges (`albIngress` above), so the header cannot be client-supplied.
+				// A PR preview is open and unproxied, so there the value is only as
+				// honest as the caller — acceptable for a test stack. Left unset until now, which is why every session
 				// recorded before this deploy has `Country = ''` — the gateway never
 				// stores a client IP, so there is nothing to backfill from.
 				MAPLE_INGEST_TRUST_PROXY_GEO: "true",

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -158,6 +158,18 @@ struct AppConfig {
     /// terminated by Cloudflare. Off simply writes `''`, which is what the
     /// column held before this existed — it cannot regress anything.
     trust_proxy_geo: bool,
+    /// Shared secret that proves a request came through OUR Cloudflare zone,
+    /// not merely from Cloudflare's address space. Cloudflare adds
+    /// `X-Maple-Origin-Token: <value>` to every request for the ingest host
+    /// (a Transform Rule on the zone); when this is `Some`, every route except
+    /// the health probes rejects a request whose header does not match. An IP
+    /// allow-list at the load balancer cannot do this: those ranges are shared
+    /// by every Cloudflare tenant, and a Worker on another account can dial the
+    /// origin from them and forge `Cf-IPCountry`. `None` (unset or empty) keeps
+    /// the gateway open — the right state for a preview stack that is hit
+    /// directly, and the state to deploy FIRST, before the Transform Rule exists,
+    /// so enabling it can never outrun the header.
+    origin_token: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -486,6 +498,11 @@ impl AppConfig {
             false,
         )?;
 
+        let origin_token = std::env::var("MAPLE_INGEST_ORIGIN_TOKEN")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty());
+
         Ok(Self {
             port,
             otlp_grpc_port,
@@ -507,6 +524,7 @@ impl AppConfig {
             replay_max_session_bytes,
             replay_blob_store,
             trust_proxy_geo,
+            origin_token,
         })
     }
 }
@@ -2108,6 +2126,13 @@ async fn main() {
         )
         .layer(cors)
         .layer(DefaultBodyLimit::max(config.max_request_body_bytes))
+        // Outermost, so it runs before CORS and the body limit: an unproven
+        // request is answered before a byte of its body is read. Cloudflare adds
+        // the header to preflights too, so browser traffic is unaffected.
+        .layer(axum::middleware::from_fn_with_state(
+            Arc::clone(&state),
+            require_origin_token,
+        ))
         .with_state(state);
 
     let listener = match tokio::net::TcpListener::bind(("0.0.0.0", config.port)).await {
@@ -2712,6 +2737,50 @@ fn is_safe_replay_id(value: &str) -> bool {
 /// breakdown carry two junk buckets.
 ///
 /// The client IP is deliberately never read or stored — country is all we take.
+/// Header Cloudflare stamps on every request for the ingest host (Transform
+/// Rule on the zone) when `MAPLE_INGEST_ORIGIN_TOKEN` is in use.
+const ORIGIN_TOKEN_HEADER: &str = "x-maple-origin-token";
+
+/// Paths the load balancer probes itself. Its health checker never passes
+/// through Cloudflare, so these stay open; they carry no data and need no key.
+const ORIGIN_TOKEN_EXEMPT_PATHS: [&str; 2] = ["/health", "/ready"];
+
+/// Length-guarded comparison that does not short-circuit on the first
+/// differing byte, so response timing says nothing about how much of a guess
+/// was right. (The length check leaks only the length, which is not secret.)
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+fn origin_token_matches(headers: &HeaderMap, expected: &str) -> bool {
+    headers
+        .get(ORIGIN_TOKEN_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|presented| constant_time_eq(presented.as_bytes(), expected.as_bytes()))
+}
+
+/// Enforces `Config::origin_token` on every route except the health probes.
+/// A rejection is a 403 — distinct from the 401 a missing ingest key earns, so
+/// a misconfigured Transform Rule is not mistaken for a credential problem —
+/// and deliberately says nothing about which of "missing" or "wrong" applied.
+async fn require_origin_token(
+    State(state): State<Arc<AppState>>,
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let Some(expected) = state.config.origin_token.as_deref() else {
+        return next.run(request).await;
+    };
+    let path = request.uri().path();
+    if ORIGIN_TOKEN_EXEMPT_PATHS.contains(&path) || origin_token_matches(request.headers(), expected) {
+        return next.run(request).await;
+    }
+    ApiError::new(StatusCode::FORBIDDEN, "Origin token missing or invalid").into_response()
+}
+
 fn derive_country(headers: &HeaderMap, trust_proxy_geo: bool) -> String {
     if !trust_proxy_geo {
         return String::new();
@@ -6115,6 +6184,34 @@ fn parse_usize(name: &str, raw: Option<String>, default: usize) -> Result<usize,
 
 #[cfg(test)]
 mod tests {
+    mod origin_token {
+        use super::super::{constant_time_eq, origin_token_matches, ORIGIN_TOKEN_HEADER};
+        use axum::http::{HeaderMap, HeaderValue};
+
+        fn headers_with(value: &str) -> HeaderMap {
+            let mut headers = HeaderMap::new();
+            headers.insert(ORIGIN_TOKEN_HEADER, HeaderValue::from_str(value).unwrap());
+            headers
+        }
+
+        #[test]
+        fn constant_time_eq_compares_bytes() {
+            assert!(constant_time_eq(b"secret", b"secret"));
+            assert!(!constant_time_eq(b"secret", b"secreT"));
+            assert!(!constant_time_eq(b"secret", b"secre"));
+            assert!(!constant_time_eq(b"", b"x"));
+            assert!(constant_time_eq(b"", b""));
+        }
+
+        #[test]
+        fn matches_only_the_exact_token() {
+            assert!(origin_token_matches(&headers_with("tok-1"), "tok-1"));
+            assert!(!origin_token_matches(&headers_with("tok-2"), "tok-1"));
+            assert!(!origin_token_matches(&headers_with("tok-1 "), "tok-1"));
+            assert!(!origin_token_matches(&HeaderMap::new(), "tok-1"));
+        }
+    }
+
     use super::*;
     // `AtomicBool` is only used by the test fakes below; keeping it out of the
     // top-level import avoids an unused-import warning in non-test bin builds.
@@ -7122,6 +7219,7 @@ mod tests {
                 replay_max_session_bytes: 1024 * 1024 * 1024,
                 replay_blob_store: None,
                 trust_proxy_geo: false,
+                origin_token: None,
             },
             #[expect(
                 clippy::useless_conversion,

--- a/packages/infra/src/aws/cloudflare-ips.test.ts
+++ b/packages/infra/src/aws/cloudflare-ips.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { CLOUDFLARE_IPV4_RANGES, CLOUDFLARE_IPV6_RANGES } from "./cloudflare-ips.ts"
+
+const IPV4_CIDR = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})$/
+const IPV6_CIDR = /^[0-9a-f:]+\/\d{1,3}$/
+
+describe("Cloudflare proxy ranges", () => {
+	it("has a non-empty, well-formed IPv4 allow-list", () => {
+		expect(CLOUDFLARE_IPV4_RANGES.length).toBeGreaterThan(5)
+		for (const cidr of CLOUDFLARE_IPV4_RANGES) {
+			const match = cidr.match(IPV4_CIDR)
+			expect(match, cidr).not.toBeNull()
+			const octets = match!.slice(1, 5).map(Number)
+			for (const octet of octets) expect(octet).toBeLessThanOrEqual(255)
+			expect(Number(match![5])).toBeLessThanOrEqual(32)
+		}
+	})
+
+	it("has a non-empty, well-formed IPv6 allow-list", () => {
+		expect(CLOUDFLARE_IPV6_RANGES.length).toBeGreaterThan(3)
+		for (const cidr of CLOUDFLARE_IPV6_RANGES) {
+			expect(cidr, cidr).toMatch(IPV6_CIDR)
+			expect(Number(cidr.split("/")[1])).toBeLessThanOrEqual(128)
+		}
+	})
+
+	it("never contains the open-internet range", () => {
+		expect(CLOUDFLARE_IPV4_RANGES).not.toContain("0.0.0.0/0")
+		expect(CLOUDFLARE_IPV6_RANGES).not.toContain("::/0")
+	})
+})

--- a/packages/infra/src/aws/cloudflare-ips.ts
+++ b/packages/infra/src/aws/cloudflare-ips.ts
@@ -1,0 +1,44 @@
+/**
+ * Cloudflare's published proxy egress ranges — the only sources that should be
+ * able to reach the ingest ALB once `ingest.<domain>` is proxied. The gateway
+ * trusts `Cf-IPCountry` (`MAPLE_INGEST_TRUST_PROXY_GEO`) and leans on
+ * Cloudflare for TLS termination and rate limiting, so a directly dialable ALB
+ * would let anyone spoof the former and skip the latter.
+ *
+ * Snapshot of https://www.cloudflare.com/ips-v4 and /ips-v6 taken 2026-08-23.
+ * Cloudflare changes these rarely and announces it; to refresh, re-run:
+ *
+ *   curl -s https://www.cloudflare.com/ips-v4 ; curl -s https://www.cloudflare.com/ips-v6
+ *
+ * and replace the lists (the test asserts every entry is a well-formed CIDR).
+ * Deliberately a checked-in snapshot rather than a fetch at deploy time: a
+ * transient fetch failure must not be able to empty the allow-list and cut
+ * production ingest off.
+ */
+export const CLOUDFLARE_IPV4_RANGES: readonly string[] = [
+	"173.245.48.0/20",
+	"103.21.244.0/22",
+	"103.22.200.0/22",
+	"103.31.4.0/22",
+	"141.101.64.0/18",
+	"108.162.192.0/18",
+	"190.93.240.0/20",
+	"188.114.96.0/20",
+	"197.234.240.0/22",
+	"198.41.128.0/17",
+	"162.158.0.0/15",
+	"104.16.0.0/13",
+	"104.24.0.0/14",
+	"172.64.0.0/13",
+	"131.0.72.0/22",
+]
+
+export const CLOUDFLARE_IPV6_RANGES: readonly string[] = [
+	"2400:cb00::/32",
+	"2606:4700::/32",
+	"2803:f800::/32",
+	"2405:b500::/32",
+	"2405:8100::/32",
+	"2a06:98c0::/29",
+	"2c0f:f248::/32",
+]

--- a/packages/infra/src/aws/index.ts
+++ b/packages/infra/src/aws/index.ts
@@ -1,1 +1,2 @@
 export * from "./stage.ts"
+export * from "./cloudflare-ips.ts"


### PR DESCRIPTION
Two layers, now that `ingest.maple.dev` is proxied to the ALB:

1. **ALB security group admits only Cloudflare's published ranges** on stages with an ingest domain (prd/stg) — one rule per IPv4/IPv6 range from a checked-in snapshot (`packages/infra/src/aws/cloudflare-ips.ts`, 2026-08-23, refresh command in the header; deliberately not a deploy-time fetch, so a transient failure can never empty the allow-list). Drops open-internet traffic at the network edge before the ALB bills a byte or a TLS handshake happens. PR previews (no domain, hit directly) stay open on 80.
2. **Origin token** (addresses the review finding below): Cloudflare's ranges are shared by every tenant, so an IP list proves "via Cloudflare", not "via our zone" — another account's Worker could dial the origin and forge `Cf-IPCountry`. The gateway now reads `MAPLE_INGEST_ORIGIN_TOKEN`; when set, every route except `/health` + `/ready` (the ALB's own probes) rejects a request without a matching `X-Maple-Origin-Token` with **403** (distinct from the 401 a missing ingest key earns). Constant-time compare, outermost layer (answered before the body is read). Unset → open, which is the state to ship first. The stack passes the token to the task via Secrets Manager like the other secrets.

**Rollout for (2)** — order matters, enabling before the header exists would blackhole ingest:
1. Cloudflare → maple.dev → Rules → Transform Rules → *Modify Request Header*: for hostname `ingest.maple.dev` (and `ingest-staging.maple.dev` for stg) set `X-Maple-Origin-Token` = a long random value.
2. Add `MAPLE_INGEST_ORIGIN_TOKEN` with that value to Infisical `prod` (and `staging`).
3. Merge/deploy. Verify: `curl https://ingest.maple.dev/health` → 200; a request at the ALB hostname → timeout (SG) / 403 (token).

Merging (1) alone is safe today (in-place SG update; proxied traffic unaffected). Tests: `cargo test origin_token` (2), `packages/infra` (13), alchemy typecheck.
