### PR TITLE
fix(ci): unbreak the two red gates on main

### DIFF
--- a/apps/web/src/lab/bench/service-map-bench.tsx
+++ b/apps/web/src/lab/bench/service-map-bench.tsx
@@ -652,6 +652,13 @@ function BenchDriver({
 		// as 4 commits of a render loop that does not exist. Intermittent by nature:
 		// it depended on ELK straddling the measurement, so it passed and failed on
 		// identical code.
+		// The escape hatch is a deadlock guard, not a budget: it exists so a
+		// genuinely broken ELK fails on an assertion instead of hanging, and it
+		// must sit well above the slowest honest layout. 8s was under it — this
+		// graph takes ~5s of worker ELK on a warm dev server and a fast laptop,
+		// so a two-core CI runner blew straight through the cap and every run
+		// declared ready while the map was still showing the fallback.
+		const ELK_SETTLE_DEADLINE_MS = 45_000
 		let raf = 0
 		const settleStart = performance.now()
 		const checkReady = () => {
@@ -661,7 +668,10 @@ function BenchDriver({
 			// "fallback" is NOT terminal — it is what is on screen while ELK works.
 			const elkSettled =
 				document.querySelector('[data-elk-status="ready"]') !== null
-			if ((measured && domEdges > 0 && elkSettled) || performance.now() - settleStart > 8000) {
+			if (
+				(measured && domEdges > 0 && elkSettled) ||
+				performance.now() - settleStart > ELK_SETTLE_DEADLINE_MS
+			) {
 				harness.readyMs = Math.round(performance.now() - settleStart)
 				harness.ready = true
 				return

--- a/packages/ui/src/lib/gen-ai.ts
+++ b/packages/ui/src/lib/gen-ai.ts
@@ -101,9 +101,10 @@ export const GEN_AI_LABELS: Record<string, string> = {
 	"gen_ai.usage.cache_read.input_tokens": "Cache read",
 	// Two spellings of the same quantity: `cache_creation` is the Anthropic-SDK
 	// dialect (and the read side's primary), `cache_write` the registry spelling
-	// Maple's own agents emit. An emitter uses one or the other, never both.
+	// Maple's own agents emit. An emitter uses one or the other, never both — but
+	// the suffix keeps the table honest if one ever sends both.
 	"gen_ai.usage.cache_creation.input_tokens": "Cache write",
-	"gen_ai.usage.cache_write.input_tokens": "Cache write",
+	"gen_ai.usage.cache_write.input_tokens": "Cache write (registry key)",
 	"gen_ai.usage.reasoning.output_tokens": "Reasoning",
 	"gen_ai.usage.cost": "Cost",
 	// Legacy spellings, all still in the wild. The suffix is what keeps two rows


### PR DESCRIPTION
Main has been red since #617. Two independent failures:

**`TypeScript (test-packages)` — `@maple/ui` gen-ai labels**

`gen_ai.usage.cache_creation.input_tokens` and `gen_ai.usage.cache_write.input_tokens` both mapped to the label `"Cache write"`, and the exhaustive label test rejects that: two rows for the same quantity in one group is exactly the table the label map exists to avoid. The registry spelling now carries a suffix, the same way the legacy aliases are already kept apart.

**`Web perf (service-map)` — ELK ready gate**

The bench harness declares `ready` once ELK has published its final layout, with an escape hatch so a broken ELK fails on an assertion instead of hanging. The hatch was 8s — under the honest cost of this graph. Measured locally on a warm dev server and a fast laptop: `readyMs: 5012`. A two-core CI runner blew straight through the cap on every attempt, declared ready while the map still showed the 2s fallback layout, and the test read `data-elk-status="fallback"`. That is also the likeliest source of the intermittent `nodes moved by a metric refresh` failure in the stability test — ELK landing mid-measurement.

Raised to 45s. It is a deadlock guard, not a budget, and it still sits under the 60s `waitForFunction` on the other side.

Verified locally: `packages/ui` 638/638 green, and the full `service-map.perf.spec.ts` under `CI=1` passes 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790209435&installation_model_id=427786&pr_number=623&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F623&signature=4124933f00c3fa3a953fc53773fad67e4b5b4877885dc7f9411525a0577f49d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->