### PR TITLE
fix(replays): retain the replay bucket, and stop hinting its location

### DIFF
--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -52,26 +52,16 @@ export interface ReplayBlobCredentials {
 	secretAccessKey: Output.Output<Redacted.Redacted<string>>
 }
 
-/**
- * R2's S3 credentials are not a Cloudflare resource — there is no "create
- * access key" API. They are a rendering of an ordinary API token:
- * the Access Key ID is the token's id, and the Secret Access Key is the
- * SHA-256 of the token's value. Cloudflare documents exactly this, and it is
- * why alchemy has nothing to provision here beyond the token itself.
- */
+/** R2 renders an API token as S3 credentials: key id = token id, secret = SHA-256 of its value. */
 const deriveSecretAccessKey = (value: Output.Output<Redacted.Redacted<string>>) =>
 	Output.map(value, (token) =>
 		Redacted.make(createHash("sha256").update(Redacted.value(token)).digest("hex")),
 	)
 
 /**
- * The session-replay payload store: one R2 bucket, plus (on stages that write)
- * a bucket-scoped API token for the ingest gateway.
- *
- * Lives here rather than inside `createMapleApi` because it has two consumers in
- * two clouds — the api Worker reads it over the native binding, and the Rust
- * gateway on ECS writes it over the S3 API. The gateway stack is constructed
- * FIRST in the root stack, so this has to be hoisted above both of them.
+ * Bucket + (where the stage writes) a bucket-scoped token for the gateway.
+ * Hoisted out of `createMapleApi` because the ECS gateway writes it and is
+ * constructed first, so neither consumer can own it.
  */
 export const createReplayBlobStore = ({ stage }: { stage: MapleStage }) =>
 	Effect.gen(function* () {
@@ -87,22 +77,9 @@ export const createReplayBlobStore = ({ stage }: { stage: MapleStage }) =>
 		// the row must disappear before the object does. The other way round
 		// leaves a session that lists as recorded but plays back empty, which is
 		// the one failure mode with no good client-side handling.
-		// NO `locationHint`. It is tempting — the gateway runs in us-east-1 and the
-		// bucket sits in `wnam`, so every PUT takes a cross-continent hop on a
-		// synchronous write path. It was tried on 2026-08-24 and must not be tried
-		// again this way, for two independent reasons:
-		//
-		//  1. It did not work. R2 treats the hint as advisory; the bucket came back
-		//     `wnam` regardless, so the hop is still there and nothing was gained.
-		//  2. Changing it is a REPLACE, and `name` is pinned, so both generations
-		//     claim the same bucket. Alchemy replaces create-first and the R2
-		//     provider sets no `deleteFirst`, so garbage collection then deletes the
-		//     surviving bucket by name. It only failed safe because the gateway had
-		//     already written objects into it and R2 refused with `BucketNotEmpty` —
-		//     which took the prd deploy red instead of destroying recordings.
-		//
-		// If colocation is ever worth pursuing, do it as a NEW bucket under a new
-		// name with a dual-read window, never as a replace of this one.
+		// Don't add `locationHint`: it is advisory (the bucket stayed `wnam` anyway)
+		// and changing it replaces a name-pinned bucket, which GC then deletes.
+		// Took prd red on 2026-08-24. Colocation needs a new bucket, not a replace.
 		const bucket = yield* Cloudflare.R2.Bucket("replay-blobs", {
 			name: bucketName,
 			// Deliberately unprefixed, so the rule covers whatever key scheme is
@@ -118,33 +95,24 @@ export const createReplayBlobStore = ({ stage }: { stage: MapleStage }) =>
 					deleteObjectsTransition: { condition: { type: "Age", maxAge: 32 * 24 * 60 * 60 } },
 				},
 			],
-			// This bucket holds customer session recordings; no stack operation
-			// should ever be able to delete it. `retain` also drains the old
-			// generation of a replacement from state WITHOUT issuing the physical
-			// delete (`retainOldGeneration` in alchemy's `collectGarbage`), which is
-			// what unwedges a half-applied replace — see the note above.
+			// Holds customer recordings. `retain` also drops a replaced generation
+			// from state without the physical delete, which unwedges a half-applied
+			// replace (`retainOldGeneration` in alchemy's `collectGarbage`).
 		}).pipe(RemovalPolicy.retain())
 
-		if (!stageEnablesReplayBlobs(stage)) {
-			// Bucket still exists and stays bound, so any objects written before the
-			// gate closed keep playing back. The gateway just has no credentials and
-			// falls back to storing payloads inline.
-			return { bucket, credentials: undefined }
-		}
+		// Bucket stays bound either way, so anything already written keeps playing
+		// back; without credentials the gateway just stores payloads inline.
+		if (!stageEnablesReplayBlobs(stage)) return { bucket, credentials: undefined }
 
-		// Plan-time, not an Output: it keys the policy's `resources` map below and
-		// builds the endpoint string, neither of which can take a lazy value. The
-		// root stack normalizes CLOUDFLARE_DEFAULT_ACCOUNT_ID onto this name.
+		// Plan-time: it keys the policy map and the endpoint, neither of which
+		// can take a lazy value.
 		const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
 		if (!accountId) {
 			throw new Error("CLOUDFLARE_ACCOUNT_ID is required to mint the replay blob store's R2 token.")
 		}
 
-		// Bucket-scoped, not account-wide: this credential reaches exactly one
-		// bucket and can only write to it. Minting it requires the DEPLOY token to
-		// carry the account-level `API Tokens > Write` permission — the same class
-		// of prerequisite as the AI Gateway binding below, and it fails the deploy
-		// outright rather than degrading.
+		// Bucket-scoped, not account-wide. Minting it needs the DEPLOY token to
+		// carry account-level `API Tokens > Write`, or the deploy fails outright.
 		const token = yield* Cloudflare.ApiToken.AccountApiToken("replay-blobs-writer", {
 			name: `${bucketName}-writer`,
 			accountId,
@@ -152,8 +120,7 @@ export const createReplayBlobStore = ({ stage }: { stage: MapleStage }) =>
 				{
 					effect: "allow",
 					permissionGroups: ["Workers R2 Storage Bucket Item Write"],
-					// `<account>_<jurisdiction>_<bucket>`; `default` is the
-					// non-jurisdictional case, which is what `Bucket` creates here.
+					// `<account>_<jurisdiction>_<bucket>`, `default` = non-jurisdictional.
 					resources: {
 						[`com.cloudflare.edge.r2.bucket.${accountId}_default_${bucketName}`]: "*",
 					},

--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto"
 import path from "node:path"
 import * as Cloudflare from "alchemy/Cloudflare"
 import * as Output from "alchemy/Output"
+import * as RemovalPolicy from "alchemy/RemovalPolicy"
 import type { Rpc } from "alchemy/Rpc"
 import * as Effect from "effect/Effect"
 import * as Redacted from "effect/Redacted"
@@ -86,20 +87,24 @@ export const createReplayBlobStore = ({ stage }: { stage: MapleStage }) =>
 		// the row must disappear before the object does. The other way round
 		// leaves a session that lists as recorded but plays back empty, which is
 		// the one failure mode with no good client-side handling.
+		// NO `locationHint`. It is tempting — the gateway runs in us-east-1 and the
+		// bucket sits in `wnam`, so every PUT takes a cross-continent hop on a
+		// synchronous write path. It was tried on 2026-08-24 and must not be tried
+		// again this way, for two independent reasons:
+		//
+		//  1. It did not work. R2 treats the hint as advisory; the bucket came back
+		//     `wnam` regardless, so the hop is still there and nothing was gained.
+		//  2. Changing it is a REPLACE, and `name` is pinned, so both generations
+		//     claim the same bucket. Alchemy replaces create-first and the R2
+		//     provider sets no `deleteFirst`, so garbage collection then deletes the
+		//     surviving bucket by name. It only failed safe because the gateway had
+		//     already written objects into it and R2 refused with `BucketNotEmpty` —
+		//     which took the prd deploy red instead of destroying recordings.
+		//
+		// If colocation is ever worth pursuing, do it as a NEW bucket under a new
+		// name with a dual-read window, never as a replace of this one.
 		const bucket = yield* Cloudflare.R2.Bucket("replay-blobs", {
 			name: bucketName,
-			// Colocated with the ingest gateway, which runs in us-east-1
-			// (`resolveAwsRegion` maps the `us` MapleRegion there). Left unset, R2
-			// picked `wnam` from wherever the creating API call originated, putting
-			// every PUT on a cross-continent hop — and the write path is synchronous
-			// on the ingest request (object first, row second), at ~60 objects per
-			// session and 267 for the largest org.
-			//
-			// This is a REPLACE, not an update: changing it destroys and recreates
-			// the bucket. Safe only while the bucket is empty, which it is until a
-			// stage first passes `stageEnablesReplayBlobs`. After that, changing
-			// this line deletes recordings.
-			locationHint: "enam",
 			// Deliberately unprefixed, so the rule covers whatever key scheme is
 			// current. `replay_object_key` is versioned (`v1/…`) precisely so a
 			// format change can write under a new prefix while the old one ages
@@ -113,7 +118,12 @@ export const createReplayBlobStore = ({ stage }: { stage: MapleStage }) =>
 					deleteObjectsTransition: { condition: { type: "Age", maxAge: 32 * 24 * 60 * 60 } },
 				},
 			],
-		})
+			// This bucket holds customer session recordings; no stack operation
+			// should ever be able to delete it. `retain` also drains the old
+			// generation of a replacement from state WITHOUT issuing the physical
+			// delete (`retainOldGeneration` in alchemy's `collectGarbage`), which is
+			// what unwedges a half-applied replace — see the note above.
+		}).pipe(RemovalPolicy.retain())
 
 		if (!stageEnablesReplayBlobs(stage)) {
 			// Bucket still exists and stays bound, so any objects written before the

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -229,16 +229,10 @@ export const createMapleIngest = ({ stage, domains, region, replayBlobs }: Creat
 		const autumnKey = process.env.AUTUMN_SECRET_KEY?.trim()
 		const autumnSecret = autumnKey ? yield* secret("autumn-secret-key", autumnKey) : undefined
 
-		// Replay blob storage. Both halves of the credential are stack-minted now
-		// (`createReplayBlobStore`), so there is no half-set configuration to guard
-		// against any more — the whole group arrives together or not at all, and
-		// `stageEnablesReplayBlobs` is what decides which.
-		//
-		// The ACCESS KEY ID goes through Secrets Manager alongside the secret, even
-		// though it is not sensitive: it is the API token's id, which does not exist
-		// until the token is created, and ECS task-definition `env` takes plan-time
-		// strings only. ECS injects `secrets` into the container as environment
-		// variables, so `AppConfig::from_env` reads it exactly as before.
+		// Both halves are stack-minted (`createReplayBlobStore`), so there is no
+		// half-set config left to guard against. The access key id is not secret,
+		// but it only exists once the token does and `env` takes plan-time strings
+		// only — ECS injects `secrets` as env vars, so the Rust side is unchanged.
 		const replayR2Secret = replayBlobs
 			? yield* secretFrom("replay-r2-secret-access-key", replayBlobs.secretAccessKey)
 			: undefined
@@ -464,19 +458,9 @@ export const createMapleIngest = ({ stage, domains, region, replayBlobs }: Creat
 				INGEST_QUEUE_MAX_BYTES: String(WAL_MAX_BYTES),
 				INGEST_WAL_SHARDS: String(WAL_SHARDS),
 
-				// Replay blobs stay on Cloudflare R2 rather than S3. Measured at
-				// $0.002/session, the two land within ~$0.0001 of each other: R2
-				// charges nothing for egress but pays AWS internet egress on the way
-				// in, while S3 writes free from this region and then bills $0.09/GB
-				// back out on every playback. What actually dominates either bill is
-				// per-object PUTs (~65%), because the SDK flushes a chunk every 100 KB
-				// — so the lever is `FLUSH_BYTES`, not the vendor. S3 would also need a
-				// SigV4 or presigned read path in the Worker, which does not exist
-				// (`apps/api/src/platform/ReplayBlobStore.ts` uses the native R2
-				// binding).
-				//
-				// Endpoint and bucket are plan-time strings; the two credential halves
-				// arrive through `secrets` above. See `createReplayBlobStore`.
+				// R2, not S3: within ~$0.0001/session of each other, and S3 would need
+				// a Worker SigV4 read path that does not exist. Per-object PUTs are
+				// ~65% of either bill, so the lever is `FLUSH_BYTES`, not the vendor.
 				...(replayBlobs
 					? {
 							INGEST_REPLAY_R2_ENDPOINT: replayBlobs.endpoint,


### PR DESCRIPTION
Unblocks the red prd deploy ([run 32729466531](https://github.com/MapleTechLabs/maple/actions/runs/32729466531)).

## What broke

```
✗ replay-blobs (Cloudflare.R2.Bucket): BucketNotEmpty:
  The bucket you tried to delete (maple-replay-blobs) is not empty
```

Pinning `locationHint` made the bucket a **replace**, and because `name` is pinned both generations claim the same physical bucket. Alchemy replaces **create-first** and the R2 provider sets no `deleteFirst`, so garbage collection then went to delete the "old" generation — by the same name as the live one.

It only failed safe because the gateway had already written objects into the bucket and R2 refused the delete. The deploy went red instead of the recordings going away.

## Fix

**Drop `locationHint`.** It never worked: R2 treats location as advisory and placed the bucket in `wnam` regardless, so the cross-continent hop it was meant to remove is still there. Nothing was gained for the risk taken. The comment now records this so it is not retried the same way — if colocation is ever worth pursuing it needs a new bucket under a new name with a dual-read window, not a replace of this one.

**Mark the bucket `retain`.** Correct on its own terms: it holds customer session recordings and no stack operation should be able to delete it. It also drains the old generation of a replacement from state *without* issuing the physical delete (`retainOldGeneration` in alchemy's `collectGarbage`), which is what unwedges the half-applied replace this deploy left behind.

## No data was lost, and the feature is live

The gateway writes the object **before** the index row, and the `?` on `put_object` turns a failed upload into a 503 — so a blob-backed row cannot exist without its object.

Blob storage cut over cleanly and is serving:

| 15-min bucket (UTC) | chunks | blob-backed |
|---|---|---|
| 12:30 | 1179 | 0 |
| 12:45 | 1462 | 175 |
| 13:00 | 432 | 432 |

R2's `object_count` still reports 0 — that metrics pipeline lags. The `BucketNotEmpty` error is direct proof the objects are there.

## Reviewer note

This is the risk called out in #612 landing exactly as described, minus the part where it destroys data. Worth merging before any further prd deploy, since every subsequent run will retry the same replace and fail the same way.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790168677&installation_model_id=427786&pr_number=613&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F613&signature=6c8c7d071c6945fc35635b6900930783a5c81cd2ba7399cd94cdc89a86df7207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->