### PR TITLE
fix(mcp): give a rehydrated session its negotiated profile

### DIFF
--- a/apps/api/src/mcp/app.test.ts
+++ b/apps/api/src/mcp/app.test.ts
@@ -7,6 +7,7 @@ import { cleanupTestDbs, createTestDb, type TestDb } from "@/platform/test-pglit
 import { ApiKeysService } from "@/services/org/ApiKeysService"
 import { AuthService } from "@/services/auth/AuthService"
 import { McpToolExecutor, type McpToolExecutorApi } from "./dispatcher"
+import { type SessionPayload, sessionStore } from "./lib/session-store"
 import { McpLive } from "./app"
 
 const createdDbs: TestDb[] = []
@@ -270,6 +271,99 @@ describe("MCP HTTP authorization", () => {
 			expect(called.status).toBe(200)
 		} finally {
 			await dispose()
+		}
+	})
+	it("serves tools/list on a session rehydrated by a fresh worker isolate", async () => {
+		// Regression: `clientSessions` (our effect patch) persists only the initialize
+		// payload, so a second isolate rebuilds the session from scratch. rc.111 reads
+		// `session?.negotiatedProfile.protocolVersion` — the `?.` guards the session but
+		// not the profile — so a rehydrate without one died with a defect that Effect
+		// serialized under id -32603, which no client can match. tools/list hung until
+		// the client timed out, and the server looked merely slow.
+		const db = createTestDb(createdDbs)
+		const base = Layer.mergeAll(db.layer, Env.layer.pipe(Layer.provide(testConfig())))
+		const services = Layer.mergeAll(
+			ApiKeysService.layer,
+			AuthService.layer,
+			makeMcpToolExecutorStubLayer(),
+		).pipe(Layer.provideMerge(base))
+		const orgId = Schema.decodeUnknownSync(OrgId)("org_test")
+		const userId = Schema.decodeUnknownSync(UserId)("user_test")
+		const key = await Effect.runPromise(
+			Effect.gen(function* () {
+				const apiKeys = yield* ApiKeysService
+				return yield* apiKeys.create(orgId, userId, { name: "Rehydrate test", kind: "mcp" })
+			}).pipe(Effect.provide(services)),
+		)
+		const headers = (extra: Record<string, string> = {}) => ({
+			authorization: `Bearer ${key.secret}`,
+			accept: "application/json, text/event-stream",
+			"content-type": "application/json",
+			host: "api.example.com",
+			"x-forwarded-proto": "https",
+			...extra,
+		})
+
+		// First isolate: initialize, which is the only call that writes to `sessionStore`.
+		const first = HttpRouter.toWebHandler(McpLive.pipe(Layer.provideMerge(services)), {
+			disableLogger: true,
+		})
+		let sessionId: string | null = null
+		let persisted: SessionPayload | undefined
+		try {
+			const initialized = await first.handler(
+				new Request("https://api.example.com/mcp", {
+					method: "POST",
+					headers: headers(),
+					body: JSON.stringify({
+						jsonrpc: "2.0",
+						id: 1,
+						method: "initialize",
+						params: {
+							protocolVersion: "2025-06-18",
+							capabilities: {},
+							clientInfo: { name: "test", version: "1.0.0" },
+						},
+					}),
+				}),
+				Context.empty() as never,
+			)
+			expect(initialized.status).toBe(200)
+			sessionId = initialized.headers.get("mcp-session-id")
+			expect(sessionId).not.toBeNull()
+			// What worker.ts hands to KV, and what the next isolate preloads back.
+			persisted = sessionStore.get(sessionId!)
+			expect(persisted).toBeDefined()
+		} finally {
+			await first.dispose()
+		}
+		sessionStore.set(sessionId!, persisted!)
+
+		// Second isolate: a fresh McpProtocolState whose in-memory session map is empty,
+		// so this request can only be served through the `clientSessions` rehydrate path.
+		const second = HttpRouter.toWebHandler(McpLive.pipe(Layer.provideMerge(services)), {
+			disableLogger: true,
+		})
+		try {
+			const listed = await second.handler(
+				new Request("https://api.example.com/mcp", {
+					method: "POST",
+					headers: headers({
+						"mcp-session-id": sessionId!,
+						"mcp-protocol-version": "2025-06-18",
+					}),
+					body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+				}),
+				Context.empty() as never,
+			)
+			const body = await listed.clone().text()
+			expect({ status: listed.status, defect: body.includes("A defect occurred") }).toEqual({
+				status: 200,
+				defect: false,
+			})
+			expect(body).toContain("inspect_trace")
+		} finally {
+			await second.dispose()
 		}
 	})
 })

--- a/patches/effect@4.0.0-rc.111.patch
+++ b/patches/effect@4.0.0-rc.111.patch
@@ -64,7 +64,7 @@ diff --git a/dist/unstable/ai/McpServer.js b/dist/unstable/ai/McpServer.js
 index d8525be5cc4e5463300abaaec001f5c228130d36..2edd4f3d8a7d99c9e0171f8970143f9f08ec81ed 100644
 --- a/dist/unstable/ai/McpServer.js
 +++ b/dist/unstable/ai/McpServer.js
-@@ -406,19 +406,60 @@ const MCP_INVALID_BATCH_METHOD = "invalid/json-rpc-batch";
+@@ -406,19 +406,68 @@ const MCP_INVALID_BATCH_METHOD = "invalid/json-rpc-batch";
  const requestKey = requestId => `${typeof requestId}:${requestId}`;
  class McpClientKey extends Data.Class {}
  class McpProtocolState extends /*#__PURE__*/Context.Service()("effect/ai/McpServer/McpProtocolState") {}
@@ -84,9 +84,17 @@ index d8525be5cc4e5463300abaaec001f5c228130d36..2edd4f3d8a7d99c9e0171f8970143f9f
 +    if (initializePayload === undefined) {
 +      return undefined;
 +    }
++    const protocol = this.protocolRegistry.select(getOfferedProtocolVersion(initializePayload));
 +    const session = {
 +      initializePayload,
-+      protocol: this.protocolRegistry.select(getOfferedProtocolVersion(initializePayload)),
++      protocol,
++      // Required since rc.111: every non-initialize read does
++      // `session?.negotiatedProfile.protocolVersion`, which guards the session but not the profile.
++      negotiatedProfile: {
++        protocolVersion: protocol.protocolVersion,
++        clientCapabilities: initializePayload.capabilities,
++        clientInfo: initializePayload.clientInfo
++      },
 +      resourceSubscriptions: undefined,
 +      logLevel: {
 +        _tag: "Effect",
@@ -129,7 +137,7 @@ index d8525be5cc4e5463300abaaec001f5c228130d36..2edd4f3d8a7d99c9e0171f8970143f9f
  /**
   * Runs an MCP server over the current `RpcServer.Protocol`.
   *
-@@ -433,7 +474,7 @@ const layerMcpProtocolState = protocols => Layer.effect(McpProtocolState)(makeMc
+@@ -433,7 +482,7 @@ const layerMcpProtocolState = protocols => Layer.effect(McpProtocolState)(makeMc
   */
  export const run = /*#__PURE__*/Effect.fnUntraced(function* (options) {
    const protocolStateOption = yield* Effect.serviceOption(McpProtocolState);
@@ -138,7 +146,7 @@ index d8525be5cc4e5463300abaaec001f5c228130d36..2edd4f3d8a7d99c9e0171f8970143f9f
    return yield* runWithProtocolState(options, protocolState);
  });
  const runWithProtocolState = /*#__PURE__*/Effect.fnUntraced(function* (options, protocolState) {
-@@ -819,7 +860,7 @@ const runWithProtocolState = /*#__PURE__*/Effect.fnUntraced(function* (options,
+@@ -819,7 +868,7 @@ const runWithProtocolState = /*#__PURE__*/Effect.fnUntraced(function* (options,
   * @category layers
   * @since 4.0.0
   */
@@ -147,7 +155,7 @@ index d8525be5cc4e5463300abaaec001f5c228130d36..2edd4f3d8a7d99c9e0171f8970143f9f
  const layerWithProtocolState = options => Layer.effectDiscard(Effect.gen(function* () {
    const protocolState = yield* McpProtocolState;
    yield* Effect.forkScoped(runWithProtocolState(options, protocolState));
-@@ -930,7 +971,7 @@ const mcpStdioSerialization = protocols => {
+@@ -930,7 +979,7 @@ const mcpStdioSerialization = protocols => {
   * @since 4.0.0
   */
  export const layerHttp = options => {


### PR DESCRIPTION
## What broke

MCP clients could connect to `api.maple.dev/mcp` but never list tools. From Claude Code's transport log:

```
Connection error: Received a response for an unknown message ID:
{"jsonrpc":"2.0","id":-32603,"error":{"code":1,"message":"A defect occurred",
 "data":{"name":"TypeError","message":"Cannot read properties of undefined (reading 'protocolVersion')"}}}
...
Failed to fetch tools: Request timed out
```

`initialize` succeeds, so the server reports as connected. The next request — `tools/list`, carrying `mcp-session-id` — throws server-side. Effect serializes the defect under `id: -32603` (the JSON-RPC error *code* used as an id), which matches no pending request, so the client never resolves and times out after 30s. It read as a slow endpoint; it was a crash on the first request into every new isolate.

First failing session in the local MCP logs is `2026-08-24T23:43`, ~1h after 4e8b2623ef ("move Effect to 4.0.0-rc.111"). The last clean one is `2026-08-24T07:44`.

## Root cause

`clientSessions` / `PersistedSessionMap` is our own addition in `patches/effect@4.0.0-rc.111.patch`, not upstream. It persists only the initialize payload, so a fresh isolate rebuilds the session:

```js
const session = {
  initializePayload,
  protocol: this.protocolRegistry.select(getOfferedProtocolVersion(initializePayload)),
  resourceSubscriptions: undefined,
  logLevel: { _tag: "Effect", level: "Info" }
};
```

No `negotiatedProfile`. rc.111's `McpServer.js` reads it as:

```js
protocolVersion: session?.negotiatedProfile.protocolVersion ?? selectedProtocol.protocolVersion,
```

The `?.` guards `session` being undefined — not `negotiatedProfile`. A rehydrated session is defined and profile-less, so it throws.

`PersistedSessionMap` was written against an older beta whose `Session` had no `negotiatedProfile`. The rc.111 bump re-anchored the patch's placement but not its shape. Sessions created in-process carry a profile from `initialize`, so nothing in-isolate ever hit it.

## Fix

The rebuild derives the profile from the persisted payload — the same three `NegotiatedProtocolProfile` fields `McpServer` itself falls back to when there is no session.

## Also in here: the patch had fuzz-applied

Adding lines to the first hunk without absorbing the delta into later `+start` offsets let bun fuzz-apply the rest of the file. The result installed clean and typechecked green, but `layerHttp` still called `layerMcpProtocolState(options.protocols)` while the patched call landed *inside a JSDoc block*, where it was a comment. `clientSessions` reached nothing, and every session 404'd on the next isolate.

This is the same failure mode 4e8b2623ef describes, one hunk over. All hunk headers in the file are now recomputed.

## Test

`app.test.ts` drives two handlers over one `sessionStore`, reseeding it between them the way `worker.ts` reseeds from KV, so the second request can only be served through the rehydrate path. It asserts on the defect text rather than the status, because the crash still answers `200`.

Verified it fails without the fix (`defect: true`) and passes with it. `bun run --cwd apps/api test src/mcp/` → 357 passed; `bun typecheck` → 40/40.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790248243&installation_model_id=427786&pr_number=625&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F625&signature=276d4015ef57852ed973492b8a6467deaeabf3ee1fa8920d7c3ceee2ae52e704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->