### PR TITLE
fix(warehouse): prune partitions on the agent-session fan-out

### DIFF
--- a/apps/api/src/routes/internal/ai-sessions.http.test.ts
+++ b/apps/api/src/routes/internal/ai-sessions.http.test.ts
@@ -148,15 +148,24 @@ describe("POST /internal/ai-sessions/spans", () => {
 		}
 	})
 
-	// A link that arrives with no `t`/`end` — pasted, or written by an agent.
-	// The endpoint must resolve the session from the id rather than invent a
-	// range, and the compiled SQL is where that is actually decidable: a
-	// fabricated window would show up as a `Timestamp` predicate.
-	it("resolves the session from its id alone when the request carries no window", async () => {
-		let compiledSql: string | undefined
+	// A link that arrives with no `t`/`end` — pasted, or written by an agent. The
+	// endpoint must resolve the session's real bounds rather than invent a range
+	// OR read unbounded, and the compiled SQL is where that is decidable: the
+	// resolve step is the only one allowed to carry no `Timestamp` predicate.
+	it("resolves bounds from the id, then reads the spans within them", async () => {
+		const resolved = {
+			startTime: "2026-08-18 09:00:00.000000000",
+			endTime: "2026-08-20 11:00:00.000000000",
+		}
+		let windowSql: string | undefined
+		let spansSql: string | undefined
 		const harness = makeHarness({
+			compiledQuery: (_tenant, compiled) => {
+				windowSql = compiled.sql
+				return compiled.decodeRows([{ ...resolved, spanCount: "9" }]).pipe(Effect.orDie)
+			},
 			compiledQueryBounded: (_tenant, compiled) => {
-				compiledSql = compiled.sql
+				spansSql = compiled.sql
 				return compiled.decodeRows([spanRow(0), spanRow(1)]).pipe(Effect.orDie)
 			},
 		})
@@ -165,11 +174,45 @@ describe("POST /internal/ai-sessions/spans", () => {
 			const response = await harness.post("/internal/ai-sessions/spans", { sessionId: SESSION_ID })
 			expect(response.status).toBe(200)
 			expect(response.body.data).toHaveLength(2)
-			expect(compiledSql).toContain(`SpanAttributes['maple_ai.session.id'] = '${SESSION_ID}'`)
-			expect(compiledSql).not.toContain("Timestamp >=")
-			expect(compiledSql).not.toContain("Timestamp <=")
+			// The bloom-indexed detection scan, unbounded on purpose.
+			expect(windowSql).toContain(`SpanAttributes['maple_ai.session.id'] = '${SESSION_ID}'`)
+			expect(windowSql).not.toContain("Timestamp >=")
+			// The fan-out, which never runs that way.
+			expect(spansSql).toContain(`Timestamp >= '${resolved.startTime}'`)
+			expect(spansSql).toContain(`Timestamp <= '${resolved.endTime}'`)
 			// An unbound placeholder would reach ClickHouse verbatim.
-			expect(compiledSql).not.toContain("__PARAM_")
+			expect(spansSql).not.toContain("__PARAM_")
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("answers an id nothing in retention carries without reading spans", async () => {
+		let spansRead = false
+		const harness = makeHarness({
+			// `min`/`max` over no rows come back as the epoch, so the count is the
+			// only thing that says the session does not exist.
+			compiledQuery: (_tenant, compiled) =>
+				compiled
+					.decodeRows([
+						{
+							startTime: "1970-01-01 00:00:00.000000000",
+							endTime: "1970-01-02 00:00:00.000000000",
+							spanCount: "0",
+						},
+					])
+					.pipe(Effect.orDie),
+			compiledQueryBounded: (_tenant, compiled) => {
+				spansRead = true
+				return compiled.decodeRows([spanRow(0)]).pipe(Effect.orDie)
+			},
+		})
+
+		try {
+			const response = await harness.post("/internal/ai-sessions/spans", { sessionId: SESSION_ID })
+			expect(response.status).toBe(200)
+			expect(response.body).toMatchObject({ data: [], truncated: false })
+			expect(spansRead).toBe(false)
 		} finally {
 			await harness.dispose()
 		}

--- a/apps/api/src/routes/internal/ai-sessions.http.ts
+++ b/apps/api/src/routes/internal/ai-sessions.http.ts
@@ -80,30 +80,50 @@ export const HttpAiSessionsInternalLive = HttpApiBuilder.group(
 						const tenant = yield* CurrentTenant.Context
 						// Both halves or neither: a lone bound would silently pin the
 						// other end of the read to the param placeholder.
-						const window =
+						const hint =
 							payload.startTime !== undefined && payload.endTime !== undefined
 								? { startTime: payload.startTime, endTime: payload.endTime }
 								: undefined
 						// Annotated before the read: a 413 never reaches the code below.
-						// `window_source` is how often the unwindowed retention scan runs
+						// `window_source` is how often the extra resolve round-trip runs
 						// gets watched — it should stay the exception.
 						yield* Effect.annotateCurrentSpan({
 							orgId: tenant.orgId,
 							"maple.ai.session.id": payload.sessionId,
-							"maple.ai.window_source": window === undefined ? "resolved" : "client",
+							"maple.ai.window_source": hint === undefined ? "resolved" : "client",
 						})
+						// The spans read has to be partition-pruned on both levels, so a
+						// caller without bounds gets bounds first rather than an unpruned
+						// fan-out — see `aiSessionSpansQuery`. One extra round trip, and
+						// only on the deep-link path.
+						const resolved =
+							hint === undefined
+								? yield* warehouse.compiledQuery(
+										tenant,
+										CH.compile(
+											Integrations.aiSessionWindowQuery(),
+											{ orgId: tenant.orgId, sessionId: payload.sessionId },
+											{ rowSchema: Integrations.aiSessionWindowRowSchema },
+										),
+										{ profile: "list", context: "aiSessionWindow" },
+									)
+								: undefined
+						// `min`/`max` over no rows return the epoch rather than nothing, so
+						// the count is what distinguishes an unknown session id.
+						const bounds = resolved?.[0]
+						const window =
+							hint ??
+							(bounds !== undefined && bounds.spanCount > 0
+								? { startTime: bounds.startTime, endTime: bounds.endTime }
+								: undefined)
+						if (window === undefined) {
+							return new GetAiSessionSpansResponse({ data: [], truncated: false })
+						}
 						// One row past the cap: the extra row is what distinguishes a
 						// session that exactly fills the cap from one whose tail was cut.
 						const compiled = CH.compile(
-							Integrations.aiSessionSpansQuery({
-								limit: AI_SESSION_SPANS_MAX_SPANS + 1,
-								windowed: window !== undefined,
-							}),
-							// The unwindowed variant references neither window param, so
-							// passing them would leave two values with nothing to bind to.
-							window === undefined
-								? { orgId: tenant.orgId, sessionId: payload.sessionId }
-								: { orgId: tenant.orgId, sessionId: payload.sessionId, ...window },
+							Integrations.aiSessionSpansQuery({ limit: AI_SESSION_SPANS_MAX_SPANS + 1 }),
+							{ orgId: tenant.orgId, sessionId: payload.sessionId, ...window },
 							{ rowSchema: Integrations.aiSessionSpansRowSchema },
 						)
 						const rows = yield* warehouse

--- a/lib/clickhouse-builder/docs/reference.md
+++ b/lib/clickhouse-builder/docs/reference.md
@@ -153,8 +153,8 @@ Note `/sql` exports a `compile` (fragment → string) distinct from the root `co
 ### Date/time
 
 `toStartOfInterval(col, seconds)`, `toStartOfHour(col)`, `toUnixTimestamp(col)`,
-`toUnixTimestamp64Nano(col)`, `intervalSub(col, seconds)`, `formatDateTime(col, format)`,
-`toDateTime(col)`. `toHour(col)` is on `/expr` only.
+`toUnixTimestamp64Nano(col)`, `intervalSub(col, seconds)`, `intervalAdd(col, seconds)`,
+`formatDateTime(col, format)`, `toDateTime(col)`. `toHour(col)` is on `/expr` only.
 
 ### Conditional
 

--- a/lib/clickhouse-builder/src/ch/core-dsl.test.ts
+++ b/lib/clickhouse-builder/src/ch/core-dsl.test.ts
@@ -106,6 +106,12 @@ describe("expression functions", () => {
 		expect(sql).toContain("Timestamp - INTERVAL 3600 SECOND AS ts")
 	})
 
+	it("compiles intervalAdd", () => {
+		const q = CH.from(TestTable).select(($) => ({ ts: CH.intervalAdd($.Timestamp, 3600) }))
+		const { sql } = compileCH(q, {})
+		expect(sql).toContain("Timestamp + INTERVAL 3600 SECOND AS ts")
+	})
+
 	it("compiles outerRef", () => {
 		const q = CH.from(TestTable)
 			.select(($) => ({ id: $.Id }))

--- a/lib/clickhouse-builder/src/ch/functions/date-time.ts
+++ b/lib/clickhouse-builder/src/ch/functions/date-time.ts
@@ -67,6 +67,15 @@ export function intervalSub(col: Expr<string>, seconds: number | Expr<number>): 
 	return makeExpr<string>(raw(`${compile(col.toFragment())} - INTERVAL ${secStr} SECOND`))
 }
 
+/** The other half of {@link intervalSub} — `expr + INTERVAL n SECOND`. */
+export function intervalAdd(col: Expr<string>, seconds: number | Expr<number>): Expr<string> {
+	const secStr =
+		typeof seconds === "number"
+			? String(Math.round(seconds))
+			: compile((seconds as Expr<number>).toFragment())
+	return makeExpr<string>(raw(`${compile(col.toFragment())} + INTERVAL ${secStr} SECOND`))
+}
+
 /** `formatDateTime(expr, 'format')` — format a DateTime/DateTime64 as a string. */
 export function formatDateTime(col: Expr<string>, format: string): Expr<string> {
 	return makeExpr<string>(raw(`formatDateTime(${compile(col.toFragment())}, ${compile(str(format))})`))

--- a/lib/clickhouse-builder/src/ch/functions/index.ts
+++ b/lib/clickhouse-builder/src/ch/functions/index.ts
@@ -66,6 +66,7 @@ export {
 	toHour,
 	toUnixTimestamp,
 	toUnixTimestamp64Nano,
+	intervalAdd,
 	intervalSub,
 	formatDateTime,
 	toDateTime,

--- a/lib/clickhouse-builder/src/ch/index.ts
+++ b/lib/clickhouse-builder/src/ch/index.ts
@@ -117,6 +117,7 @@ export {
 	toStartOfMinute,
 	toUnixTimestamp,
 	toUnixTimestamp64Nano,
+	intervalAdd,
 	intervalSub,
 	formatDateTime,
 	toDateTime,

--- a/packages/domain/src/http/ai-sessions.ts
+++ b/packages/domain/src/http/ai-sessions.ts
@@ -83,15 +83,15 @@ export class GetAiSessionSpansRequest extends Schema.Class<GetAiSessionSpansRequ
 	// fan-out), which is the fast path every link from the list page takes: the
 	// row already knows the session's own bounds, so it hands them over.
 	//
-	// Without one the warehouse resolves the session from the id alone. That is
-	// viable rather than reckless: `traces` carries a `bloom_filter(0.01)` skip
-	// index over `mapValues(SpanAttributes)`, and its TTL caps any scan at 30
-	// days, so the id lookup was measured instant against production and found
-	// sessions several days back that spanned multiple traces. Bloom pruning
-	// still degrades as an org's volume grows, so this is the exception path for
-	// hint-less deep links — a pasted id, an MCP answer — and not the default.
-	// The client is expected to write the bounds it got back into its URL, which
-	// makes the second load of any such link the pruned one.
+	// Without one the handler resolves the session's bounds from the id first and
+	// then runs the same pruned read. That resolve step is viable rather than
+	// reckless where the fan-out would not be: `traces` carries a
+	// `bloom_filter(0.01)` skip index over `mapValues(SpanAttributes)` for the id
+	// to prune with, and its TTL caps any scan at 30 days. It still costs an
+	// extra round trip and still degrades as an org's volume grows, so this is
+	// the exception path for hint-less deep links — a pasted id, an MCP answer —
+	// and not the default. The client is expected to write the bounds it got back
+	// into its URL, which makes the second load of any such link the direct one.
 	startTime: Schema.optionalKey(TinybirdDateTime),
 	endTime: Schema.optionalKey(TinybirdDateTime),
 }) {}

--- a/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
+++ b/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
@@ -53,6 +53,8 @@ SELECT
           max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS traceEndNanos
         FROM trace_detail_spans
         WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00' - INTERVAL 86400 SECOND
+          AND Timestamp <= '2026-01-03 14:15:00' + INTERVAL 86400 SECOND
           AND TraceId IN (SELECT
           TraceId AS TraceId
         FROM traces
@@ -92,6 +94,8 @@ SELECT
           max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS traceEndNanos
         FROM trace_detail_spans
         WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00' - INTERVAL 86400 SECOND
+          AND Timestamp <= '2026-01-03 14:15:00' + INTERVAL 86400 SECOND
           AND TraceId IN (SELECT
           TraceId AS TraceId
         FROM traces
@@ -138,30 +142,15 @@ SELECT
         LIMIT 2000
         FORMAT JSON
 
--- builder:ai-sessions:aiSessionSpansQuery:unwindowed
+-- builder:ai-sessions:aiSessionWindowQuery:default
 SELECT
-          TraceId AS traceId,
-          SpanId AS spanId,
-          ParentSpanId AS parentSpanId,
-          SpanName AS spanName,
-          SpanKind AS spanKind,
-          ServiceName AS serviceName,
-          Duration / 1000000 AS durationMs,
-          StatusCode AS statusCode,
-          StatusMessage AS statusMessage,
-          toString(Timestamp) AS timestamp,
-          SpanAttributes AS spanAttributes,
-          ResourceAttributes AS resourceAttributes
-        FROM trace_detail_spans
-        WHERE OrgId = 'org_sql_catalog'
-          AND TraceId IN (SELECT
-          TraceId AS TraceId
+          toString(min(Timestamp) - INTERVAL 86400 SECOND) AS startTime,
+          toString(max(Timestamp) + INTERVAL 86400 SECOND) AS endTime,
+          count() AS spanCount
         FROM traces
         WHERE OrgId = 'org_sql_catalog'
           AND (mapContains(SpanAttributes, 'maple_ai.session.id') AND SpanAttributes['maple_ai.session.id'] != '')
-          AND SpanAttributes['maple_ai.session.id'] = 'wrun_sql_catalog')
-        ORDER BY timestamp ASC, spanId ASC
-        LIMIT 2000
+          AND SpanAttributes['maple_ai.session.id'] = 'wrun_sql_catalog'
         FORMAT JSON
 
 -- builder:cloudflare-infra-breakdowns:cloudflareZoneBreakdownTimeseriesSQL:default

--- a/packages/query-engine-integrations/src/ai/ai-sessions.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.test.ts
@@ -8,6 +8,8 @@ import {
 	aiSessionListRowSchema,
 	aiSessionSpansQuery,
 	aiSessionSpansRowSchema,
+	aiSessionWindowQuery,
+	aiSessionWindowRowSchema,
 } from "./ai-sessions"
 
 const params = {
@@ -98,6 +100,22 @@ describe("aiSessionListQuery", () => {
 		expect(detection).toContain("ServiceName IN ('maple-slack-agent')")
 		expect(fanOut).not.toContain("IN ('eve')")
 		expect(sql).toContain("LIMIT 25")
+	})
+
+	it("pads the fan-out window rather than dropping it", () => {
+		const { sql } = compileCH(aiSessionListQuery(), params)
+		const [fanOut, detection] = sql.split("TraceId IN (SELECT")
+
+		// `trace_detail_spans` is PARTITION BY toDate(Timestamp), so this predicate
+		// is the only thing standing between a seek over the window's partitions
+		// and a seek over every partition the 30-day TTL retains.
+		expect(fanOut).toContain(`Timestamp >= '${params.startTime}' - INTERVAL 86400 SECOND`)
+		expect(fanOut).toContain(`Timestamp <= '${params.endTime}' + INTERVAL 86400 SECOND`)
+		// Detection stays exact: the pad keeps a straddling trace whole, it does not
+		// widen which sessions the range reports.
+		expect(detection).toContain(`Timestamp >= '${params.startTime}'`)
+		expect(detection).toContain(`Timestamp <= '${params.endTime}'`)
+		expect(detection).not.toContain("INTERVAL")
 	})
 
 	it("leaves no unresolved param placeholder", () => {
@@ -236,6 +254,15 @@ describe("aiSessionSpansQuery", () => {
 		expect(escaped.sql).toContain("SpanAttributes['maple_ai.session.id'] = 'sess\\'evil'")
 	})
 
+	it("bounds both levels by the window", () => {
+		const { sql } = compileCH(aiSessionSpansQuery(), spanParams)
+
+		// Both, not one: the fan-out's copy is what prunes partitions, and the
+		// caller is responsible for bounds that contain the whole session.
+		expect(sql.split(`Timestamp >= '${params.startTime}'`).length - 1).toBe(2)
+		expect(sql.split(`Timestamp <= '${params.endTime}'`).length - 1).toBe(2)
+	})
+
 	it("honours a caller-supplied limit", () => {
 		expect(compileCH(aiSessionSpansQuery({ limit: 100 }), spanParams).sql).toContain("LIMIT 100")
 	})
@@ -275,5 +302,70 @@ describe("aiSessionSpansQuery", () => {
 			"maple_ai.session.id": "wrun_01M0CSAEW96BH2W9185XZPRPKH",
 		})
 		expect(row?.resourceAttributes).toEqual({ "service.name": "maple-slack-agent" })
+	})
+})
+
+describe("aiSessionWindowQuery", () => {
+	const windowParams = { orgId: params.orgId, sessionId: spanParams.sessionId }
+
+	it("resolves the bounds from the id alone, without a time predicate", () => {
+		const { sql } = compileCH(aiSessionWindowQuery(), windowParams)
+
+		// The one read in this file that runs unbounded, and the only one that can:
+		// `traces` has the mapValues bloom index for the id and a 30-day TTL. The
+		// fan-out has neither, which is why the caller resolves bounds first.
+		expect(sql).toContain("FROM traces")
+		expect(sql).not.toContain("trace_detail_spans")
+		expect(sql).not.toContain("Timestamp >=")
+		expect(sql).not.toContain("Timestamp <=")
+	})
+
+	it("reports bounds already padded for the fan-out", () => {
+		const { sql } = compileCH(aiSessionWindowQuery(), windowParams)
+
+		// The bounds are measured over session-BEARING spans; the read they bound
+		// returns every span of those spans' traces.
+		expect(sql).toContain("toString(min(Timestamp) - INTERVAL 86400 SECOND) AS startTime")
+		expect(sql).toContain("toString(max(Timestamp) + INTERVAL 86400 SECOND) AS endTime")
+	})
+
+	it("guards session-id presence, and escapes the id", () => {
+		const { sql } = compileCH(aiSessionWindowQuery(), windowParams)
+		expect(sql).toContain(
+			"(mapContains(SpanAttributes, 'maple_ai.session.id') AND SpanAttributes['maple_ai.session.id'] != '')",
+		)
+
+		const escaped = compileCH(aiSessionWindowQuery(), { ...windowParams, sessionId: "sess'evil" })
+		expect(escaped.sql).toContain("SpanAttributes['maple_ai.session.id'] = 'sess\\'evil'")
+	})
+
+	it("is org-scoped", () => {
+		expect(compileCH(aiSessionWindowQuery(), windowParams).tenantScope).toBe("org")
+	})
+
+	it("leaves no unresolved param placeholder", () => {
+		expect(compileCH(aiSessionWindowQuery(), windowParams).sql).not.toContain("__PARAM_")
+	})
+
+	it("decodes the quoted 64-bit count", () => {
+		const compiled = compileCH(aiSessionWindowQuery(), windowParams, {
+			rowSchema: aiSessionWindowRowSchema,
+		})
+
+		expect(
+			decodeRows(compiled, [
+				{
+					startTime: "2026-08-18 10:33:25.825000000",
+					endTime: "2026-08-20 10:33:36.242000000",
+					spanCount: "17",
+				},
+			]),
+		).toEqual([
+			{
+				startTime: "2026-08-18 10:33:25.825000000",
+				endTime: "2026-08-20 10:33:36.242000000",
+				spanCount: 17,
+			},
+		])
 	})
 })

--- a/packages/query-engine-integrations/src/ai/ai-sessions.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.ts
@@ -32,21 +32,25 @@
 // rather than a JOIN for the same reason too — ClickHouse pushes the id set into
 // the read, which a JOIN does not do.
 //
-// Where the window predicate sits differs by query, and it is a correctness
-// choice rather than a cost one. `aiSessionSpansQuery` keeps it on both levels
-// when it has one: the caller that links from the list already knows the
-// session's bounds and passes them in, so bounding the fan-out is what keeps a
-// session read to the session. `aiSessionListQuery` keeps it on detection ONLY
-// — see that function's comment; a bounded fan-out there clamps the reported
-// start/end of every session that began before the range. The unbounded seek
-// costs nothing measurable: `TraceId` is a sort-key prefix, and a `TraceId IN
-// (…)` fan-out over `trace_detail_spans` with no time filter at all returns
-// instantly in production.
+// The window predicate sits on BOTH levels, and the fan-out's copy is PADDED
+// rather than exact. That is what reconciles the two demands on it:
+// `trace_detail_spans` is `PARTITION BY toDate(Timestamp)`, so the predicate is
+// the only thing that prunes partitions there, while an exact copy of the
+// window would clamp the reported start/end of every session that began before
+// the range. A day of padding costs one extra partition on each side and
+// contains any trace shorter than 24h.
 //
-// A caller with no window at all (`windowed: false`) drops the predicate from
-// both levels and leans on the detection scan's bloom index and the table's
-// 30-day TTL instead — see `aiSessionSpansQuery` for what that was measured to
-// cost and why it is the exception rather than the norm.
+// What omitting it costs is invisible warm and severe cold. Measured against
+// production, one fixed set of 20 trace ids whose parts were not cached:
+// 328ms with an exact window, 1,089ms with the padded one, 8,389ms with no
+// predicate at all — while re-running all three against warm parts puts them
+// within ~100ms of each other. Cold is the normal state of a dashboard query
+// against a month of partitions, and the `list` profile kills it at 15s.
+//
+// A caller that has no window — a deep link carrying only a session id —
+// resolves one with `aiSessionWindowQuery` first, rather than running the
+// fan-out unpruned. That query is the detection scan alone, which the
+// `mapValues(SpanAttributes)` bloom index and the table's 30-day TTL do bound.
 //
 // Tenant scoping: a subquery contributes nothing to the outer query's scope, so
 // every level that reads a table repeats `OrgId = {orgId}` itself. The outermost
@@ -83,6 +87,15 @@ const VENDOR_VERSION_ATTR = "maple_ai.vendor.version"
  * tops out at 2106-02-07 and anything past it fails to parse.
  */
 const SESSION_ORDER_SENTINEL = "2106-01-01 00:00:00"
+
+/**
+ * How far past the caller's window the `trace_detail_spans` fan-out reads, in
+ * seconds. See this file's header: the point is a predicate ClickHouse can
+ * prune partitions with, not an exact bound, so the pad is chosen to be a whole
+ * partition (`PARTITION BY toDate(Timestamp)`) and to contain any trace that
+ * straddles the window edge.
+ */
+const FAN_OUT_PAD_SECONDS = 86_400
 
 /** ClickHouse returns `''` for a missing Map key, so presence needs both halves. */
 const hasSessionId = (attrs: CH.Expr<Record<string, string>>, get: CH.Expr<string>) =>
@@ -154,15 +167,18 @@ export const aiSessionListRowSchema: CompiledQueryRowSchema<AiSessionListOutput>
  * silently drop spans and under-count `spanCount`. The session-bearing spans come
  * from the agent's own service, which is the one a user filtering by service means.
  *
- * The time window bounds DETECTION only. Once a trace qualifies it is aggregated
- * in full, so `startTime`/`endTime`/`durationMs`/`spanCount`/`errorSpanCount`/
+ * The time window bounds DETECTION exactly and the fan-out loosely. Once a trace
+ * qualifies it is aggregated across the padded window rather than the caller's,
+ * so `startTime`/`endTime`/`durationMs`/`spanCount`/`errorSpanCount`/
  * `serviceNames` describe the whole trace rather than the slice of it that fell
  * inside the range — a session that began an hour before the range no longer
  * reports the range edge as its start, and the detail page can read the bounds
- * this row carries as the session's own. The remaining gap is between traces,
- * not inside one: a session whose OTHER traces lie entirely outside the range is
- * still found only by the traces that touched it, which needs a session-keyed
- * table to fix and not a wider window.
+ * this row carries as the session's own. A trace longer than `FAN_OUT_PAD_SECONDS`
+ * is clamped again, which no observed trace comes close to.
+ *
+ * The remaining gap is between traces, not inside one: a session whose OTHER
+ * traces lie entirely outside the range is still found only by the traces that
+ * touched it, which needs a session-keyed table to fix and not a wider window.
  */
 export function aiSessionListQuery(opts: AiSessionListOpts = {}) {
 	const limit = opts.limit ?? 50
@@ -180,9 +196,9 @@ export function aiSessionListQuery(opts: AiSessionListOpts = {}) {
 			opts.serviceNames?.length ? CH.inList($.ServiceName, opts.serviceNames) : undefined,
 		])
 
-	// Per trace: every span of a qualifying trace, session-bearing or not — and
-	// deliberately without the window predicate, so "every span" means every span
-	// the trace has rather than every span it has inside the range.
+	// Per trace: every span of a qualifying trace, session-bearing or not. The
+	// window is padded here rather than dropped, so "every span" means every span
+	// the trace has, while the read still prunes to a handful of partitions.
 	const perTrace = from(TraceDetailSpans)
 		.select(($) => {
 			const sessionOrder = CH.if_(
@@ -219,7 +235,12 @@ export function aiSessionListQuery(opts: AiSessionListOpts = {}) {
 				traceEndNanos: CH.max_(CH.toUnixTimestamp64Nano($.Timestamp).add(CH.toInt64($.Duration))),
 			}
 		})
-		.where(($) => [$.OrgId.eq(param.string("orgId")), inSubquery($.TraceId, sessionTraceIds)])
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.Timestamp.gte(CH.intervalSub(param.dateTime("startTime"), FAN_OUT_PAD_SECONDS)),
+			$.Timestamp.lte(CH.intervalAdd(param.dateTime("endTime"), FAN_OUT_PAD_SECONDS)),
+			inSubquery($.TraceId, sessionTraceIds),
+		])
 		.groupBy("traceId")
 
 	return (
@@ -318,16 +339,59 @@ export function aiSessionFacetsQuery(): CHUnionQuery<AiSessionFacetsOutput> {
 	).format("JSON")
 }
 
+// Session window resolution (id → bounds)
+
+export interface AiSessionWindowOutput {
+	/** Warehouse datetime literals, already padded — feed them straight back in. */
+	readonly startTime: string
+	readonly endTime: string
+	/** Zero means no such session, which the bounds cannot say on their own. */
+	readonly spanCount: number
+}
+
+export const aiSessionWindowRowSchema: CompiledQueryRowSchema<AiSessionWindowOutput> = Schema.Struct({
+	startTime: Schema.String,
+	endTime: Schema.String,
+	spanCount: CHNumber,
+})
+
+/**
+ * The bounds of one session, for a caller that holds its id and nothing else.
+ *
+ * This is `aiSessionSpansQuery`'s detection half with the trace ids replaced by
+ * an aggregate, and it is the one read in this file that legitimately runs with
+ * no time predicate: `traces` carries a `bloom_filter(0.01)` skip index over
+ * `mapValues(SpanAttributes)` for the id to prune with, and the table's 30-day
+ * TTL caps what is left. The fan-out has neither and must not be run that way.
+ *
+ * The bounds come back padded by `FAN_OUT_PAD_SECONDS`, because they are
+ * measured over the session-BEARING spans while the read they bound returns
+ * every span of those spans' traces — a trace whose first span is not the
+ * session-bearing one starts earlier than any window this could report exactly.
+ *
+ * `min`/`max` over no rows return the epoch rather than nothing, so a caller
+ * must read `spanCount` to tell an unknown session from a real one.
+ */
+export function aiSessionWindowQuery() {
+	return from(Traces)
+		.select(($) => ({
+			startTime: CH.toString_(CH.intervalSub(CH.min_($.Timestamp), FAN_OUT_PAD_SECONDS)),
+			endTime: CH.toString_(CH.intervalAdd(CH.max_($.Timestamp), FAN_OUT_PAD_SECONDS)),
+			spanCount: CH.count(),
+		}))
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			// Same presence guard as `aiSessionSpansQuery`, for the same reason: a
+			// missing Map key reads back as `''`, so equality alone would resolve a
+			// blank id to the bounds of every span in the org that lacks the key.
+			hasSessionId($.SpanAttributes, $.SpanAttributes.get(SESSION_ID_ATTR)),
+			$.SpanAttributes.get(SESSION_ID_ATTR).eq(param.string("sessionId")),
+		])
+		.format("JSON")
+}
+
 export interface AiSessionSpansOpts {
 	readonly limit?: number
-	/**
-	 * Bound both levels by `startTime`/`endTime` (the default), or resolve the
-	 * session from its id across whatever the table still retains.
-	 *
-	 * `false` also drops the two window params from the compiled SQL, so an
-	 * unwindowed compile takes `orgId` + `sessionId` and nothing else.
-	 */
-	readonly windowed?: boolean
 }
 
 export interface AiSessionSpansOutput {
@@ -380,22 +444,13 @@ export const aiSessionSpansRowSchema: CompiledQueryRowSchema<AiSessionSpansOutpu
  * scope-based vendor detection at write time and encoded its verdict in
  * `maple_ai.vendor.id`; re-deriving the dialect here would only second-guess it.
  *
- * The window, when the caller has one, bounds BOTH levels: a session whose
- * traces straddle the window edge then returns only the spans inside it, which
- * is why the padding a caller applies has to contain the whole session.
- *
- * `windowed: false` drops it from both instead, and the session id alone
- * carries the read. Measured against production: the detection scan has the
- * `idx_span_attr_vals` bloom index (`bloom_filter(0.01)` over
- * `mapValues(SpanAttributes)`) to prune with and a 30-day table TTL to bound
- * it, and an unfiltered `SpanAttributes['maple_ai.session.id'] = …` lookup
- * returned instantly while correctly finding a multi-trace session days back;
- * the fan-out is a `TraceId` sort-key seek that is instant with no time filter
- * regardless — `aiSessionListQuery` already runs it that way. Bloom pruning
- * degrades as an org's span volume grows, so this is the exception path for a
- * deep link that arrives with no bounds, not the shape the product should
- * settle on: a client that gets rows back is expected to record the session's
- * real bounds and ask with them next time.
+ * The window bounds BOTH levels and is required, because the fan-out without one
+ * reads every partition the table retains — see this file's header for what that
+ * was measured to cost. A session whose traces straddle the window edge returns
+ * only the spans inside it, so the bounds a caller passes have to contain the
+ * whole session: the list row's `startTime`/`endTime` do by construction, and a
+ * caller holding only a session id gets bounds that do from
+ * `aiSessionWindowQuery`.
  *
  * Truncation drops the END of the session, because the rows come back oldest
  * first and an agent's answer is the last thing it writes. Ask for
@@ -408,14 +463,13 @@ export const aiSessionSpansRowSchema: CompiledQueryRowSchema<AiSessionSpansOutpu
  */
 export function aiSessionSpansQuery(opts: AiSessionSpansOpts = {}) {
 	const limit = opts.limit ?? AI_SESSION_SPANS_MAX_SPANS
-	const windowed = opts.windowed ?? true
 
 	const sessionTraceIds = from(Traces)
 		.select(($) => ({ TraceId: $.TraceId }))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			windowed ? $.Timestamp.gte(param.dateTime("startTime")) : undefined,
-			windowed ? $.Timestamp.lte(param.dateTime("endTime")) : undefined,
+			$.Timestamp.gte(param.dateTime("startTime")),
+			$.Timestamp.lte(param.dateTime("endTime")),
 			// The presence guard is what stops an empty `sessionId` param from
 			// matching every span that simply LACKS the key — ClickHouse reads a
 			// missing Map key back as `''`, so equality alone would turn a blank
@@ -442,8 +496,8 @@ export function aiSessionSpansQuery(opts: AiSessionSpansOpts = {}) {
 			}))
 			.where(($) => [
 				$.OrgId.eq(param.string("orgId")),
-				windowed ? $.Timestamp.gte(param.dateTime("startTime")) : undefined,
-				windowed ? $.Timestamp.lte(param.dateTime("endTime")) : undefined,
+				$.Timestamp.gte(param.dateTime("startTime")),
+				$.Timestamp.lte(param.dateTime("endTime")),
 				inSubquery($.TraceId, sessionTraceIds),
 			])
 			// `spanId` breaks ties: agent spans routinely share a millisecond, and

--- a/packages/query-engine-integrations/src/ai/index.ts
+++ b/packages/query-engine-integrations/src/ai/index.ts
@@ -14,11 +14,14 @@ export {
 	aiSessionListRowSchema,
 	aiSessionSpansQuery,
 	aiSessionSpansRowSchema,
+	aiSessionWindowQuery,
+	aiSessionWindowRowSchema,
 	type AiSessionFacetsOutput,
 	type AiSessionListOpts,
 	type AiSessionListOutput,
 	type AiSessionSpansOpts,
 	type AiSessionSpansOutput,
+	type AiSessionWindowOutput,
 } from "./ai-sessions"
 
 export {

--- a/packages/query-engine-integrations/src/catalog.ts
+++ b/packages/query-engine-integrations/src/catalog.ts
@@ -72,18 +72,18 @@ export const integrationFixtures: ReadonlyArray<IntegrationFixture> = [
 			),
 	},
 	{
-		// A session detail page opened from a link that carries no time hints.
-		// Compiled with no window params at all, which is half the point: the
-		// baseline is what proves neither level kept a `Timestamp` predicate (or
-		// an unsubstituted `__PARAM_startTime__`) behind.
+		// A session detail page opened from a link that carries no time hints
+		// resolves its bounds with this first. The baseline is what proves the
+		// only read in the file with no `Timestamp` predicate is this one — the
+		// bloom-indexed detection scan, never the fan-out.
 		module: "ai-sessions",
-		name: "aiSessionSpansQuery",
-		label: "unwindowed",
+		name: "aiSessionWindowQuery",
+		label: "default",
 		compile: () =>
 			compile(
-				CH.aiSessionSpansQuery({ windowed: false }),
+				CH.aiSessionWindowQuery(),
 				{ orgId: ORG_ID, sessionId: "wrun_sql_catalog" },
-				{ rowSchema: CH.aiSessionSpansRowSchema },
+				{ rowSchema: CH.aiSessionWindowRowSchema },
 			),
 	},
 	{


### PR DESCRIPTION
The Agent Sessions list times out on the `list` profile's 15s ceiling whenever its partitions aren't already cached. #546 dropped the `Timestamp` predicate from the `trace_detail_spans` fan-out, so the `TraceId IN (…)` seek runs against every partition the 30-day TTL retains instead of the window's two.

It was a deliberate correctness change — an exact window clamps the reported start/end of any session that began before the range — and the cost was measured warm, where it does not show.

## What it costs

One fixed set of 20 trace ids (16k–19k spans), parts not cached, timings read off `WarehouseQueryService.executeSql`'s `db.duration_ms` in production:

| fan-out predicate | db time |
| --- | --- |
| exact window | 328 ms |
| padded ±1 day (this PR) | 1,089 ms |
| none (`main`) | 8,389 ms |

Re-run against warm parts all three land within ~100ms of each other. In real traffic the same query fingerprint ranges 408ms → 15,675ms, and the 15s runs come back with no `result.rowCount` — `max_execution_time` killing them. The facets query, which is the same detection scan with no fan-out, stays at 250ms–1.1s throughout; that gap is the whole bug.

## The fix

Put the predicate back on the fan-out, **padded** by a day instead of exact. Partitions prune (`PARTITION BY toDate(Timestamp)`, so a day of pad is one partition on each side), and a trace straddling the window edge is still aggregated whole — the list row keeps reporting the session's own bounds rather than the range edge.

`aiSessionSpansQuery` had the same unbounded fan-out on its hint-less path, so `windowed: false` is gone. A caller holding only a session id resolves the bounds first with the new `aiSessionWindowQuery` and then runs the ordinary pruned read — one extra round trip, only on the deep-link path. That resolve step is the one read in the file that can legitimately run with no time predicate: it is the detection scan alone, which the `mapValues(SpanAttributes)` bloom index prunes and the TTL caps. Behaviour for a bare link is unchanged; the empty state still means "not in retention".

`intervalAdd` joins `intervalSub` in the builder, since a padded window needs both ends.

## Verification

- The compiled shape (`Timestamp >= '…' - INTERVAL 86400 SECOND`, a String literal ClickHouse folds to DateTime64(3)) was checked against production for pruning: 627ms on a third cold set of 20 traces.
- `bun run test` green in `packages/query-engine-integrations`, `apps/api`, `lib/clickhouse-builder`; typecheck green in those plus `packages/domain`.
- The ClickHouse analyzer sweep (`CLICKHOUSE_E2E=1`, 178 shapes) passes with the new SQL in the catalog.
- Regression guards added: the list fan-out must carry the padded predicate and detection must not, the spans read must be bounded on both levels, and the window query must be the only unbounded one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790120963&installation_model_id=427786&pr_number=609&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F609&signature=b032acdc097a656181788ab7af9c090bf7beee48002b35dbbf5ddaba4a3228f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## The shipped query, measured

The SQL below is `compileCH(aiSessionListQuery(), …)` off this branch, run against production with only `OrgId = '…'` swapped for the macro `run_sql` requires. Timings are `db.duration_ms` off each run's own `executeSql` span.

**Cold** — the real aggregate select list over 20 traces / ~17.7k spans whose parts were not cached. Padded ran FIRST, on its own id set; unpadded ran second on an equally cold set, so ordering favours the loser:

| fan-out predicate | db time |
| --- | --- |
| padded ±1 day (this PR) | 2,684 ms |
| none (`main`) | >10,535 ms — killed at the 10s cap |

**Warm**, live session, 12h window, both shapes back to back and returning identical rows (11 traces / 2,474 spans): `main` 660 ms, this PR 754 ms. Warm parity is the expected result — the pad costs one extra partition of index and buys nothing until the parts are cold.

Correctness parity checked on the live session: same session id, trace count, span count, error count, services and bounds as `main`'s shape.

## Blast radius

Agent sessions only.

- `@maple/query-engine-integrations` is a dependency of **`apps/api` alone** — no other deployable can reach these builders — and within it only `ai-sessions.ts` changed. `aiSessionFacetsQuery` and both detection subqueries are byte-identical; the diff is the fan-out predicate, the deleted `windowed` branch, and the new window query.
- `@maple-dev/clickhouse-builder` is shared (api, query-engine, integrations, domain), but the change is one **new** exported function. No existing expression compiles differently: `packages/query-engine`'s 1,256 tests and its own SQL baseline are untouched and green.
- `@maple/domain` change is a comment.
- The MCP `get_session_traces` / `search_sessions` / `get_session_transcript` tools are **session replay**, `@maple/query-engine/observability` — a different domain that shares only the word "session".
- Full `apps/api` suite green (2,362 passed, 5 files skipped).
