### PR TITLE
feat(replays): mint the R2 blob credentials in the stack

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -17,7 +17,7 @@ import { parseMapleRegion, resolveAwsRegion, stageDeploysIngest } from "@maple/i
 import { formatMapleStage, parseMapleStage, resolveMapleDomains } from "@maple/infra/cloudflare"
 import { requiredPlain } from "@maple/infra/env"
 import { createAlertingWorker } from "./apps/alerting/alchemy.run.ts"
-import { createMapleApi } from "./apps/api/alchemy.run.ts"
+import { createMapleApi, createReplayBlobStore } from "./apps/api/alchemy.run.ts"
 import { createElectricSyncWorker } from "./apps/electric-sync/alchemy.run.ts"
 import { createMapleIngest } from "./apps/ingest/alchemy.run.ts"
 import { createLandingWorker } from "./apps/landing/alchemy.run.ts"
@@ -149,8 +149,20 @@ export default Alchemy.Stack(
 		// via a Cloudflare CNAME at the ALB, so the URL below stays a plain string
 		// and does not depend on the service resource; a PR preview gets no ingest
 		// domain, so its ALB answers plain HTTP on 80 at `ingest.serviceUrl`.
+		// Hoisted above BOTH consumers on purpose. The bucket is read by the api
+		// Worker over its native binding and written by the Rust gateway on ECS over
+		// the S3 API, and the gateway is constructed first — so neither factory can
+		// own it. `credentials` is undefined on stages that keep replay payloads
+		// inline (`stageEnablesReplayBlobs`).
+		const replayBlobStore = yield* createReplayBlobStore({ stage })
+
 		const ingest = stageDeploysIngest(stage)
-			? yield* createMapleIngest({ stage, domains, region })
+			? yield* createMapleIngest({
+					stage,
+					domains,
+					region,
+					replayBlobs: replayBlobStore.credentials,
+				})
 			: undefined
 
 		const ingestUrl = resolveUrl(domains.ingest, "VITE_INGEST_URL", "https://ingest.maple.dev")
@@ -160,6 +172,7 @@ export default Alchemy.Stack(
 		const { worker: api, db: mapleDb } = yield* createMapleApi({
 			stage,
 			domains,
+			replayBlobs: replayBlobStore.bucket,
 		})
 
 		// Standalone ElectricSQL shape-proxy worker (DB-free); its public origin is

--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto"
 import path from "node:path"
 import * as Cloudflare from "alchemy/Cloudflare"
+import * as Output from "alchemy/Output"
 import type { Rpc } from "alchemy/Rpc"
 import * as Effect from "effect/Effect"
 import * as Redacted from "effect/Redacted"
@@ -13,6 +15,7 @@ import {
 	resolveHyperdriveRefId,
 	resolveWorkerName,
 } from "@maple/infra/cloudflare"
+import { stageEnablesReplayBlobs } from "@maple/infra/aws"
 import {
 	apnsEnv,
 	appUrlsEnv,
@@ -33,7 +36,131 @@ import {
 export interface CreateMapleApiOptions {
 	stage: MapleStage
 	domains: MapleDomains
+	/** Read side of the replay payload store; see `createReplayBlobStore`. */
+	replayBlobs: Cloudflare.R2.Bucket
 }
+
+/** R2 credentials for the ingest gateway, when this stage writes replay blobs. */
+export interface ReplayBlobCredentials {
+	/** Account-scoped S3 endpoint. A plan-time string — the account id is env-supplied. */
+	endpoint: string
+	bucket: string
+	/** The API token's id. Only known after the token exists, hence an Output. */
+	accessKeyId: Output.Output<string>
+	/** SHA-256 of the token value; see `deriveSecretAccessKey`. */
+	secretAccessKey: Output.Output<Redacted.Redacted<string>>
+}
+
+/**
+ * R2's S3 credentials are not a Cloudflare resource — there is no "create
+ * access key" API. They are a rendering of an ordinary API token:
+ * the Access Key ID is the token's id, and the Secret Access Key is the
+ * SHA-256 of the token's value. Cloudflare documents exactly this, and it is
+ * why alchemy has nothing to provision here beyond the token itself.
+ */
+const deriveSecretAccessKey = (value: Output.Output<Redacted.Redacted<string>>) =>
+	Output.map(value, (token) =>
+		Redacted.make(createHash("sha256").update(Redacted.value(token)).digest("hex")),
+	)
+
+/**
+ * The session-replay payload store: one R2 bucket, plus (on stages that write)
+ * a bucket-scoped API token for the ingest gateway.
+ *
+ * Lives here rather than inside `createMapleApi` because it has two consumers in
+ * two clouds — the api Worker reads it over the native binding, and the Rust
+ * gateway on ECS writes it over the S3 API. The gateway stack is constructed
+ * FIRST in the root stack, so this has to be hoisted above both of them.
+ */
+export const createReplayBlobStore = ({ stage }: { stage: MapleStage }) =>
+	Effect.gen(function* () {
+		const bucketName = resolveWorkerName("replay-blobs", stage)
+
+		// Session-replay rrweb payloads. The ingest gateway (a Rust service on ECS
+		// Fargate, not a Worker) writes these over the S3 API with SigV4; the api
+		// Worker binds the same bucket to hydrate `session_replay_events` rows
+		// whose `Events` is empty. Stage-isolated, so a pr/stg deploy can never
+		// serve or overwrite prd recordings.
+		//
+		// The 32-day expiry is deliberately LONGER than the table's 30-day TTL:
+		// the row must disappear before the object does. The other way round
+		// leaves a session that lists as recorded but plays back empty, which is
+		// the one failure mode with no good client-side handling.
+		const bucket = yield* Cloudflare.R2.Bucket("replay-blobs", {
+			name: bucketName,
+			// Colocated with the ingest gateway, which runs in us-east-1
+			// (`resolveAwsRegion` maps the `us` MapleRegion there). Left unset, R2
+			// picked `wnam` from wherever the creating API call originated, putting
+			// every PUT on a cross-continent hop — and the write path is synchronous
+			// on the ingest request (object first, row second), at ~60 objects per
+			// session and 267 for the largest org.
+			//
+			// This is a REPLACE, not an update: changing it destroys and recreates
+			// the bucket. Safe only while the bucket is empty, which it is until a
+			// stage first passes `stageEnablesReplayBlobs`. After that, changing
+			// this line deletes recordings.
+			locationHint: "enam",
+			// Deliberately unprefixed, so the rule covers whatever key scheme is
+			// current. `replay_object_key` is versioned (`v1/…`) precisely so a
+			// format change can write under a new prefix while the old one ages
+			// out — a rule pinned to `v1/` would silently stop expiring anything
+			// the moment that happens, and the bucket would grow forever with no
+			// failing test to catch it. Nothing else writes here.
+			lifecycleRules: [
+				{
+					id: "expire-replay-chunks",
+					enabled: true,
+					deleteObjectsTransition: { condition: { type: "Age", maxAge: 32 * 24 * 60 * 60 } },
+				},
+			],
+		})
+
+		if (!stageEnablesReplayBlobs(stage)) {
+			// Bucket still exists and stays bound, so any objects written before the
+			// gate closed keep playing back. The gateway just has no credentials and
+			// falls back to storing payloads inline.
+			return { bucket, credentials: undefined }
+		}
+
+		// Plan-time, not an Output: it keys the policy's `resources` map below and
+		// builds the endpoint string, neither of which can take a lazy value. The
+		// root stack normalizes CLOUDFLARE_DEFAULT_ACCOUNT_ID onto this name.
+		const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
+		if (!accountId) {
+			throw new Error("CLOUDFLARE_ACCOUNT_ID is required to mint the replay blob store's R2 token.")
+		}
+
+		// Bucket-scoped, not account-wide: this credential reaches exactly one
+		// bucket and can only write to it. Minting it requires the DEPLOY token to
+		// carry the account-level `API Tokens > Write` permission — the same class
+		// of prerequisite as the AI Gateway binding below, and it fails the deploy
+		// outright rather than degrading.
+		const token = yield* Cloudflare.ApiToken.AccountApiToken("replay-blobs-writer", {
+			name: `${bucketName}-writer`,
+			accountId,
+			policies: [
+				{
+					effect: "allow",
+					permissionGroups: ["Workers R2 Storage Bucket Item Write"],
+					// `<account>_<jurisdiction>_<bucket>`; `default` is the
+					// non-jurisdictional case, which is what `Bucket` creates here.
+					resources: {
+						[`com.cloudflare.edge.r2.bucket.${accountId}_default_${bucketName}`]: "*",
+					},
+				},
+			],
+		})
+
+		return {
+			bucket,
+			credentials: {
+				endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+				bucket: bucketName,
+				accessKeyId: Output.asOutput(token.tokenId),
+				secretAccessKey: deriveSecretAccessKey(Output.asOutput(token.value)),
+			} satisfies ReplayBlobCredentials,
+		}
+	})
 
 /**
  * Everything in the api worker's env that comes from configuration rather than
@@ -143,7 +270,7 @@ const createManagedMapleDb = Effect.fnUntraced(function* (stage: MapleStage) {
 	})
 })
 
-export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
+export const createMapleApi = ({ stage, domains, replayBlobs }: CreateMapleApiOptions) =>
 	Effect.gen(function* () {
 		// MAPLE_DB Hyperdrive comes in two flavors:
 		//
@@ -213,33 +340,6 @@ export const createMapleApi = ({ stage, domains }: CreateMapleApiOptions) =>
 		const planetScaleWebhookQueueName = resolveWorkerName("planetscale-webhooks", stage)
 		const planetScaleWebhookQueue = yield* Cloudflare.Queues.Queue("planetscale-webhooks", {
 			name: planetScaleWebhookQueueName,
-		})
-
-		// Session-replay rrweb payloads. The ingest gateway (a Rust service on ECS
-		// Fargate, not a Worker) writes these over the S3 API with SigV4; this binding is
-		// the read side, hydrating `session_replay_events` rows whose `Events` is
-		// empty. Stage-isolated, so a pr/stg deploy can never serve or overwrite
-		// prd recordings.
-		//
-		// The 32-day expiry is deliberately LONGER than the table's 30-day TTL:
-		// the row must disappear before the object does. The other way round
-		// leaves a session that lists as recorded but plays back empty, which is
-		// the one failure mode with no good client-side handling.
-		const replayBlobs = yield* Cloudflare.R2.Bucket("replay-blobs", {
-			name: resolveWorkerName("replay-blobs", stage),
-			// Deliberately unprefixed, so the rule covers whatever key scheme is
-			// current. `replay_object_key` is versioned (`v1/…`) precisely so a
-			// format change can write under a new prefix while the old one ages
-			// out — a rule pinned to `v1/` would silently stop expiring anything
-			// the moment that happens, and the bucket would grow forever with no
-			// failing test to catch it. Nothing else writes here.
-			lifecycleRules: [
-				{
-					id: "expire-replay-chunks",
-					enabled: true,
-					deleteObjectsTransition: { condition: { type: "Age", maxAge: 32 * 24 * 60 * 60 } },
-				},
-			],
 		})
 
 		const worker = (yield* Cloudflare.Worker("api", {

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs"
 import { resolve } from "node:path"
 import * as AWS from "alchemy/AWS"
+import * as Output from "alchemy/Output"
 import * as Effect from "effect/Effect"
 import * as Redacted from "effect/Redacted"
 import type { MapleRegion } from "@maple/infra/aws"
@@ -18,6 +19,7 @@ import {
 	resolveIngestTaskSize,
 	stageDeploysCollector,
 } from "@maple/infra/aws"
+import type { ReplayBlobCredentials } from "../api/alchemy.run.ts"
 import type { MapleDomains, MapleStage } from "@maple/infra/cloudflare"
 import { resolveDeploymentEnvironment } from "@maple/infra/cloudflare"
 // Only the primitives. The grouped helpers in that module return Worker-binding
@@ -76,6 +78,12 @@ export interface CreateMapleIngestOptions {
 	domains: MapleDomains
 	/** Geographic instance. Every AWS resource here is scoped to it. */
 	region: MapleRegion
+	/**
+	 * Stack-minted R2 credentials for the replay payload store, or `undefined`
+	 * on a stage that keeps payloads inline. See `createReplayBlobStore` in
+	 * `apps/api/alchemy.run.ts` — the gate is `stageEnablesReplayBlobs`.
+	 */
+	replayBlobs: ReplayBlobCredentials | undefined
 }
 
 /**
@@ -104,7 +112,7 @@ export interface CreateMapleIngestOptions {
  * has no load balancer: an internal ALB would bill the same bytes again for a
  * single private consumer, and Cloud Map costs a private hosted zone.
  */
-export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestOptions) =>
+export const createMapleIngest = ({ stage, domains, region, replayBlobs }: CreateMapleIngestOptions) =>
 	Effect.gen(function* () {
 		const taskSize = resolveIngestTaskSize(stage)
 		const scaling = resolveIngestScaling(stage)
@@ -190,6 +198,17 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 				tags: { Service: "maple-ingest", Region: region },
 			})
 
+		/**
+		 * Same, for a value that does not exist until another resource does —
+		 * `secret` above takes a plan-time string, this takes an alchemy Output.
+		 */
+		const secretFrom = (id: string, value: Output.Output<Redacted.Redacted<string>>) =>
+			AWS.SecretsManager.Secret(id, {
+				name: `${name("ingest")}/${id}`,
+				secretString: value,
+				tags: { Service: "maple-ingest", Region: region },
+			})
+
 		const tinybirdToken = yield* secret("tinybird-token", yield* requiredPlain("TINYBIRD_TOKEN"))
 		// Deliberately NOT `MAPLE_PG_URL`. That one is the direct-5432 admin URL the
 		// deploy workflows use for DDL; the gateway must reach Postgres through
@@ -210,22 +229,21 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 		const autumnKey = process.env.AUTUMN_SECRET_KEY?.trim()
 		const autumnSecret = autumnKey ? yield* secret("autumn-secret-key", autumnKey) : undefined
 
-		// Replay blob storage keys off the ENDPOINT, matching the gateway's own
-		// switch (`Config::from_env` in `apps/ingest/src/main.rs` treats
-		// INGEST_REPLAY_R2_ENDPOINT as the enable flag and `required()`s the rest).
-		// Gating on any other variable inverts the contract: a deploy holding the
-		// endpoint, bucket and access key but missing the secret would drop the
-		// endpoint from the task env, and the gateway — seeing no R2 config at all —
-		// would silently fall back to storing replay payloads inline. That is the
-		// exact failure the Rust guard exists to prevent, so the check moves here:
-		// endpoint set means the deploy fails now rather than the tasks crash-loop
-		// later.
-		const replayR2Endpoint = process.env.INGEST_REPLAY_R2_ENDPOINT?.trim()
-		const replayR2Secret = replayR2Endpoint
-			? yield* secret(
-					"replay-r2-secret-access-key",
-					yield* requiredPlain("INGEST_REPLAY_R2_SECRET_ACCESS_KEY"),
-				)
+		// Replay blob storage. Both halves of the credential are stack-minted now
+		// (`createReplayBlobStore`), so there is no half-set configuration to guard
+		// against any more — the whole group arrives together or not at all, and
+		// `stageEnablesReplayBlobs` is what decides which.
+		//
+		// The ACCESS KEY ID goes through Secrets Manager alongside the secret, even
+		// though it is not sensitive: it is the API token's id, which does not exist
+		// until the token is created, and ECS task-definition `env` takes plan-time
+		// strings only. ECS injects `secrets` into the container as environment
+		// variables, so `AppConfig::from_env` reads it exactly as before.
+		const replayR2Secret = replayBlobs
+			? yield* secretFrom("replay-r2-secret-access-key", replayBlobs.secretAccessKey)
+			: undefined
+		const replayR2AccessKeyId = replayBlobs
+			? yield* secretFrom("replay-r2-access-key-id", Output.map(replayBlobs.accessKeyId, Redacted.make))
 			: undefined
 
 		// ── OTel collector ──────────────────────────────────────────────────
@@ -419,8 +437,11 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 				MAPLE_INGEST_KEY_ENCRYPTION_KEY: keyEncryptionKey.secretArn,
 				MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: keyLookupHmacKey.secretArn,
 				...(autumnSecret ? { AUTUMN_SECRET_KEY: autumnSecret.secretArn } : undefined),
-				...(replayR2Secret
-					? { INGEST_REPLAY_R2_SECRET_ACCESS_KEY: replayR2Secret.secretArn }
+				...(replayR2Secret && replayR2AccessKeyId
+					? {
+							INGEST_REPLAY_R2_SECRET_ACCESS_KEY: replayR2Secret.secretArn,
+							INGEST_REPLAY_R2_ACCESS_KEY_ID: replayR2AccessKeyId.secretArn,
+						}
 					: undefined),
 			},
 
@@ -443,20 +464,23 @@ export const createMapleIngest = ({ stage, domains, region }: CreateMapleIngestO
 				INGEST_QUEUE_MAX_BYTES: String(WAL_MAX_BYTES),
 				INGEST_WAL_SHARDS: String(WAL_SHARDS),
 
-				// Replay blobs stay on Cloudflare R2. The AWS egress this costs is
-				// single-digit dollars a month; moving them to S3 would save nothing
-				// and would require a SigV4 or presigned read path in the Worker
+				// Replay blobs stay on Cloudflare R2 rather than S3. Measured at
+				// $0.002/session, the two land within ~$0.0001 of each other: R2
+				// charges nothing for egress but pays AWS internet egress on the way
+				// in, while S3 writes free from this region and then bills $0.09/GB
+				// back out on every playback. What actually dominates either bill is
+				// per-object PUTs (~65%), because the SDK flushes a chunk every 100 KB
+				// — so the lever is `FLUSH_BYTES`, not the vendor. S3 would also need a
+				// SigV4 or presigned read path in the Worker, which does not exist
 				// (`apps/api/src/platform/ReplayBlobStore.ts` uses the native R2
-				// binding). `requiredPlain` on the companions rather than
-				// `optionalPlain`, so a half-set config fails the deploy instead of
-				// reaching a task that refuses to boot.
-				...(replayR2Endpoint
+				// binding).
+				//
+				// Endpoint and bucket are plan-time strings; the two credential halves
+				// arrive through `secrets` above. See `createReplayBlobStore`.
+				...(replayBlobs
 					? {
-							INGEST_REPLAY_R2_ENDPOINT: replayR2Endpoint,
-							INGEST_REPLAY_R2_BUCKET: yield* requiredPlain("INGEST_REPLAY_R2_BUCKET"),
-							INGEST_REPLAY_R2_ACCESS_KEY_ID: yield* requiredPlain(
-								"INGEST_REPLAY_R2_ACCESS_KEY_ID",
-							),
+							INGEST_REPLAY_R2_ENDPOINT: replayBlobs.endpoint,
+							INGEST_REPLAY_R2_BUCKET: replayBlobs.bucket,
 							...(yield* optionalPlain("INGEST_REPLAY_R2_REGION", "auto")),
 						}
 					: undefined),

--- a/packages/infra/src/aws/stage.test.ts
+++ b/packages/infra/src/aws/stage.test.ts
@@ -12,6 +12,7 @@ import {
 	resolveIngestScaling,
 	stageDeploysCollector,
 	stageDeploysIngest,
+	stageEnablesReplayBlobs,
 } from "./stage.ts"
 
 describe("parseMapleRegion", () => {
@@ -77,6 +78,21 @@ describe("collector service discovery", () => {
 		expect(stageDeploysIngest(parseMapleStage("stg"))).toBe(true)
 		expect(stageDeploysIngest(parseMapleStage("pr-12"))).toBe(true)
 		expect(stageDeploysIngest(parseMapleStage("dev-alice"))).toBe(false)
+	})
+
+	it("writes replay blobs on stg and prd, and only where the gateway runs", () => {
+		expect(stageEnablesReplayBlobs(parseMapleStage("prd"))).toBe(true)
+		// stg deliberately included: production must not be the first place the
+		// R2 write path ever runs.
+		expect(stageEnablesReplayBlobs(parseMapleStage("stg"))).toBe(true)
+		expect(stageEnablesReplayBlobs(parseMapleStage("pr-12"))).toBe(false)
+		expect(stageEnablesReplayBlobs(parseMapleStage("dev-alice"))).toBe(false)
+		// A stage cannot write blobs without a gateway to write them.
+		for (const stage of ["prd", "stg", "pr-12", "dev-alice"]) {
+			if (stageEnablesReplayBlobs(parseMapleStage(stage))) {
+				expect(stageDeploysIngest(parseMapleStage(stage))).toBe(true)
+			}
+		}
 	})
 
 	it("deploys the collector to prd only for now, a subset of the gateway stages", () => {

--- a/packages/infra/src/aws/stage.ts
+++ b/packages/infra/src/aws/stage.ts
@@ -213,6 +213,27 @@ export function stageDeploysCollector(stage: MapleStage): boolean {
 }
 
 /**
+ * Whether this stage stores session-replay rrweb payloads as R2 objects
+ * instead of inline in the `session_replay_events.Events` column.
+ *
+ * This is an EXPLICIT gate rather than the older "is INGEST_REPLAY_R2_ENDPOINT
+ * set?" test. Once the stack mints the R2 credentials itself (a bucket-scoped
+ * `AccountApiToken`, see the root stack) the endpoint is always available, so
+ * config presence stops being able to express intent — and with it went the
+ * only rollback lever, which was "unset the secret and redeploy". Flipping this
+ * function is now that lever.
+ *
+ * stg + prd. Deliberately NOT prd-only like `stageDeploysCollector`: that gate
+ * is a cash-flow call and R2 costs pennies here, whereas gating this to prd
+ * would make production the first place the write path ever runs. Previews stay
+ * off — a PR preview writing real objects into its own bucket buys nothing and
+ * leaves more to reap.
+ */
+export function stageEnablesReplayBlobs(stage: MapleStage): boolean {
+	return stage.kind === "prd" || stage.kind === "stg"
+}
+
+/**
  * Fargate task size for the collector per stage.
  *
  * In `tinybird` write mode (prod) the collector only carries the gateway's own


### PR DESCRIPTION
## What

Session replay rrweb payloads are still stored **inline** in the `session_replay_events.Events` column. The blob-backed path was built a while ago but switches on the presence of configuration, and that configuration was never set — `countIf(Events = '') = 0` in production confirms it has never run.

This makes the stack own the credentials outright instead of expecting four hand-placed `INGEST_REPLAY_R2_*` values.

- **`createReplayBlobStore`** (`apps/api/alchemy.run.ts`) creates the bucket plus a **bucket-scoped** account API token, and derives the S3 pair from it. R2 has no "create access key" API — the Access Key ID is the token's `id` and the Secret Access Key is the SHA-256 of the token's `value`, which is why there is nothing to provision beyond the token.
- It is **hoisted above both consumers** in the root stack: the api Worker reads the bucket over its native binding, the Rust gateway writes it over the S3 API, and the gateway is constructed first — so neither factory could own it.
- **`stageEnablesReplayBlobs`** replaces "is the endpoint set?" as the on/off switch.
- The bucket is pinned to **`enam`**, colocating it with the gateway in `us-east-1`.

## Why this shape

**The access key id goes through Secrets Manager**, despite not being sensitive: it does not exist until the token does, and ECS task-definition `env` takes plan-time strings only. ECS injects secrets as environment variables, so `AppConfig::from_env` on the Rust side is untouched.

**The gate had to become explicit.** Once credentials are always available, config presence can no longer express intent — and that was the entire rollback mechanism ("unset the secret and redeploy"). Flipping `stageEnablesReplayBlobs` is that lever now. It covers stg + prd, deliberately not prd-only like the collector: that gate is a cash-flow call that does not apply here, and gating this to prd would make production the first place the write path ever runs.

**R2 rather than S3.** Measured at \$0.002/session the two land within ~\$0.0001 of each other — R2 charges no egress but pays AWS egress inbound, while S3 writes free from this region then bills \$0.09/GB back out on every playback. What dominates either bill is per-object PUTs (~65%), because the SDK flushes a chunk every 100 KB. S3 would additionally need a SigV4 or presigned read path in the Worker, which does not exist.

## Reviewer notes

⚠️ **The `locationHint` change is a bucket replace, and the bucket name is pinned.** Alchemy's replacement is create-first and the R2 provider does not set `deleteFirst`, so both generations claim the same physical name. This is only safe while the bucket is empty.

- The **prd** bucket has already been deleted out of band for exactly this reason, but its row remains in alchemy state, so the next prd deploy will still diff to `replace`. Watch the plan.
- The **stg** bucket does not exist at all, so staging is a pure create with no replace and no GC — **deploy stg first**. It exercises the whole path end to end: token minting, credential derivation, both Secrets Manager entries, and the gateway writing objects.

Other things worth a look:

- `apps/ingest` gains a **type-only** import from `apps/api` for `ReplayBlobCredentials`. No cycle, erased at build, but it is apps→apps.
- Minting the token requires the **deploy token to carry account-level `API Tokens > Write`** — same class of prerequisite as the AI Gateway binding. It fails the deploy outright rather than degrading. This has been granted.
- The next prd deploy **activates replay blob storage**. That is the intent, not a side effect.
- Dual-read is unchanged: rows with non-empty `Events` pass through untouched, there is no backfill, and old rows age out on the 30-day TTL.

## Verification

- `tsc -p tsconfig.alchemy.json` — exit 0
- `oxlint` / `oxfmt --check` — clean
- `packages/infra` tests — 15/15, including a new case asserting the gate is a subset of `stageDeploysIngest`

## Follow-up (not in this PR)

Per-object PUTs dominate blob cost, driven by `FLUSH_BYTES = 100 KB` in `packages/browser-session/src/replay/record.ts`. Raising it is worth more to margin than any backend choice, but it is a behavioural SDK change affecting seek granularity and live tailing, so it deserves its own PR once this lands and the baseline is clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790167010&installation_model_id=427786&pr_number=612&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F612&signature=ee97a9b950226cddd2bbb3c5c989834de90aa769d95cba62b0b0591426b268e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->