### PR TITLE
fix(slack-agent): adaptive chart tick precision + percent unit contract

### DIFF
--- a/apps/slack-agent/agent/instructions.md
+++ b/apps/slack-agent/agent/instructions.md
@@ -117,7 +117,9 @@ reader's next move.
 - When a trend over time IS the finding (a latency spike, an error-rate step,
   a throughput drop), call the `render_chart` tool with the data you already
   fetched — it posts a chart image into the thread. Do not re-describe a
-  posted chart point by point.
+  posted chart point by point. Maple tools report rates (`errorRate`) as
+  fractions of 1; `render_chart` unit `percent` takes percentage points, so
+  always multiply by 100 first (0.0004 → 0.04).
 - Before composing your reply, decide the emoji reaction. Call the
   `add_reaction` tool whenever the message or your findings carry any
   social, emotional, or diagnostic charge: the user greets you or says hi

--- a/apps/slack-agent/agent/lib/chart.test.ts
+++ b/apps/slack-agent/agent/lib/chart.test.ts
@@ -30,6 +30,40 @@ describe("formatValue", () => {
 	test("requests_per_sec appends /s", () => {
 		expect(formatValue(1200, "requests_per_sec")).toBe("1.2k/s")
 	})
+
+	test("tick step drives precision so tiny ranges stay distinct", () => {
+		expect(formatValue(0, "percent", 0.01)).toBe("0%")
+		expect(formatValue(0.01, "percent", 0.01)).toBe("0.01%")
+		expect(formatValue(0.04, "percent", 0.01)).toBe("0.04%")
+		expect(formatValue(0.02, "number", 0.01)).toBe("0.02")
+		expect(formatValue(0.03, "duration_ms", 0.01)).toBe("0.03 ms")
+		expect(formatValue(0.5, "requests_per_sec", 0.25)).toBe("0.5/s")
+	})
+
+	test("step precision respects the unit's display scale", () => {
+		expect(formatValue(1500, "duration_ms", 500)).toBe("1.5 s") // step 0.5 s → 1 decimal
+		expect(formatValue(2_500_000, "number", 500_000)).toBe("2.5M")
+		expect(formatValue(1536, "bytes", 512)).toBe("1.5 KiB")
+	})
+
+	test("coarse steps do not add decimal noise", () => {
+		expect(formatValue(2000, "duration_ms", 1000)).toBe("2 s")
+		expect(formatValue(40, "percent", 10)).toBe("40%")
+	})
+
+	test("a 2.5-mantissa step earns one extra decimal", () => {
+		expect(formatValue(2.5, "number", 2.5)).toBe("2.5")
+		expect(formatValue(0.025, "percent", 0.025)).toBe("0.025%")
+	})
+
+	test("every tick of a 0–0.04 percent axis formats distinctly", () => {
+		const ticks = niceTicks(0.012, 0.04)
+		const step = ticks[1]! - ticks[0]!
+		const labels = ticks.map((t) => formatValue(t, "percent", step))
+		expect(labels.length).toBeGreaterThanOrEqual(3)
+		expect(new Set(labels).size).toBe(labels.length)
+		expect(labels).not.toContain("0.00%")
+	})
 })
 
 // ── niceTicks ───────────────────────────────────────────────────────────────
@@ -118,6 +152,23 @@ describe("renderChartSvg", () => {
 	test("bar charts render one path per point", () => {
 		const svg = renderChartSvg(spec({ kind: "bar" }))
 		expect(svg.match(/<path/gu)?.length).toBe(12)
+	})
+
+	test("a 0.04%-peak error-rate series renders distinct y-axis labels", () => {
+		// Regression: fixed toFixed(2) rendered every tick of this chart "0.00%".
+		const svg = renderChartSvg(
+			spec({
+				unit: "percent",
+				points: Array.from({ length: 12 }, (_, i) => [T0 + i * 300_000, 0.005 + (0.035 * i) / 11] as const),
+			}),
+		)
+		const labels = [...svg.matchAll(/x="56" y="[^"]+" text-anchor="end"[^>]*>([^<]+)<\/text>/gu)].map(
+			(m) => m[1]!,
+		)
+		expect(labels.length).toBeGreaterThanOrEqual(3)
+		expect(new Set(labels).size).toBe(labels.length)
+		expect(labels.every((l) => l.endsWith("%"))).toBe(true)
+		expect(labels).not.toContain("0.00%")
 	})
 
 	test("throws on an empty series", () => {

--- a/apps/slack-agent/agent/lib/chart.ts
+++ b/apps/slack-agent/agent/lib/chart.ts
@@ -65,32 +65,59 @@ const FONT = `"Geist Mono", "Geist Mono Variable", "DejaVu Sans Mono", ui-monosp
 
 const round = (n: number, digits = 1): string => {
 	const s = n.toFixed(digits)
-	return s.endsWith(".0") ? s.slice(0, -2) : s
+	return s.includes(".") ? s.replace(/\.?0+$/u, "") : s
 }
 
-/** Formats a value for axis labels and direct labels, unit-aware. */
-export function formatValue(value: number, unit: ChartUnit): string {
+/**
+ * Decimals needed to tell values `step` apart after formatting: magnitude
+ * (0.0001 → 4) plus one when the mantissa itself carries a decimal (2.5 → 1).
+ * Fixed 1–2 decimals collapsed every tick of a 0–0.04% axis to "0.00%".
+ */
+const stepDecimals = (step: number): number => {
+	if (!(step > 0) || !Number.isFinite(step)) return 0
+	const d = Math.max(0, -Math.floor(Math.log10(step)))
+	const mantissa = step * 10 ** d
+	return Math.abs(mantissa - Math.round(mantissa)) < 1e-6 ? d : d + 1
+}
+
+/** `base` decimals, widened by `step` when adjacent ticks need more to differ. */
+const decimalsFor = (base: number, step: number | undefined): number =>
+	step !== undefined ? Math.max(base, stepDecimals(step)) : base
+
+/**
+ * Formats a value for axis labels and direct labels, unit-aware. `step` is the
+ * spacing between adjacent axis ticks (same raw unit as `value`); when given,
+ * precision widens so neighboring ticks never format to the same string —
+ * `round`'s trailing-zero trim keeps the extra decimals invisible elsewhere.
+ */
+export function formatValue(value: number, unit: ChartUnit, step?: number): string {
 	switch (unit) {
 		case "percent":
-			return `${round(value, Math.abs(value) < 1 ? 2 : 1)}%`
-		case "duration_ms":
-			if (Math.abs(value) >= 60_000) return `${round(value / 60_000)} min`
-			if (Math.abs(value) >= 1000) return `${round(value / 1000)} s`
-			return `${round(value)} ms`
+			return `${round(value, decimalsFor(Math.abs(value) < 1 ? 2 : 1, step))}%`
+		case "duration_ms": {
+			const abs = Math.abs(value)
+			const [div, suffix] = abs >= 60_000 ? [60_000, " min"] : abs >= 1000 ? [1000, " s"] : [1, " ms"]
+			return `${round(value / div, decimalsFor(1, step === undefined ? undefined : step / div))}${suffix}`
+		}
 		case "bytes": {
 			const abs = Math.abs(value)
-			if (abs >= 1024 ** 3) return `${round(value / 1024 ** 3)} GiB`
-			if (abs >= 1024 ** 2) return `${round(value / 1024 ** 2)} MiB`
-			if (abs >= 1024) return `${round(value / 1024)} KiB`
-			return `${round(value)} B`
+			const [div, suffix] =
+				abs >= 1024 ** 3
+					? [1024 ** 3, " GiB"]
+					: abs >= 1024 ** 2
+						? [1024 ** 2, " MiB"]
+						: abs >= 1024
+							? [1024, " KiB"]
+							: [1, " B"]
+			return `${round(value / div, decimalsFor(1, step === undefined ? undefined : step / div))}${suffix}`
 		}
 		case "requests_per_sec":
-			return `${formatValue(value, "number")}/s`
+			return `${formatValue(value, "number", step)}/s`
 		case "number": {
 			const abs = Math.abs(value)
-			if (abs >= 1_000_000) return `${round(value / 1_000_000)}M`
-			if (abs >= 1000) return `${round(value / 1000)}k`
-			return round(value, abs < 10 && !Number.isInteger(value) ? 1 : 0)
+			const [div, suffix] = abs >= 1_000_000 ? [1_000_000, "M"] : abs >= 1000 ? [1000, "k"] : [1, ""]
+			const base = div === 1 ? (abs < 10 && !Number.isInteger(value) ? 1 : 0) : 1
+			return `${round(value / div, decimalsFor(base, step === undefined ? undefined : step / div))}${suffix}`
 		}
 	}
 }
@@ -139,6 +166,7 @@ export function renderChartSvg(spec: ChartSpec): string {
 	const ticks = niceTicks(Math.min(...values), Math.max(...values))
 	const yMin = ticks[0]!
 	const yMax = ticks[ticks.length - 1]!
+	const tickStep = ticks.length > 1 ? ticks[1]! - ticks[0]! : undefined
 	const tMin = points[0]![0]
 	const tMax = points[points.length - 1]![0]
 	const tRange = Math.max(1, tMax - tMin)
@@ -175,7 +203,7 @@ export function renderChartSvg(spec: ChartSpec): string {
 		const isBaseline = tick === yMin
 		parts.push(
 			`<line x1="${PAD_LEFT}" y1="${ty}" x2="${WIDTH - PAD_RIGHT}" y2="${ty}" stroke="${COLORS.border}"${isBaseline ? "" : ' stroke-opacity="0.5"'} stroke-width="1"/>`,
-			`<text x="${PAD_LEFT - 8}" y="${ty + 4}" text-anchor="end" font-family='${FONT}' font-size="12" fill="${COLORS.muted}">${esc(formatValue(tick, spec.unit))}</text>`,
+			`<text x="${PAD_LEFT - 8}" y="${ty + 4}" text-anchor="end" font-family='${FONT}' font-size="12" fill="${COLORS.muted}">${esc(formatValue(tick, spec.unit, tickStep))}</text>`,
 		)
 	}
 
@@ -212,7 +240,7 @@ export function renderChartSvg(spec: ChartSpec): string {
 		const dx = anchor === "end" ? -8 : 8
 		parts.push(
 			`<circle cx="${x(lt).toFixed(1)}" cy="${y(lv).toFixed(1)}" r="4" fill="${series}" stroke="${COLORS.surface}" stroke-width="2"/>`,
-			`<text x="${(x(lt) + dx).toFixed(1)}" y="${(y(lv) - 8).toFixed(1)}" text-anchor="${anchor}" font-family='${FONT}' font-size="12" font-weight="600" fill="${COLORS.primaryInk}">${esc(formatValue(lv, spec.unit))}</text>`,
+			`<text x="${(x(lt) + dx).toFixed(1)}" y="${(y(lv) - 8).toFixed(1)}" text-anchor="${anchor}" font-family='${FONT}' font-size="12" font-weight="600" fill="${COLORS.primaryInk}">${esc(formatValue(lv, spec.unit, tickStep))}</text>`,
 		)
 	}
 

--- a/apps/slack-agent/agent/tools/render_chart.ts
+++ b/apps/slack-agent/agent/tools/render_chart.ts
@@ -36,7 +36,12 @@ const inputSchema = z.object({
 		),
 	unit: z
 		.enum(["number", "percent", "duration_ms", "bytes", "requests_per_sec"])
-		.describe("Unit of the values; drives axis and label formatting."),
+		.describe(
+			"Unit of the values; drives axis and label formatting. percent values are " +
+				"percentage points on the 0–100 scale: pass 3.2 for 3.2%. Maple tools " +
+				"report rates (errorRate, hit rates) as fractions of 1 — always multiply " +
+				"them by 100 before charting as percent (0.0004 → 0.04).",
+		),
 	// Not z.tuple(): tuples serialize to the draft-07 `items: [..]` array form,
 	// which Workers AI rejects as an invalid 2020-12 tool schema.
 	// .finite() because bare z.number() admits Infinity/-Infinity, which turn


### PR DESCRIPTION
## Problem

A chart of ingest error rate with a 0.04% peak rendered every y-axis tick as `0.00%`. Two causes:

1. `formatValue()` in `agent/lib/chart.ts` used fixed precision (percent: `toFixed(2)` under 1), so any axis whose tick step is below 0.01 collapsed to identical labels.
2. Maple tools report rates (`errorRate`) as fractions of 1 in their structured payloads, but `render_chart`'s `percent` unit expects percentage points — nothing told the model to convert, so fractions like `0.0004` were charted as percent, putting the whole axis under the fixed 2-decimal floor.

## Fix

- `formatValue()` now takes the tick step from `niceTicks()` and widens decimals to `max(previous default, decimals needed to distinguish adjacent ticks)` — magnitude of the step plus one when the step mantissa carries a decimal (2.5 → 1, 0.025 → 3). Applied across all units in their display scale (percent, ms/s/min, B/KiB/MiB/GiB, k/M), so tiny `number` ranges are covered too. `round()` trims trailing zeros, so coarse axes look exactly as before.
- The `unit` tool-schema description and `agent/instructions.md` now state directively that `percent` takes percentage points (pass 3.2 for 3.2%) and that rates from Maple tools must be multiplied by 100 first. A boundary heuristic (values ≤ 1 → fraction) was rejected: it would misconvert genuine sub-1% series, which is precisely the error-rate case. If a fraction still slips through, the adaptive axis now renders distinct labels instead of a wall of `0.00%`, making the mistake visible.

## Tests

New coverage in `chart.test.ts`: a 0.04-max percent series must produce all-distinct tick labels (both at the `formatValue`/`niceTicks` level and extracted from the rendered SVG), per-unit step scaling, the 2.5-mantissa step, and a guard that coarse steps gain no decimal noise.

`bun test` in `apps/slack-agent`: 287 pass, 0 fail. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790112036&installation_model_id=427786&pr_number=605&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F605&signature=7d73f1f777698a2f48fa0b4718f7b5404576f039da6a41f4e189e0f19f1e832e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->