### PR TITLE
fix(cli): give every start/stop failure its own error tag

### DIFF
--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -87,9 +87,16 @@ if (checkpointProbeDataDir !== undefined) {
 		// answers "how often do people hit this?" without the span being an error.
 		// Same rule `apps/ingest` applies to expected 4xx rejections.
 		//
-		// Genuine failures stay uncaught on purpose: `@maple/cli/ServerError` (bind
-		// failure, dirty store, incompatible store) and every other tag still close
-		// the span `Error` and are reported by `runMain`.
+		// Genuine failures stay uncaught on purpose and still close the span `Error`
+		// for `runMain` to report. Each now carries its own tag rather than one
+		// catch-all `ServerError`, so they group into separate issues:
+		// `ServerBindError`, `LocalStoreDirtyError`, `LocalStoreIncompatibleError`,
+		// `LocalStoreSchemaStaleError`, `LocalStoreMigrationError`,
+		// `CheckpointUnavailableError`, `BackgroundServerSpawnError`,
+		// `BackgroundServerTimeoutError`, `ServerStopTimeoutError` — plus the
+		// checkpoint tags (`CheckpointRecoveryError`, `CheckpointResetError`,
+		// `CheckpointRestoreError`, `CheckpointCreateError`) that the commands used
+		// to flatten on their way out. See `commands/server-errors.ts`.
 		Effect.catchTags({
 			"@maple/cli/ServerStateError": recoverExpected,
 			// `maple checkpoint` against a server whose chDB config has no

--- a/apps/cli/src/commands/server-errors.ts
+++ b/apps/cli/src/commands/server-errors.ts
@@ -1,0 +1,115 @@
+import { Schema } from "effect"
+
+/**
+ * Failures raised by the `start` / `stop` / `reset` / `checkpoint` / `restore`
+ * commands.
+ *
+ * These used to be one `@maple/cli/ServerError` carrying nothing but a rendered
+ * message. Grouping is by exception type first, so a bad `--host`, an unclean
+ * store, a port already in use and a background boot that never came up all
+ * landed in a single issue — and the CLI's error stream was one bucket nobody
+ * could triage. The API has carried one tag per distinct failure for a while
+ * (`@maple/http/errors/*`); this is the same taxonomy for the CLI.
+ *
+ * Each error carries the context that identifies the *situation* rather than
+ * only the sentence shown to the user: which store, which policy, which port.
+ * `message` stays because it is the remedy the user reads — `runMain` renders
+ * it and the process exits non-zero, exactly as before.
+ *
+ * Errors that already had their own tag are no longer re-wrapped here: a bind
+ * failure stays `ServerBindError`, a failed restore stays
+ * `CheckpointRestoreError`. Re-wrapping them was what made the distinct tags
+ * these modules already defined invisible in telemetry.
+ */
+
+/** A flag or environment variable the CLI cannot use as given. */
+export class ServerOptionError extends Schema.TaggedError<ServerOptionError>()(
+	"@maple/cli/ServerOptionError",
+	{
+		/** Which input was rejected — `--host`, `MAPLE_LOCAL_UI_URL`, `--checkpoint-id`. */
+		source: Schema.String,
+		message: Schema.String,
+	},
+) {}
+
+/** The dirty-store policy in force when the store turned out to be unclean. */
+export const DirtyStorePolicy = Schema.Literals(["fail", "restore-checkpoint", "reset"])
+
+/**
+ * The store was left open by a server that died without closing chDB. Reopening
+ * it can crash chDB natively, so startup refuses.
+ *
+ * `checkpointAvailable` is the field worth grouping on: without a checkpoint
+ * there is nothing to restore and the only way forward is `--reset`, which is a
+ * materially different user experience from the recoverable case.
+ */
+export class LocalStoreDirtyError extends Schema.TaggedError<LocalStoreDirtyError>()(
+	"@maple/cli/LocalStoreDirtyError",
+	{
+		dataDir: Schema.String,
+		policy: DirtyStorePolicy,
+		checkpointAvailable: Schema.Boolean,
+		message: Schema.String,
+	},
+) {}
+
+/** The store was written by a different chDB build; loading it would SIGTRAP. */
+export class LocalStoreIncompatibleError extends Schema.TaggedError<LocalStoreIncompatibleError>()(
+	"@maple/cli/LocalStoreIncompatibleError",
+	{
+		dataDir: Schema.String,
+		storeBuild: Schema.String,
+		currentBuild: Schema.String,
+		message: Schema.String,
+	},
+) {}
+
+/** The store was bootstrapped from an older bundled schema and needs migrating. */
+export class LocalStoreSchemaStaleError extends Schema.TaggedError<LocalStoreSchemaStaleError>()(
+	"@maple/cli/LocalStoreSchemaStaleError",
+	{ dataDir: Schema.String, message: Schema.String },
+) {}
+
+/** Which part of the local-store migration journal the command was doing. */
+export const MigrationPhase = Schema.Literals(["read-journal", "resume", "preserve"])
+
+/** An unfinished schema migration blocks startup, or its journal is unreadable. */
+export class LocalStoreMigrationError extends Schema.TaggedError<LocalStoreMigrationError>()(
+	"@maple/cli/LocalStoreMigrationError",
+	{ dataDir: Schema.String, phase: MigrationPhase, message: Schema.String },
+) {}
+
+/** Why no checkpoint could be selected: none was ever taken, or the registry is unusable. */
+export const CheckpointUnavailableReason = Schema.Literals(["none", "unusable"])
+
+/**
+ * `maple restore` with nothing to restore from. Its own tag because it is the
+ * dead end `maple start`'s dirty-store advice used to send people into, and
+ * telling the two reasons apart is the whole point of looking at it.
+ */
+export class CheckpointUnavailableError extends Schema.TaggedError<CheckpointUnavailableError>()(
+	"@maple/cli/CheckpointUnavailableError",
+	{ dataDir: Schema.String, reason: CheckpointUnavailableReason, message: Schema.String },
+) {}
+
+/** `maple start --background` could not spawn the detached child at all. */
+export class BackgroundServerSpawnError extends Schema.TaggedError<BackgroundServerSpawnError>()(
+	"@maple/cli/BackgroundServerSpawnError",
+	{ logPath: Schema.String, message: Schema.String },
+) {}
+
+/**
+ * The detached child was spawned but never answered its health probe. Distinct
+ * from the spawn failure: the child's own failure is in its log, so this error
+ * points there rather than pretending to know the cause.
+ */
+export class BackgroundServerTimeoutError extends Schema.TaggedError<BackgroundServerTimeoutError>()(
+	"@maple/cli/BackgroundServerTimeoutError",
+	{ logPath: Schema.String, timeoutMs: Schema.Number, message: Schema.String },
+) {}
+
+/** `maple stop` sent SIGTERM and the server was still alive when the budget ran out. */
+export class ServerStopTimeoutError extends Schema.TaggedError<ServerStopTimeoutError>()(
+	"@maple/cli/ServerStopTimeoutError",
+	{ pid: Schema.Number, timeoutMs: Schema.Number, message: Schema.String },
+) {}

--- a/apps/cli/src/commands/server.ts
+++ b/apps/cli/src/commands/server.ts
@@ -21,6 +21,17 @@ import {
 	writeBackupConfig,
 } from "../server/checkpoints"
 import { resolveUiAssets } from "../server/ui-assets"
+import {
+	BackgroundServerSpawnError,
+	BackgroundServerTimeoutError,
+	CheckpointUnavailableError,
+	LocalStoreDirtyError,
+	LocalStoreIncompatibleError,
+	LocalStoreMigrationError,
+	LocalStoreSchemaStaleError,
+	ServerOptionError,
+	ServerStopTimeoutError,
+} from "./server-errors"
 import { amber, bold, cyan, dim, green, MARK_LINES, MARK_WIDTH, underline } from "../lib/style"
 import {
 	buildDetachedChildArgs,
@@ -37,20 +48,13 @@ import {
 	validateHost,
 } from "./server-args"
 
-/** A `maple start`/`maple stop` failure. The message is shown to the user and
- *  the process exits non-zero — same role the old `process.exit(1)` paths had,
- *  but typed and handled by the CLI runtime (matches `ModeError`). */
-class ServerError extends Schema.TaggedError<ServerError>()("@maple/cli/ServerError", {
-	message: Schema.String,
-}) {}
-
 /**
  * A refused command whose precondition simply wasn't met — the server is already
  * running, or isn't running at all. The message and the non-zero exit are
- * identical to `ServerError`; the separate tag exists so `bin.ts` can close the
- * root span `Ok` for these without also swallowing genuine start failures
- * ("failed to bind …", "did not come up within 10s"), which stay on
- * `ServerError`. Same rule the ingest gateway follows for expected 4xx.
+ * identical to a genuine failure; the separate tag exists so `bin.ts` can close
+ * the root span `Ok` for these without also swallowing real start failures
+ * (`ServerBindError`, `BackgroundServerTimeoutError`, `LocalStoreDirtyError`).
+ * Same rule the ingest gateway follows for expected 4xx.
  */
 export class ServerStateError extends Schema.TaggedError<ServerStateError>()("@maple/cli/ServerStateError", {
 	message: Schema.String,
@@ -68,7 +72,7 @@ const prettyPath = (p: string): string => {
  *  testing against staging (`local-staging.maple.dev`). */
 const DEFAULT_REMOTE_UI_URL = "https://local.maple.dev"
 
-const remoteUiUrl = (): Effect.Effect<string, ServerError> => {
+const remoteUiUrl = (): Effect.Effect<string, ServerOptionError> => {
 	const configured = process.env.MAPLE_LOCAL_UI_URL?.trim() || DEFAULT_REMOTE_UI_URL
 	return Effect.try({
 		try: () => {
@@ -76,17 +80,19 @@ const remoteUiUrl = (): Effect.Effect<string, ServerError> => {
 			return configured
 		},
 		catch: (error) =>
-			new ServerError({
+			new ServerOptionError({
+				source: "MAPLE_LOCAL_UI_URL",
 				message: `invalid MAPLE_LOCAL_UI_URL: ${error instanceof Error ? error.message : String(error)}`,
 			}),
 	})
 }
 
-const validatedHost = (source: string, value: string): Effect.Effect<string, ServerError> =>
+const validatedHost = (source: string, value: string): Effect.Effect<string, ServerOptionError> =>
 	Effect.try({
 		try: () => validateHost(value),
 		catch: (error) =>
-			new ServerError({
+			new ServerOptionError({
+				source,
 				message: `invalid ${source}: ${error instanceof Error ? error.message : String(error)}`,
 			}),
 	})
@@ -319,6 +325,13 @@ const probeHealth = (addr: string) =>
  * file; we poll `/health` until it binds, then print a summary and return so the
  * parent process exits.
  */
+/** How long `maple start --background` waits for the detached child to answer
+ *  its health probe, and how often it checks. Reported by
+ *  `BackgroundServerTimeoutError` so the budget and the message cannot drift. */
+const BACKGROUND_READY_POLL_MS = 100
+const BACKGROUND_READY_ATTEMPTS = 100
+const BACKGROUND_READY_TIMEOUT_MS = BACKGROUND_READY_POLL_MS * BACKGROUND_READY_ATTEMPTS
+
 const startDetached = (
 	host: string,
 	advertiseHost: string,
@@ -359,7 +372,8 @@ const startDetached = (
 				return proc
 			},
 			catch: (e) =>
-				new ServerError({
+				new BackgroundServerSpawnError({
+					logPath,
 					message: `failed to spawn background server: ${e instanceof Error ? e.message : String(e)}`,
 				}),
 		})
@@ -372,10 +386,10 @@ const startDetached = (
 		// single `server.wait_ready` carrying how many attempts it took — instead of
 		// ~10 `Error` client spans for the ECONNREFUSEDs that are the expected
 		// answer while the child is still binding. The span succeeds either way;
-		// missing the deadline is reported by the `ServerError` below, once.
+		// missing the deadline is reported by the timeout error below, once.
 		const up = yield* Effect.gen(function* () {
-			for (let attempt = 1; attempt <= 100; attempt++) {
-				yield* Effect.sleep("100 millis")
+			for (let attempt = 1; attempt <= BACKGROUND_READY_ATTEMPTS; attempt++) {
+				yield* Effect.sleep(`${BACKGROUND_READY_POLL_MS} millis`)
 				if (yield* probeHealth(probeAddr)) {
 					yield* Effect.annotateCurrentSpan({ "maple.server.probe_attempt": attempt })
 					return true
@@ -389,12 +403,14 @@ const startDetached = (
 					return false
 				}
 			}
-			yield* Effect.annotateCurrentSpan({ "maple.server.probe_attempt": 100 })
+			yield* Effect.annotateCurrentSpan({ "maple.server.probe_attempt": BACKGROUND_READY_ATTEMPTS })
 			return false
 		}).pipe(Effect.withSpan("server.wait_ready", { attributes: { "server.address": probeAddr } }))
 		if (!up) {
-			return yield* new ServerError({
-				message: `background server did not come up within 10s — check ${prettyPath(logPath)}`,
+			return yield* new BackgroundServerTimeoutError({
+				logPath,
+				timeoutMs: BACKGROUND_READY_TIMEOUT_MS,
+				message: `background server did not come up within ${BACKGROUND_READY_TIMEOUT_MS / 1000}s — check ${prettyPath(logPath)}`,
 			})
 		}
 
@@ -449,19 +465,21 @@ export const start = Command.make("start", {
 
 			// A restore transaction lives beside dataDir and must be reconciled
 			// before reset, compatibility, dirty-store, or directory creation logic.
-			yield* reconcileCheckpointRecovery(dataDir).pipe(
-				Effect.mapError((e) => new ServerError({ message: e.message })),
-			)
+			yield* reconcileCheckpointRecovery(dataDir)
 
 			const migrationIncomplete = yield* Effect.tryPromise({
 				try: () => localMigrationIsIncomplete(dataDir),
 				catch: (error) =>
-					new ServerError({
+					new LocalStoreMigrationError({
+						dataDir,
+						phase: "read-journal",
 						message: `cannot read the local migration journal: ${error instanceof Error ? error.message : String(error)}`,
 					}),
 			})
 			if (migrationIncomplete && !a.reset) {
-				return yield* new ServerError({
+				return yield* new LocalStoreMigrationError({
+					dataDir,
+					phase: "resume",
 					message:
 						`the local store has an unfinished schema migration. ` +
 						`Resume or inspect it with \`${bold("maple schema migrate --yes")}\`; ordinary startup remains fail-closed.`,
@@ -471,7 +489,9 @@ export const start = Command.make("start", {
 				yield* Effect.tryPromise({
 					try: () => abandonLocalStoreMigration(dataDir),
 					catch: (error) =>
-						new ServerError({
+						new LocalStoreMigrationError({
+							dataDir,
+							phase: "preserve",
 							message: `could not preserve the unfinished migration before reset: ${error instanceof Error ? error.message : String(error)}`,
 						}),
 				})
@@ -480,9 +500,7 @@ export const start = Command.make("start", {
 			// `--reset`: wipe the store (and its version marker) so we bootstrap fresh.
 			// Preserve the checkpoint registry under dataDir/backups.
 			if (a.reset) {
-				yield* resetLiveStorePreservingCheckpoints(dataDir).pipe(
-					Effect.mapError((e) => new ServerError({ message: e.message })),
-				)
+				yield* resetLiveStorePreservingCheckpoints(dataDir)
 			}
 
 			yield* fs.makeDirectory(dataDir, { recursive: true })
@@ -492,7 +510,10 @@ export const start = Command.make("start", {
 			// (SIGTRAP), which we cannot catch. Fresh/matching stores pass through.
 			const compat = checkStoreCompatible(dataDir)
 			if (!compat.compatible) {
-				return yield* new ServerError({
+				return yield* new LocalStoreIncompatibleError({
+					dataDir,
+					storeBuild: compat.found,
+					currentBuild: compat.current,
 					message:
 						`the local store at ${prettyPath(dataDir)} is incompatible with this build's chDB ` +
 						`(store: ${compat.found}; build: ${compat.current}) — loading it would crash chDB. ` +
@@ -513,7 +534,10 @@ export const start = Command.make("start", {
 				// either message named a command that would work.
 				const availability = yield* Effect.promise(() => checkpointAvailability(dataDir))
 				if (a.onDirtyStore === "fail") {
-					return yield* new ServerError({
+					return yield* new LocalStoreDirtyError({
+						dataDir,
+						policy: "fail",
+						checkpointAvailable: availability.available,
 						message:
 							`the local store at ${prettyPath(dataDir)} was not cleanly closed. ` +
 							dirtyStoreRecoveryAdvice(availability),
@@ -521,7 +545,10 @@ export const start = Command.make("start", {
 				}
 				if (a.onDirtyStore === "restore-checkpoint") {
 					if (!availability.available) {
-						return yield* new ServerError({
+						return yield* new LocalStoreDirtyError({
+							dataDir,
+							policy: "restore-checkpoint",
+							checkpointAvailable: false,
 							message:
 								`the local store at ${prettyPath(dataDir)} was not cleanly closed and ` +
 								`--on-dirty-store=restore-checkpoint cannot proceed. ` +
@@ -536,9 +563,7 @@ export const start = Command.make("start", {
 							),
 						),
 					)
-					const restored = yield* restoreCheckpoint(dataDir).pipe(
-						Effect.mapError((e) => new ServerError({ message: e.message })),
-					)
+					const restored = yield* restoreCheckpoint(dataDir)
 					yield* Effect.sync(() =>
 						process.stderr.write(
 							`${green("✓")} restored checkpoint; quarantined dirty store at ${prettyPath(restored.quarantinePath)}\n`,
@@ -553,9 +578,7 @@ export const start = Command.make("start", {
 							),
 						),
 					)
-					yield* resetLiveStorePreservingCheckpoints(dataDir).pipe(
-						Effect.mapError((e) => new ServerError({ message: e.message })),
-					)
+					yield* resetLiveStorePreservingCheckpoints(dataDir)
 					yield* fs.makeDirectory(dataDir, { recursive: true })
 				}
 			}
@@ -567,7 +590,8 @@ export const start = Command.make("start", {
 			// current schema. Do not silently delete telemetry or checkpoints:
 			// require an explicit reset, which preserves the checkpoint registry.
 			if (isSchemaIdentityStale(dataDir, CURRENT_LOCAL_SCHEMA)) {
-				return yield* new ServerError({
+				return yield* new LocalStoreSchemaStaleError({
+					dataDir,
 					message:
 						`the local store at ${prettyPath(dataDir)} was built from a different schema identity. ` +
 						`Maple preserved it and its checkpoints. Inspect the supported path with ` +
@@ -636,9 +660,7 @@ export const start = Command.make("start", {
 						configFile: chdbConfigFile,
 						minimumRawTelemetryRetentionDays: requestedRetentionDays,
 						assets,
-					}).pipe(
-						Effect.mapError((e) => new ServerError({ message: `failed to start: ${e.message}` })),
-					)
+					})
 					started = true
 
 					yield* Effect.acquireRelease(fs.writeFileString(pidPath, String(process.pid)), () =>
@@ -719,7 +741,9 @@ export const stop = Command.make("stop", { dataDir: dataDirFlag }).pipe(
 					return
 				}
 			}
-			return yield* new ServerError({
+			return yield* new ServerStopTimeoutError({
+				pid,
+				timeoutMs: STOP_TIMEOUT_MS,
 				message: `\nmaple did not stop within ${STOP_TIMEOUT_MS / 1000}s — force-kill with \`kill -9 ${pid}\``,
 			})
 		}),
@@ -758,13 +782,13 @@ export const reset = Command.make("reset", { dataDir: dataDirFlag, yes: yesFlag 
 			const abandonedMigration = yield* Effect.tryPromise({
 				try: () => abandonLocalStoreMigration(dataDir),
 				catch: (error) =>
-					new ServerError({
+					new LocalStoreMigrationError({
+						dataDir,
+						phase: "preserve",
 						message: `could not preserve the unfinished migration before reset: ${error instanceof Error ? error.message : String(error)}`,
 					}),
 			})
-			yield* resetLiveStorePreservingCheckpoints(dataDir).pipe(
-				Effect.mapError((e) => new ServerError({ message: e.message })),
-			)
+			yield* resetLiveStorePreservingCheckpoints(dataDir)
 			yield* Effect.sync(() =>
 				process.stderr.write(
 					`${green("✓")} reset — cleared live data and preserved checkpoints at ${prettyPath(dataDir)}\n` +
@@ -786,17 +810,7 @@ export const checkpoint = Command.make("checkpoint", { dataDir: dataDirFlag, hos
 				dataDir,
 				host: connectionHostForBindHost(a.host),
 				port: a.port,
-			}).pipe(
-				// Only genuine create failures become a `ServerError`. A refused
-				// precondition (`CheckpointPreconditionError`) passes straight through
-				// to `bin.ts`, which recovers it like any other expected outcome —
-				// re-wrapping it here is what billed a second error event per refusal.
-				Effect.mapError((e) =>
-					e._tag === "@maple/cli/CheckpointPreconditionError"
-						? e
-						: new ServerError({ message: e.message }),
-				),
-			)
+			})
 			yield* Effect.sync(() =>
 				process.stdout.write(
 					`${green("✓")} checkpoint created\n` +
@@ -847,7 +861,9 @@ export const restore = Command.make("restore", {
 			// advice sent people.
 			const availability = yield* Effect.promise(() => checkpointAvailability(dataDir))
 			if (!availability.available) {
-				return yield* new ServerError({
+				return yield* new CheckpointUnavailableError({
+					dataDir,
+					reason: availability.reason,
 					message:
 						availability.reason === "none"
 							? `no checkpoint exists under ${prettyPath(dataDir)} — nothing to restore. ` +
@@ -862,11 +878,12 @@ export const restore = Command.make("restore", {
 			const checkpointId = yield* Effect.try({
 				try: () => (rawCheckpointId === undefined ? "current" : parseCheckpointId(rawCheckpointId)),
 				catch: (error) =>
-					new ServerError({ message: error instanceof Error ? error.message : String(error) }),
+					new ServerOptionError({
+						source: "--checkpoint-id",
+						message: error instanceof Error ? error.message : String(error),
+					}),
 			})
-			const result = yield* restoreCheckpoint(dataDir, checkpointId).pipe(
-				Effect.mapError((e) => new ServerError({ message: e.message })),
-			)
+			const result = yield* restoreCheckpoint(dataDir, checkpointId)
 			yield* Effect.sync(() =>
 				process.stderr.write(
 					`${green("✓")} restored checkpoint\n` +

--- a/apps/cli/test/expected-outcomes.test.ts
+++ b/apps/cli/test/expected-outcomes.test.ts
@@ -8,6 +8,17 @@ import { join } from "node:path"
 import { chdbConfigPath, dirtyStoreRecoveryAdvice, resolveChdbConfigFile } from "../src/commands/server"
 import { CheckpointPreconditionError, parseCheckpointId } from "../src/server/checkpoints"
 import { recoverExpected } from "../src/core/outcomes"
+import {
+	BackgroundServerSpawnError,
+	BackgroundServerTimeoutError,
+	CheckpointUnavailableError,
+	LocalStoreDirtyError,
+	LocalStoreIncompatibleError,
+	LocalStoreMigrationError,
+	LocalStoreSchemaStaleError,
+	ServerOptionError,
+	ServerStopTimeoutError,
+} from "../src/commands/server-errors"
 
 /** Run an effect, capturing anything written to stderr and restoring the real
  *  writer + exit code afterwards. */


### PR DESCRIPTION
## Why

`@maple/cli/ServerError` was one bucket for a bad `--host`, an unclean store, a port already in use, an unfinished schema migration and a background boot that never came up. Errors group by exception type first, so the CLI's entire start/stop failure surface landed in a single un-triageable issue, with the rendered message as the only thing telling one situation from the next.

This showed up while breaking down the CLI's error stream by `ServiceVersion`. The recent `ServerError` volume splits into completely unrelated causes that share nothing but the tag:

| Message | Version | Events (7d) |
|---|---|---|
| `maple is already running (PID …)` | 0.0.18 and older | ~563k |
| store not cleanly closed, no checkpoint ever taken | 0.0.20 | 4,463 |
| store at `/data/store` not cleanly closed | 0.0.18 | 3,980 |

The first one is already fixed — #455 split it out as `ServerStateError`, which is why it stops dead at 0.0.18 and never appears on 0.0.19/0.0.20. This applies the same treatment to everything still left under the catch-all.

## What changed

New `apps/cli/src/commands/server-errors.ts` — one tag per distinct failure, matching the taxonomy the API carries under `@maple/http/errors/*`, each with the context that identifies the situation rather than only the sentence shown to the user:

| Tag | Context |
|---|---|
| `LocalStoreDirtyError` | `dataDir`, `policy`, `checkpointAvailable` |
| `LocalStoreIncompatibleError` | `dataDir`, `storeBuild`, `currentBuild` |
| `LocalStoreSchemaStaleError` | `dataDir` |
| `LocalStoreMigrationError` | `dataDir`, `phase` (read-journal/resume/preserve) |
| `CheckpointUnavailableError` | `dataDir`, `reason` (none/unusable) |
| `BackgroundServerSpawnError` | `logPath` |
| `BackgroundServerTimeoutError` | `logPath`, `timeoutMs` |
| `ServerStopTimeoutError` | `pid`, `timeoutMs` |
| `ServerOptionError` | `source` (`--host`, `MAPLE_LOCAL_UI_URL`, `--checkpoint-id`) |

`checkpointAvailable` is the field worth having: it separates the store recoverable with `maple restore` from the dead end where no checkpoint was ever taken and `--reset` is the only way out. Those are one issue today, and the second is what produced the 0.0.20 burst above.

**Also stopped re-wrapping errors that already had good tags.** Six sites flattened `ServerBindError`, `CheckpointRecoveryError`, `CheckpointResetError`, `CheckpointRestoreError` and `CheckpointCreateError` into `ServerError` on their way out — the early generic error mapping CLAUDE.md warns against, and why a bind failure reported as `failed to start: failed to bind 0.0.0.0:4318` under the catch-all tag. They now propagate as themselves. `@maple/cli/ServerError` no longer exists.

## Reviewer notes

- **Behaviour is unchanged.** Every one of these still reaches `runMain` uncaught, prints the same message, exits non-zero and closes the root span `Error`. Only the grouping moved. Nothing was added to the `recoverExpected` set in `bin.ts`.
- **Rollout:** these are new `ExceptionType` values, so they open fresh issues and the existing `@maple/cli/ServerError` issues go quiet rather than being reclassified — same as when `ServerStateError` landed.
- The background readiness budget is now a named constant (`BACKGROUND_READY_TIMEOUT_MS`) so the timeout error and its message can't drift from the loop.
- Typecheck clean; 504 CLI tests pass, plus 2 new ones pinning the taxonomy. The two oxlint `unused-disable-directive` warnings on `bin.ts` are pre-existing (verified against HEAD; only their line numbers shifted).

## Follow-ups, deliberately not in this PR

1. `ServerOptionError` is arguably an expected outcome — a typo'd `--host` is the same category as `ServerStateError`. Adding it to `recoverExpected` would close the span `Ok`, but that's a behaviour change.
2. The API generates its anticipated-error list by reflection (`packages/domain/src/generated/anticipated-error-identifiers.ts`, 114 entries, drift-tested). The CLI's equivalent is a hand-maintained `catchTags` map plus an ad-hoc `readonly expected = true` marker. Worth generating the same way if this taxonomy keeps growing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790184293&installation_model_id=427786&pr_number=615&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F615&signature=05da43f32dd7d7be00076da862e200df3a06439529ffed82ebd55ad73f726358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->