### PR TITLE
fix(ios): merge rc.111's numbered branded-id components back into one type

### DIFF
--- a/apps/ios/Packages/MapleAPI/Sources/MapleAPI/openapi.json
+++ b/apps/ios/Packages/MapleAPI/Sources/MapleAPI/openapi.json
@@ -540,7 +540,7 @@
             "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/_maple_UserId_2"
+            "$ref": "#/components/schemas/_maple_UserId"
           },
           "destination_ids": {
             "description": "The alert destinations (`dest_…`) this rule notifies.",
@@ -696,7 +696,7 @@
             "type": "string"
           },
           "updated_by": {
-            "$ref": "#/components/schemas/_maple_UserId_3"
+            "$ref": "#/components/schemas/_maple_UserId"
           },
           "window_minutes": {
             "description": "Length of the evaluation window in minutes.",
@@ -1481,7 +1481,7 @@
             "$ref": "#/components/schemas/_maple_ActorType"
           },
           "user_id": {
-            "$ref": "#/components/schemas/_maple_UserId_1"
+            "$ref": "#/components/schemas/_maple_UserId"
           }
         },
         "required": [
@@ -2739,7 +2739,7 @@
             "type": "string"
           },
           "organization_id": {
-            "$ref": "#/components/schemas/_maple_OrgId_1"
+            "$ref": "#/components/schemas/_maple_OrgId"
           },
           "scopes": {
             "description": "Fixed by the server. Today, exactly `widget_summary:read`.",
@@ -2857,7 +2857,7 @@
             "type": "string"
           },
           "organization_id": {
-            "$ref": "#/components/schemas/_maple_OrgId_1"
+            "$ref": "#/components/schemas/_maple_OrgId"
           },
           "schema_version": {
             "type": "number"
@@ -3384,10 +3384,11 @@
         "title": "Mobile Push Environment",
         "type": "string"
       },
-      "_maple_OrgId_1": {
+      "_maple_OrgId": {
+        "description": "The organization's opaque `org_…` ID (e.g. `org_2abcDEF`).",
         "minLength": 1,
         "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
-        "title": "Org ID",
+        "title": "Organization ID",
         "type": "string"
       },
       "_maple_QueryEngineAlertReducer": {
@@ -3427,21 +3428,8 @@
         "title": "Trace ID",
         "type": "string"
       },
-      "_maple_UserId_1": {
-        "minLength": 1,
-        "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
-        "title": "User ID",
-        "type": "string"
-      },
-      "_maple_UserId_2": {
-        "description": "Maple user ID of the rule's creator.",
-        "minLength": 1,
-        "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
-        "title": "User ID",
-        "type": "string"
-      },
-      "_maple_UserId_3": {
-        "description": "Maple user ID of the last editor.",
+      "_maple_UserId": {
+        "description": "Maple user ID of the key's creator (e.g. `user_…`).",
         "minLength": 1,
         "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
         "title": "User ID",

--- a/scripts/generate-ios-openapi.ts
+++ b/scripts/generate-ios-openapi.ts
@@ -152,7 +152,7 @@ function render(): { text: string; doc: JsonObject } {
 	prunePaths(doc)
 	collapseNullableUnions(doc)
 	collapseErrorResponses(doc)
-	mergeDuplicateEnums(doc)
+	mergeDuplicateComponents(doc)
 	sweepUnreachableSchemas(doc)
 
 	const sorted = sortKeysDeep(doc)
@@ -552,36 +552,55 @@ function errorEnvelopeSchema(): JsonObject {
 	}
 }
 
-/** Pass 4a — drop components no longer reachable from the pruned paths. */
 /**
- * Pass 3b — one Swift enum per domain enum.
+ * Pass 3b — one Swift type per domain schema.
  *
- * Effect registers a component per *annotation site*, so a domain enum such as
- * `AlertSignalType` that is re-annotated on the incident, the check, and the
- * rule arrives as `_maple_AlertSignalType`, `_maple_AlertSignalType_2`,
- * `_maple_AlertSignalType_3` — identical `enum` + `type`, differing only in
- * `description`/`examples`. Left alone, the generator emits three unrelated
- * Swift enums and every comparison across them needs a raw-value round trip.
- * When the numbered copy is the same string enum as its base, point every
- * `$ref` at the base and drop the copy.
+ * Effect registers a component per *annotation site*, so a domain schema that
+ * is re-annotated where it is used arrives numbered: `AlertSignalType` on the
+ * incident, the check and the rule as `_maple_AlertSignalType`,
+ * `_maple_AlertSignalType_2`, `_maple_AlertSignalType_3`; a branded id like
+ * `UserId` with per-field descriptions ("the rule's creator", "the last
+ * editor") as `_maple_UserId_1..3` — since rc.111 sometimes without ever
+ * claiming the bare name. The copies are one wire shape differing only in
+ * documentation, but the generator would emit an unrelated Swift type per
+ * copy, and every comparison across them needs a raw-value round trip.
+ *
+ * So: a numbered copy that matches its base modulo `title`/`description`/
+ * `examples` collapses into it, every `$ref` is redirected, and when no bare
+ * base exists the lowest-numbered copy is promoted to it. The per-site
+ * descriptions are deliberately dropped with the copies — a second Swift type
+ * is a far worse cost than a lost doc string. A numbered copy whose wire
+ * shape genuinely differs from its base is left alone, and the domain suite's
+ * "one component per domain enum" test then fails loudly, which is the
+ * correct signal for real divergence.
  */
-function mergeDuplicateEnums(doc: JsonObject): void {
+function mergeDuplicateComponents(doc: JsonObject): void {
 	const schemas = asObject(asObject(doc.components)?.schemas) ?? {}
 	const aliases = new Map<string, string>()
 
-	for (const name of Object.keys(schemas)) {
-		const match = /^(.+)_(\d+)$/.exec(name)
-		if (match === null) continue
-		const base = match[1]
-		const baseSchema = asObject(schemas[base])
+	const docKeys = ["title", "description", "examples"]
+	const wireShape = (schema: JsonObject): string =>
+		JSON.stringify(
+			sortKeysDeep(Object.fromEntries(Object.entries(schema).filter(([key]) => !docKeys.includes(key)))),
+		)
+
+	const numbered = Object.keys(schemas)
+		.map((name) => ({ name, match: /^(.+)_(\d+)$/.exec(name) }))
+		.filter((entry): entry is { name: string; match: RegExpExecArray } => entry.match !== null)
+		.sort((a, b) => Number(a.match[2]) - Number(b.match[2]))
+
+	for (const { name, match } of numbered) {
+		const base = match[1]!
 		const copy = asObject(schemas[name])
-		if (baseSchema === undefined || copy === undefined) continue
-		const baseEnum = asStringArray(baseSchema.enum)
-		const copyEnum = asStringArray(copy.enum)
-		if (baseEnum === undefined || copyEnum === undefined) continue
-		if (baseSchema.type !== "string" || copy.type !== "string") continue
-		if (baseEnum.length !== copyEnum.length || baseEnum.some((value, index) => value !== copyEnum[index]))
+		if (copy === undefined) continue
+		const baseSchema = asObject(schemas[base])
+		if (baseSchema === undefined) {
+			// No annotation site claimed the bare name: promote the lowest copy.
+			schemas[base] = copy
+			aliases.set(name, base)
 			continue
+		}
+		if (wireShape(baseSchema) !== wireShape(copy)) continue
 		aliases.set(name, base)
 	}
 
@@ -605,6 +624,7 @@ function mergeDuplicateEnums(doc: JsonObject): void {
 	for (const name of aliases.keys()) delete schemas[name]
 }
 
+/** Pass 4a — drop components no longer reachable from the pruned paths. */
 function sweepUnreachableSchemas(doc: JsonObject): void {
 	const schemas = asObject(asObject(doc.components)?.schemas) ?? {}
 	const reachable = new Set<string>()

--- a/scripts/generate-ios-openapi.ts
+++ b/scripts/generate-ios-openapi.ts
@@ -579,7 +579,7 @@ function mergeDuplicateComponents(doc: JsonObject): void {
 	const aliases = new Map<string, string>()
 
 	const docKeys = ["title", "description", "examples"]
-	const wireShape = (schema: JsonObject): string =>
+	const identity = (schema: JsonObject): string =>
 		JSON.stringify(
 			sortKeysDeep(Object.fromEntries(Object.entries(schema).filter(([key]) => !docKeys.includes(key)))),
 		)
@@ -600,7 +600,7 @@ function mergeDuplicateComponents(doc: JsonObject): void {
 			aliases.set(name, base)
 			continue
 		}
-		if (wireShape(baseSchema) !== wireShape(copy)) continue
+		if (identity(baseSchema) !== identity(copy)) continue
 		aliases.set(name, base)
 	}
 


### PR DESCRIPTION
Main's `test-packages` shard is failing again after #619 — a different gate this time: `packages/domain`'s `openapi-ios.test.ts > emits one component per domain enum` rejects the committed iOS spec, which carries `_maple_OrgId_1` and `_maple_UserId_1..3`.

## Cause

Effect rc.111 registers an OpenAPI component per annotation site for **branded ids** as well as enums. The alert-rule contract's per-field descriptions on `UserId` ("the rule's creator", "the last editor") mint `_maple_UserId_2`/`_3`, and sometimes no site claims the bare name at all — the spec ends up with only numbered variants. Each numbered copy becomes an unrelated Swift type, which is exactly what the test exists to prevent. The spec regens in #619/fc17dc871 were faithful to the generator; the generator itself needed to normalize the new shape.

## Fix

The existing `mergeDuplicateEnums` pass generalizes into `mergeDuplicateComponents`:
- a numbered copy collapses into its base when their **wire shape** (everything except `title`/`description`/`examples`) matches, with every `$ref` redirected — subsumes the old enum-only merge;
- when no bare base exists, the lowest-numbered copy is **promoted** to the base name;
- per-site descriptions are dropped with the copies, the same trade the enum merge has always made;
- a numbered copy whose wire shape genuinely differs is left alone, so the domain test still fails loudly on real divergence.

Spec regenerated: 94 → 92 schemas, zero numbered components.

## Testing

- `openapi-ios.test.ts` 11/11, full `packages/domain` suite 602/602.
- `bun run ios:openapi:check` and `bun knip` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790204930&installation_model_id=427786&pr_number=620&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F620&signature=8ed71b09925bff8dc169ea24b46ab9c59a9797bd0f16124e20c32bf064cc1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->