### PR TITLE
iOS: scope the app to a deployment environment

### DIFF
--- a/apps/api/src/routes/v2/telemetry.http.test.ts
+++ b/apps/api/src/routes/v2/telemetry.http.test.ts
@@ -168,6 +168,12 @@ const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
 			},
 		]
 	}
+	// Before the catalog branch below: both read `service_overview_spans`, and
+	// the environments listing projects a single column the catalog rows would
+	// not decode against.
+	if (sql.includes("AS environment")) {
+		return [{ environment: "production" }, { environment: "staging" }]
+	}
 	if (sql.includes("FROM service_overview_spans")) {
 		return [
 			{
@@ -726,6 +732,54 @@ describe("v2 telemetry reads over HTTP", () => {
 		})
 		expect(response.status).toBe(200)
 		expect(observedOptions?.settings).toMatchObject({ maxBlockSize: 512 })
+		await harness.dispose()
+	})
+
+	it("lists the organization's deployment environments", async () => {
+		const observedSql: string[] = []
+		const observingWarehouse: WarehouseQueryServiceApi = {
+			...warehouseStub,
+			compiledQuery: (tenant, compiled, options) => {
+				observedSql.push(compiled.sql)
+				return warehouseStub.compiledQuery(tenant, compiled, options)
+			},
+		}
+		const harness = makeHarness(observingWarehouse)
+		const key = await harness.bootstrapKey(["environments:read"])
+
+		const environments = await harness.request(
+			"GET",
+			`/v2/environments?start_time=${START}&end_time=${END}`,
+			key.secret,
+		)
+		expect(environments.status).toBe(200)
+		expect(environments.body).toEqual({
+			object: "list",
+			data: [
+				{ object: "environment", name: "production" },
+				{ object: "environment", name: "staging" },
+			],
+			// Always the whole list — a cursor here would never be non-null.
+			has_more: false,
+			next_cursor: null,
+		})
+		// The blank environment is excluded in SQL, not filtered afterwards: the
+		// DSL reads `''` as "no filter", so offering it would hand the caller back
+		// every environment under a label claiming otherwise.
+		expect(observedSql[0]).toContain("!= ''")
+		await harness.dispose()
+	})
+
+	it("fences the environments listing behind its own scope family", async () => {
+		const harness = makeHarness()
+		const key = await harness.bootstrapKey(["services:read"])
+		const environments = await harness.request(
+			"GET",
+			`/v2/environments?start_time=${START}&end_time=${END}`,
+			key.secret,
+		)
+		expect(environments.status).toBe(403)
+		expect(environments.body.error.message).toContain("environments:read")
 		await harness.dispose()
 	})
 

--- a/apps/api/src/routes/v2/telemetry.http.ts
+++ b/apps/api/src/routes/v2/telemetry.http.ts
@@ -1241,6 +1241,54 @@ const toMapEdge = (row: {
 	}
 }
 
+const serviceEnvironmentsRowSchema = Schema.Struct({
+	environment: Schema.String,
+})
+
+/**
+ * The values every other endpoint's `deployment_environment` filter accepts.
+ *
+ * `"discovery"` rather than `"aggregation"`: the read is a `GROUP BY` over one
+ * LowCardinality column, and clients poll it to keep an environment picker
+ * populated. A cheap ceiling is the honest description of that work, and it
+ * stops a slow one from spending an analytical budget it never needed.
+ */
+export const HttpV2EnvironmentsLive = HttpApiBuilder.group(MapleApiV2, "environments", (handlers) =>
+	Effect.gen(function* () {
+		const warehouse = yield* WarehouseQueryService
+		return handlers.handle("list", ({ query }) =>
+			Effect.gen(function* () {
+				const tenant = yield* CurrentTenant.Context
+				const window = yield* parseWindow(query.start_time, query.end_time, {
+					maxSeconds: MAX_SUMMARY_RANGE_SECONDS,
+					// Reads the hourly rollups, whose Timestamp is a plain DateTime.
+					precision: "second",
+					rangeLabel: "Environment queries",
+				})
+				const compiled = CH.compile(
+					CH.serviceEnvironmentsQuery(),
+					{ orgId: tenant.orgId, ...window },
+					{ rowSchema: serviceEnvironmentsRowSchema },
+				)
+				const rows = yield* warehouse.compiledQuery(tenant, compiled, {
+					profile: "discovery",
+					context: "v2Environments",
+				})
+
+				return {
+					object: "list" as const,
+					data: rows.map((row) => ({ object: "environment" as const, name: row.environment })),
+					// The query's own limit sits well above any real organization's
+					// environment count, so a page is always the whole list. Paginating
+					// would hand clients a cursor that is never non-null.
+					has_more: false,
+					next_cursor: null,
+				}
+			}),
+		)
+	}),
+)
+
 export const HttpV2ServiceMapLive = HttpApiBuilder.group(MapleApiV2, "serviceMap", (handlers) =>
 	Effect.gen(function* () {
 		const warehouse = yield* WarehouseQueryService

--- a/apps/api/src/routes/v2/v2-test-support.ts
+++ b/apps/api/src/routes/v2/v2-test-support.ts
@@ -47,6 +47,7 @@ import { HttpV2InstrumentationAuditLive } from "./setup-audit.http"
 import { HttpV2SharePublicLive } from "./share.http"
 import { DashboardWidgetDataService } from "@/services/dashboards/DashboardWidgetDataService"
 import {
+	HttpV2EnvironmentsLive,
 	HttpV2LogsLive,
 	HttpV2MetricsLive,
 	HttpV2ServiceMapLive,
@@ -92,6 +93,7 @@ export const AllV2GroupLayersLive = Layer.mergeAll(
 	HttpV2MetricsLive,
 	HttpV2ServicesLive,
 	HttpV2ServiceMapLive,
+	HttpV2EnvironmentsLive,
 	HttpV2WidgetSummaryLive,
 	HttpV2WidgetCredentialsLive,
 	// The share group's own dependencies are satisfied here rather than by every

--- a/apps/api/src/routes/v2/widget-summary.http.test.ts
+++ b/apps/api/src/routes/v2/widget-summary.http.test.ts
@@ -144,6 +144,7 @@ const seriesEngine = queryEngineStub((_tenant, request) =>
 const makeHarness = (options: {
 	readonly listIssues?: ErrorIssueReadModelsService["listIssues"]
 	readonly queryEngine?: QueryEngineServiceApi
+	readonly warehouse?: WarehouseQueryService
 }) => {
 	const testDb = createTestDb(createdDbs)
 	const envLive = Env.layer.pipe(Layer.provide(testConfig()))
@@ -159,7 +160,7 @@ const makeHarness = (options: {
 	// Provided ahead of `ConfigResourceServiceStubsLayer`, whose issue read
 	// models all `die` — this suite is the one that actually calls them.
 	const readsLive = Layer.mergeAll(
-		Layer.succeed(WarehouseQueryService, warehouseStub),
+		Layer.succeed(WarehouseQueryService, options.warehouse ?? warehouseStub),
 		Layer.succeed(QueryEngineService, options.queryEngine ?? seriesEngine),
 		Layer.succeed(ErrorIssueReadModelsService, {
 			listIssues:
@@ -195,9 +196,9 @@ const makeHarness = (options: {
 				return yield* service.create(org, user, { name: "widget-test", scopes })
 			}),
 		)
-	const get = async (token: string, headers: Record<string, string> = {}) => {
+	const get = async (token: string, headers: Record<string, string> = {}, query = "") => {
 		const response = await handler(
-			new Request("http://maple.test/v2/widget_summary", {
+			new Request(`http://maple.test/v2/widget_summary${query}`, {
 				headers: { authorization: `Bearer ${token}`, ...headers },
 			}),
 			Context.empty() as never,
@@ -305,6 +306,77 @@ describe("GET /v2/widget_summary", () => {
 			const summary = await harness.get(key.secret)
 			expect(summary.status).toBe(403)
 			expect(summary.body.error.message).toContain("widget_summary:read")
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("applies deployment_environment to all three reads and echoes it", async () => {
+		// Asserted per read rather than on the response alone: a filter that
+		// reached the issues query but not the throughput one would still return a
+		// plausible payload, with an error rate the traffic under it cannot make.
+		let issuesEnv: string | undefined
+		let catalogSql = ""
+		const seriesEnvironments: Array<ReadonlyArray<string> | undefined> = []
+
+		const harness = makeHarness({
+			listIssues: (_orgId, opts) => {
+				issuesEnv = opts.deploymentEnv
+				return Effect.succeed(new ErrorIssuesListResponse({ issues: [issueDocument()] }))
+			},
+			warehouse: makeWarehouseServiceStub({
+				compiledQuery: (_tenant, compiled) => {
+					catalogSql = compiled.sql
+					return compiled.decodeRows(
+						compiled.sql.includes("FROM service_overview_spans") ? [serviceRow] : [],
+					)
+				},
+				compiledQueryFirst: (_tenant, compiled) =>
+					compiled.decodeRows([]).pipe(Effect.map((rows) => Option.fromNullishOr(rows[0]))),
+				ingest: () => Effect.void,
+			}) as WarehouseQueryService,
+			queryEngine: queryEngineStub((tenant, request) => {
+				seriesEnvironments.push(request.query.filters?.environments)
+				return seriesEngine.execute(tenant, request)
+			}),
+		})
+		try {
+			const key = await harness.bootstrapKey(["widget_summary:read"])
+			const summary = await harness.get(key.secret, {}, "?deployment_environment=staging")
+
+			expect(summary.status).toBe(200)
+			expect(issuesEnv).toBe("staging")
+			expect(catalogSql).toContain("staging")
+			// Both series — grouped and ungrouped — or the sparkline and the
+			// headline it sits under would describe different populations.
+			expect(seriesEnvironments).toHaveLength(2)
+			expect(seriesEnvironments).toEqual([["staging"], ["staging"]])
+			// Echoed so the client can prove the payload belongs to the snapshot
+			// slot it is about to overwrite.
+			expect(summary.body.deployment_environment).toBe("staging")
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("reads the whole organization when no environment is given", async () => {
+		let issuesEnv: string | undefined = "unset"
+		const harness = makeHarness({
+			listIssues: (_orgId, opts) => {
+				issuesEnv = opts.deploymentEnv
+				return Effect.succeed(new ErrorIssuesListResponse({ issues: [issueDocument()] }))
+			},
+		})
+		try {
+			const key = await harness.bootstrapKey(["widget_summary:read"])
+			const summary = await harness.get(key.secret)
+
+			expect(summary.status).toBe(200)
+			expect(issuesEnv).toBeUndefined()
+			// Null, not absent: widgets placed before the parameter existed keep
+			// asking for the organization, and must be able to tell that apart from
+			// a server that ignored their filter.
+			expect(summary.body.deployment_environment).toBeNull()
 		} finally {
 			await harness.dispose()
 		}

--- a/apps/api/src/routes/v2/widget-summary.http.ts
+++ b/apps/api/src/routes/v2/widget-summary.http.ts
@@ -83,9 +83,13 @@ export const HttpV2WidgetSummaryLive = HttpApiBuilder.group(MapleApiV2, "widgetS
 		const warehouse = yield* WarehouseQueryService
 		const queryEngine = yield* QueryEngineService
 
-		return handlers.handle("retrieve", () =>
+		return handlers.handle("retrieve", ({ query }) =>
 			Effect.gen(function* () {
 				const tenant = yield* CurrentTenant.Context
+				// One filter for the whole response, applied to all three reads. A
+				// half filtered to staging next to a half that is not would render as
+				// an error rate the traffic underneath it cannot produce.
+				const deploymentEnv = query.deployment_environment
 				// One clock for the whole response. Two `Date.now()` calls would let
 				// the issues window and the throughput window describe times that do
 				// not line up, which is the sort of skew a widget renders as a
@@ -97,6 +101,11 @@ export const HttpV2WidgetSummaryLive = HttpApiBuilder.group(MapleApiV2, "widgetS
 				const issuesPage = yield* readModels.listIssues(tenant.orgId, {
 					actionable: true,
 					sort: "severity",
+					// Costs one extra warehouse round-trip, and drops alert-kind issues
+					// — their synthetic fingerprints carry no environment. Both are
+					// documented on `listIssues` and both are the right trade here: a
+					// widget filtered to staging must not count production's issues.
+					deploymentEnv,
 					startTime: new Date(issuesStartMs).toISOString(),
 					endTime: new Date(nowMs).toISOString(),
 					limit: WIDGET_SUMMARY_ISSUE_LIMIT,
@@ -105,7 +114,10 @@ export const HttpV2WidgetSummaryLive = HttpApiBuilder.group(MapleApiV2, "widgetS
 				// Whole seconds: the catalog reads the hourly rollups, whose
 				// Timestamp is a plain `DateTime` and rejects a fractional literal.
 				const compiled = CH.compile(
-					CH.serviceCatalogQuery({ limit: WIDGET_SUMMARY_SERVICE_LIMIT }),
+					CH.serviceCatalogQuery({
+						limit: WIDGET_SUMMARY_SERVICE_LIMIT,
+						deploymentEnvironment: deploymentEnv,
+					}),
 					{
 						orgId: tenant.orgId,
 						startTime: formatWarehouseDateTime(throughputStartMs),
@@ -130,6 +142,11 @@ export const HttpV2WidgetSummaryLive = HttpApiBuilder.group(MapleApiV2, "widgetS
 							source: "traces",
 							metric: "count",
 							bucketSeconds,
+							// The runtime takes a list even where the public parameter is
+							// one value, so the single filter becomes a one-element set.
+							...(deploymentEnv === undefined
+								? undefined
+								: { filters: { environments: [deploymentEnv] } }),
 							...(groupByService
 								? { groupBy: ["service"], seriesLimit: WIDGET_SUMMARY_SERIES_LIMIT }
 								: undefined),
@@ -169,6 +186,7 @@ export const HttpV2WidgetSummaryLive = HttpApiBuilder.group(MapleApiV2, "widgetS
 					schema_version: WIDGET_SUMMARY_SCHEMA_VERSION,
 					generated_at: timestamp(new Date(nowMs).toISOString()),
 					organization_id: tenant.orgId,
+					deployment_environment: deploymentEnv ?? null,
 					issues: {
 						window_seconds: WIDGET_SUMMARY_ISSUES_WINDOW_SECONDS,
 						has_more: issuesPage.nextCursor !== undefined,

--- a/apps/api/src/runtime/http-graph.ts
+++ b/apps/api/src/runtime/http-graph.ts
@@ -53,6 +53,7 @@ import { HttpV2ScrapeTargetsLive } from "@/routes/v2/scrape-targets.http"
 import { HttpV2InstrumentationAuditLive } from "@/routes/v2/setup-audit.http"
 import { HttpV2SessionReplaysLive } from "@/routes/v2/session-replays.http"
 import {
+	HttpV2EnvironmentsLive,
 	HttpV2LogsLive,
 	HttpV2MetricsLive,
 	HttpV2ServiceMapLive,
@@ -143,6 +144,7 @@ const ApiV2Routes = HttpApiBuilder.layer(MapleApiV2).pipe(
 			HttpV2MetricsLive,
 			HttpV2ServicesLive,
 			HttpV2ServiceMapLive,
+			HttpV2EnvironmentsLive,
 			HttpV2WidgetSummaryLive,
 			HttpV2WidgetCredentialsLive,
 		),

--- a/apps/ios/Maple/App/MapleApp.swift
+++ b/apps/ios/Maple/App/MapleApp.swift
@@ -10,6 +10,10 @@ struct MapleApp: App {
 	@State private var session: SessionController
 	@State private var navigation: AppNavigation
 	@State private var opener: DestinationOpener
+	/// The second scoping axis, alongside `session`'s organization. Owned here
+	/// rather than by a screen because the choice is app-wide — see
+	/// `EnvironmentController`.
+	@State private var environments = EnvironmentController()
 
 	init() {
 		// `Clerk.shared` traps until `configure` has run, and Swift evaluates
@@ -43,7 +47,8 @@ struct MapleApp: App {
 			// and screenshots would have no widgets to take.
 			WidgetPublisher.shared.configure(
 				api: fixtureAPI,
-				organizationId: FixtureSession.organizationId
+				organizationId: FixtureSession.organizationId,
+				environment: nil
 			)
 			return
 		}
@@ -114,6 +119,7 @@ struct MapleApp: App {
 				.environment(session)
 				.environment(navigation)
 				.environment(opener)
+				.environment(environments)
 		}
 	}
 }

--- a/apps/ios/Maple/App/RootView.swift
+++ b/apps/ios/Maple/App/RootView.swift
@@ -86,6 +86,7 @@ struct MainTabView: View {
 	@Environment(AppNavigation.self) private var navigation
 	@Environment(SessionController.self) private var session
 	@Environment(DestinationOpener.self) private var opener
+	@Environment(EnvironmentController.self) private var environments
 	@Environment(\.scenePhase) private var scenePhase
 	private let push = PushRegistrar.shared
 	private let widgets = WidgetPublisher.shared
@@ -122,13 +123,32 @@ struct MainTabView: View {
 			guard let orgId = session.currentOrganizationId else { return }
 			liveActivities.configure(api: session.api, organizationId: orgId)
 		}
-		.task(id: session.widgetPublishKey) {
+		// The environment picker's options, keyed on the organization rather
+		// than on `dataGeneration`: environments are an organization's facts,
+		// and re-reading them every time the user *changes* the environment
+		// would be a request per selection to learn nothing new.
+		//
+		// Unscoped `session.api` on purpose — this is the list the picker
+		// offers, and filtering it by the current choice would leave the user
+		// unable to pick anything else.
+		.task(id: session.currentOrganizationId) {
+			guard let orgId = session.currentOrganizationId else { return }
+			await environments.load(organizationId: orgId, api: session.api)
+		}
+		// The environment joins the key rather than moving into
+		// `widgetPublishKey` itself: that property is the session's, and the
+		// session has no business knowing about a filter. What matters is that
+		// changing the environment republishes at once — a widget following the
+		// app would otherwise keep the environment the user just left on the
+		// Home Screen until some later trigger.
+		.task(id: "\(session.widgetPublishKey)|\(environments.selected ?? "")") {
 			guard let orgId = session.currentOrganizationId else { return }
 			widgets.configure(
 				api: session.api,
 				organizationId: orgId,
 				memberships: session.widgetOrganizations,
-				membershipsVerified: session.membershipsLoaded
+				membershipsVerified: session.membershipsLoaded,
+				environment: environments.selected
 			)
 			// Only a verified list may prune: `membershipsLoaded` is false when
 			// Clerk's client payload was the source, and that list can be partial —

--- a/apps/ios/Maple/Auth/EnvironmentController.swift
+++ b/apps/ios/Maple/Auth/EnvironmentController.swift
@@ -1,0 +1,132 @@
+import Foundation
+import MapleAPI
+import Observation
+
+/// Owns "which deployment environment is everything on screen scoped to".
+///
+/// The second scoping axis, after the organization, and deliberately shaped
+/// like the first: one app-wide choice, a control next to the organization
+/// switcher, and a change that invalidates every screen at once rather than
+/// each screen growing its own filter.
+///
+/// It differs from the organization in one way that shapes everything here.
+/// The organization travels in the session token, so every request carries it
+/// whether the endpoint knows about it or not. An environment is a **query
+/// parameter, per endpoint** — so the scope reaches the reads that declare one
+/// and silently does not reach the rest. `MapleAPI` documents which is which;
+/// the visible consequence is that alerts and service detail keep showing every
+/// environment.
+@MainActor
+@Observable
+final class EnvironmentController {
+	/// Nil is "all environments" — a real choice, not a missing one, and the
+	/// state every install starts in.
+	private(set) var selected: String?
+	/// What the organization has actually reported in, most recent window
+	/// first. Empty until the first load, and after a failed one.
+	private(set) var available: [String] = []
+
+	/// Which organization `selected` and `available` belong to. Environments
+	/// are an organization's facts, so both are meaningless without it — and
+	/// carrying one organization's choice into another is the bug this exists
+	/// to make impossible.
+	private(set) var organizationId: String?
+
+	/// A day, matching what the Services tab defaults to. Wide enough that an
+	/// environment which was quiet this hour still appears, narrow enough that
+	/// one decommissioned last month does not.
+	private static let window = TimeWindow.last24Hours
+
+	private let defaults: UserDefaults
+
+	init(defaults: UserDefaults = .standard) {
+		self.defaults = defaults
+	}
+
+	/// Per organization, never global. A single key would carry "staging" into
+	/// an organization that has no such environment, where it filters every
+	/// screen to nothing and looks like an outage.
+	private static func key(for organizationId: String) -> String {
+		"environment.selected.v1.\(organizationId)"
+	}
+
+	/// Whether the control is worth showing. One environment is not a choice —
+	/// same rule as the organization switcher, which hides itself for an
+	/// account with a single organization.
+	var canSwitch: Bool { available.count > 1 }
+
+	/// Adopt an organization: restore its stored choice, then load its
+	/// environments.
+	///
+	/// Called with the same `dataGeneration` key the screens use, so an
+	/// organization switch re-runs it and the picker never offers the previous
+	/// organization's environments.
+	func load(organizationId: String, api: any MapleAPI) async {
+		if self.organizationId != organizationId {
+			self.organizationId = organizationId
+			// Restored before the fetch, not after: screens build their models
+			// from `selected` as soon as the generation moves, and a load that
+			// takes a second would otherwise show organization-wide data first
+			// and then re-fetch — a visible flash of the wrong numbers.
+			selected = defaults.string(forKey: Self.key(for: organizationId))
+			available = []
+		}
+
+		let environments = (try? await api.environments(window: Self.window.resolve())) ?? []
+		// A failed load leaves `available` empty, which hides the control. The
+		// alternative — an empty menu the user can open — reads as "this
+		// organization has no environments", which is a different claim and
+		// usually a false one.
+		guard !environments.isEmpty else { return }
+		available = environments
+
+		// A stored choice the organization no longer has would filter every
+		// screen to nothing. Fall back to all environments rather than leaving
+		// the app showing empty lists it cannot explain.
+		if let selected, !environments.contains(selected) {
+			self.selected = nil
+			defaults.removeObject(forKey: Self.key(for: organizationId))
+		}
+
+		publishToWidgets()
+	}
+
+	/// Change the selection and make every screen reload against it.
+	///
+	/// The reload is not this type's doing: it bumps `dataGeneration`, and the
+	/// `.task(id:)` on every screen does the rest. That is the whole reason the
+	/// selection is global — one lever, already built for organization
+	/// switching, rather than a filter each screen has to remember to apply.
+	func select(_ environment: String?, session: SessionController) {
+		guard environment != selected, let organizationId else { return }
+		selected = environment
+
+		if let environment {
+			defaults.set(environment, forKey: Self.key(for: organizationId))
+		} else {
+			defaults.removeObject(forKey: Self.key(for: organizationId))
+		}
+
+		Telemetry.track(
+			Telemetry.Event.environmentChanged,
+			["organization.id": organizationId, "environment": environment ?? "all"]
+		)
+		publishToWidgets()
+		session.invalidateData()
+	}
+
+	/// Tell the widget extension what the app knows.
+	///
+	/// It has no session and cannot ask, so the App Group index is the only
+	/// place a widget's environment picker can get its options — and the only
+	/// way a newly placed widget can land on what the user is already looking
+	/// at instead of on a question.
+	private func publishToWidgets() {
+		guard let organizationId else { return }
+		WidgetPublisher.shared.recordEnvironments(
+			available,
+			selected: selected,
+			for: organizationId
+		)
+	}
+}

--- a/apps/ios/Maple/Auth/EnvironmentController.swift
+++ b/apps/ios/Maple/Auth/EnvironmentController.swift
@@ -64,10 +64,13 @@ final class EnvironmentController {
 	func load(organizationId: String, api: any MapleAPI) async {
 		if self.organizationId != organizationId {
 			self.organizationId = organizationId
-			// Restored before the fetch, not after: screens build their models
-			// from `selected` as soon as the generation moves, and a load that
-			// takes a second would otherwise show organization-wide data first
-			// and then re-fetch — a visible flash of the wrong numbers.
+			// Restored before the fetch so a screen that builds after this point
+			// gets the stored value first time and never fetches twice. It is
+			// not relied on: `.task` ordering between this and the screens is
+			// not guaranteed, and the stale-value clear below cannot happen
+			// before the network answers anyway. Both are safe because
+			// `selected` is part of `SessionController.DataScope`, so a screen
+			// that built against the wrong value rebuilds when it changes.
 			selected = defaults.string(forKey: Self.key(for: organizationId))
 			available = []
 		}
@@ -91,13 +94,15 @@ final class EnvironmentController {
 		publishToWidgets()
 	}
 
-	/// Change the selection and make every screen reload against it.
+	/// Change the selection. Every screen reloads against it as a consequence,
+	/// not as something this method arranges.
 	///
-	/// The reload is not this type's doing: it bumps `dataGeneration`, and the
-	/// `.task(id:)` on every screen does the rest. That is the whole reason the
-	/// selection is global — one lever, already built for organization
-	/// switching, rather than a filter each screen has to remember to apply.
-	func select(_ environment: String?, session: SessionController) {
+	/// `selected` is half of `SessionController.DataScope`, which is what the
+	/// screens key `.task(id:)` on — so writing it here is the whole
+	/// notification. That is also why this does *not* bump `dataGeneration`:
+	/// doing both would drag the detail screens, which are unfiltered, through
+	/// a refetch that could not change what they show.
+	func select(_ environment: String?) {
 		guard environment != selected, let organizationId else { return }
 		selected = environment
 
@@ -112,7 +117,6 @@ final class EnvironmentController {
 			["organization.id": organizationId, "environment": environment ?? "all"]
 		)
 		publishToWidgets()
-		session.invalidateData()
 	}
 
 	/// Tell the widget extension what the app knows.

--- a/apps/ios/Maple/Auth/EnvironmentPickerView.swift
+++ b/apps/ios/Maple/Auth/EnvironmentPickerView.swift
@@ -17,7 +17,6 @@ import SwiftUI
 /// control with one option is not a choice, and the screen's own title already
 /// says where you are.
 struct EnvironmentPickerView: View {
-	@Environment(SessionController.self) private var session
 	@Environment(EnvironmentController.self) private var environments
 
 	var body: some View {
@@ -58,12 +57,12 @@ struct EnvironmentPickerView: View {
 	}
 
 	/// Writes through the controller rather than binding to its property: the
-	/// selection has to persist and bump `dataGeneration`, and a plain binding
-	/// would set the value and leave every screen showing the old one.
+	/// selection has to be persisted and published to the widgets, and a plain
+	/// binding would set the value and do neither.
 	private var selection: Binding<String?> {
 		Binding(
 			get: { environments.selected },
-			set: { environments.select($0, session: session) }
+			set: { environments.select($0) }
 		)
 	}
 }

--- a/apps/ios/Maple/Auth/EnvironmentPickerView.swift
+++ b/apps/ios/Maple/Auth/EnvironmentPickerView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// The deployment-environment control, next to the organization switcher.
+///
+/// The two sit together because they are the same kind of thing: the context
+/// everything on screen is scoped to. Neither belongs in the title slot — iOS
+/// puts the screen's *name* there — so both are leading items, with the
+/// organization first because it is the wider scope.
+///
+/// It renders as a compact chip rather than a second name-and-chevron. The
+/// switcher next to it already caps itself at 160pt precisely so the trailing
+/// toolbar item survives on a small device; a second full-width control there
+/// would spend that headroom and push the time-window menu off the bar.
+///
+/// Hidden when the organization reports fewer than two environments, for the
+/// same reason the switcher hides itself for a single-organization account: a
+/// control with one option is not a choice, and the screen's own title already
+/// says where you are.
+struct EnvironmentPickerView: View {
+	@Environment(SessionController.self) private var session
+	@Environment(EnvironmentController.self) private var environments
+
+	var body: some View {
+		if environments.canSwitch {
+			Menu {
+				Picker("Environment", selection: selection) {
+					// The whole organization, and the state an install starts
+					// in. First so it is where the thumb lands when backing out
+					// of a filter.
+					Text("All environments").tag(String?.none)
+					ForEach(environments.available, id: \.self) { environment in
+						Text(environment).tag(String?.some(environment))
+					}
+				}
+			} label: {
+				HStack(spacing: 4) {
+					Image(systemName: "line.3.horizontal.decrease")
+						.font(.system(size: 9, weight: .semibold))
+						.foregroundStyle(
+							environments.selected == nil ? Token.mutedForeground : Token.foreground
+						)
+					// Only the chosen environment is named. "All environments"
+					// spelled out would be the widest label on the bar for the
+					// state that is not filtering anything.
+					if let selected = environments.selected {
+						Text(selected)
+							.font(Typo.smallMedium)
+							.foregroundStyle(Token.foreground)
+							.lineLimit(1)
+							.truncationMode(.tail)
+					}
+				}
+				.frame(maxWidth: 110, alignment: .leading)
+			}
+			.accessibilityLabel("Filter by environment")
+			.accessibilityValue(environments.selected ?? "All environments")
+		}
+	}
+
+	/// Writes through the controller rather than binding to its property: the
+	/// selection has to persist and bump `dataGeneration`, and a plain binding
+	/// would set the value and leave every screen showing the old one.
+	private var selection: Binding<String?> {
+		Binding(
+			get: { environments.selected },
+			set: { environments.select($0, session: session) }
+		)
+	}
+}

--- a/apps/ios/Maple/Auth/SessionController.swift
+++ b/apps/ios/Maple/Auth/SessionController.swift
@@ -246,21 +246,23 @@ final class SessionController {
 		}
 	}
 
-	/// Declare that every screen's data is stale, without the organization
-	/// having changed.
+	/// Everything a screen's rows are scoped to, as one value.
 	///
-	/// The one other thing that scopes what a screen shows is the deployment
-	/// environment (`EnvironmentController`), and it needs exactly the same
-	/// effect an organization switch has: cancel what is in flight, rebuild the
-	/// models, refetch. Reusing the lever rather than teaching every screen a
-	/// second one is the point — the alternative is a filter each screen has to
-	/// remember to apply, and the one that forgets looks like stale data rather
-	/// than a bug.
+	/// Screens key `.task(id:)` on this and rebuild their models whenever it
+	/// moves, so the two axes are handled by one mechanism instead of the
+	/// organization getting a generation counter and the environment getting
+	/// its own reload path.
 	///
-	/// No token invalidation here: the environment is a query parameter, not a
-	/// claim, so the token that was valid a moment ago still is.
-	func invalidateData() {
-		dataGeneration += 1
+	/// The environment belongs here rather than being pushed at the screens
+	/// because it is not always known when they first build.
+	/// `EnvironmentController` restores a stored selection and drops one the
+	/// organization no longer has, and the second of those can only happen
+	/// after a network read — by which time the screens have already built.
+	/// Making the value part of what a model *is* rebuilds them when it
+	/// resolves, whatever order the tasks happened to start in.
+	struct DataScope: Equatable {
+		var generation: Int
+		var environment: String?
 	}
 
 	/// React to an API failure that the session is responsible for.

--- a/apps/ios/Maple/Auth/SessionController.swift
+++ b/apps/ios/Maple/Auth/SessionController.swift
@@ -246,6 +246,23 @@ final class SessionController {
 		}
 	}
 
+	/// Declare that every screen's data is stale, without the organization
+	/// having changed.
+	///
+	/// The one other thing that scopes what a screen shows is the deployment
+	/// environment (`EnvironmentController`), and it needs exactly the same
+	/// effect an organization switch has: cancel what is in flight, rebuild the
+	/// models, refetch. Reusing the lever rather than teaching every screen a
+	/// second one is the point — the alternative is a filter each screen has to
+	/// remember to apply, and the one that forgets looks like stale data rather
+	/// than a bug.
+	///
+	/// No token invalidation here: the environment is a query parameter, not a
+	/// claim, so the token that was valid a moment ago still is.
+	func invalidateData() {
+		dataGeneration += 1
+	}
+
 	/// React to an API failure that the session is responsible for.
 	///
 	/// Returns true when the caller should retry once — a 401 is most often a

--- a/apps/ios/Maple/Features/Alerts/AlertsHubView.swift
+++ b/apps/ios/Maple/Features/Alerts/AlertsHubView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct AlertsHubView: View {
 	@Environment(AppNavigation.self) private var navigation
 	@Environment(SessionController.self) private var session
+	@Environment(EnvironmentController.self) private var environments
 	@State private var models: AlertsHubModels?
 
 	var body: some View {
@@ -39,14 +40,18 @@ struct AlertsHubView: View {
 				ToolbarItem(placement: .topBarLeading) {
 					OrganizationSwitcherButton()
 				}
+				ToolbarItem(placement: .topBarLeading) {
+					EnvironmentPickerView()
+				}
 			}
 			.mapleDestinations()
 		}
-		// Re-runs on org switch, replacing all three models at once so no
-		// segment shows one org's rows under the next org's title.
+		// Re-runs on org switch — and on an environment change, which bumps the
+		// same generation — replacing all three models at once so no segment
+		// shows one scope's rows under the next scope's title.
 		.task(id: session.dataGeneration) {
 			if models?.generation != session.dataGeneration {
-				models = AlertsHubModels(session: session)
+				models = AlertsHubModels(session: session, environment: environments.selected)
 			}
 		}
 	}
@@ -73,10 +78,16 @@ final class AlertsHubModels {
 	let anomalies: AnomaliesListModel
 	let generation: Int
 
-	init(session: SessionController) {
-		incidents = IncidentsListModel(api: session.api, session: session)
-		issues = IssuesListModel(api: session.api, session: session)
-		anomalies = AnomaliesListModel(api: session.api, session: session)
+	/// - Parameter environment: the app-wide deployment-environment scope. It
+	///   reaches issues and anomalies, whose endpoints take the filter, and is
+	///   ignored by incidents, whose endpoints do not — the scoped client is
+	///   still handed to all three so the day `/v2/alerts` grows the parameter,
+	///   this segment starts honouring it without another change here.
+	init(session: SessionController, environment: String?) {
+		let api = session.api.scoped(toEnvironment: environment)
+		incidents = IncidentsListModel(api: api, session: session)
+		issues = IssuesListModel(api: api, session: session)
+		anomalies = AnomaliesListModel(api: api, session: session)
 		generation = session.dataGeneration
 	}
 }

--- a/apps/ios/Maple/Features/Alerts/AlertsHubView.swift
+++ b/apps/ios/Maple/Features/Alerts/AlertsHubView.swift
@@ -10,6 +10,10 @@ struct AlertsHubView: View {
 	@Environment(EnvironmentController.self) private var environments
 	@State private var models: AlertsHubModels?
 
+	private var scope: SessionController.DataScope {
+		.init(generation: session.dataGeneration, environment: environments.selected)
+	}
+
 	var body: some View {
 		@Bindable var navigation = navigation
 		NavigationStack(path: $navigation.alertsPath) {
@@ -46,12 +50,12 @@ struct AlertsHubView: View {
 			}
 			.mapleDestinations()
 		}
-		// Re-runs on org switch — and on an environment change, which bumps the
-		// same generation — replacing all three models at once so no segment
-		// shows one scope's rows under the next scope's title.
-		.task(id: session.dataGeneration) {
-			if models?.generation != session.dataGeneration {
-				models = AlertsHubModels(session: session, environment: environments.selected)
+		// Re-runs on an org switch or an environment change, replacing all three
+		// models at once so no segment shows one scope's rows under the next
+		// scope's title.
+		.task(id: scope) {
+			if models?.scope != scope {
+				models = AlertsHubModels(session: session, scope: scope)
 			}
 		}
 	}
@@ -76,19 +80,19 @@ final class AlertsHubModels {
 	let incidents: IncidentsListModel
 	let issues: IssuesListModel
 	let anomalies: AnomaliesListModel
-	let generation: Int
+	let scope: SessionController.DataScope
 
-	/// - Parameter environment: the app-wide deployment-environment scope. It
-	///   reaches issues and anomalies, whose endpoints take the filter, and is
-	///   ignored by incidents, whose endpoints do not — the scoped client is
-	///   still handed to all three so the day `/v2/alerts` grows the parameter,
-	///   this segment starts honouring it without another change here.
-	init(session: SessionController, environment: String?) {
-		let api = session.api.scoped(toEnvironment: environment)
+	/// The scope's environment reaches issues and anomalies, whose endpoints
+	/// take the filter, and is ignored by incidents, whose endpoints do not —
+	/// the scoped client is still handed to all three so the day `/v2/alerts`
+	/// grows the parameter, this segment starts honouring it without another
+	/// change here.
+	init(session: SessionController, scope: SessionController.DataScope) {
+		let api = session.api.scoped(toEnvironment: scope.environment)
 		incidents = IncidentsListModel(api: api, session: session)
 		issues = IssuesListModel(api: api, session: session)
 		anomalies = AnomaliesListModel(api: api, session: session)
-		generation = session.dataGeneration
+		self.scope = scope
 	}
 }
 

--- a/apps/ios/Maple/Features/Home/HomeModel.swift
+++ b/apps/ios/Maple/Features/Home/HomeModel.swift
@@ -120,10 +120,10 @@ enum OverallStatus {
 @Observable
 final class HomeModel {
 	private(set) var loader: ScreenLoader<HomeSnapshot>!
-	/// The `SessionController.dataGeneration` this model was built for; the
-	/// view builds a fresh one when it moves, so one org's board never lingers
-	/// while the next org loads.
-	let generation: Int
+	/// The organization and environment this model was built for; the view
+	/// builds a fresh one when either moves, so one scope's board never lingers
+	/// while the next one loads.
+	let scope: SessionController.DataScope
 
 	private let api: any MapleAPI
 
@@ -133,9 +133,9 @@ final class HomeModel {
 	static let rateWindow = TimeWindow.lastHour
 	static let recentWindow = TimeWindow.last24Hours
 
-	init(api: any MapleAPI, session: SessionController) {
+	init(api: any MapleAPI, session: SessionController, scope: SessionController.DataScope) {
 		self.api = api
-		self.generation = session.dataGeneration
+		self.scope = scope
 		self.loader = ScreenLoader(session: session, screen: Screen.home) { [unowned self] in try await self.fetch() }
 	}
 

--- a/apps/ios/Maple/Features/Home/HomeView.swift
+++ b/apps/ios/Maple/Features/Home/HomeView.swift
@@ -11,6 +11,10 @@ struct HomeView: View {
 	@State private var model: HomeModel?
 	@State private var showsNotificationSettings = false
 
+	private var scope: SessionController.DataScope {
+		.init(generation: session.dataGeneration, environment: environments.selected)
+	}
+
 	var body: some View {
 		NavigationStack {
 			ZStack {
@@ -54,12 +58,18 @@ struct HomeView: View {
 			.mapleDestinations()
 			.mapleScreen(Screen.home)
 		}
-		.task(id: session.dataGeneration) {
-			// A new org means a new model: the old board is dropped rather than
-			// left on screen until the new one arrives, and any refresh still
-			// running against the old org has nowhere to write.
-			let model = model?.generation == session.dataGeneration
-				? model! : HomeModel(api: session.api.scoped(toEnvironment: environments.selected), session: session)
+		.task(id: scope) {
+			// A new org or environment means a new model: the old board is
+			// dropped rather than left on screen until the new one arrives, and
+			// any refresh still running against the old scope has nowhere to
+			// write.
+			let model = model?.scope == scope
+				? model!
+				: HomeModel(
+					api: session.api.scoped(toEnvironment: scope.environment),
+					session: session,
+					scope: scope
+				)
 			self.model = model
 			await model.loader.loadIfNeeded()
 			// Home is a status board: keep it current while it's on screen.

--- a/apps/ios/Maple/Features/Home/HomeView.swift
+++ b/apps/ios/Maple/Features/Home/HomeView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct HomeView: View {
 	@Environment(SessionController.self) private var session
 	@Environment(AppNavigation.self) private var navigation
+	@Environment(EnvironmentController.self) private var environments
 	@Environment(\.scenePhase) private var scenePhase
 	@State private var model: HomeModel?
 	@State private var showsNotificationSettings = false
@@ -33,6 +34,9 @@ struct HomeView: View {
 				ToolbarItem(placement: .topBarLeading) {
 					OrganizationSwitcherButton()
 				}
+				ToolbarItem(placement: .topBarLeading) {
+					EnvironmentPickerView()
+				}
 				ToolbarItem(placement: .topBarTrailing) {
 					Button {
 						showsNotificationSettings = true
@@ -55,7 +59,7 @@ struct HomeView: View {
 			// left on screen until the new one arrives, and any refresh still
 			// running against the old org has nowhere to write.
 			let model = model?.generation == session.dataGeneration
-				? model! : HomeModel(api: session.api, session: session)
+				? model! : HomeModel(api: session.api.scoped(toEnvironment: environments.selected), session: session)
 			self.model = model
 			await model.loader.loadIfNeeded()
 			// Home is a status board: keep it current while it's on screen.

--- a/apps/ios/Maple/Features/Services/ServicesListView.swift
+++ b/apps/ios/Maple/Features/Services/ServicesListView.swift
@@ -7,6 +7,12 @@ final class ServicesListModel {
 	private(set) var loader: ScreenLoader<[Service]>!
 	/// Open-issue counts, keyed by service. Fetched once alongside the list so
 	/// each row can carry a badge without an N+1.
+	///
+	/// **Organization-wide, even when an environment is selected.**
+	/// `/v2/error_issues/service_counts` takes no parameters at all, so with
+	/// "staging" chosen a row's metrics are staging and its badge is not. It is
+	/// the only place in the app where one row mixes the two; the fix is a
+	/// parameter on that endpoint, not a second request here.
 	private(set) var openIssueCounts: [String: Int] = [:]
 	var window: TimeWindow = .default
 	let generation: Int
@@ -50,6 +56,7 @@ final class ServicesListModel {
 struct ServicesListView: View {
 	@Environment(SessionController.self) private var session
 	@Environment(AppNavigation.self) private var navigation
+	@Environment(EnvironmentController.self) private var environments
 	@State private var model: ServicesListModel?
 	@State private var search = ""
 
@@ -68,6 +75,9 @@ struct ServicesListView: View {
 				ToolbarItem(placement: .topBarLeading) {
 					OrganizationSwitcherButton()
 				}
+				ToolbarItem(placement: .topBarLeading) {
+					EnvironmentPickerView()
+				}
 				if let model {
 					ToolbarItem(placement: .topBarTrailing) {
 						TimeWindowMenu(window: windowBinding(model))
@@ -81,7 +91,7 @@ struct ServicesListView: View {
 		// the next org's arrive.
 		.task(id: session.dataGeneration) {
 			let model = model?.generation == session.dataGeneration
-				? model! : ServicesListModel(api: session.api, session: session)
+				? model! : ServicesListModel(api: session.api.scoped(toEnvironment: environments.selected), session: session)
 			self.model = model
 			await model.loader.loadIfNeeded()
 		}

--- a/apps/ios/Maple/Features/Services/ServicesListView.swift
+++ b/apps/ios/Maple/Features/Services/ServicesListView.swift
@@ -15,13 +15,15 @@ final class ServicesListModel {
 	/// parameter on that endpoint, not a second request here.
 	private(set) var openIssueCounts: [String: Int] = [:]
 	var window: TimeWindow = .default
-	let generation: Int
+	/// The organization *and* environment these rows answer for. The view
+	/// rebuilds the model when it moves.
+	let scope: SessionController.DataScope
 
 	private let api: any MapleAPI
 
-	init(api: any MapleAPI, session: SessionController) {
+	init(api: any MapleAPI, session: SessionController, scope: SessionController.DataScope) {
 		self.api = api
-		self.generation = session.dataGeneration
+		self.scope = scope
 		self.loader = ScreenLoader(session: session, screen: Screen.services, isEmpty: { $0.isEmpty }) { [unowned self] in try await self.fetch() }
 	}
 
@@ -58,6 +60,10 @@ struct ServicesListView: View {
 	@Environment(AppNavigation.self) private var navigation
 	@Environment(EnvironmentController.self) private var environments
 	@State private var model: ServicesListModel?
+
+	private var scope: SessionController.DataScope {
+		.init(generation: session.dataGeneration, environment: environments.selected)
+	}
 	@State private var search = ""
 
 	var body: some View {
@@ -87,11 +93,19 @@ struct ServicesListView: View {
 			.mapleDestinations()
 			.mapleScreen(Screen.services)
 		}
-		// Re-runs on org switch, which is what clears one org's services before
-		// the next org's arrive.
-		.task(id: session.dataGeneration) {
-			let model = model?.generation == session.dataGeneration
-				? model! : ServicesListModel(api: session.api.scoped(toEnvironment: environments.selected), session: session)
+		// Re-runs on an org switch or an environment change, which is what clears
+		// one scope's services before the next scope's arrive. The environment is
+		// in the key rather than pushed at this screen because it can resolve
+		// *after* the first build — a stored selection is only checked against
+		// the organization's real environments once the network answers.
+		.task(id: scope) {
+			let model = model?.scope == scope
+				? model!
+				: ServicesListModel(
+					api: session.api.scoped(toEnvironment: scope.environment),
+					session: session,
+					scope: scope
+				)
 			self.model = model
 			await model.loader.loadIfNeeded()
 		}

--- a/apps/ios/Maple/Fixtures/FixtureAPI.swift
+++ b/apps/ios/Maple/Fixtures/FixtureAPI.swift
@@ -54,7 +54,7 @@ struct FixtureAPI: MapleAPI {
 		return Service(
 			baselineP95LatencyMs: seed.baselineP95,
 			baselineSpanCount: (seed.throughput * 7 * 24 * 3_600).rounded(),
-			deploymentEnvironments: ["production"],
+			deploymentEnvironments: Self.environments,
 			errorCount: (spans * seed.errorRate).rounded(),
 			errorRate: seed.errorRate,
 			hasSampling: false,
@@ -69,6 +69,22 @@ struct FixtureAPI: MapleAPI {
 			throughput: seed.throughput,
 			tracedThroughput: seed.throughput
 		)
+	}
+
+	/// Two, not one: the environment picker hides itself when there is nothing
+	/// to switch to, so a single-environment fixture organization would make
+	/// the control invisible in exactly the mode the screens are built and
+	/// screenshotted in.
+	///
+	/// The fixture client ignores the environment scope — `FixtureAPI` serves
+	/// one fixed world, like every other stub — so switching here proves the
+	/// control and its layout, not the filtering. The filtering is proved
+	/// against the real API and in `MapleAPI`'s own tests.
+	static let environments = ["production", "staging"]
+
+	func environments(window: ResolvedTimeWindow) async throws -> [String] {
+		try await pause()
+		return Self.environments
 	}
 
 	func services(window: ResolvedTimeWindow, limit: Int) async throws -> Page<Service> {

--- a/apps/ios/Maple/Telemetry/Telemetry.swift
+++ b/apps/ios/Maple/Telemetry/Telemetry.swift
@@ -119,6 +119,7 @@ enum Telemetry {
 	enum Event {
 		static let organizationSwitched = "organization.switched"
 		static let timeWindowChanged = "time_window.changed"
+		static let environmentChanged = "environment.changed"
 		static let screenRefreshed = "screen.refreshed"
 		static let issuesFiltered = "issues.filtered"
 		static let notificationsPrompted = "notifications.prompted"

--- a/apps/ios/Maple/Widgets/WidgetPublisher.swift
+++ b/apps/ios/Maple/Widgets/WidgetPublisher.swift
@@ -65,6 +65,19 @@ final class WidgetPublisher {
 	/// ceiling now: each one is a bearer token that then has to be revoked.
 	private static let maximumOrganizations = 3
 
+	/// One organization filtered to one deployment environment — the unit a
+	/// round actually fetches and stores.
+	///
+	/// The organization alone stopped being enough once widgets could be pinned
+	/// to an environment: two widgets on the same organization, one on
+	/// production and one on staging, are two different questions with two
+	/// different snapshot slots. Nil is the whole organization, which is what
+	/// every widget placed before the environment picker asks for.
+	struct PublishTarget: Hashable, Sendable {
+		var organizationId: String
+		var environment: String?
+	}
+
 	private let index: WidgetOrganizationIndex
 	/// Where the widgets' own credential lives — a file in the shared App Group
 	/// container, written here and read by the extension.
@@ -91,6 +104,12 @@ final class WidgetPublisher {
 		/// Every organization the user belongs to, for widgets pinned to one
 		/// that is not active.
 		var memberships: [WidgetOrganization]
+		/// The environment the app itself is showing, or nil for all of them.
+		///
+		/// The floor of every round: whatever else is pinned, what the user is
+		/// looking at right now gets published. It is also what an unconfigured
+		/// widget resolves to through the index.
+		var activeEnvironment: String?
 	}
 
 	/// What asked for this refresh. Recorded on every `widget.refresh` span,
@@ -139,7 +158,15 @@ final class WidgetPublisher {
 		// costs nothing: `organizationsToPublish` intersects with what is
 		// actually pinned anyway, and a background round's budget is one extra
 		// organization.
-		context = Context(api: api, active: organization, memberships: published)
+		// The environment comes off the index too — a headless launch has no
+		// `EnvironmentController`, and the index is where the app last wrote
+		// what it was showing.
+		context = Context(
+			api: api,
+			active: organization,
+			memberships: published,
+			activeEnvironment: organization.activeEnvironment
+		)
 	}
 
 	/// Called whenever the signed-in organization, or the set the user belongs
@@ -156,11 +183,17 @@ final class WidgetPublisher {
 	/// - Parameter membershipsVerified: false when the list came from Clerk's
 	///   client payload, which can be partial. Only a verified list may be
 	///   written to the index — the same rule `prune` documents.
+	/// - Parameter environment: what the app is showing right now, or nil for
+	///   the whole organization. Not defaulted: an omitted argument would read
+	///   as "organization-wide" at every call site that simply had not been
+	///   updated, which is the silent-reset this parameter exists to make
+	///   impossible.
 	func configure(
 		api: any MapleAPI,
 		organizationId: String,
 		memberships: [WidgetOrganization] = [],
-		membershipsVerified: Bool = false
+		membershipsVerified: Bool = false,
+		environment: String?
 	) {
 		let isNewOrganization = context?.active.id != organizationId
 		let active = WidgetOrganization(
@@ -174,7 +207,8 @@ final class WidgetPublisher {
 		context = Context(
 			api: api,
 			active: active,
-			memberships: memberships.isEmpty ? [active] : memberships
+			memberships: memberships.isEmpty ? [active] : memberships,
+			activeEnvironment: environment
 		)
 		// Every membership goes into the index, not just the ones a round will
 		// fetch for: the picker reads it, and an organization the app has never
@@ -186,6 +220,29 @@ final class WidgetPublisher {
 		// A switch invalidates the throttle: the numbers on the Home Screen
 		// belong to the organization the user just left.
 		if isNewOrganization { lastRefreshedAt = nil }
+	}
+
+	/// Publish what the app has learned about one organization's environments:
+	/// which exist, and which the app is showing.
+	///
+	/// Separate from `configure` because the sources differ — memberships come
+	/// from Clerk on launch, environments from the warehouse whenever the
+	/// organization changes — and because only this one can arrive late. See
+	/// `WidgetOrganizationIndex.record(environments:activeEnvironment:for:)`.
+	///
+	/// An environment change moves what an unconfigured widget renders without
+	/// moving any snapshot's contents, exactly as an organization switch does,
+	/// so it sets the same flag: the next round spends a reload on it.
+	func recordEnvironments(_ environments: [String], selected: String?, for organizationId: String) {
+		if index.record(environments: environments, activeEnvironment: selected, for: organizationId) {
+			resolutionChanged = true
+		}
+		if context?.active.id == organizationId, context?.activeEnvironment != selected {
+			context?.activeEnvironment = selected
+			// The Home Screen's numbers belong to the environment the user just
+			// left — the same reason an organization switch clears the throttle.
+			lastRefreshedAt = nil
+		}
 	}
 
 	/// One `reloadAllTimelines` after an update that changed how widgets resolve
@@ -211,6 +268,9 @@ final class WidgetPublisher {
 	/// when the list came from Clerk's client payload, which can be partial —
 	/// pruning against that would wipe live organizations.
 	func prune(to memberIds: Set<String>) {
+		// Read before pruning: the entries carry the environments whose
+		// snapshots have to be wiped, and `prune` is what deletes the entries.
+		let knownBefore = index.load()
 		let evicted = index.prune(to: memberIds)
 		// Nothing changed on the common path — this runs on every launch and every
 		// organization switch, and `reloadAllTimelines` spends the widget refresh
@@ -219,8 +279,10 @@ final class WidgetPublisher {
 		let api = context?.api
 		let installationId = AppInstallation.identifier
 		for organizationId in evicted {
-			WidgetSnapshotStore<IssuesSnapshot>.issues(organizationId: organizationId).clear()
-			WidgetSnapshotStore<ThroughputSnapshot>.throughput(organizationId: organizationId).clear()
+			Self.clearSnapshots(
+				organizationId: organizationId,
+				environments: knownBefore.first { $0.id == organizationId }
+			)
 			credentials.clear(organizationId: organizationId)
 			fetchStates.clear(organizationId: organizationId)
 			// Server-side too, and not only locally: deleting the file stops this
@@ -233,6 +295,30 @@ final class WidgetPublisher {
 			}
 		}
 		WidgetCenter.shared.reloadAllTimelines()
+	}
+
+	/// Wipe every snapshot one organization has, across every environment.
+	///
+	/// The organization-wide slot alone is not enough any more. Snapshots are
+	/// keyed per (organization, environment), so clearing only the first would
+	/// leave one account's staging issue list readable in the App Group to
+	/// whoever holds the phone next — which is the whole point of clearing.
+	///
+	/// The index entry is the list of what to wipe. `activeEnvironment` is
+	/// included separately because the app can be showing an environment that
+	/// the environments list has not caught up with yet.
+	private static func clearSnapshots(organizationId: String, environments organization: WidgetOrganization?) {
+		var slots: [String?] = [nil]
+		slots.append(contentsOf: (organization?.environments ?? []).map { $0 })
+		if let active = organization?.activeEnvironment, !slots.contains(active) { slots.append(active) }
+		for environment in slots {
+			WidgetSnapshotStore<IssuesSnapshot>
+				.issues(organizationId: organizationId, environment: environment)
+				.clear()
+			WidgetSnapshotStore<ThroughputSnapshot>
+				.throughput(organizationId: organizationId, environment: environment)
+				.clear()
+		}
 	}
 
 	/// Fetch and publish both snapshots.
@@ -249,6 +335,7 @@ final class WidgetPublisher {
 
 		let plan = await organizationsToPublish(context, trigger: trigger)
 		let organizations = plan.organizations
+		let targets = plan.targets
 		// A widget with no configuration — every instance migrated from before
 		// the picker — resolves through the index's active organization, so a
 		// switch changes what it renders without changing any snapshot's
@@ -272,8 +359,10 @@ final class WidgetPublisher {
 				Telemetry.Key.widgetKnownOrganizationCount: .int(Int64(known.count)),
 			]
 		) { span in
-			let rounds = organizations.map { organization in
-				PublishRound(
+			let rounds = targets.compactMap { target -> PublishRound? in
+				guard let organization = organizations.first(where: { $0.id == target.organizationId })
+				else { return nil }
+				return PublishRound(
 					// Resolved again here, not taken as assembled: this name is
 					// baked into `IssuesSnapshot.organizationName`, and a
 					// snapshot that carries the wrong organization's name
@@ -287,7 +376,12 @@ final class WidgetPublisher {
 						),
 						lastPublishedAt: organization.lastPublishedAt
 					),
-					api: context.api.scoped(to: organization.id),
+					environment: target.environment,
+					// Both scopes, and both are needed: the organization travels
+					// in a header, the environment in the query string.
+					api: context.api
+						.scoped(to: organization.id)
+						.scoped(toEnvironment: target.environment),
 					isActive: organization.id == context.active.id
 				)
 			}
@@ -369,6 +463,10 @@ final class WidgetPublisher {
 	/// actor.
 	private struct PublishRound: Sendable {
 		let organization: WidgetOrganization
+		/// Nil for the whole organization. Selects the snapshot slot as well as
+		/// the query, so two rounds for one organization do not overwrite each
+		/// other.
+		let environment: String?
 		let api: any MapleAPI
 		let isActive: Bool
 	}
@@ -376,7 +474,11 @@ final class WidgetPublisher {
 	/// One organization's round: one request covering both surfaces, then record
 	/// it in the index the widget extension reads.
 	private func publish(_ round: PublishRound) async -> (issues: PublishOutcome, throughput: PublishOutcome) {
-		let outcome = await publishSummary(round.organization, api: round.api)
+		let outcome = await publishSummary(
+			round.organization,
+			environment: round.environment,
+			api: round.api
+		)
 
 		// Only a round that actually published stamps the time. It used to
 		// stamp unconditionally, which made a repeatedly failing organization
@@ -493,10 +595,11 @@ final class WidgetPublisher {
 	private func organizationsToPublish(
 		_ context: Context,
 		trigger: Trigger
-	) async -> (organizations: [WidgetOrganization], pinnedCount: Int) {
-		let pinned = await pinnedOrganizationIds()
+	) async -> (targets: [PublishTarget], organizations: [WidgetOrganization], pinnedCount: Int) {
+		let pinned = await pinnedTargets()
+		let pinnedOrganizationIds = Set(pinned.map(\.organizationId))
 		let others = context.memberships.filter {
-			$0.id != context.active.id && pinned.contains($0.id)
+			$0.id != context.active.id && pinnedOrganizationIds.contains($0.id)
 		}
 
 		// There used to be an oldest-first ordering here, so a background round
@@ -513,26 +616,48 @@ final class WidgetPublisher {
 		// organization nobody pinned is battery spent to make iOS trust the app
 		// less.
 		let budget = trigger == .background ? 1 : Self.maximumOrganizations - 1
-		return ([context.active] + others.prefix(budget), pinned.count)
+		let organizations = [context.active] + others.prefix(budget)
+		let covered = Set(organizations.map(\.id))
+
+		// The environments come from what is *pinned*, never from the
+		// organization's full environment list. Fanning out over every
+		// environment would multiply a five-environment organization's round by
+		// five, to publish four snapshots nobody put on a Home Screen — the same
+		// mistake as publishing every membership, one level down.
+		//
+		// The app's own selection is the floor, and it is added unconditionally.
+		// `currentConfigurations()` failing is indistinguishable from "nothing
+		// pinned" at the call site, so without the floor a single failed read
+		// would publish nothing at all for the organization on screen.
+		var targets = [PublishTarget(
+			organizationId: context.active.id,
+			environment: context.activeEnvironment
+		)]
+		for target in pinned where covered.contains(target.organizationId) {
+			if !targets.contains(target) { targets.append(target) }
+		}
+
+		return (targets, organizations, pinned.count)
 	}
 
-	/// The organizations the user actually pinned a widget to.
-	private func pinnedOrganizationIds() async -> Set<String> {
+	/// The (organization, environment) pairs the user actually pinned a widget
+	/// to.
+	private func pinnedTargets() async -> [PublishTarget] {
 		guard let configurations = try? await WidgetCenter.shared.currentConfigurations() else { return [] }
-		var ids: Set<String> = []
+		var targets: [PublishTarget] = []
 		for info in configurations {
 			if let intent = info.widgetConfigurationIntent(of: SelectOrganizationIntent.self),
 				let id = intent.organization?.id
 			{
-				ids.insert(id)
+				targets.append(PublishTarget(organizationId: id, environment: intent.environment?.id))
 			}
 			if let intent = info.widgetConfigurationIntent(of: SelectServiceIntent.self),
 				let id = intent.organization?.id
 			{
-				ids.insert(id)
+				targets.append(PublishTarget(organizationId: id, environment: intent.environment?.id))
 			}
 		}
-		return ids
+		return targets
 	}
 
 	/// One surface's fetch-and-publish, as a child of the refresh.
@@ -578,13 +703,18 @@ final class WidgetPublisher {
 		credentials.clearAll()
 		// Every organization, not just the active one: anything left behind
 		// stays readable on the Home Screen of a phone that has been signed out.
+		// Read before clearing, for the environments each entry carries — every
+		// one of them has its own snapshot slot to wipe.
+		let knownBefore = index.load()
 		for organizationId in index.clear() {
 			fetchStates.clear(organizationId: organizationId)
 			if let api {
 				Task { try? await api.scoped(to: organizationId).revokeWidgetCredential(installationId: installationId) }
 			}
-			WidgetSnapshotStore<IssuesSnapshot>.issues(organizationId: organizationId).clear()
-			WidgetSnapshotStore<ThroughputSnapshot>.throughput(organizationId: organizationId).clear()
+			Self.clearSnapshots(
+				organizationId: organizationId,
+				environments: knownBefore.first { $0.id == organizationId }
+			)
 		}
 		// The pre-per-organization keys too. They are not in the index — nothing
 		// published them — so iterating it alone would leave a widget placed
@@ -605,6 +735,7 @@ final class WidgetPublisher {
 	/// whichever half failed before.
 	private func publishSummary(
 		_ organization: WidgetOrganization,
+		environment: String?,
 		api: any MapleAPI
 	) async -> (issues: PublishOutcome, throughput: PublishOutcome) {
 		await snapshot("summary") {
@@ -620,7 +751,12 @@ final class WidgetPublisher {
 			// class of error as opening the wrong organization from a
 			// notification, and just as invisible once it has happened.
 			guard payload.organizationId == organization.id else { return failed }
-			return await self.store(payload, for: organization)
+			// And the same check for the environment, which is the more likely
+			// of the two to disagree: a server that predates the parameter
+			// answers organization-wide with a cheerful 200, and storing that
+			// would put production's numbers in the staging slot.
+			guard payload.deploymentEnvironment == environment else { return failed }
+			return await self.store(payload, for: organization, environment: environment)
 		}
 	}
 
@@ -628,7 +764,8 @@ final class WidgetPublisher {
 	/// reload budget is still spent per widget kind.
 	private func store(
 		_ payload: WidgetSummaryPayload,
-		for organization: WidgetOrganization
+		for organization: WidgetOrganization,
+		environment: String?
 	) async -> (issues: PublishOutcome, throughput: PublishOutcome) {
 		// The name comes from the caller (resolved against the membership index),
 		// never from the payload — see the endpoint's own note on why it carries
@@ -636,8 +773,14 @@ final class WidgetPublisher {
 		let issues = payload.issuesSnapshot(organizationName: organization.name)
 		let throughput = payload.throughputSnapshot()
 
-		let issuesStore = WidgetSnapshotStore<IssuesSnapshot>.issues(organizationId: organization.id)
-		let throughputStore = WidgetSnapshotStore<ThroughputSnapshot>.throughput(organizationId: organization.id)
+		let issuesStore = WidgetSnapshotStore<IssuesSnapshot>.issues(
+			organizationId: organization.id,
+			environment: environment
+		)
+		let throughputStore = WidgetSnapshotStore<ThroughputSnapshot>.throughput(
+			organizationId: organization.id,
+			environment: environment
+		)
 		// Read before writing: the reload decision is "does this differ from what
 		// is on screen", and after the save there is nothing to compare to.
 		let storedIssues = issuesStore.load()

--- a/apps/ios/PRODUCT.md
+++ b/apps/ios/PRODUCT.md
@@ -122,6 +122,12 @@ Reads needed, all in v2 already:
 | Services | `listServices`, `getService`, `queryTraceTimeseries`, `queryTraceBreakdown`, `listAlertIncidents`, `listErrorIssues`                                                                                                     |
 | Alerts   | `listAlertIncidents`, `getAlertIncident`, `getAlertRule`, `listAlertRuleChecks`, `listAlertDeliveries`, `listErrorIssues`, `getErrorIssue`, `listAnomalyIncidents`, `getAnomalyIncident`, `getAnomalyIncidentTimeseries` |
 
+Every screen also calls `listEnvironments` once per organization, to populate
+the deployment-environment control that sits beside the organization switcher on
+all three tab roots. Both controls hide themselves when there is nothing to
+switch to. See "The environment axis" in the README for which reads the
+selection reaches and which it does not.
+
 Add these `operationId`s to `IOS_OPERATIONS` in `scripts/generate-ios-openapi.ts`.
 Sparkline queries: batch per screen, 1h/24 buckets, `p95_duration` and
 `error_rate` aggregations — cheap, and the API is already cost-profiled.

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+Alerts.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+Alerts.swift
@@ -84,6 +84,10 @@ extension MapleClient {
 						cursor: cursor,
 						status: status,
 						serviceName: serviceName,
+						// `deployment_env`, not `deployment_environment`: this is the
+						// one v2 endpoint that spells the parameter short, and the
+						// generated names follow the wire.
+						deploymentEnv: environment,
 						startTime: window?.startTime,
 						endTime: window?.endTime
 					)

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+Telemetry.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+Telemetry.swift
@@ -116,9 +116,15 @@ extension MapleClient {
 		}
 	}
 
+	/// The environment comes from the client's scope rather than the request:
+	/// it is a property of what the user is looking at, not of one chart.
+	///
+	/// Note the guard covers it too. Before, an environment-only filter would
+	/// have fallen through to `nil` and been dropped on the floor — the request
+	/// would still succeed, and the chart would quietly show every environment.
 	private func filters(serviceName: String?, hasError: Bool?) -> Components.Schemas.TraceFilters? {
-		guard serviceName != nil || hasError != nil else { return nil }
-		return .init(hasError: hasError, serviceName: serviceName)
+		guard serviceName != nil || hasError != nil || environment != nil else { return nil }
+		return .init(deploymentEnvironment: environment, hasError: hasError, serviceName: serviceName)
 	}
 }
 

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+WidgetSummary.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient+WidgetSummary.swift
@@ -10,9 +10,15 @@ import MapleWidgetData
 /// the same one the widget extension decodes for itself, so the app and the
 /// Home Screen cannot drift apart about what a row says.
 extension MapleClient {
+	/// Filtered to the client's environment scope, if it has one. The server
+	/// echoes the filter it applied, and `payload(from:)` carries that echo —
+	/// not the value asked for — into the snapshot, so a server that ignored
+	/// the parameter cannot be mistaken for one that honoured it.
 	public func widgetSummary() async throws -> WidgetSummaryPayload {
 		try await mapping {
-			let output = try await client.getWidgetSummary(.init())
+			let output = try await client.getWidgetSummary(
+				.init(query: .init(deploymentEnvironment: environment))
+			)
 			return try Self.payload(from: output.ok.body.json)
 		}
 	}
@@ -35,6 +41,7 @@ extension MapleClient {
 			schemaVersion: Int(summary.schemaVersion),
 			generatedAt: generatedAt,
 			organizationId: summary.organizationId,
+			deploymentEnvironment: summary.deploymentEnvironment,
 			issues: WidgetSummaryPayload.Issues(
 				windowSeconds: Int(summary.issues.windowSeconds),
 				hasMore: summary.issues.hasMore,

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/MapleClient.swift
@@ -120,14 +120,39 @@ public protocol MapleAPI: Sendable {
 	/// the exact bug this exists to prevent.
 	func scoped(to organizationId: String) -> any MapleAPI
 
+	/// A view of this client that filters every read it can to one deployment
+	/// environment. Nil means the whole organization.
+	///
+	/// A scoped instance for the same reason as `scoped(to:)` above, but the
+	/// mechanism is different and the difference matters: the organization
+	/// travels in the token (or, when named, in a header), while the
+	/// environment is a **query parameter or body field, per endpoint**. Several
+	/// endpoints have no such parameter, so this scope is not uniform — see the
+	/// per-method notes below for which reads ignore it.
+	func scoped(toEnvironment environment: String?) -> any MapleAPI
+
+	/// Every environment the organization has reported telemetry in. The list
+	/// that populates a picker, so it is deliberately *not* filtered by the
+	/// environment scope.
+	func environments(window: ResolvedTimeWindow) async throws -> [String]
+
 	func services(window: ResolvedTimeWindow, limit: Int) async throws -> Page<Service>
+	/// Aggregated across environments: `GET /v2/services/{name}` takes no
+	/// environment parameter, so the scope is ignored here rather than faked.
 	func service(named name: String, window: ResolvedTimeWindow) async throws -> Service
 	func issues(query: IssueQuery, window: ResolvedTimeWindow?, limit: Int, cursor: String?) async throws
 		-> Page<ErrorIssue>
 	func issue(id: String) async throws -> ErrorIssueDetail
+	/// Organization-wide. `GET /v2/error_issues/service_counts` takes no
+	/// parameters at all, so with an environment selected these badges keep
+	/// counting every environment's issues — the one place in the app where a
+	/// filtered row carries an unfiltered number.
 	func issueCountsByService() async throws -> [ErrorIssueServiceCount]
 
 	// Alerts — see MapleClient+Alerts.swift
+	// None of the alerts reads take an environment parameter; a rule's
+	// `environments` field is the scope it fires on, not a filter over rules.
+	// The scope is ignored throughout this section.
 	func alertIncidents(status: AlertIncidentStatus?, ruleId: String?, limit: Int, cursor: String?) async throws
 		-> Page<AlertIncident>
 	func alertIncident(id: String) async throws -> AlertIncident
@@ -163,6 +188,9 @@ public protocol MapleAPI: Sendable {
 extension MapleAPI {
 	/// Stubs and fixtures serve one organization and ignore the scope.
 	public func scoped(to organizationId: String) -> any MapleAPI { self }
+
+	/// Same for the environment scope: a fixture serves one fixed world.
+	public func scoped(toEnvironment environment: String?) -> any MapleAPI { self }
 }
 
 /// The live client: generated operations, wrapped so call sites see plain
@@ -172,6 +200,14 @@ public struct MapleClient: MapleAPI {
 	private let tokens: any MapleTokenProvider
 	let serverURL: URL
 	private let transport: any ClientTransport
+	/// Nil means every environment. Sent per request as a query parameter or a
+	/// body filter — never a header, unlike the organization scope — so it only
+	/// reaches the endpoints that declare one.
+	let environment: String?
+	/// Retained, not just consumed when building the middleware chain, so that
+	/// scoping to an environment can carry the organization forward instead of
+	/// silently dropping it back to the token's active one.
+	private let organizationId: String?
 	/// Shared with every client `scoped(to:)` produces, so a widget fetch for
 	/// one organization still dedupes against a foreground fetch for another
 	/// when they happen to be identical.
@@ -188,6 +224,7 @@ public struct MapleClient: MapleAPI {
 			serverURL: try baseURL ?? Servers.Server1.url(),
 			transport: URLSessionTransport(),
 			organizationId: nil,
+			environment: nil,
 			coalescer: RequestCoalescer()
 		)
 	}
@@ -205,6 +242,7 @@ public struct MapleClient: MapleAPI {
 			serverURL: serverURL,
 			transport: transport,
 			organizationId: nil,
+			environment: nil,
 			coalescer: coalescer
 		)
 	}
@@ -214,11 +252,14 @@ public struct MapleClient: MapleAPI {
 		serverURL: URL,
 		transport: any ClientTransport,
 		organizationId: String?,
+		environment: String?,
 		coalescer: RequestCoalescer
 	) {
 		self.tokens = tokens
 		self.serverURL = serverURL
 		self.transport = transport
+		self.environment = environment
+		self.organizationId = organizationId
 		self.coalescer = coalescer
 
 		// Order matters, outermost first: auth runs outermost so the error
@@ -249,8 +290,35 @@ public struct MapleClient: MapleAPI {
 			serverURL: serverURL,
 			transport: transport,
 			organizationId: organizationId,
+			environment: environment,
 			coalescer: coalescer
 		)
+	}
+
+	/// Composes with `scoped(to:)` in either order — both carry the other's
+	/// scope forward, so a widget fetch can name an organization and an
+	/// environment without the second call dropping the first.
+	public func scoped(toEnvironment environment: String?) -> any MapleAPI {
+		MapleClient(
+			tokens: tokens,
+			serverURL: serverURL,
+			transport: transport,
+			organizationId: organizationId,
+			environment: environment,
+			coalescer: coalescer
+		)
+	}
+
+	/// Deliberately unfiltered by the environment scope: this is the list the
+	/// picker offers, so filtering it by the current choice would leave a user
+	/// unable to pick anything else.
+	public func environments(window: ResolvedTimeWindow) async throws -> [String] {
+		try await mapping {
+			let output = try await client.listEnvironments(
+				.init(query: .init(startTime: window.startTime, endTime: window.endTime))
+			)
+			return try output.ok.body.json.data.map(\.name)
+		}
 	}
 
 	public func services(window: ResolvedTimeWindow, limit: Int = 50) async throws -> Page<Service> {
@@ -260,7 +328,8 @@ public struct MapleClient: MapleAPI {
 					query: .init(
 						startTime: window.startTime,
 						endTime: window.endTime,
-						limit: String(limit)
+						limit: String(limit),
+						deploymentEnvironment: environment
 					)
 				)
 			)
@@ -297,6 +366,7 @@ public struct MapleClient: MapleAPI {
 						severity: query.severity,
 						kind: query.kind,
 						serviceName: query.serviceName,
+						deploymentEnvironment: environment,
 						startTime: window?.startTime,
 						endTime: window?.endTime,
 						// The contract accepts the literal string "true" only —

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/openapi.json
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/openapi.json
@@ -1239,6 +1239,77 @@
         "title": "Breakdown item",
         "type": "object"
       },
+      "Environment": {
+        "additionalProperties": false,
+        "description": "One deployment environment telemetry has been observed in.",
+        "examples": [
+          {
+            "name": "production",
+            "object": "environment"
+          }
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "environment"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "name"
+        ],
+        "title": "Environment",
+        "type": "object"
+      },
+      "EnvironmentList": {
+        "additionalProperties": false,
+        "description": "Cursor-paginated list envelope wrapping a page of objects.",
+        "properties": {
+          "data": {
+            "description": "The page of objects, in the ordering documented by the endpoint.",
+            "items": {
+              "$ref": "#/components/schemas/Environment"
+            },
+            "type": "array"
+          },
+          "has_more": {
+            "description": "Whether more objects exist after this page. When `true`, use `next_cursor` to fetch them.",
+            "examples": [
+              true
+            ],
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "description": "Cursor for the next page, or `null` on the last page. Pass it back as the `cursor` query param.",
+            "examples": [
+              "off_1k"
+            ],
+            "type": "string"
+          },
+          "object": {
+            "description": "Always `\"list\"` for a list response.",
+            "enum": [
+              "list"
+            ],
+            "examples": [
+              "list"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
+        "title": "Environment list",
+        "type": "object"
+      },
       "ErrorIncident": {
         "additionalProperties": false,
         "properties": {
@@ -2755,6 +2826,7 @@
         "description": "Everything the Maple iOS Home Screen widgets draw, in one response: ongoing error issues over the last day, and per-service traffic over the last hour.",
         "examples": [
           {
+            "deployment_environment": "production",
             "generated_at": "2026-08-21T09:10:00.000Z",
             "issues": {
               "data": [
@@ -2802,6 +2874,9 @@
           }
         ],
         "properties": {
+          "deployment_environment": {
+            "type": "string"
+          },
           "generated_at": {
             "type": "string"
           },
@@ -4810,6 +4885,148 @@
         "summary": "Retrieve incident timeseries",
         "tags": [
           "Anomalies"
+        ]
+      }
+    },
+    "/v2/environments": {
+      "get": {
+        "description": "Lists the deployment environments observed in an explicit time window, in name order. The list is unpaginated — `has_more` is always false — because an organization has tens of environments, not thousands. Requires `environments:read`.",
+        "operationId": "listEnvironments",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "start_time",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_time",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnvironmentList"
+                }
+              }
+            },
+            "description": "Cursor-paginated list envelope wrapping a page of objects."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/TimeRangeInvalidError failure. HTTP 400. | The @maple/http/v2/TelemetryRangeTooLargeError failure. HTTP 400. | The @maple/http/v2/InvalidRequestError failure. HTTP 400."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InvalidCredentialsError failure. HTTP 401. | The @maple/http/errors/UnauthorizedError failure. HTTP 401."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/InsufficientScopeError failure. HTTP 403. | The @maple/http/v2/OrganizationAccessDeniedError failure. HTTP 403."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQuotaExceededError failure. HTTP 429. | The @maple/http/v2/RateLimitError failure. HTTP 429.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait or an HTTP-date indicating when the request may be retried.",
+                "example": 60,
+                "schema": {
+                  "oneOf": [
+                    {
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseMalformedQueryError failure. HTTP 500. | The @maple/http/errors/WarehouseScopeError failure. HTTP 500. | The @maple/http/errors/OrgClickHouseSettingsEncryptionError failure. HTTP 500. | The @maple/http/v2/ResponseSchemaError failure. HTTP 500. | The @maple/http/v2/UnexpectedError failure. HTTP 500."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseQueryError failure. HTTP 502. | The @maple/http/errors/WarehouseAuthError failure. HTTP 502. | The @maple/http/errors/WarehouseConfigError failure. HTTP 502. | The @maple/http/errors/WarehouseClientError failure. HTTP 502. | The @maple/http/errors/WarehouseSchemaDriftError failure. HTTP 502. | The @maple/http/errors/WarehouseResultDecodeError failure. HTTP 502. | The @maple/http/errors/OrgClickHouseSettingsStoredConfigInvalidError failure. HTTP 502."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/errors/WarehouseUpstreamError failure. HTTP 503. | The @maple/http/errors/OrgClickHouseSettingsPersistenceError failure. HTTP 503. | The @maple/http/errors/ApiKeyLookupPersistenceError failure. HTTP 503. | The @maple/http/errors/AuthorizationUnavailableError failure. HTTP 503."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapleErrorEnvelope"
+                }
+              }
+            },
+            "description": "The @maple/http/v2/WorkerUnavailableError failure. HTTP 504."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List deployment environments",
+        "tags": [
+          "Environments"
         ]
       }
     },
@@ -6919,9 +7136,18 @@
     },
     "/v2/widget_summary": {
       "get": {
-        "description": "Returns ongoing error issues and per-service traffic in a single small payload sized for a Home Screen widget. The windows are fixed by the server. Requires the `widget_summary:read` scope.",
+        "description": "Returns ongoing error issues and per-service traffic in a single small payload sized for a Home Screen widget. The windows are fixed by the server; `deployment_environment` optionally narrows both halves to one environment and is echoed on the response. Requires the `widget_summary:read` scope.",
         "operationId": "getWidgetSummary",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "deployment_environment",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -7146,6 +7372,10 @@
     {
       "description": "Service-to-service topology.",
       "name": "Service Map"
+    },
+    {
+      "description": "The deployment environments telemetry has been observed in.",
+      "name": "Environments"
     },
     {
       "description": "Read a dashboard through a share link. The only unauthenticated group in this API: the token in the request body is the credential, so these operations resolve for a viewer with no Maple account.",

--- a/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/SelectEnvironmentIntent.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/SelectEnvironmentIntent.swift
@@ -1,0 +1,82 @@
+import AppIntents
+import Foundation
+
+/// One row of the widget's environment picker.
+///
+/// The deployment environment name is the identifier: environments are named,
+/// not numbered, and a widget pinned to "staging" should keep meaning staging
+/// across every republish that reorders the list.
+///
+/// There is no "All environments" row. The parameter is optional on both
+/// intents, so unset already means the whole organization — the same shape
+/// `SelectServiceIntent.service` uses for "no service in particular". A
+/// sentinel entity would give the same state two spellings, and a widget
+/// configured with one of them would not match a widget configured with the
+/// other.
+public struct EnvironmentEntity: AppEntity {
+	public var id: String
+
+	public init(id: String) {
+		self.id = id
+	}
+
+	public static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Environment")
+	public static let defaultQuery = EnvironmentEntityQuery()
+
+	public var displayRepresentation: DisplayRepresentation {
+		DisplayRepresentation(title: "\(id)")
+	}
+}
+
+/// The options come from the App Group index, which is the only thing in the
+/// extension that knows an environment exists — it holds no session, and its
+/// one network call is fenced to `/v2/widget_summary`.
+///
+/// Both widget intents carry an environment parameter, so this declares a
+/// dependency on each. Exactly one resolves for any given configuration
+/// screen; the other stays nil. A single shared query rather than two is what
+/// keeps the two pickers from drifting apart about what an environment is.
+public struct EnvironmentEntityQuery: EntityQuery {
+	public init() {}
+
+	@IntentParameterDependency<SelectOrganizationIntent>(\.$organization)
+	public var issuesConfiguration
+
+	@IntentParameterDependency<SelectServiceIntent>(\.$organization)
+	public var throughputConfiguration
+
+	/// The dependency is nil until the organization parameter resolves, and an
+	/// empty picker on first open reads as broken — so fall back to the
+	/// organization the app is in, exactly as `ServiceEntityQuery` does.
+	private var organizationId: String? {
+		issuesConfiguration?.organization.id
+			?? throughputConfiguration?.organization.id
+			?? WidgetOrganizationIndex().activeOrganizationId
+	}
+
+	private var organization: WidgetOrganization? {
+		guard let organizationId else { return nil }
+		return WidgetOrganizationIndex().load().first { $0.id == organizationId }
+	}
+
+	/// Resolving what a configured widget already holds. An environment that
+	/// has since stopped reporting still resolves, by name — dropping it would
+	/// silently re-point the widget at the whole organization, which reads as
+	/// "your staging traffic recovered" rather than "staging went quiet". The
+	/// widget renders it as an empty environment instead.
+	public func entities(for identifiers: [String]) async throws -> [EnvironmentEntity] {
+		identifiers.map(EnvironmentEntity.init(id:))
+	}
+
+	public func suggestedEntities() async throws -> [EnvironmentEntity] {
+		(organization?.environments ?? []).map(EnvironmentEntity.init(id:))
+	}
+
+	/// A newly placed widget lands on whatever the app is currently showing,
+	/// rather than on a question the user has to answer before the widget says
+	/// anything. Nil — the whole organization — is a real answer here, which is
+	/// why this may legitimately return nothing.
+	public func defaultResult() async -> EnvironmentEntity? {
+		organization?.activeEnvironment.map(EnvironmentEntity.init(id:))
+	}
+}

--- a/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/SelectOrganizationIntent.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/SelectOrganizationIntent.swift
@@ -14,10 +14,21 @@ public struct SelectOrganizationIntent: WidgetConfigurationIntent {
 	@Parameter(title: "Organization")
 	public var organization: OrganizationEntity?
 
+	/// Which deployment environment's issues, or all of them when unset.
+	///
+	/// Added as a new optional parameter rather than as a new intent type: iOS
+	/// persists the intent *type name* for every configured widget, so renaming
+	/// or replacing this type would unconfigure every widget already on a Home
+	/// Screen. Existing instances decode with this nil, which is the
+	/// organization-wide behaviour they already had.
+	@Parameter(title: "Environment")
+	public var environment: EnvironmentEntity?
+
 	public init() {}
 
-	public init(organization: OrganizationEntity?) {
+	public init(organization: OrganizationEntity?, environment: EnvironmentEntity? = nil) {
 		self.organization = organization
+		self.environment = environment
 	}
 }
 

--- a/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/SelectServiceIntent.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/SelectServiceIntent.swift
@@ -21,11 +21,21 @@ public struct SelectServiceIntent: WidgetConfigurationIntent {
 	@Parameter(title: "Organization")
 	public var organization: OrganizationEntity?
 
+	/// Which deployment environment's throughput, or all of it when unset.
+	/// Optional and additive for the same reason the organization above is.
+	@Parameter(title: "Environment")
+	public var environment: EnvironmentEntity?
+
 	public init() {}
 
-	public init(service: ServiceEntity?, organization: OrganizationEntity? = nil) {
+	public init(
+		service: ServiceEntity?,
+		organization: OrganizationEntity? = nil,
+		environment: EnvironmentEntity? = nil
+	) {
 		self.service = service
 		self.organization = organization
+		self.environment = environment
 	}
 }
 
@@ -64,6 +74,18 @@ public struct ServiceEntityQuery: EntityQuery {
 
 	/// Reads the organization parameter of the very intent being configured, so
 	/// the service list belongs to the organization the user just picked.
+	/// Reads the organization parameter of the very intent being configured, so
+	/// the service list belongs to the organization the user just picked.
+	///
+	/// The environment is deliberately *not* a second dependency here. A
+	/// multi-parameter dependency resolves only when **every** parameter in it
+	/// has a value, and the environment is legitimately unset — so adding it
+	/// would leave `configuration` nil for the common case and send the
+	/// organization lookup back to whichever one the app happens to be in. The
+	/// cost is that a staging widget's service picker lists the organization's
+	/// services rather than staging's; a service missing from the staging
+	/// snapshot already resolves as absent, which is the same handling a
+	/// service that went quiet gets.
 	@IntentParameterDependency<SelectServiceIntent>(\.$organization)
 	public var configuration
 

--- a/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetOrganizationIndex.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetOrganizationIndex.swift
@@ -13,11 +13,49 @@ public struct WidgetOrganization: Codable, Hashable, Sendable, Identifiable {
 	/// until a round covers it, and the widget renders it as "Open Maple"
 	/// rather than as "you are not a member".
 	public var lastPublishedAt: Date?
+	/// The deployment environments this organization reports telemetry in, for
+	/// the widget's environment picker.
+	///
+	/// Written by the app, because the extension cannot ask: it holds no
+	/// session and its one network call is fenced to `/v2/widget_summary`.
+	/// Empty means "the app has not looked yet", which the picker renders as
+	/// the whole-organization choice alone rather than as an empty list.
+	public var environments: [String]
+	/// Which environment the *app* is currently showing, so a newly placed
+	/// widget lands on what the user was just looking at instead of on a
+	/// question. Nil is the whole organization, and a real answer — not a
+	/// missing one.
+	public var activeEnvironment: String?
 
-	public init(id: String, name: String?, lastPublishedAt: Date? = nil) {
+	public init(
+		id: String,
+		name: String?,
+		lastPublishedAt: Date? = nil,
+		environments: [String] = [],
+		activeEnvironment: String? = nil
+	) {
 		self.id = id
 		self.name = name
 		self.lastPublishedAt = lastPublishedAt
+		self.environments = environments
+		self.activeEnvironment = activeEnvironment
+	}
+
+	private enum CodingKeys: String, CodingKey {
+		case id, name, lastPublishedAt, environments, activeEnvironment
+	}
+
+	/// Hand-written so an entry written by a build before the environment
+	/// picker still decodes. Synthesis would make `environments` a required key
+	/// and drop the whole index — every widget on the Home Screen would fall
+	/// back to "Open Maple" on upgrade.
+	public init(from decoder: any Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		self.id = try container.decode(String.self, forKey: .id)
+		self.name = try container.decodeIfPresent(String.self, forKey: .name)
+		self.lastPublishedAt = try container.decodeIfPresent(Date.self, forKey: .lastPublishedAt)
+		self.environments = try container.decodeIfPresent([String].self, forKey: .environments) ?? []
+		self.activeEnvironment = try container.decodeIfPresent(String.self, forKey: .activeEnvironment)
 	}
 }
 
@@ -85,8 +123,14 @@ public struct WidgetOrganizationIndex: Sendable {
 	public func record(_ organization: WidgetOrganization, isActive: Bool) {
 		guard let defaults else { return }
 		let existing = load()
+		let previous = existing.first { $0.id == organization.id }
 		var updated = organization
-		if updated.name == nil { updated.name = existing.first { $0.id == organization.id }?.name }
+		if updated.name == nil { updated.name = previous?.name }
+		// A publish round knows nothing about environments — same reason the
+		// name is preserved rather than blanked. Losing them here would empty
+		// the widget's environment picker on the next background fetch.
+		if updated.environments.isEmpty { updated.environments = previous?.environments ?? [] }
+		if updated.activeEnvironment == nil { updated.activeEnvironment = previous?.activeEnvironment }
 		write(existing.filter { $0.id != organization.id } + [updated], to: defaults)
 		if isActive { defaults.set(organization.id, forKey: Key.active) }
 	}
@@ -116,7 +160,11 @@ public struct WidgetOrganizationIndex: Sendable {
 			byId[membership.id] = WidgetOrganization(
 				id: membership.id,
 				name: membership.name,
-				lastPublishedAt: byId[membership.id]?.lastPublishedAt
+				lastPublishedAt: byId[membership.id]?.lastPublishedAt,
+				// Same rule as the timestamp: the membership list is authoritative
+				// for the name and silent about everything else.
+				environments: byId[membership.id]?.environments ?? [],
+				activeEnvironment: byId[membership.id]?.activeEnvironment
 			)
 		}
 
@@ -126,6 +174,40 @@ public struct WidgetOrganizationIndex: Sendable {
 		guard before != after else { return false }
 
 		write(updated, to: defaults)
+		return true
+	}
+
+	/// Record what the app has learned about one organization's environments:
+	/// which exist, and which the app is currently showing.
+	///
+	/// Separate from `record(memberships:)` because the two have different
+	/// sources and different cadences — memberships come from Clerk on launch,
+	/// environments from the warehouse whenever the organization changes — and
+	/// folding them together would mean either fetching environments to correct
+	/// a name or blanking them when a membership refresh arrives first.
+	///
+	/// Does nothing for an organization the index has never heard of: the entry
+	/// would have no name and no snapshot, and would show up in the picker as a
+	/// bare `org_…` id. Memberships are recorded first, on every launch.
+	///
+	/// Returns whether a reader could tell the difference, so the caller only
+	/// spends a metered widget reload when there is something new to see.
+	@discardableResult
+	public func record(
+		environments: [String],
+		activeEnvironment: String?,
+		for organizationId: String
+	) -> Bool {
+		guard let defaults else { return false }
+		let existing = load()
+		guard let previous = existing.first(where: { $0.id == organizationId }) else { return false }
+		guard previous.environments != environments || previous.activeEnvironment != activeEnvironment
+		else { return false }
+
+		var updated = previous
+		updated.environments = environments
+		updated.activeEnvironment = activeEnvironment
+		write(existing.filter { $0.id != organizationId } + [updated], to: defaults)
 		return true
 	}
 

--- a/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetSnapshotStore.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetSnapshotStore.swift
@@ -70,17 +70,40 @@ public struct WidgetSnapshotStore<Value: Codable & Sendable>: Sendable {
 	private static var decoder: JSONDecoder { WidgetJSON.decoder }
 }
 
-// Keys are per organization, because a widget can be pinned to one. The `v1`
-// keys below are read-only leftovers: a widget placed before this shipped has a
-// snapshot under the old key and would otherwise render "Open Maple" until the
-// next publish. Delete them, and the fallbacks that read them, one release on.
+// Keys are per organization *and* environment, because a widget can be pinned
+// to either. One slot per organization was enough only while every widget
+// showed the whole organization: two widgets on the same organization, one
+// filtered to production and one to staging, would otherwise overwrite each
+// other on every publish — and each would render the other's numbers under its
+// own label, which looks exactly like working software.
+//
+// The unfiltered key is left as it was rather than versioned up. "All
+// environments" is precisely what the existing key already means, so widgets
+// placed before the environment picker keep reading the snapshot they always
+// read, with no migration and no fallback to delete later.
+//
+// The `v1` keys below are read-only leftovers from before per-organization
+// snapshots: a widget placed before that shipped would otherwise render "Open
+// Maple" until the next publish. Delete them, and their readers, one release on.
+
+/// The key segment identifying one environment, or nothing at all for the
+/// whole organization. Shared so the two surfaces cannot disagree about which
+/// slot a snapshot belongs in.
+private func environmentKeySuffix(_ environment: String?) -> String {
+	guard let environment, !environment.isEmpty else { return "" }
+	return ".env.\(environment)"
+}
 
 extension WidgetSnapshotStore where Value == IssuesSnapshot {
 	public static func issues(
 		organizationId: String,
+		environment: String? = nil,
 		appGroupIdentifier: String = WidgetAppGroup.identifier
 	) -> WidgetSnapshotStore<IssuesSnapshot> {
-		.init(key: "issues.snapshot.v2.\(organizationId)", appGroupIdentifier: appGroupIdentifier)
+		.init(
+			key: "issues.snapshot.v2.\(organizationId)\(environmentKeySuffix(environment))",
+			appGroupIdentifier: appGroupIdentifier
+		)
 	}
 
 	/// Read-only fallback for widgets placed before per-organization snapshots.
@@ -91,9 +114,13 @@ extension WidgetSnapshotStore where Value == IssuesSnapshot {
 extension WidgetSnapshotStore where Value == ThroughputSnapshot {
 	public static func throughput(
 		organizationId: String,
+		environment: String? = nil,
 		appGroupIdentifier: String = WidgetAppGroup.identifier
 	) -> WidgetSnapshotStore<ThroughputSnapshot> {
-		.init(key: "throughput.snapshot.v2.\(organizationId)", appGroupIdentifier: appGroupIdentifier)
+		.init(
+			key: "throughput.snapshot.v2.\(organizationId)\(environmentKeySuffix(environment))",
+			appGroupIdentifier: appGroupIdentifier
+		)
 	}
 
 	/// Read-only fallback for widgets placed before per-organization snapshots.

--- a/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetSummary.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetSummary.swift
@@ -26,6 +26,14 @@ public struct WidgetSummaryPayload: Codable, Sendable, Equatable {
 	/// membership index, and a second source could put one organization's name
 	/// over another's numbers.
 	public var organizationId: String
+	/// The deployment environment the payload was filtered to, or nil for all of
+	/// them.
+	///
+	/// Echoed for the same reason `organizationId` is, and it matters more here:
+	/// snapshots are stored per (organization, environment), so a response whose
+	/// filter the server ignored would overwrite a production widget's numbers
+	/// with organization-wide ones and look entirely plausible doing it.
+	public var deploymentEnvironment: String?
 	public var issues: Issues
 	public var throughput: Throughput
 
@@ -172,12 +180,14 @@ public struct WidgetSummaryPayload: Codable, Sendable, Equatable {
 		schemaVersion: Int,
 		generatedAt: Date,
 		organizationId: String,
+		deploymentEnvironment: String? = nil,
 		issues: Issues,
 		throughput: Throughput
 	) {
 		self.schemaVersion = schemaVersion
 		self.generatedAt = generatedAt
 		self.organizationId = organizationId
+		self.deploymentEnvironment = deploymentEnvironment
 		self.issues = issues
 		self.throughput = throughput
 	}
@@ -186,6 +196,7 @@ public struct WidgetSummaryPayload: Codable, Sendable, Equatable {
 		case schemaVersion = "schema_version"
 		case generatedAt = "generated_at"
 		case organizationId = "organization_id"
+		case deploymentEnvironment = "deployment_environment"
 		case issues
 		case throughput
 	}

--- a/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetSummaryFetcher.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetSummaryFetcher.swift
@@ -87,9 +87,13 @@ public actor WidgetSummaryFetcher {
 	/// Writes a successful payload's snapshots into the App Group **before**
 	/// returning, so a provider killed on the way to rendering still leaves the
 	/// data behind for the next rebuild.
+	/// - Parameter environment: the deployment environment to filter to, or nil
+	///   for the whole organization. It selects the snapshot slot as well as the
+	///   query, so two widgets on one organization can hold different answers.
 	public func fetch(
 		organizationId: String,
 		organizationName: String?,
+		environment: String? = nil,
 		storedGeneratedAt: Date?,
 		now: Date = Date()
 	) async -> Attempt {
@@ -105,6 +109,12 @@ public actor WidgetSummaryFetcher {
 		// The app and the extension are different processes and share nothing but
 		// the App Group, so this is the only thing standing between them when a
 		// foreground and a timeline rebuild land in the same second.
+		//
+		// Per organization, not per environment: the state it guards is the
+		// credential's, and a credential is bound to an organization. The cost
+		// is that a staging widget can be told `.coalesced` while production is
+		// fetching — which it answers by rendering its own stored snapshot with
+		// an honest age, the same thing it does for every other skip.
 		if state.isInFlight(at: now, within: Self.attemptLock) { return .coalesced }
 
 		guard let credential = credentials.load(organizationId: organizationId) else {
@@ -115,7 +125,12 @@ public actor WidgetSummaryFetcher {
 		// request to be told so helps nobody.
 		if credential.isExpired(at: now) { return .needsApp }
 
-		if let existing = inFlight[organizationId] {
+		// Keyed by organization *and* environment: within this process two
+		// widgets asking for different environments are asking different
+		// questions, and folding them together would hand one of them the
+		// other's answer.
+		let inFlightKey = "\(organizationId)|\(environment ?? "")"
+		if let existing = inFlight[inFlightKey] {
 			return await existing.value.map(Attempt.fetched) ?? .coalesced
 		}
 
@@ -124,14 +139,27 @@ public actor WidgetSummaryFetcher {
 		fetchStates.save(state.attempting(at: now), organizationId: organizationId)
 
 		let task = Task<WidgetSummaryPayload?, Never> { [credentials, fetchStates, session] in
-			let outcome = await Self.request(credential: credential, session: session)
+			let outcome = await Self.request(
+				credential: credential,
+				environment: environment,
+				session: session
+			)
 			switch outcome {
 			case .success(let payload):
 				// The organization the credential is bound to is the one the
 				// server answers for. A disagreement would write one
 				// organization's numbers under another's name — invisible until
 				// someone reads the wrong figure off their Home Screen.
-				guard payload.organizationId == organizationId, payload.isSupported else {
+				//
+				// The environment is checked for the same reason and is the more
+				// likely of the two to disagree: a server that predates the
+				// parameter answers organization-wide, cheerfully, with a 200.
+				// Writing that into the staging slot would put production's
+				// numbers under a staging label.
+				guard payload.organizationId == organizationId,
+					payload.deploymentEnvironment == environment,
+					payload.isSupported
+				else {
 					fetchStates.save(
 						fetchStates.load(organizationId: organizationId)
 							.recording(.undecodable, at: Date()),
@@ -142,10 +170,10 @@ public actor WidgetSummaryFetcher {
 				// Saved before the caller gets it back: a provider killed between
 				// here and rendering still leaves the data for the next rebuild.
 				WidgetSnapshotStore<IssuesSnapshot>
-					.issues(organizationId: organizationId)
+					.issues(organizationId: organizationId, environment: environment)
 					.save(payload.issuesSnapshot(organizationName: organizationName))
 				WidgetSnapshotStore<ThroughputSnapshot>
-					.throughput(organizationId: organizationId)
+					.throughput(organizationId: organizationId, environment: environment)
 					.save(payload.throughputSnapshot())
 				fetchStates.save(
 					fetchStates.load(organizationId: organizationId).recording(.success, at: Date()),
@@ -161,9 +189,9 @@ public actor WidgetSummaryFetcher {
 				return nil
 			}
 		}
-		inFlight[organizationId] = task
+		inFlight[inFlightKey] = task
 		let payload = await task.value
-		inFlight[organizationId] = nil
+		inFlight[inFlightKey] = nil
 		return payload.map(Attempt.fetched) ?? .failed
 	}
 
@@ -174,12 +202,18 @@ public actor WidgetSummaryFetcher {
 
 	private static func request(
 		credential: WidgetCredential,
+		environment: String?,
 		session: URLSession
 	) async -> RequestOutcome {
-		var request = URLRequest(
-			url: credential.apiBaseURL.appendingPathComponent("v2/widget_summary"),
-			timeoutInterval: deadline
-		)
+		let path = credential.apiBaseURL.appendingPathComponent("v2/widget_summary")
+		// `URLComponents` rather than string interpolation: environment names
+		// are user-defined and may carry a space or a slash, which would
+		// otherwise produce a URL that silently fails to build.
+		var components = URLComponents(url: path, resolvingAgainstBaseURL: false)
+		if let environment, !environment.isEmpty {
+			components?.queryItems = [URLQueryItem(name: "deployment_environment", value: environment)]
+		}
+		var request = URLRequest(url: components?.url ?? path, timeoutInterval: deadline)
 		request.httpMethod = "GET"
 		request.setValue("Bearer \(credential.secret)", forHTTPHeaderField: "Authorization")
 		request.setValue("application/json", forHTTPHeaderField: "Accept")

--- a/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetTimelineRefresh.swift
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleWidgetData/WidgetTimelineRefresh.swift
@@ -33,11 +33,16 @@ public enum WidgetTimelineRefresh {
 	///   - organizationName: from the widget's organization index, passed
 	///     through so a fetched snapshot is named the same way a published one
 	///     is.
+	///   - environment: the deployment environment this widget is pinned to, or
+	///     nil for the whole organization. It selects the snapshot slot as well
+	///     as the query, so a production widget and a staging widget on the same
+	///     organization neither share data nor overwrite each other.
 	///   - storedGeneratedAt: the snapshot already on disk, so a widget woken
 	///     moments after the app published does not re-fetch what it has.
 	public static func run(
 		organizationId: String?,
 		organizationName: String?,
+		environment: String? = nil,
 		storedGeneratedAt: Date?,
 		now: Date = Date(),
 		fetcher: WidgetSummaryFetcher = .shared,
@@ -50,6 +55,7 @@ public enum WidgetTimelineRefresh {
 		let attempt = await fetcher.fetch(
 			organizationId: organizationId,
 			organizationName: organizationName,
+			environment: environment,
 			storedGeneratedAt: storedGeneratedAt,
 			now: now
 		)

--- a/apps/ios/Packages/MapleAPI/Tests/MapleAPITests/EnvironmentScopeTests.swift
+++ b/apps/ios/Packages/MapleAPI/Tests/MapleAPITests/EnvironmentScopeTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+import Testing
+
+@testable import MapleAPI
+
+/// Records what a request actually carried, and answers with a body the
+/// generated client can decode so the call completes.
+///
+/// The environment scope is checked on the **wire**, not on the client, for one
+/// reason: it is not a header. Every endpoint spells it in its own query
+/// parameter or body field, several endpoints have none at all, and one of them
+/// spells it differently from all the others. A scope that silently reaches
+/// nothing looks exactly like a scope that reaches everything until someone
+/// reads a filtered screen and sees unfiltered numbers.
+private final class ScriptedTransport: ClientTransport, @unchecked Sendable {
+	private(set) var lastRequest: HTTPRequest?
+	private(set) var lastBody: String?
+	private let responseJSON: String
+
+	init(responseJSON: String) {
+		self.responseJSON = responseJSON
+	}
+
+	func send(
+		_ request: HTTPRequest,
+		body: HTTPBody?,
+		baseURL: URL,
+		operationID: String
+	) async throws -> (HTTPResponse, HTTPBody?) {
+		lastRequest = request
+		if let body {
+			let collected = try await [UInt8](collecting: body, upTo: 1_000_000)
+			lastBody = String(decoding: collected, as: UTF8.self)
+		} else {
+			lastBody = nil
+		}
+		var response = HTTPResponse(status: .ok)
+		response.headerFields[.contentType] = "application/json"
+		return (response, HTTPBody(responseJSON))
+	}
+}
+
+private struct StaticTokens: MapleTokenProvider {
+	func token(forceRefresh: Bool) async throws -> String? { "test-token" }
+}
+
+@Suite("Environment scoping")
+struct EnvironmentScopeTests {
+	private static let emptyList = #"{"object":"list","has_more":false,"next_cursor":null,"data":[]}"#
+
+	private func client(_ transport: ScriptedTransport, environment: String?) -> any MapleAPI {
+		MapleClient(
+			tokens: StaticTokens(),
+			serverURL: URL(string: "https://api.maple.test")!,
+			transport: transport
+		)
+		.scoped(toEnvironment: environment)
+	}
+
+	private var window: ResolvedTimeWindow {
+		TimeWindow.last24Hours.resolve(now: Date(timeIntervalSince1970: 1_756_000_000))
+	}
+
+	@Test("The services listing carries the scope, and carries nothing without one")
+	func services() async throws {
+		let scoped = ScriptedTransport(responseJSON: Self.emptyList)
+		_ = try await client(scoped, environment: "staging").services(window: window, limit: 50)
+		#expect(scoped.lastRequest?.path?.contains("deployment_environment=staging") == true)
+
+		let unscoped = ScriptedTransport(responseJSON: Self.emptyList)
+		_ = try await client(unscoped, environment: nil).services(window: window, limit: 50)
+		// Absent, not empty: `deployment_environment=` would filter to the blank
+		// environment, which the warehouse reads as "unset" and answers with
+		// everything — a filter that silently does nothing.
+		#expect(unscoped.lastRequest?.path?.contains("deployment_environment") == false)
+	}
+
+	@Test("The issues listing carries the scope")
+	func issues() async throws {
+		let transport = ScriptedTransport(responseJSON: Self.emptyList)
+		_ = try await client(transport, environment: "staging").issues(
+			query: IssueQuery(),
+			window: nil,
+			limit: 20,
+			cursor: nil
+		)
+		#expect(transport.lastRequest?.path?.contains("deployment_environment=staging") == true)
+	}
+
+	/// The one endpoint that spells the parameter short. Pinned because nothing
+	/// else would catch it: sending `deployment_environment` here is not an
+	/// error, it is an ignored parameter and an unfiltered list.
+	@Test("The anomalies listing spells it deployment_env, not deployment_environment")
+	func anomalies() async throws {
+		let transport = ScriptedTransport(responseJSON: Self.emptyList)
+		_ = try await client(transport, environment: "staging").anomalyIncidents(
+			status: nil,
+			serviceName: nil,
+			window: nil,
+			limit: 20,
+			cursor: nil
+		)
+		let path = try #require(transport.lastRequest?.path)
+		#expect(path.contains("deployment_env=staging"))
+		#expect(!path.contains("deployment_environment="))
+	}
+
+	/// The regression this guard exists for: `filters` used to be built only
+	/// when a service or an error flag was set, so an environment-only chart
+	/// sent no filters at all — a successful request, and every environment's
+	/// traffic drawn under one environment's label.
+	@Test("A trace query with only an environment still sends a filters object")
+	func traceFiltersSurviveWithoutAServiceName() async throws {
+		let transport = ScriptedTransport(
+			responseJSON: """
+				{"object":"trace_timeseries","aggregation":"count","bucket_seconds":300,
+				 "start_time":"2026-08-21T08:00:00.000Z","end_time":"2026-08-21T09:00:00.000Z",
+				 "series":[]}
+				"""
+		)
+		_ = try await client(transport, environment: "staging").traceTimeseries(
+			TraceTimeseriesRequest(aggregation: .count, window: window)
+		)
+		// Whitespace-insensitive: the generated client pretty-prints its bodies,
+		// so matching the compact spelling would fail on formatting rather than
+		// on the thing under test.
+		let body = try #require(transport.lastBody).filter { !$0.isWhitespace }
+		#expect(body.contains("\"deployment_environment\":\"staging\""))
+	}
+
+	@Test("The widget summary carries the scope")
+	func widgetSummary() async throws {
+		let transport = ScriptedTransport(
+			responseJSON: """
+				{"object":"widget_summary","schema_version":1,
+				 "generated_at":"2026-08-21T09:10:00.000Z","organization_id":"org_2abc",
+				 "deployment_environment":"staging",
+				 "issues":{"window_seconds":86400,"has_more":false,"data":[]},
+				 "throughput":{"window_seconds":3600,"bucket_seconds":300,"services":[],"total_points":[]}}
+				"""
+		)
+		let payload = try await client(transport, environment: "staging").widgetSummary()
+		#expect(transport.lastRequest?.path?.contains("deployment_environment=staging") == true)
+		// The echo, not the value asked for: it is what the caller keys its
+		// snapshot slot on, so a server that ignored the parameter has to be
+		// distinguishable from one that honoured it.
+		#expect(payload.deploymentEnvironment == "staging")
+	}
+
+	/// The endpoints that have no environment parameter must not grow a
+	/// hand-rolled one — a query string the contract does not declare is a
+	/// decode error at the boundary, not a filter.
+	@Test("Endpoints with no environment parameter send nothing extra")
+	func unfilterableEndpointsStayUnfiltered() async throws {
+		let transport = ScriptedTransport(responseJSON: Self.emptyList)
+		_ = try await client(transport, environment: "staging").alertIncidents(
+			status: nil,
+			ruleId: nil,
+			limit: 20,
+			cursor: nil
+		)
+		#expect(transport.lastRequest?.path?.contains("deployment") == false)
+	}
+
+	@Test("The environments listing is not filtered by the current selection")
+	func environmentsListingIgnoresTheScope() async throws {
+		// Otherwise choosing "staging" would leave the picker offering staging
+		// alone, and the user unable to choose anything else.
+		let transport = ScriptedTransport(
+			responseJSON: #"{"object":"list","has_more":false,"next_cursor":null,"data":[{"object":"environment","name":"production"}]}"#
+		)
+		let environments = try await client(transport, environment: "staging").environments(window: window)
+		#expect(transport.lastRequest?.path?.contains("deployment_environment") == false)
+		#expect(environments == ["production"])
+	}
+
+	@Test("Scoping to an environment keeps the organization scope")
+	func scopesCompose() async throws {
+		let transport = ScriptedTransport(responseJSON: Self.emptyList)
+		let api = MapleClient(
+			tokens: StaticTokens(),
+			serverURL: URL(string: "https://api.maple.test")!,
+			transport: transport
+		)
+		.scoped(to: "org_2abc")
+		.scoped(toEnvironment: "staging")
+
+		_ = try await api.services(window: window, limit: 50)
+		// The organization travels in a header and the environment in the query
+		// string, so the second scope dropping the first would be invisible on
+		// the wire it does control.
+		#expect(transport.lastRequest?.headerFields[OrganizationMiddleware.headerName] == "org_2abc")
+		#expect(transport.lastRequest?.path?.contains("deployment_environment=staging") == true)
+	}
+}

--- a/apps/ios/Packages/MapleAPI/Tests/MapleWidgetDataTests/IssuesSnapshotTests.swift
+++ b/apps/ios/Packages/MapleAPI/Tests/MapleWidgetDataTests/IssuesSnapshotTests.swift
@@ -132,6 +132,55 @@ struct IssuesSnapshotStoreTests {
 		#expect(store.load() == nil)
 	}
 
+	/// The bug this keying exists to prevent: two widgets on one organization,
+	/// one filtered to production and one to staging, writing over each other on
+	/// every publish — each then rendering the other's numbers under its own
+	/// label, which looks exactly like working software.
+	@Test("Two environments in one organization do not share a slot")
+	func environmentsGetTheirOwnSlots() {
+		UserDefaults(suiteName: Self.suiteName)?.removePersistentDomain(forName: Self.suiteName)
+		let production = WidgetSnapshotStore<IssuesSnapshot>.issues(
+			organizationId: "org_1",
+			environment: "production",
+			appGroupIdentifier: Self.suiteName
+		)
+		let staging = WidgetSnapshotStore<IssuesSnapshot>.issues(
+			organizationId: "org_1",
+			environment: "staging",
+			appGroupIdentifier: Self.suiteName
+		)
+
+		production.save(IssuesSnapshot.make(
+			organizationId: "org_1",
+			organizationName: "Maple",
+			generatedAt: now,
+			issues: [issue("prod", severity: .critical, incident: true)]
+		))
+		staging.save(IssuesSnapshot.empty(organizationId: "org_1", generatedAt: now))
+
+		#expect(production.load()?.issues.count == 1)
+		#expect(staging.load()?.issues.isEmpty == true)
+	}
+
+	/// "All environments" keeps the key it always had, so a widget placed before
+	/// the environment picker keeps reading the snapshot it has always read
+	/// instead of falling back to "Open Maple" on upgrade.
+	@Test("The unfiltered slot is the pre-environment key, unchanged")
+	func unfilteredSlotIsUnchanged() {
+		UserDefaults(suiteName: Self.suiteName)?.removePersistentDomain(forName: Self.suiteName)
+		let unfiltered = WidgetSnapshotStore<IssuesSnapshot>.issues(
+			organizationId: "org_1",
+			appGroupIdentifier: Self.suiteName
+		)
+		let legacyShaped = WidgetSnapshotStore<IssuesSnapshot>(
+			key: "issues.snapshot.v2.org_1",
+			appGroupIdentifier: Self.suiteName
+		)
+
+		unfiltered.save(IssuesSnapshot.empty(organizationId: "org_1", generatedAt: now))
+		#expect(legacyShaped.load() != nil)
+	}
+
 	/// Dates cross the process boundary as ISO-8601 strings; a lossy encoding
 	/// would make "12m" drift between the app and the widget.
 	@Test("Preserves the timestamp exactly")

--- a/apps/ios/Packages/MapleAPI/Tests/MapleWidgetDataTests/WidgetOrganizationIndexTests.swift
+++ b/apps/ios/Packages/MapleAPI/Tests/MapleWidgetDataTests/WidgetOrganizationIndexTests.swift
@@ -156,6 +156,86 @@ struct WidgetOrganizationIndexTests {
 		#expect(index.load().isEmpty)
 		#expect(index.activeOrganizationId == nil)
 	}
+
+	// MARK: Environments
+
+	/// Environments are the app's to know — the extension holds no session and
+	/// its one network call is fenced to the widget summary — so the index is
+	/// the only place its picker can read them from.
+	@Test("Records an organization's environments and the one the app is showing")
+	func recordsEnvironments() {
+		let index = makeIndex()
+		index.record(organization("org_a", name: "Initech"), isActive: true)
+
+		#expect(index.record(environments: ["production", "staging"], activeEnvironment: "staging", for: "org_a"))
+		let stored = try? #require(index.load().first)
+		#expect(stored?.environments == ["production", "staging"])
+		#expect(stored?.activeEnvironment == "staging")
+	}
+
+	/// The caller spends a metered widget reload on `true`, so a call that
+	/// teaches the index nothing has to say so.
+	@Test("Recording the same environments again reports no change")
+	func recordingEnvironmentsIsIdempotent() {
+		let index = makeIndex()
+		index.record(organization("org_a", name: "Initech"), isActive: true)
+		index.record(environments: ["production"], activeEnvironment: nil, for: "org_a")
+
+		#expect(index.record(environments: ["production"], activeEnvironment: nil, for: "org_a") == false)
+	}
+
+	/// A publish round knows nothing about environments. Letting it write an
+	/// empty list would empty the widget's environment picker on the next
+	/// background fetch — the same reason a round never blanks a name.
+	@Test("A publish round does not blank the environments it does not know")
+	func publishPreservesEnvironments() {
+		let index = makeIndex()
+		index.record(organization("org_a", name: "Initech"), isActive: true)
+		index.record(environments: ["production", "staging"], activeEnvironment: "staging", for: "org_a")
+
+		index.record(organization("org_a", name: "Initech", minutesAgo: 0), isActive: true)
+
+		#expect(index.load().first?.environments == ["production", "staging"])
+		#expect(index.load().first?.activeEnvironment == "staging")
+	}
+
+	/// Same rule for the membership refresh, which is authoritative for the
+	/// name and silent about everything else.
+	@Test("A membership refresh does not blank the environments")
+	func membershipsPreserveEnvironments() {
+		let index = makeIndex()
+		index.record(organization("org_a", name: "Initech"), isActive: true)
+		index.record(environments: ["production"], activeEnvironment: "production", for: "org_a")
+
+		index.record(memberships: [WidgetOrganization(id: "org_a", name: "Initech Renamed")])
+
+		#expect(index.load().first?.name == "Initech Renamed")
+		#expect(index.load().first?.environments == ["production"])
+	}
+
+	/// An organization the index has never heard of has no name and no
+	/// snapshot; adding one here would put a bare `org_…` id in the picker.
+	@Test("Environments for an unknown organization are ignored")
+	func ignoresUnknownOrganizations() {
+		let index = makeIndex()
+		#expect(index.record(environments: ["production"], activeEnvironment: nil, for: "org_ghost") == false)
+		#expect(index.load().isEmpty)
+	}
+
+	/// The upgrade path. An entry written by a build before the environment
+	/// picker has no `environments` key at all; a synthesized decoder would
+	/// treat that as required and drop the whole index, sending every widget on
+	/// the Home Screen back to "Open Maple".
+	@Test("An entry written before environments existed still decodes")
+	func decodesPreEnvironmentEntries() throws {
+		let json = Data(#"[{"id":"org_a","name":"Initech"}]"#.utf8)
+		let decoded = try WidgetJSON.decoder.decode([WidgetOrganization].self, from: json)
+
+		#expect(decoded.first?.id == "org_a")
+		#expect(decoded.first?.environments.isEmpty == true)
+		#expect(decoded.first?.activeEnvironment == nil)
+	}
+
 }
 
 /// The rule that keeps a widget from putting one organization's name over
@@ -264,4 +344,5 @@ struct PerOrganizationSnapshotStoreTests {
 		issues.save(snapshot(organizationId: "org_a"))
 		#expect(throughput.load() == nil)
 	}
+
 }

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -335,6 +335,17 @@ shaped like the first — one app-wide choice, a control next to the switcher, a
 a change that invalidates every screen at once rather than each screen growing
 its own filter.
 
+Both axes travel together as `SessionController.DataScope`, which the list
+screens key `.task(id:)` on and store on their models. The environment is part
+of what a model *is* rather than something pushed at it, because it is not
+always known when a screen first builds: `EnvironmentController.load` restores a
+stored selection and drops one the organization no longer has, and the second of
+those can only happen once the network answers. Making it part of the scope
+rebuilds the affected screens when it resolves, whatever order the tasks
+happened to start in — and rebuilds nothing when it does not. The detail screens
+stay keyed on `dataGeneration` alone; they are unfiltered, so an environment
+change cannot alter what they show.
+
 The mechanism is where they differ, and the difference is the thing to know:
 
 - The **organization** travels in the session token, so every request carries it

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -327,6 +327,55 @@ The switcher lives in the title slot on both tabs. The gate alone is not enough:
 once an organization is active the gate is unreachable, so without it a
 multi-org account is stuck.
 
+## The environment axis
+
+Everything on screen is scoped twice: by organization, and by **deployment
+environment**. `EnvironmentController` owns the second, and it is deliberately
+shaped like the first — one app-wide choice, a control next to the switcher, and
+a change that invalidates every screen at once rather than each screen growing
+its own filter.
+
+The mechanism is where they differ, and the difference is the thing to know:
+
+- The **organization** travels in the session token, so every request carries it
+  whether the endpoint knows about it or not.
+- The **environment** is a query parameter or body field, **per endpoint**. So
+  `MapleClient.scoped(toEnvironment:)` reaches the reads that declare one and
+  silently does not reach the rest.
+
+What it does not reach, and why:
+
+| Read                                | Behaviour                                                         |
+| ----------------------------------- | ----------------------------------------------------------------- |
+| `GET /v2/services/{name}`           | Aggregates across environments by contract — service detail is unfiltered. |
+| `/v2/alerts/*`                      | No filter exists. A rule's `environments` is the scope it fires on, not a filter over rules. |
+| `GET /v2/error_issues/service_counts` | No parameters at all. **The one visible seam:** with an environment selected, a Services row's metrics are filtered and its open-issue badge is not. |
+
+`GET /v2/anomalies/incidents` spells the parameter **`deployment_env`**, not
+`deployment_environment`. It is the only one that does; sending the long name
+there is not an error, it is an ignored parameter and an unfiltered list.
+`EnvironmentScopeTests` pins it.
+
+The picker's options come from `GET /v2/environments`, not from unioning
+`deployment_environments` across a page of services — that listing is capped by
+its own `limit`, so an environment appearing only on the hundredth service would
+never be offered. The blank environment is never returned: the warehouse DSL
+reads `''` as "no filter", so offering it would hand back every environment
+under a label claiming otherwise.
+
+The selection persists in `UserDefaults.standard` **keyed per organization**.
+A single key would carry "staging" into an organization that has no such
+environment, where it filters every screen to nothing and looks like an outage;
+a stored value the organization does not have falls back to all environments.
+
+Widgets pin their own environment, the way they pin their own organization —
+two widgets, two environments, both correct at once. That makes snapshots
+per `(organization, environment)`: one slot per organization would let a
+production widget and a staging widget overwrite each other on every publish,
+each then rendering the other's numbers under its own label. The unfiltered slot
+keeps the key it always had, so a widget placed before this shipped needs no
+migration.
+
 ## Design system
 
 `Maple/DesignSystem` ports the product's visual language rather than inventing a

--- a/apps/ios/Widgets/IssuesWidget.swift
+++ b/apps/ios/Widgets/IssuesWidget.swift
@@ -53,6 +53,11 @@ struct IssuesEntry: TimelineEntry {
 	/// resolves in that organization rather than in whichever one is active.
 	var organizationId: String?
 	var organizationName: String?
+	/// The deployment environment on screen, or nil for the whole
+	/// organization. Carried so the header can say which — a widget filtered to
+	/// staging that looks identical to one that is not is a widget nobody can
+	/// read.
+	var environment: String?
 	/// Shown only when the account publishes more than one organization — a
 	/// single-organization Home Screen does not need its name repeated. Decided
 	/// at timeline-build time so the view does no I/O.
@@ -106,7 +111,13 @@ struct IssuesProvider: AppIntentTimelineProvider {
 			return IssuesEntry(date: date, snapshot: legacySnapshot())
 		}
 
-		let stored = WidgetSnapshotStore<IssuesSnapshot>.issues(organizationId: organizationId).load()
+		// A widget with no environment configured reads the organization-wide
+		// slot — the same key it read before the environment picker existed, so
+		// a migrated instance keeps rendering what it always did.
+		let environment = configuration.environment?.id
+		let stored = WidgetSnapshotStore<IssuesSnapshot>
+			.issues(organizationId: organizationId, environment: environment)
+			.load()
 		// Deliberately no fallback to another organization's snapshot. Rendering
 		// one organization's counts under another's name is the same class of
 		// error as opening the wrong organization from a notification.
@@ -121,6 +132,7 @@ struct IssuesProvider: AppIntentTimelineProvider {
 			snapshot: snapshot,
 			organizationId: organizationId,
 			organizationName: name,
+			environment: environment,
 			showsOrganization: known.count > 1,
 			// Configured, and not an organization the user belongs to: they
 			// were removed from it. An organization that is known but has no
@@ -157,6 +169,7 @@ struct IssuesProvider: AppIntentTimelineProvider {
 		let outcome = await WidgetTimelineRefresh.run(
 			organizationId: base.organizationId,
 			organizationName: base.organizationName,
+			environment: base.environment,
 			storedGeneratedAt: base.snapshot?.generatedAt,
 			now: now
 		)

--- a/apps/ios/Widgets/ThroughputWidget.swift
+++ b/apps/ios/Widgets/ThroughputWidget.swift
@@ -45,6 +45,9 @@ struct ThroughputEntry: TimelineEntry {
 	/// The organization whose numbers are on screen, carried into deep links.
 	var organizationId: String?
 	var organizationName: String?
+	/// The deployment environment on screen, or nil for the whole
+	/// organization. Carried so the header can say which — see `IssuesEntry`.
+	var environment: String?
 	/// Only worth showing when the account has more than one.
 	var showsOrganization = false
 	/// Pinned to an organization the app no longer publishes.
@@ -87,7 +90,12 @@ struct ThroughputProvider: AppIntentTimelineProvider {
 			return ThroughputEntry(date: date, snapshot: legacySnapshot(), serviceName: serviceName)
 		}
 
-		let stored = WidgetSnapshotStore<ThroughputSnapshot>.throughput(organizationId: organizationId).load()
+		// Unset reads the organization-wide slot, which is the key a widget
+		// placed before the environment picker already reads.
+		let environment = configuration.environment?.id
+		let stored = WidgetSnapshotStore<ThroughputSnapshot>
+			.throughput(organizationId: organizationId, environment: environment)
+			.load()
 		// No fallback to another organization's snapshot — see `IssuesProvider`.
 		let snapshot = stored ?? (configuredId == nil ? legacySnapshot() : nil)
 
@@ -97,6 +105,7 @@ struct ThroughputProvider: AppIntentTimelineProvider {
 			serviceName: serviceName,
 			organizationId: organizationId,
 			organizationName: known.first { $0.id == organizationId }?.name,
+			environment: environment,
 			showsOrganization: known.count > 1,
 			// "Not a member any more", not "nothing fetched yet" — see
 			// `IssuesProvider.makeEntry`.
@@ -124,6 +133,7 @@ struct ThroughputProvider: AppIntentTimelineProvider {
 		let outcome = await WidgetTimelineRefresh.run(
 			organizationId: base.organizationId,
 			organizationName: base.organizationName,
+			environment: base.environment,
 			storedGeneratedAt: base.snapshot?.generatedAt,
 			now: now
 		)

--- a/packages/domain/src/http/v2/api.ts
+++ b/packages/domain/src/http/v2/api.ts
@@ -22,6 +22,7 @@ import { V2SharePublicApiGroup } from "./share"
 import { V2WidgetCredentialsApiGroup } from "./widget-credentials"
 import { V2WidgetSummaryApiGroup } from "./widget-summary"
 import {
+	V2EnvironmentsApiGroup,
 	V2LogsApiGroup,
 	V2MetricsApiGroup,
 	V2ServiceMapApiGroup,
@@ -106,6 +107,7 @@ export class MapleApiV2 extends HttpApi.make("MapleApiV2")
 	.add(V2MetricsApiGroup)
 	.add(V2ServicesApiGroup)
 	.add(V2ServiceMapApiGroup)
+	.add(V2EnvironmentsApiGroup)
 	.add(V2SharePublicApiGroup)
 	.add(V2WidgetSummaryApiGroup)
 	.add(V2WidgetCredentialsApiGroup)

--- a/packages/domain/src/http/v2/openapi-ios.test.ts
+++ b/packages/domain/src/http/v2/openapi-ios.test.ts
@@ -33,6 +33,7 @@ const schemas = spec.components.schemas as JsonObject
 /** Every operation the app calls. Must match `IOS_OPERATIONS` in the generator. */
 const IOS_OPERATIONS = [
 	"listServices",
+	"listEnvironments",
 	"getService",
 	"queryTraceTimeseries",
 	"queryTraceBreakdown",

--- a/packages/domain/src/http/v2/openapi.test.ts
+++ b/packages/domain/src/http/v2/openapi.test.ts
@@ -126,6 +126,7 @@ describe("MapleApiV2 OpenAPI", () => {
 			"GET /v2/dashboards/{id}/versions",
 			"GET /v2/dashboards/{id}/versions/{version_id}",
 			"GET /v2/dashboards/{id}/widgets/{widget_id}/share",
+			"GET /v2/environments",
 			"GET /v2/error_issues",
 			"GET /v2/error_issues/service_counts",
 			"GET /v2/error_issues/{id}",

--- a/packages/domain/src/http/v2/telemetry.ts
+++ b/packages/domain/src/http/v2/telemetry.ts
@@ -1062,6 +1062,60 @@ export class V2ServicesApiGroup extends HttpApiGroup.make("services")
 		}),
 	) {}
 
+export const V2Environment = Schema.Struct({
+	object: Schema.Literal("environment"),
+	name: Schema.String,
+}).annotate({
+	identifier: "Environment",
+	title: "Environment",
+	description: "One deployment environment telemetry has been observed in.",
+	examples: [wireExample({ object: "environment", name: "production" })],
+})
+export type V2Environment = Schema.Schema.Type<typeof V2Environment>
+
+const EnvironmentList = ListOf(V2Environment).annotate({
+	identifier: "EnvironmentList",
+	title: "Environment list",
+})
+
+/**
+ * The values every other endpoint's `deployment_environment` filter accepts.
+ *
+ * Its own resource family rather than a field on the service listing: an
+ * environment picker is organization-wide, and a client that derived the list
+ * from a page of `/v2/services` would silently miss an environment that only
+ * appears past that page's `limit`. Reading the rollups grouped by environment
+ * is also the cheaper question — it does not aggregate per-service health
+ * nobody asked for.
+ *
+ * The empty environment is never returned. Downstream the DSL reads `''` as
+ * "no filter", so a caller who selected it would get every environment back
+ * under a label claiming otherwise.
+ */
+export class V2EnvironmentsApiGroup extends HttpApiGroup.make("environments")
+	.add(
+		HttpApiEndpoint.get("list", "/", {
+			query: V2TelemetryWindowQuery,
+			success: EnvironmentList,
+			error: warehouseWindowErrors,
+		}).annotateMerge(
+			OpenApi.annotations({
+				identifier: "listEnvironments",
+				summary: "List deployment environments",
+				description:
+					"Lists the deployment environments observed in an explicit time window, in name order. The list is unpaginated — `has_more` is always false — because an organization has tens of environments, not thousands. Requires `environments:read`.",
+			}),
+		),
+	)
+	.prefix("/v2/environments")
+	.middleware(AuthorizationV2)
+	.annotateMerge(
+		OpenApi.annotations({
+			title: "Environments",
+			description: "The deployment environments telemetry has been observed in.",
+		}),
+	) {}
+
 export class V2ServiceMapApiGroup extends HttpApiGroup.make("serviceMap")
 	.add(
 		HttpApiEndpoint.get("retrieve", "/", {

--- a/packages/domain/src/http/v2/widget-summary.ts
+++ b/packages/domain/src/http/v2/widget-summary.ts
@@ -30,6 +30,12 @@ import { ErrorIssuePublicId } from "./resource-ids"
  * The windows are the server's, not the caller's: "ongoing issues" and "traffic
  * right now" are product definitions the widgets render, and a query parameter
  * would let two builds of the app disagree about what the Home Screen means.
+ *
+ * `deployment_environment` is a parameter anyway, and the two are not in
+ * tension. A window is what the Home Screen *means*; an environment is which
+ * slice of the organization the person holding the phone asked to look at. The
+ * server cannot know the second, and two builds cannot disagree about it —
+ * whatever they send comes back echoed on the response.
  */
 
 /** Ongoing means the app's "Needs attention" filter over the day Home considers recent. */
@@ -160,6 +166,16 @@ export const V2WidgetSummary = Schema.Struct({
 	 * one organization's name over another's numbers.
 	 */
 	organization_id: OrgId,
+	/**
+	 * The environment the payload was filtered to, or null for all of them.
+	 *
+	 * Echoed for the same reason `organization_id` is: the caller keeps one
+	 * cached snapshot per (organization, environment) and has to prove a
+	 * response belongs to the slot it is about to overwrite. Without it a
+	 * request whose filter the server ignored would quietly overwrite a
+	 * production widget's numbers with organization-wide ones.
+	 */
+	deployment_environment: Schema.NullOr(Schema.String),
 	issues: V2WidgetSummaryIssues,
 	throughput: V2WidgetSummaryThroughput,
 }).annotate({
@@ -173,6 +189,7 @@ export const V2WidgetSummary = Schema.Struct({
 			schema_version: 1,
 			generated_at: "2026-08-21T09:10:00.000Z",
 			organization_id: "org_2abcDEF",
+			deployment_environment: "production",
 			issues: {
 				window_seconds: 86_400,
 				has_more: false,
@@ -210,9 +227,19 @@ export const V2WidgetSummary = Schema.Struct({
 })
 export type V2WidgetSummary = Schema.Schema.Type<typeof V2WidgetSummary>
 
+export const V2WidgetSummaryQuery = Schema.Struct({
+	/**
+	 * Restrict every half of the payload to one deployment environment. Absent
+	 * means the whole organization, which is what widgets placed before this
+	 * parameter existed keep asking for.
+	 */
+	deployment_environment: Schema.optional(Schema.String),
+}).annotate({ identifier: "WidgetSummaryQuery", title: "Widget summary query" })
+
 export class V2WidgetSummaryApiGroup extends HttpApiGroup.make("widgetSummary")
 	.add(
 		HttpApiEndpoint.get("retrieve", "/", {
+			query: V2WidgetSummaryQuery,
 			success: V2WidgetSummary,
 			error: [publicError(ErrorPersistenceError), ...V2QueryErrors],
 		}).annotateMerge(
@@ -220,7 +247,7 @@ export class V2WidgetSummaryApiGroup extends HttpApiGroup.make("widgetSummary")
 				identifier: "getWidgetSummary",
 				summary: "Retrieve the mobile widget summary",
 				description:
-					"Returns ongoing error issues and per-service traffic in a single small payload sized for a Home Screen widget. The windows are fixed by the server. Requires the `widget_summary:read` scope.",
+					"Returns ongoing error issues and per-service traffic in a single small payload sized for a Home Screen widget. The windows are fixed by the server; `deployment_environment` optionally narrows both halves to one environment and is echoed on the response. Requires the `widget_summary:read` scope.",
 			}),
 		),
 	)

--- a/packages/query-engine/src/ch/queries/services.ts
+++ b/packages/query-engine/src/ch/queries/services.ts
@@ -593,21 +593,33 @@ export function serviceReleasesTimelineQuery(
 
 // Service environments
 //
-// Distinct non-empty deployment environments a single service reports in the
-// window. Backs the service-detail environment switcher, replacing an
+// Distinct non-empty deployment environments reported in the window, for one
+// service or for the whole organization. Backs the service-detail environment
+// switcher and the mobile app's global environment picker, replacing an
 // all-services overview scan that fetched every service's rows just to extract
-// one service's environments. Service-scoped + time-windowed so ClickHouse
-// prunes both the service and the date partitions.
+// one service's environments. Time-windowed — and service-scoped when a service
+// is named — so ClickHouse prunes the date partitions and, where it can, the
+// service too.
+//
+// Deriving the organization-wide list from a page of `serviceCatalogQuery`
+// instead would be wrong rather than merely slower: that listing is capped by
+// its own `limit`, so an environment that only appears on the hundredth service
+// would never be discovered.
+//
+// The empty environment is dropped on purpose. The DSL reads `''` as "no
+// filter", so offering it as a choice would hand the caller back every
+// environment under a label claiming otherwise.
 
 export interface ServiceEnvironmentsOpts {
-	serviceName: string
+	/** Omitted for the organization-wide list. */
+	serviceName?: string
 }
 
 export interface ServiceEnvironmentsOutput {
 	readonly environment: string
 }
 
-export function serviceEnvironmentsQuery(opts: ServiceEnvironmentsOpts) {
+export function serviceEnvironmentsQuery(opts: ServiceEnvironmentsOpts = {}) {
 	return serviceOverviewWindows({ serviceName: opts.serviceName })
 		.select(($) => ({
 			environment: $.bEnvironment,

--- a/scripts/generate-ios-openapi.ts
+++ b/scripts/generate-ios-openapi.ts
@@ -41,6 +41,7 @@ import { MapleApiV2 } from "../packages/domain/src/http/v2/api"
 const IOS_OPERATIONS: ReadonlyArray<string> = [
 	// Services
 	"listServices",
+	"listEnvironments",
 	"getService",
 	"queryTraceTimeseries",
 	"queryTraceBreakdown",


### PR DESCRIPTION
The app scopes everything it shows to one **organization** and one **time window**, and has no notion of **deployment environment**. So the Services list, the Issues list, the anomaly feed and the Home Screen widgets all blend production and staging into a single number nobody reads that way. Environment is already the second axis people filter on in the web app; on the phone it was only ever *displayed* (`ServiceDetailView`'s "Environments" row, the anomaly chips), never applied.

This adds one app-wide selection, beside the organization switcher on all three tab roots.

## How it works

Changing the selection bumps `SessionController.dataGeneration` — the lever organization switching already pulls — so every screen's `.task(id:)` cancels, rebuilds its model and refetches. No screen grew a filter of its own, which is the point: the one that forgets to apply it looks like stale data rather than a bug.

The mechanism differs from the organization in a way that shapes the whole change:

- the **organization** travels in the session token, so every request carries it whether the endpoint knows about it or not;
- the **environment** is a query parameter *per endpoint*.

`MapleClient` gains `scoped(toEnvironment:)` alongside the existing `scoped(to:)`. The reads that have no such parameter are commented at the protocol as deliberately unfiltered rather than silently missed.

## Backend

**`GET /v2/environments`** — the picker's options. It reuses `serviceEnvironmentsQuery`, generalized to drop its mandatory `serviceName`, rather than unioning `deployment_environments` across a page of `/v2/services`: that listing is capped by its own `limit`, so an environment appearing only on the hundredth service would never be offered. The blank environment stays excluded in SQL — the DSL reads `''` as "no filter", so offering it would hand back every environment under a label claiming otherwise.

**`deployment_environment` on `/v2/widget_summary`** — threaded through all three of its reads (issues, service catalog, both timeseries) and echoed on the response. The echo is what lets a caller prove a payload belongs to the snapshot slot it is about to overwrite; a server predating the parameter answers organization-wide with a cheerful 200.

The file's header comment argues the *windows* are the server's and not the caller's. That argument is about product definitions — what "ongoing" means — not about a user-chosen filter, and the comment now draws that line so the new parameter doesn't read as a violation of the rule directly above it.

## Widgets

Widgets pin their own environment, the way they already pin their own organization — two widgets, two environments, both correct at once.

That makes snapshots per `(organization, environment)`. **One slot per organization would let a production widget and a staging widget overwrite each other on every publish**, each then rendering the other's numbers under its own label — which looks exactly like working software. The unfiltered slot keeps the key it always had, so instances placed before this need no migration and there is no fallback to delete later.

The publish round fans out over what is actually *pinned*, read from `currentConfigurations()`, not over every environment an organization has — otherwise a five-environment organization multiplies its round by five to publish four snapshots nobody put on a Home Screen. The app's own selection stays an unconditional floor, because `currentConfigurations()` failing is indistinguishable from "nothing pinned" and would otherwise publish nothing at all for the organization on screen.

`WidgetOrganization` grows `environments` and `activeEnvironment` with a hand-written `init(from:)`: synthesis would make the new key required and drop the whole index on upgrade, sending every widget on the Home Screen back to "Open Maple".

## Two things worth a reviewer's attention

**`deployment_env`, not `deployment_environment`.** `/v2/anomalies/incidents` is the one endpoint that spells it short. Sending the long name there is not an error — it is an ignored parameter and an unfiltered list. `EnvironmentScopeTests` pins both the presence of the short name and the absence of the long one.

**One seam left in on purpose.** `/v2/error_issues/service_counts` takes no parameters at all, so with an environment selected a Services row's metrics are filtered and its open-issue badge is not. It is the only place in the app where a single row mixes the two scopes. Leaving it was the chosen behaviour for endpoints with no server-side filter; the fix is a parameter on that endpoint, not a second request on the client. It is commented at both the call site and in the README.

Also unfiltered, and unchanged: `GET /v2/services/{name}` (aggregates across environments by contract) and the whole alerts family (a rule's `environments` is the scope it fires on, not a filter over rules).

## Verification

- `BUILD SUCCEEDED` — app target + widget extension + package
- 196 Swift package tests, 18 API route tests, 118 domain v2 tests, 36 query-engine tests
- `bun run ios:openapi:check` clean; `@maple/api`, `@maple/query-engine`, `@maple/domain` typecheck clean; oxlint clean
- Driven in the simulator under fixtures: the picker opens with All / production / staging, selecting staging relabels the chip and reloads the screen, and the selection carries to Services alongside the time-window control without crowding the bar

New tests cover the wire contract per endpoint (including the `deployment_env` spelling and the environment-only trace filter that used to be dropped on the floor), the snapshot-key separation, the unchanged unfiltered key, and the pre-environment index decode.

Not run: repo-wide `bun run test` / `bun typecheck`. Scoped equivalents covered every package touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790155748&installation_model_id=427786&pr_number=611&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F611&signature=1051cb30a3c5b024fbe5d3e518a6ebb78b46269beeef9e63a2cb59019f7d688a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
