### PR TITLE
fix(ai): move the agent-session opt-in keys into the maple_ai namespace

### DIFF
--- a/apps/api/src/chat/loop/genai.ts
+++ b/apps/api/src/chat/loop/genai.ts
@@ -8,7 +8,7 @@
  *     `@maple/domain/gen-ai`) carry what happened: operation, model, token
  *     usage, messages, tool calls. The read-side default integration decodes
  *     them with no per-vendor mapping.
- *   - **`maple.session.id` / `maple.turn.id`** carry where it belongs. The
+ *   - **`maple_ai.session.id` / `maple_ai.turn.id`** carry where it belongs. The
  *     ingest gateway's `maple` vendor (see `apps/ingest/src/ai_session.rs`)
  *     detects on the session key and lifts it into `maple_ai.session.id` — the
  *     attribute that actually groups traces into a session. Without it, spans

--- a/apps/api/src/chat/loop/types.ts
+++ b/apps/api/src/chat/loop/types.ts
@@ -61,7 +61,7 @@ export interface TurnCompletion {
 export interface ChatTurnInput {
 	readonly sessionId: string
 	/**
-	 * Session id the turn's gen-ai spans are grouped under (`maple.session.id`),
+	 * Session id the turn's gen-ai spans are grouped under (`maple_ai.session.id`),
 	 * when it differs from `sessionId`. A headless investigation pass runs with a
 	 * per-pass `sessionId`, but every pass of one investigation belongs to one
 	 * agent session — this is that session's id. Defaults to `sessionId`, which

--- a/apps/api/src/workflows/agent-pass.ts
+++ b/apps/api/src/workflows/agent-pass.ts
@@ -37,7 +37,7 @@ export interface AgentPassInput<S extends Schema.Top> {
 	/** Correlation id; becomes the turn's `messageId`. */
 	readonly id: string
 	/**
-	 * Gen-ai session this pass's spans group under (`maple.session.id`), so every
+	 * Gen-ai session this pass's spans group under (`maple_ai.session.id`), so every
 	 * pass of one investigation lands in one agent session. Omitted, each pass
 	 * fragments into a session of its own under its correlation id.
 	 */

--- a/apps/ingest/src/ai_session.rs
+++ b/apps/ingest/src/ai_session.rs
@@ -10,8 +10,17 @@
 //! - `maple_ai.vendor.version` — identified vendor version, currently always `"0"`
 //! - `maple_ai.session.id` — the vendor's own session identifier, verbatim
 //!
-//! Any customer-supplied `maple_ai.*` keys are stripped first; the gateway is
-//! the authority for this namespace, like it is for `maple_org_id`.
+//! Any customer-supplied `maple_ai.*` key is stripped first, except the two
+//! the gateway does not own (`PRESERVED_ATTRS`); the gateway is the authority
+//! for the rest of this namespace, like it is for `maple_org_id`.
+//!
+//! The whole AI surface lives under `maple_ai.`, including the keys an emitter
+//! writes itself. The native opt-in used to be a bare `maple.session.id`, which
+//! is the browser-session/replay SDK's own key — the replay read routes
+//! annotate their spans with the session they are reading, so every replay read
+//! surfaced as an agent session. `maple_*` is now uniformly Maple-internal
+//! (like `maple_org_id`) and `maple.*` belongs to the SDKs, so the two can
+//! never collide again.
 //!
 //! Detection is ordered first-match over the vendor predicates below; the
 //! session ID is the first non-empty session-granularity attribute for the
@@ -20,9 +29,10 @@
 //! `maple_ai.session.id`.
 //!
 //! One vendor is not a framework: `maple` matches any span carrying a
-//! `maple.session.id` attribute (note the dot — the gateway-owned namespace is
-//! `maple_ai.*` with an underscore). It is Maple's own native convention —
-//! `apps/api`'s chat and investigation agents emit it — and doubles as the
+//! `maple_ai.session.id` attribute. That is the one key an emitter both writes
+//! and reads back — the gateway strips it and re-stamps it verbatim. It is
+//! Maple's own native convention — `apps/api`'s chat and investigation agents
+//! emit it — and doubles as the
 //! documented opt-in for a generic OTel GenAI emitter that no framework
 //! predicate recognises, which would otherwise land in the unknown tier where
 //! no session is ever stamped. It sits first because it is the only predicate
@@ -52,10 +62,17 @@ pub const VENDOR_ID_ATTR: &str = "maple_ai.vendor.id";
 pub const VENDOR_VERSION_ATTR: &str = "maple_ai.vendor.version";
 pub const SESSION_ID_ATTR: &str = "maple_ai.session.id";
 pub const VENDOR_VERSION: &str = "0";
-/// Maple's native session key (dot, not the gateway-owned underscore namespace
-/// above) — must match `MAPLE_NATIVE_SESSION_ID_ATTR` in
+/// Maple's native session key. Since the whole AI surface moved under
+/// `maple_ai.`, this *is* [`SESSION_ID_ATTR`]: an emitter writes it as the
+/// deliberate opt-in, the gateway strips it with the rest of the namespace and
+/// re-stamps it verbatim. Must match `MAPLE_NATIVE_SESSION_ID_ATTR` in
 /// `packages/domain/src/gen-ai.ts`.
-const MAPLE_SESSION_KEY: &str = "maple.session.id";
+const MAPLE_SESSION_KEY: &str = SESSION_ID_ATTR;
+/// Keys inside the namespace the gateway does *not* own: an emitter writes
+/// them and nothing here re-stamps them, so the strip must let them through.
+/// Must match `MAPLE_NATIVE_TURN_ID_ATTR` and
+/// `MAPLE_GENAI_INPUT_MESSAGES_DROPPED_ATTR` in `packages/domain/src/gen-ai.ts`.
+const PRESERVED_ATTRS: [&str; 2] = ["maple_ai.turn.id", "maple_ai.input_messages_dropped"];
 
 #[derive(Debug, PartialEq)]
 pub struct AiClassification {
@@ -105,7 +122,7 @@ pub fn stamp_trace_request(request: &mut ExportTraceServiceRequest) {
                 {
                     continue;
                 }
-                let (classification, has_maple_ai) = {
+                let (classification, has_ai_namespace) = {
                     let mut ev = SpanEvidence::default();
                     collect_evidence(&mut ev, &span.attributes, &span.events);
                     let classification =
@@ -114,11 +131,13 @@ pub fn stamp_trace_request(request: &mut ExportTraceServiceRequest) {
                         } else {
                             None
                         };
-                    (classification, ev.has_maple_ai)
+                    (classification, ev.has_ai_namespace)
                 };
-                if has_maple_ai {
-                    span.attributes
-                        .retain(|attr| !attr.key.starts_with(ATTR_NAMESPACE));
+                if has_ai_namespace {
+                    span.attributes.retain(|attr| {
+                        !attr.key.starts_with(ATTR_NAMESPACE)
+                            || PRESERVED_ATTRS.contains(&attr.key.as_str())
+                    });
                 }
                 let Some(classification) = classification else {
                     continue;
@@ -341,9 +360,14 @@ fn scope_facts(scope_name: &str, resource: &ResourceFacts) -> ScopeFacts {
 )]
 #[derive(Default)]
 struct SpanEvidence<'a> {
-    /// Any field below (except `has_maple_ai`) is set.
+    /// Any field below (except `has_ai_namespace`) is set.
     any: bool,
-    has_maple_ai: bool,
+    has_ai_namespace: bool,
+    /// A gateway-owned `maple_ai.vendor.id` was present on the way in, i.e.
+    /// this payload has already been stamped once. Clears `maple_session` so a
+    /// re-ingest re-derives its original vendor instead of collapsing to
+    /// `maple` off the session id the previous pass wrote.
+    has_vendor_stamp: bool,
     // Value slots.
     span_type: &'a str,
     has_span_type: bool,
@@ -425,7 +449,6 @@ const SCREEN_KEYS: &[&str] = &[
     "llamaindex.",
     "llm.",
     "logfire.json_schema",
-    MAPLE_SESSION_KEY,
     "mastra.",
     "message.",
     "model_request_parameters",
@@ -593,9 +616,15 @@ fn absorb_key<'a>(ev: &mut SpanEvidence<'a>, attr: &'a KeyValue, b0: u8) {
             } else if key == "model_request_parameters" {
                 ev.model_request_parameters = true;
             } else if key == MAPLE_SESSION_KEY {
+                // Also arms the strip: this key is re-stamped verbatim below,
+                // and without the strip the span would carry it twice.
                 ev.maple_session = true;
+                ev.has_ai_namespace = true;
             } else if key.starts_with(ATTR_NAMESPACE) {
-                ev.has_maple_ai = true;
+                ev.has_ai_namespace = true;
+                if key == VENDOR_ID_ATTR {
+                    ev.has_vendor_stamp = true;
+                }
                 return;
             } else {
                 return;
@@ -670,6 +699,11 @@ fn collect_evidence<'a>(
         if ev.llamaindex_event {
             break;
         }
+    }
+    if ev.has_vendor_stamp {
+        // Re-ingest: the session key on this span is the previous pass's
+        // stamp, not a deliberate opt-in. Both get stripped and re-derived.
+        ev.maple_session = false;
     }
 }
 
@@ -1566,7 +1600,7 @@ mod tests {
         classified(
             "",
             "invoke_agent default",
-            &[("maple.session.id", "org_1:tab-1")],
+            &[("maple_ai.session.id", "org_1:tab-1")],
             &[],
             "maple",
             Some("org_1:tab-1"),
@@ -1584,7 +1618,7 @@ mod tests {
             &[
                 ("gen_ai.operation.name", "chat"),
                 ("gen_ai.usage.input_tokens", "123"),
-                ("maple.session.id", "org_1:inv-abc"),
+                ("maple_ai.session.id", "org_1:inv-abc"),
             ],
             &[],
             "maple",
@@ -1593,10 +1627,22 @@ mod tests {
     }
 
     #[test]
-    fn maple_session_key_is_not_the_gateway_namespace() {
-        // `maple_ai.*` (underscore) is gateway-owned and stripped; a customer
-        // supplying it must not classify as the maple vendor through it.
-        assert!(classify("", "chat", &[("maple_ai.session.id", "forged")], &[]).is_none());
+    fn a_gateway_vendor_stamp_disarms_the_maple_session_key() {
+        // Re-ingest: a payload that already carries our stamps must re-derive
+        // its original vendor, not collapse to `maple` off the session id the
+        // previous pass wrote. The forged vendor id is stripped either way.
+        classified(
+            "@mastra/otel-exporter",
+            "agent.generate",
+            &[
+                ("gen_ai.conversation.id", "conv-42"),
+                ("maple_ai.vendor.id", "mastra"),
+                ("maple_ai.session.id", "conv-42"),
+            ],
+            &[],
+            "mastra",
+            Some("conv-42"),
+        );
     }
 
     #[test]
@@ -1670,6 +1716,58 @@ mod tests {
                 other => panic!("expected string value for {key}, got {other:?}"),
             }
         })
+    }
+
+    #[test]
+    fn the_strip_preserves_the_keys_the_gateway_does_not_own() {
+        let mut request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource::default()),
+                scope_spans: vec![ScopeSpans {
+                    scope: Some(InstrumentationScope::default()),
+                    spans: vec![Span {
+                        name: "invoke_agent default".to_owned(),
+                        attributes: attrs(&[
+                            ("maple_ai.session.id", "org_1:tab-1"),
+                            ("maple_ai.turn.id", "msg_1"),
+                            ("maple_ai.input_messages_dropped", "2"),
+                        ]),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        stamp_trace_request(&mut request);
+
+        let span = &request.resource_spans[0].scope_spans[0].spans[0];
+        assert_eq!(
+            attr_value(&span.attributes, VENDOR_ID_ATTR).as_deref(),
+            Some("maple")
+        );
+        // Stripped and re-stamped verbatim - once, not twice.
+        assert_eq!(
+            span.attributes
+                .iter()
+                .filter(|kv| kv.key == SESSION_ID_ATTR)
+                .count(),
+            1
+        );
+        assert_eq!(
+            attr_value(&span.attributes, SESSION_ID_ATTR).as_deref(),
+            Some("org_1:tab-1")
+        );
+        // Emitter-owned: never stripped, never re-stamped.
+        assert_eq!(
+            attr_value(&span.attributes, "maple_ai.turn.id").as_deref(),
+            Some("msg_1")
+        );
+        assert_eq!(
+            attr_value(&span.attributes, "maple_ai.input_messages_dropped").as_deref(),
+            Some("2")
+        );
     }
 
     #[test]

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
@@ -45,7 +45,7 @@ export function AgentSessionsList({ sessions, limit }: AgentSessionsListProps) {
 						<code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.8em]">gen_ai</code>{" "}
 						spans with a{" "}
 						<code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.8em]">
-							maple.session.id
+							maple_ai.session.id
 						</code>{" "}
 						attribute, and their sessions will show up here.
 					</EmptyDescription>

--- a/packages/domain/src/gen-ai.ts
+++ b/packages/domain/src/gen-ai.ts
@@ -23,21 +23,35 @@ export const MAPLE_AI_VENDOR_VERSION_ATTR = "maple_ai.vendor.version"
 export const MAPLE_AI_SESSION_ID_ATTR = "maple_ai.session.id"
 
 // Maple's native convention — the one dialect an app opts into deliberately
-// rather than inheriting from a framework. Distinct from the gateway-owned
-// `maple_ai.*` namespace above: these are ordinary span attributes an emitter
-// writes itself (the gateway strips `maple_ai.*` but honours `maple.*`), and
-// Maple's own agents (`apps/api` chat + investigations) are the first emitter.
+// rather than inheriting from a framework. These are ordinary span attributes
+// an emitter writes itself, and Maple's own agents (`apps/api` chat +
+// investigations) are the first emitter.
+//
+// The whole AI surface sits under `maple_ai.`, these included. The session id
+// used to be a bare `maple.session.id` — the browser-session/replay SDK's own
+// key, which the replay read routes annotate their spans with, so every replay
+// read surfaced as an agent session. The rule that avoids a repeat: `maple_*`
+// is Maple-internal (like `maple_org_id`), `maple.*` belongs to the SDKs.
+//
+// The gateway strips `maple_ai.*` on the way in and re-stamps its own verdict,
+// with two exceptions it does not own and lets through: the turn id and the
+// dropped-messages counter (`PRESERVED_ATTRS` in `apps/ingest/src/ai_session.rs`).
 
-/** Groups every span of one conversation/investigation into one agent session. */
-export const MAPLE_NATIVE_SESSION_ID_ATTR = "maple.session.id"
+/**
+ * Groups every span of one conversation/investigation into one agent session.
+ * The one key an emitter both writes and reads back: the gateway strips it with
+ * the rest of the namespace, then re-stamps it verbatim as
+ * {@link MAPLE_AI_SESSION_ID_ATTR}, which is why they are the same string.
+ */
+export const MAPLE_NATIVE_SESSION_ID_ATTR = "maple_ai.session.id"
 /** Groups one turn's spans inside a session; lifted into `conversationId` read-side. */
-export const MAPLE_NATIVE_TURN_ID_ATTR = "maple.turn.id"
+export const MAPLE_NATIVE_TURN_ID_ATTR = "maple_ai.turn.id"
 /**
  * Count of whole oldest messages dropped from `gen_ai.input.messages` to fit
  * the emitter's attribute budget. Write-only diagnostics: nothing decodes it,
  * it is visible in raw span attributes.
  */
-export const MAPLE_GENAI_INPUT_MESSAGES_DROPPED_ATTR = "maple.genai.input_messages_dropped"
+export const MAPLE_GENAI_INPUT_MESSAGES_DROPPED_ATTR = "maple_ai.input_messages_dropped"
 
 export interface AiFieldDef {
 	/** Primary source attribute key (the semconv key where one exists). */

--- a/packages/query-engine-integrations/src/ai/ai-vendors.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-vendors.test.ts
@@ -256,9 +256,10 @@ describe("maple", () => {
 				"gen_ai.request.model": "openai/gpt-5.6-luna",
 				"gen_ai.provider.name": "openrouter",
 				"gen_ai.usage.input_tokens": "15400",
-				"maple.session.id": "org_1:inv-abc",
-				"maple.turn.id": "msg_1",
+				// Emitter-written and gateway-stamped are the same key now that
+				// the AI surface lives under one namespace.
 				"maple_ai.session.id": "org_1:inv-abc",
+				"maple_ai.turn.id": "msg_1",
 			}),
 		)
 
@@ -272,7 +273,7 @@ describe("maple", () => {
 
 	it("does not overwrite a conversation id the span already declared", () => {
 		const mapped = mapAiSpan(
-			row("maple", { "gen_ai.conversation.id": "conv-1", "maple.turn.id": "msg_1" }),
+			row("maple", { "gen_ai.conversation.id": "conv-1", "maple_ai.turn.id": "msg_1" }),
 		)
 
 		expect(mapped.genAi.conversationId).toBe("conv-1")

--- a/packages/query-engine-integrations/src/ai/ai-vendors.ts
+++ b/packages/query-engine-integrations/src/ai/ai-vendors.ts
@@ -129,9 +129,9 @@ const eveIntegration: AiIntegration = {
 
 /**
  * maple — Maple's own native convention (`apps/api` chat + investigations), and
- * the opt-in for any generic emitter that adopts `maple.session.id`. The spans
+ * the opt-in for any generic emitter that adopts `maple_ai.session.id`. The spans
  * carry canonical `gen_ai.*`, so the default integration decodes them; like eve,
- * only the turn id needs lifting — `maple.turn.id` is the conversation-level
+ * only the turn id needs lifting — `maple_ai.turn.id` is the conversation-level
  * grouping key inside a session, kept out of `gen_ai.conversation.id` on the
  * wire because the semconv key names the whole conversation, not one turn.
  */


### PR DESCRIPTION
## The collision

`maple.session.id` is the browser-session/replay key, in use since #338. The agent-session work then adopted the same key as its native opt-in.

The ingest gateway classifies a span as vendor `maple` on the presence of that attribute alone (`detect_maple` is `c.ev.maple_session`), and the predicate is ordered first. So the replay read routes — which annotate their own spans with the session they are reading — surfaced in production as agent sessions:

- `apps/api/src/routes/v1/session-replay.http.ts` (`getReplay`, `sessionTranscript`)
- `apps/api/src/routes/v2/session-replays.http.ts` (`events`)

Because maple-api self-traces through the gateway, every replay read produced one.

## The change

The keys an emitter writes itself move into `maple_ai.*`, where the gateway-stamped ones already lived. That restores a single rule: **`maple_*` is Maple-internal** (like `maple_org_id`), **`maple.*` belongs to the SDKs** — which also own `maple.session.recorded` and `maple.session.replay_format`, so the prefix has one owner again. The replay routes are untouched.

| before | after |
| --- | --- |
| `maple.session.id` (opt-in) | `maple_ai.session.id` |
| `maple.turn.id` | `maple_ai.turn.id` |
| `maple.genai.input_messages_dropped` | `maple_ai.input_messages_dropped` |

Three parts are not a rename. Putting emitter-written keys inside the gateway-owned namespace changes what the strip means:

1. **The opt-in and the stamp are now the same key.** An emitter writes `maple_ai.session.id`; the gateway strips it with the rest of the namespace and re-stamps it verbatim. The session key therefore has to arm the strip — without that the span carries the key twice.
2. **`PRESERVED_ATTRS` carves out what the gateway does not own.** `maple_ai.turn.id` and `maple_ai.input_messages_dropped` are emitter-written and nothing re-stamps them, so a plain prefix strip would drop them.
3. **A `maple_ai.vendor.id` on the way in marks a re-ingest** and disarms the maple predicate. Sharing the key otherwise means a payload that already passed through a gateway classifies as `maple` off the session id the previous pass wrote, losing its real vendor.

The read path, the SQL baseline and the attributes table need no changes: the stamped keys keep their names, and the attributes table already folded internal keys on a `maple_` prefix.

The attribute was live briefly, so there is no read-side migration.

## Verification

- `cargo test` in `apps/ingest`: 114 + 78 pass. `cargo clippy --all-targets` reports nothing in `ai_session.rs`.
- The anti-spoof test asserting a customer `maple_ai.session.id` cannot classify as `maple` no longer describes anything — that key *is* the opt-in now — and is replaced by a re-ingest idempotency test. Added one asserting the preserved keys survive the strip and the session id is stamped once.
- `apps/api` 2423 · `packages/ui` 638 · `query-engine-integrations` 290 · `apps/web` attributes 5.
- `turbo typecheck --concurrency=1` green across domain, query-engine-integrations, ui, api, web.

Unrelated and pre-existing on this base: 4 failures in `use-timezone-preference` / `use-recently-used-times`, the known jsdom `localStorage` gap.