### PR TITLE
feat(ingest): autoscale the production gateway on CPU (2–6 tasks)

### DIFF
--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -14,6 +14,7 @@ import {
 	resolveIngestCidrBlock,
 	resolveIngestDesiredCount,
 	resolveIngestNamespaceName,
+	resolveIngestScaling,
 	resolveIngestTaskSize,
 	stageDeploysCollector,
 } from "@maple/infra/aws"
@@ -101,6 +102,7 @@ export interface CreateMapleIngestOptions {
 export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestOptions) =>
 	Effect.gen(function* () {
 		const taskSize = resolveIngestTaskSize(stage)
+		const scaling = resolveIngestScaling(stage)
 		const name = (base: string) => resolveAwsResourceName(base, stage, region)
 
 		// Public subnets with public IPs on the tasks, and NO NAT gateway. NAT
@@ -364,6 +366,10 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 			memory: taskSize.memory,
 
 			desiredCount: resolveIngestDesiredCount(stage),
+			// prd autoscales on CPU between this count and a burst ceiling; alchemy
+			// stops pinning desiredCount while `scaling` is set, so the autoscaler's
+			// decisions survive redeploys. Other stages stay fixed.
+			...(scaling ? { scaling } : undefined),
 			vpcId: network.vpcId,
 			subnets: network.publicSubnetIds,
 			securityGroups: [albSecurityGroup.groupId, taskSecurityGroup.groupId],

--- a/packages/infra/src/aws/stage.test.ts
+++ b/packages/infra/src/aws/stage.test.ts
@@ -7,7 +7,9 @@ import {
 	resolveCollectorEndpoint,
 	resolveCollectorTaskSize,
 	resolveIngestCidrBlock,
+	resolveIngestDesiredCount,
 	resolveIngestNamespaceName,
+	resolveIngestScaling,
 	stageDeploysCollector,
 	stageDeploysIngest,
 } from "./stage.ts"
@@ -85,5 +87,22 @@ describe("collector service discovery", () => {
 		expect(resolveCollectorTaskSize(parseMapleStage("prd"))).toEqual({ cpu: 512, memory: 1024 })
 		expect(resolveCollectorTaskSize(parseMapleStage("stg"))).toEqual({ cpu: 256, memory: 1024 })
 		expect(resolveCollectorTaskSize(parseMapleStage("pr-12"))).toEqual({ cpu: 256, memory: 1024 })
+	})
+})
+
+describe("resolveIngestScaling", () => {
+	it("autoscales production between the fixed count and a burst ceiling", () => {
+		const scaling = resolveIngestScaling(parseMapleStage("prd"))
+		expect(scaling).toBeDefined()
+		expect(scaling!.min).toBe(resolveIngestDesiredCount(parseMapleStage("prd")))
+		expect(scaling!.max).toBeGreaterThan(scaling!.min)
+		expect(scaling!.cpuUtilization).toBeGreaterThan(0)
+		expect(scaling!.cpuUtilization).toBeLessThan(100)
+	})
+
+	it("keeps every other stage at a fixed count", () => {
+		expect(resolveIngestScaling(parseMapleStage("stg"))).toBeUndefined()
+		expect(resolveIngestScaling(parseMapleStage("pr-12"))).toBeUndefined()
+		expect(resolveIngestScaling(parseMapleStage("dev-alice"))).toBeUndefined()
 	})
 })

--- a/packages/infra/src/aws/stage.ts
+++ b/packages/infra/src/aws/stage.ts
@@ -100,6 +100,34 @@ export function resolveIngestDesiredCount(stage: MapleStage): number {
 	return stage.kind === "prd" ? 2 : 1
 }
 
+/**
+ * Target-tracking autoscaling for the ingest service, or `undefined` for a
+ * fixed desired count.
+ *
+ * prd: 2–6 tasks on 60% average CPU. The floor is today's fixed count (AZ
+ * redundancy); the ceiling is ~6x current traffic at ~1,300 req/s per vCPU.
+ * Scale-out is eager (1 min) because a burst that outruns the gateway turns
+ * into 5xx at the edge; scale-in is lazy (5 min) so a lull does not thrash.
+ * Note the per-org replay byte budget is process-local, so the effective
+ * ceiling scales with the task count (see `resolveIngestDesiredCount`).
+ * Other stages stay fixed: nothing bursts at staging or a preview.
+ */
+export interface IngestScaling {
+	min: number
+	max: number
+	/** Target average CPU utilization, percent. */
+	cpuUtilization: number
+	/** Shaped like effect's `Duration.Input` so it can flow straight into alchemy. */
+	scaleInCooldown: `${number} ${"seconds" | "minutes"}`
+	scaleOutCooldown: `${number} ${"seconds" | "minutes"}`
+}
+
+export function resolveIngestScaling(stage: MapleStage): IngestScaling | undefined {
+	return stage.kind === "prd"
+		? { min: 2, max: 6, cpuUtilization: 60, scaleInCooldown: "5 minutes", scaleOutCooldown: "60 seconds" }
+		: undefined
+}
+
 export interface IngestTaskSize {
 	/** Fargate CPU units. 1024 = 1 vCPU. */
 	cpu: number


### PR DESCRIPTION
Today the prod ingest service is a fixed `desiredCount: 2` (≈2,600 req/s headroom) with nothing between a burst and 5xx at the edge. This adds target-tracking autoscaling for **prd only**: 2–6 tasks on 60% average CPU, scale-out cooldown 60 s, scale-in 5 min (`resolveIngestScaling` in `packages/infra/src/aws/stage.ts`, wired as `scaling` on the ECS service). alchemy stops pinning `desiredCount` while `scaling` is set, so redeploys don't fight the autoscaler. Staging/previews unchanged.

Cost: floor is today's cost; ceiling ≈3× gateway compute at full burst (compute is a rounding error next to egress). Note the per-org replay byte budget is process-local, so its effective ceiling scales with task count.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790087680&installation_model_id=427786&pr_number=601&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F601&signature=9dec96b31fe431fa2d9863b0cc7f88096c6f01ab6884944f3eff34f0bd95084d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->