### PR TITLE
chore(ci): make the quality gates green again

### DIFF
--- a/apps/api/src/services/product-events/svix.ts
+++ b/apps/api/src/services/product-events/svix.ts
@@ -16,13 +16,6 @@ import { Effect, Schema } from "effect"
 
 export const SVIX_TOLERANCE_SECONDS = 5 * 60
 
-export type SvixRejection =
-	| "missing_headers"
-	| "bad_timestamp"
-	| "stale_timestamp"
-	| "bad_secret"
-	| "signature_mismatch"
-
 export class SvixVerificationError extends Schema.TaggedError<SvixVerificationError>()(
 	"@maple/api/services/product-events/SvixVerificationError",
 	{

--- a/apps/cli/src/server/local-store-migration-module.ts
+++ b/apps/cli/src/server/local-store-migration-module.ts
@@ -1,17 +1,13 @@
 // BOUNDARY: This module owns unparsed external values and narrows them before domain use.
 import type { Chdb } from "./chdb"
 import type { LocalSchemaIdentity } from "./schema-identity"
-import type {
-	MigrationPhase,
-	MigrationStepJournalSchema,
-	MigrationStepStatus,
-} from "./local-store-migrations/journal-schema"
+import type { MigrationPhase, MigrationStepJournalSchema } from "./local-store-migrations/journal-schema"
 
 /** Coordinator-owned transaction phases. Modules may report progress, but
- * only the coordinator advances this top-level state machine. Both unions are
+ * only the coordinator advances this top-level state machine. The union is
  * derived from the journal schema so the persisted form and the in-memory type
  * cannot drift. */
-export type { MigrationPhase, MigrationStepStatus }
+export type { MigrationPhase }
 
 export type StateDisposition =
 	| "preserve-exact"

--- a/apps/cli/src/server/local-store-migrations/journal-schema.ts
+++ b/apps/cli/src/server/local-store-migrations/journal-schema.ts
@@ -54,8 +54,6 @@ export type MigrationPhase = typeof MigrationPhaseSchema.Type
 
 export const MigrationStepStatusSchema = Schema.Literals(["pending", "running", "verified", "completed"])
 
-export type MigrationStepStatus = typeof MigrationStepStatusSchema.Type
-
 /**
  * A schema identity as persisted in a journal.
  *

--- a/apps/cli/src/server/schema-identity.ts
+++ b/apps/cli/src/server/schema-identity.ts
@@ -91,37 +91,26 @@ const snapshotAt = (version: number): LocalSchemaSnapshot => {
 
 export const LOCAL_SCHEMA_V1_SQL = snapshotAt(1).sql
 export const LOCAL_SCHEMA_V1_MANIFEST = snapshotAt(1).manifest
-export const LOCAL_SCHEMA_V1_MANIFEST_DIGEST = snapshotAt(1).manifestDigest
 export const LOCAL_SCHEMA_V2_SQL = snapshotAt(2).sql
 export const LOCAL_SCHEMA_V2_MANIFEST = snapshotAt(2).manifest
-export const LOCAL_SCHEMA_V2_MANIFEST_DIGEST = snapshotAt(2).manifestDigest
 export const LOCAL_SCHEMA_V3_SQL = snapshotAt(3).sql
 export const LOCAL_SCHEMA_V3_MANIFEST = snapshotAt(3).manifest
-export const LOCAL_SCHEMA_V3_MANIFEST_DIGEST = snapshotAt(3).manifestDigest
 export const LOCAL_SCHEMA_V4_SQL = snapshotAt(4).sql
 export const LOCAL_SCHEMA_V4_MANIFEST = snapshotAt(4).manifest
-export const LOCAL_SCHEMA_V4_MANIFEST_DIGEST = snapshotAt(4).manifestDigest
 export const LOCAL_SCHEMA_V5_SQL = snapshotAt(5).sql
 export const LOCAL_SCHEMA_V5_MANIFEST = snapshotAt(5).manifest
-export const LOCAL_SCHEMA_V5_MANIFEST_DIGEST = snapshotAt(5).manifestDigest
 export const LOCAL_SCHEMA_V6_SQL = snapshotAt(6).sql
 export const LOCAL_SCHEMA_V6_MANIFEST = snapshotAt(6).manifest
-export const LOCAL_SCHEMA_V6_MANIFEST_DIGEST = snapshotAt(6).manifestDigest
 export const LOCAL_SCHEMA_V7_SQL = snapshotAt(7).sql
 export const LOCAL_SCHEMA_V7_MANIFEST = snapshotAt(7).manifest
-export const LOCAL_SCHEMA_V7_MANIFEST_DIGEST = snapshotAt(7).manifestDigest
 export const LOCAL_SCHEMA_V8_SQL = snapshotAt(8).sql
 export const LOCAL_SCHEMA_V8_MANIFEST = snapshotAt(8).manifest
-export const LOCAL_SCHEMA_V8_MANIFEST_DIGEST = snapshotAt(8).manifestDigest
 export const LOCAL_SCHEMA_V9_SQL = snapshotAt(9).sql
 export const LOCAL_SCHEMA_V9_MANIFEST = snapshotAt(9).manifest
-export const LOCAL_SCHEMA_V9_MANIFEST_DIGEST = snapshotAt(9).manifestDigest
 export const LOCAL_SCHEMA_V10_SQL = snapshotAt(10).sql
 export const LOCAL_SCHEMA_V10_MANIFEST = snapshotAt(10).manifest
-export const LOCAL_SCHEMA_V10_MANIFEST_DIGEST = snapshotAt(10).manifestDigest
 export const LOCAL_SCHEMA_V11_SQL = snapshotAt(11).sql
 export const LOCAL_SCHEMA_V11_MANIFEST = snapshotAt(11).manifest
-export const LOCAL_SCHEMA_V11_MANIFEST_DIGEST = snapshotAt(11).manifestDigest
 
 export interface LocalSchemaIdentity {
 	readonly version: number

--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/openapi.json
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/openapi.json
@@ -2242,7 +2242,7 @@
             "type": "boolean"
           },
           "name": {
-            "$ref": "#/components/schemas/_maple_ServiceName_1"
+            "$ref": "#/components/schemas/_maple_ServiceName"
           },
           "object": {
             "enum": [
@@ -2958,7 +2958,7 @@
             "type": "number"
           },
           "name": {
-            "$ref": "#/components/schemas/_maple_ServiceName_1"
+            "$ref": "#/components/schemas/_maple_ServiceName"
           },
           "p95_latency_ms": {
             "type": "number"
@@ -3412,10 +3412,6 @@
         "type": "string"
       },
       "_maple_ServiceName": {
-        "title": "Service Name",
-        "type": "string"
-      },
-      "_maple_ServiceName_1": {
         "title": "Service Name",
         "type": "string"
       },
@@ -6458,7 +6454,7 @@
             "name": "name",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/_maple_ServiceName_1"
+              "$ref": "#/components/schemas/_maple_ServiceName"
             }
           },
           {

--- a/apps/web/src/components/errors/issue-sidebar.tsx
+++ b/apps/web/src/components/errors/issue-sidebar.tsx
@@ -62,9 +62,8 @@ const GHOST_TRIGGER = cn(
 )
 
 /**
- * Who set the severity, short enough for the rail's 88px label column — the
- * long forms ("set by AI triage") truncate there. Keys mirror
- * `SEVERITY_SOURCE_LABEL`.
+ * Who set the severity, short enough for the rail's 88px label column — a
+ * longer form like "set by AI triage" truncates there.
  */
 const SEVERITY_SOURCE_HINT: Record<IssueSeveritySource, string> = {
 	detector: "by detector",

--- a/apps/web/src/components/errors/severity-badge.tsx
+++ b/apps/web/src/components/errors/severity-badge.tsx
@@ -1,4 +1,4 @@
-import type { IssueSeverity, IssueSeveritySource } from "@maple/domain/http"
+import type { IssueSeverity } from "@maple/domain/http"
 import { Badge } from "@maple/ui/components/ui/badge"
 import { cn } from "@maple/ui/lib/utils"
 
@@ -64,12 +64,6 @@ export function severityRank(severity: IssueSeverity | null): number {
 	if (severity === null) return SEVERITY_ORDER.length
 	return SEVERITY_ORDER.indexOf(severity)
 }
-
-export const SEVERITY_SOURCE_LABEL: Record<IssueSeveritySource, string> = {
-	detector: "from detector",
-	ai: "set by AI triage",
-	manual: "manual override",
-} satisfies Record<IssueSeveritySource, string>
 
 export function SeverityBadge({
 	severity,

--- a/apps/web/src/components/funnels/definition.ts
+++ b/apps/web/src/components/funnels/definition.ts
@@ -10,27 +10,18 @@ import {
 	FUNNEL_MAX_STEPS,
 	FUNNEL_SESSION_DIMENSION_LABEL,
 	FunnelSessionDimension,
-	funnelStepLabel,
 	type FunnelBreakdownBy as FunnelBreakdownByType,
 	type FunnelKeyBy as FunnelKeyByType,
 	type FunnelSessionDimension as FunnelSessionDimensionType,
 	type FunnelStep as FunnelStepType,
 } from "@maple/query-model"
 
-export type { FunnelStepType as FunnelStep, FunnelKeyByType as FunnelKeyBy }
 export type {
 	FunnelBreakdownByType as FunnelBreakdownBy,
 	FunnelSessionDimensionType as FunnelSessionDimension,
 }
 
 export { FUNNEL_MAX_STEPS }
-
-export interface FunnelDefinition {
-	readonly steps: ReadonlyArray<FunnelStepType>
-	readonly keyBy: FunnelKeyByType
-	readonly windowSeconds: number
-	readonly breakdownBy?: FunnelBreakdownByType
-}
 
 export const DEFAULT_FUNNEL_KEY_BY: FunnelKeyByType = "person"
 export const DEFAULT_FUNNEL_WINDOW_SECONDS = 24 * 3600
@@ -83,11 +74,3 @@ export const completedSteps = (steps: ReadonlyArray<FunnelStepType>): ReadonlyAr
 		}
 	})
 
-/** Human label for a step — the bar label in the chart and the row label in the table. */
-export const stepLabel = funnelStepLabel
-
-/** What the breakdown select shows for a `breakdownBy` value. */
-export const breakdownLabel = (breakdownBy: FunnelBreakdownByType): string =>
-	breakdownBy.startsWith("attribute:")
-		? `attribute ${breakdownBy.slice("attribute:".length)}`
-		: FUNNEL_SESSION_DIMENSION_LABEL[breakdownBy as FunnelSessionDimensionType]

--- a/apps/web/src/lab/service-map-3d/color.ts
+++ b/apps/web/src/lab/service-map-3d/color.ts
@@ -104,6 +104,3 @@ export function edgeColor(errorRate: number, sourceColor: string): string {
 	if (errorRate > 0.01) return SEVERITY.warn
 	return sourceColor
 }
-
-export const NAMESPACE_COLORS = (namespace: string): string =>
-	oklchToHex(0.66, 0.11, getServiceHueFromName(namespace))

--- a/packages/query-engine/src/ch/queries/errors.ts
+++ b/packages/query-engine/src/ch/queries/errors.ts
@@ -1156,7 +1156,6 @@ export const ErrorIssueEnvironmentsOutputSchema = Schema.Struct({
 	name: Schema.String,
 	count: CHNumber,
 })
-export type ErrorIssueEnvironmentsOutput = Schema.Schema.Type<typeof ErrorIssueEnvironmentsOutputSchema>
 
 export function errorIssueEnvironmentsQuery(opts: { limit?: number } = {}) {
 	return from(ErrorEvents)


### PR DESCRIPTION
Main's CI has been red since last night — every PR (e.g. #618) inherits the failures. Two gates, re-verified against tip of main (fc17dc871):

## iOS OpenAPI spec (`ios:openapi:check`)

Regenerated. fc17dc871's regen was made on a tree that still registered `ServiceName` twice, so the committed spec carries a `_maple_ServiceName_1` duplicate the generator no longer emits — the check fails even on pristine main. The generator is deterministic (identical hash across runs), and this PR's own changes are type-only, so the spec here is exactly what tip-of-main code produces.

## knip

All findings were genuinely dead code, so they are removed rather than ignored:

- **`LOCAL_SCHEMA_V1..V11_MANIFEST_DIGEST`** — never read anywhere; the digest still travels as `*_MANIFEST.digest`, and the used `*_SQL` / `*_MANIFEST` siblings stay.
- **`SEVERITY_SOURCE_LABEL`** — its only reference was a doc comment in `issue-sidebar.tsx` (reworded).
- **funnels `definition.ts` shims** — `FunnelStep`/`FunnelKeyBy` re-exports, the `FunnelDefinition` interface, `stepLabel`, `breakdownLabel`: consumers all import from `@maple/query-model` directly.
- **`SvixRejection`** — the reason union lives in `SvixVerificationError`'s schema; the standalone type had no consumers.
- **`MigrationStepStatus`** — the type alias and its module re-export were unused; `MigrationStepStatusSchema` (used by the journal) stays.
- **`ErrorIssueEnvironmentsOutput`** — type alias unused; the row schema the API decodes with stays.
- **`NAMESPACE_COLORS`** in the new service-map 3D lab — landed without a caller.

(The three.js dependency removal from the first revision of this PR is gone: b300c81e8 landed the 3D lab that uses them.)

## Testing

- `bun run ios:openapi:check` and `bun knip` both green locally on this branch.
- `tsc --noEmit` clean in apps/web, apps/cli, apps/api and packages/query-engine.