### PR TITLE
fix(api): stop malformed time bounds reaching ClickHouse DateTime params

### DIFF
--- a/apps/api/src/mcp/lib/time.test.ts
+++ b/apps/api/src/mcp/lib/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { normalizeTime, rangeExceededResult, resolveTimeRange } from "./time"
+import { normalizeTime, rangeExceededResult, resolveTimeRange, timeRangeInvalidResult } from "./time"
 
 describe("normalizeTime", () => {
 	it("passes through already-correct format", () => {
@@ -26,8 +26,15 @@ describe("normalizeTime", () => {
 		expect(normalizeTime("2026-03-30T00:00:00+09:00")).toBe("2026-03-29 15:00:00")
 	})
 
-	it("returns unparseable strings as-is", () => {
-		expect(normalizeTime("not-a-date")).toBe("not-a-date")
+	it("returns null for unparseable strings", () => {
+		expect(normalizeTime("not-a-date")).toBeNull()
+	})
+
+	// The shape an agent actually produced: a real date sheared into nonsense.
+	// Passing it through put `toDateTime('2026-08-47:53')` into live SQL.
+	it("returns null for a malformed date that looks plausible", () => {
+		expect(normalizeTime("2026-08-47:53")).toBeNull()
+		expect(normalizeTime("2026-13-01 00:00:00")).toBeNull()
 	})
 
 	it("trims whitespace", () => {
@@ -94,6 +101,64 @@ describe("resolveTimeRange", () => {
 	it("never flags exceeded when no cap is set", () => {
 		const result = resolveTimeRange("2020-01-01T00:00:00Z", "2026-03-30T00:00:00Z")
 		expect(result.exceeded).toBe(false)
+	})
+
+	it("reports an unparseable bound and falls back to the default for it", () => {
+		const result = resolveTimeRange("2026-08-47:53", "2026-03-30T16:00:00Z")
+		expect(result.invalid).toEqual([{ param: "start_time", value: "2026-08-47:53" }])
+		// The bad bound never reaches SQL — it becomes a well-formed default.
+		expect(result.st).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+		expect(result.et).toBe("2026-03-30 16:00:00")
+	})
+
+	it("reports both bounds when both are unparseable", () => {
+		const result = resolveTimeRange("nope", "also-nope")
+		expect(result.invalid).toEqual([
+			{ param: "start_time", value: "nope" },
+			{ param: "end_time", value: "also-nope" },
+		])
+		expect(result.st).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+		expect(result.et).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+	})
+
+	it("is empty-invalid for a sound range", () => {
+		expect(resolveTimeRange("2026-03-30T10:00:00Z", "2026-03-30T16:00:00Z").invalid).toEqual([])
+		expect(resolveTimeRange(undefined, undefined).invalid).toEqual([])
+	})
+
+	// A garbage bound collapses to the default window, whose width is under any
+	// cap — reporting `exceeded` there would send the agent chasing the wrong fix.
+	it("prefers the invalid signal over exceeded", () => {
+		const result = resolveTimeRange("nope", "2026-03-30T16:00:00Z", { maxHours: 1 })
+		expect(result.invalid).toHaveLength(1)
+		expect(result.exceeded).toBe(false)
+	})
+})
+
+describe("timeRangeInvalidResult", () => {
+	it("names the bad value and the accepted formats", () => {
+		const result = timeRangeInvalidResult(
+			{ invalid: [{ param: "start_time", value: "2026-08-47:53" }] },
+			"explore_attributes",
+		)
+		expect(result.isError).toBe(true)
+		const text = result.content[0].text
+		expect(text).toContain("explore_attributes")
+		expect(text).toContain('start_time="2026-08-47:53"')
+		expect(text).toContain("YYYY-MM-DD HH:mm:ss")
+	})
+
+	it("lists both bounds when both were bad", () => {
+		const text = timeRangeInvalidResult(
+			{
+				invalid: [
+					{ param: "start_time", value: "a" },
+					{ param: "end_time", value: "b" },
+				],
+			},
+			"search_traces",
+		).content[0].text
+		expect(text).toContain('start_time="a" and end_time="b"')
 	})
 })
 

--- a/apps/api/src/mcp/lib/time.ts
+++ b/apps/api/src/mcp/lib/time.ts
@@ -23,12 +23,16 @@ export const MCP_LOG_PATTERN_MAX_HOURS = MAX_LOG_PATTERN_RANGE_SECONDS / 3600
  *
  * Handles ISO 8601 (with T, Z, timezone offsets, milliseconds) and the
  * already-correct `YYYY-MM-DD HH:mm:ss` format — which the shared parser reads
- * as UTC rather than local. Returns the input trimmed if it can't be parsed.
+ * as UTC rather than local.
+ *
+ * Returns `null` when the input isn't a timestamp at all. It used to return the
+ * input verbatim, which meant an agent-supplied `'2026-08-47:53'` was spliced
+ * into a `DateTime` literal and only failed at ClickHouse, as an unhandled
+ * `Cannot parse string … as DateTime`.
  */
-export function normalizeTime(input: string): string {
-	const trimmed = input.trim()
-	const ms = parseWarehouseDateTime(trimmed)
-	return Number.isNaN(ms) ? trimmed : formatWarehouseDateTime(ms)
+export function normalizeTime(input: string): string | null {
+	const ms = parseWarehouseDateTime(input.trim())
+	return Number.isNaN(ms) ? null : formatWarehouseDateTime(ms)
 }
 
 const DEFAULT_HOURS = 6
@@ -48,6 +52,12 @@ export interface ResolveTimeRangeOptions {
 	readonly maxHours?: number
 }
 
+/** An agent-supplied bound that wasn't a timestamp, kept for the error message. */
+export interface InvalidTimeBound {
+	readonly param: "start_time" | "end_time"
+	readonly value: string
+}
+
 export interface ResolvedTimeRange {
 	readonly st: string
 	readonly et: string
@@ -57,6 +67,8 @@ export interface ResolvedTimeRange {
 	readonly maxHours: number | undefined
 	/** Width of the agent-supplied window in hours, when both bounds parsed. */
 	readonly requestedHours: number | undefined
+	/** Agent-supplied bounds that weren't timestamps. Empty when the range is sound. */
+	readonly invalid: ReadonlyArray<InvalidTimeBound>
 }
 
 /**
@@ -67,6 +79,11 @@ export interface ResolvedTimeRange {
  * *unchanged* with `exceeded: true` — callers must reject it. This used to clamp
  * `st` forward silently, which meant an agent asking for 30 days got 7 and had no
  * way to tell that its answer was computed from a fraction of the window.
+ *
+ * A bound that isn't a timestamp is reported in `invalid` and replaced by the
+ * default window's bound, so `st`/`et` are always a well-formed warehouse
+ * DateTime even for a caller that doesn't check. Callers that do check return
+ * `timeRangeInvalidResult`, which tells the agent the expected format.
  *
  * Back-compat: the third arg also accepts a bare number (treated as `defaultHours`).
  */
@@ -79,17 +96,37 @@ export function resolveTimeRange(
 		typeof opts === "number" ? { defaultHours: opts, maxHours: undefined } : opts
 
 	const defaults = defaultTimeRange(defaultHours)
-	const st = startTime ? normalizeTime(startTime) : defaults.startTime
-	const et = endTime ? normalizeTime(endTime) : defaults.endTime
+	const invalid: InvalidTimeBound[] = []
+
+	const resolveBound = (
+		supplied: string | undefined,
+		param: InvalidTimeBound["param"],
+		fallback: string,
+	): string => {
+		if (supplied === undefined) return fallback
+		const normalized = normalizeTime(supplied)
+		if (normalized === null) {
+			invalid.push({ param, value: supplied })
+			return fallback
+		}
+		return normalized
+	}
+
+	const st = resolveBound(startTime, "start_time", defaults.startTime)
+	const et = resolveBound(endTime, "end_time", defaults.endTime)
 
 	const stMs = parseWarehouseDateTime(st)
 	const etMs = parseWarehouseDateTime(et)
 	const requestedHours = Number.isNaN(stMs) || Number.isNaN(etMs) ? undefined : (etMs - stMs) / 3_600_000
 
 	const exceeded =
-		maxHours !== undefined && maxHours > 0 && requestedHours !== undefined && requestedHours > maxHours
+		invalid.length === 0 &&
+		maxHours !== undefined &&
+		maxHours > 0 &&
+		requestedHours !== undefined &&
+		requestedHours > maxHours
 
-	return { st, et, exceeded, maxHours, requestedHours }
+	return { st, et, exceeded, maxHours, requestedHours, invalid }
 }
 
 const formatHours = (hours: number): string => {
@@ -130,6 +167,30 @@ export function rangeExceededResult(
 ) {
 	return {
 		content: [{ type: "text" as const, text: rangeExceededMessage(range, toolName) }],
+		isError: true as const,
+	}
+}
+
+/**
+ * Builds the message for bounds that aren't timestamps. Names each bad value so
+ * the agent can see what it actually sent, and states the accepted formats.
+ */
+export function timeRangeInvalidMessage(range: Pick<ResolvedTimeRange, "invalid">, toolName: string): string {
+	const bounds = range.invalid.map((b) => `${b.param}="${b.value}"`).join(" and ")
+	return [
+		`Invalid time value for \`${toolName}\`: ${bounds}.`,
+		`Use \`YYYY-MM-DD HH:mm:ss\` (UTC) or an ISO-8601 timestamp, or omit the bound to use the default window.`,
+	].join(" ")
+}
+
+/**
+ * Standard MCP error result for unparseable bounds. Returned directly by tools,
+ * so a malformed timestamp fails as a retryable tool error rather than as a
+ * ClickHouse parse error the agent can't act on.
+ */
+export function timeRangeInvalidResult(range: Pick<ResolvedTimeRange, "invalid">, toolName: string) {
+	return {
+		content: [{ type: "text" as const, text: timeRangeInvalidMessage(range, toolName) }],
 		isError: true as const,
 	}
 }

--- a/apps/api/src/mcp/tools/explore-attributes.ts
+++ b/apps/api/src/mcp/tools/explore-attributes.ts
@@ -2,7 +2,12 @@ import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from 
 import { toMcpQueryError } from "@/mcp/lib/map-warehouse-error"
 import { CurrentMcpTenant } from "@/mcp/lib/query-warehouse"
 import { queryWarehouse } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_DISCOVERY_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_DISCOVERY_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { clampLimit } from "@/mcp/lib/limits"
 import { formatNumber, formatTable } from "@/mcp/lib/format"
 import { Array as Arr, Effect, Schema } from "effect"
@@ -39,6 +44,7 @@ export function registerExploreAttributesTool(server: McpToolRegistrar) {
 				maxHours: MCP_DISCOVERY_MAX_HOURS,
 			})
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, "explore_attributes")
 			if (range.exceeded) return rangeExceededResult(range, "explore_attributes")
 			const lim = clampLimit(params.limit, { defaultValue: 50, max: 500 })
 			const scope = (params.scope ?? "span") as "span" | "resource"

--- a/apps/api/src/mcp/tools/find-slow-traces.ts
+++ b/apps/api/src/mcp/tools/find-slow-traces.ts
@@ -1,7 +1,12 @@
 import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
 import { warehouseToMcpHandlers } from "@/mcp/lib/map-warehouse-error"
 import { withTenantExecutor } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_SEARCH_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { clampLimit } from "@/mcp/lib/limits"
 import { formatDurationFromMs, formatTable } from "@/mcp/lib/format"
 import { formatNextSteps } from "@/mcp/lib/next-steps"
@@ -29,6 +34,7 @@ export function registerFindSlowTracesTool(server: McpToolRegistrar) {
 		}) {
 			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_SEARCH_MAX_HOURS })
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, "find_slow_traces")
 			if (range.exceeded) return rangeExceededResult(range, "find_slow_traces")
 			const lim = clampLimit(limit, { defaultValue: 10, max: 100 })
 

--- a/apps/api/src/mcp/tools/get-service-top-operations.ts
+++ b/apps/api/src/mcp/tools/get-service-top-operations.ts
@@ -6,7 +6,12 @@ import {
 	type McpToolRegistrar,
 } from "./types"
 import { CurrentMcpTenant } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_SEARCH_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { clampLimit } from "@/mcp/lib/limits"
 import { formatTable } from "@/mcp/lib/format"
 import { formatMetricValue } from "@/mcp/lib/format-query-result"
@@ -42,6 +47,7 @@ export function registerGetServiceTopOperationsTool(server: McpToolRegistrar) {
 		}) {
 			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_SEARCH_MAX_HOURS })
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, "get_service_top_operations")
 			if (range.exceeded) return rangeExceededResult(range, "get_service_top_operations")
 			const metricOption =
 				metric === undefined ? Option.some("count" as const) : decodeTracesMetric(metric)

--- a/apps/api/src/mcp/tools/list-metrics.ts
+++ b/apps/api/src/mcp/tools/list-metrics.ts
@@ -1,6 +1,11 @@
 import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
 import { queryWarehouse, CurrentMcpTenant } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_DISCOVERY_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_DISCOVERY_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { clampLimit, clampOffset } from "@/mcp/lib/limits"
 import { formatNumber, formatTable } from "@/mcp/lib/format"
 import { formatNextSteps } from "@/mcp/lib/next-steps"
@@ -33,6 +38,7 @@ export function registerListMetricsTool(server: McpToolRegistrar) {
 		}) {
 			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_DISCOVERY_MAX_HOURS })
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, "list_metrics")
 			if (range.exceeded) return rangeExceededResult(range, "list_metrics")
 			const lim = clampLimit(limit, { defaultValue: 50, max: 500 })
 			const off = clampOffset(offset, { max: 10_000 })

--- a/apps/api/src/mcp/tools/list-product-events.ts
+++ b/apps/api/src/mcp/tools/list-product-events.ts
@@ -1,7 +1,12 @@
 import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
 import { warehouseToMcpHandlers } from "@/mcp/lib/map-warehouse-error"
 import { withTenantExecutor, CurrentMcpTenant } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_DISCOVERY_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_DISCOVERY_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { clampLimit } from "@/mcp/lib/limits"
 import { formatTable, formatNumber, truncate } from "@/mcp/lib/format"
 import { formatNextSteps } from "@/mcp/lib/next-steps"
@@ -41,6 +46,7 @@ export function registerListProductEventsTool(server: McpToolRegistrar) {
 				maxHours: MCP_DISCOVERY_MAX_HOURS,
 			})
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, TOOL)
 			if (range.exceeded) return rangeExceededResult(range, TOOL)
 			const limit = clampLimit(params.limit, { defaultValue: 50, max: 200 })
 

--- a/apps/api/src/mcp/tools/mine-log-patterns.ts
+++ b/apps/api/src/mcp/tools/mine-log-patterns.ts
@@ -1,7 +1,12 @@
 import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
 import { toMcpQueryError } from "@/mcp/lib/map-warehouse-error"
 import { CurrentMcpTenant } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_LOG_PATTERN_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_LOG_PATTERN_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { truncate, formatNumber } from "@/mcp/lib/format"
 import { formatNextSteps } from "@/mcp/lib/next-steps"
 import { Effect, Schema } from "effect"
@@ -39,6 +44,7 @@ export function registerMineLogPatternsTool(server: McpToolRegistrar) {
 		}) {
 			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_LOG_PATTERN_MAX_HOURS })
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, "mine_log_patterns")
 			if (range.exceeded) return rangeExceededResult(range, "mine_log_patterns")
 			const sampleSize = Math.min(Math.max(Number(sample_size) || 10_000, 1), 50_000)
 			const lim = Math.min(Math.max(Number(limit) || 50, 1), 200)

--- a/apps/api/src/mcp/tools/query-funnel.ts
+++ b/apps/api/src/mcp/tools/query-funnel.ts
@@ -7,7 +7,12 @@ import {
 } from "./types"
 import { warehouseToMcpHandlers } from "@/mcp/lib/map-warehouse-error"
 import { withTenantExecutor, CurrentMcpTenant } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_DISCOVERY_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_DISCOVERY_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { clampLimit } from "@/mcp/lib/limits"
 import { formatTable, formatNumber, formatPercent, truncate } from "@/mcp/lib/format"
 import { formatNextSteps } from "@/mcp/lib/next-steps"
@@ -94,6 +99,7 @@ export function registerQueryFunnelTool(server: McpToolRegistrar) {
 				maxHours: MCP_DISCOVERY_MAX_HOURS,
 			})
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, TOOL)
 			if (range.exceeded) return rangeExceededResult(range, TOOL)
 
 			const stepsResult = yield* Effect.result(decodeSteps(params.steps_json))

--- a/apps/api/src/mcp/tools/search-logs.ts
+++ b/apps/api/src/mcp/tools/search-logs.ts
@@ -1,7 +1,12 @@
 import { optionalNumberParam, optionalStringParam, type McpToolRegistrar } from "./types"
 import { toMcpQueryError } from "@/mcp/lib/map-warehouse-error"
 import { CurrentMcpTenant } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_SEARCH_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { clampLimit, clampOffset } from "@/mcp/lib/limits"
 import { truncate, formatNumber } from "@/mcp/lib/format"
 import { formatNextSteps } from "@/mcp/lib/next-steps"
@@ -42,6 +47,7 @@ export function registerSearchLogsTool(server: McpToolRegistrar) {
 		}) {
 			const range = resolveTimeRange(start_time, end_time, { maxHours: MCP_SEARCH_MAX_HOURS })
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, "search_logs")
 			if (range.exceeded) return rangeExceededResult(range, "search_logs")
 			const lim = clampLimit(limit, { defaultValue: 30, max: 200 })
 			const off = clampOffset(offset, { max: 10_000 })

--- a/apps/api/src/mcp/tools/search-sessions.ts
+++ b/apps/api/src/mcp/tools/search-sessions.ts
@@ -6,7 +6,12 @@ import {
 } from "./types"
 import { warehouseToMcpHandlers } from "@/mcp/lib/map-warehouse-error"
 import { withTenantExecutor, CurrentMcpTenant } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_SEARCH_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { clampLimit, clampOffset } from "@/mcp/lib/limits"
 import { formatTable, truncate } from "@/mcp/lib/format"
 import { formatNextSteps } from "@/mcp/lib/next-steps"
@@ -59,6 +64,7 @@ export function registerSearchSessionsTool(server: McpToolRegistrar) {
 				maxHours: MCP_SEARCH_MAX_HOURS,
 			})
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, "search_sessions")
 			if (range.exceeded) return rangeExceededResult(range, "search_sessions")
 			const lim = clampLimit(params.limit, { defaultValue: 25, max: 200 })
 			const off = clampOffset(params.offset, { max: 10_000 })

--- a/apps/api/src/mcp/tools/search-traces.ts
+++ b/apps/api/src/mcp/tools/search-traces.ts
@@ -7,7 +7,12 @@ import {
 } from "./types"
 import { warehouseToMcpHandlers } from "@/mcp/lib/map-warehouse-error"
 import { withTenantExecutor } from "@/mcp/lib/query-warehouse"
-import { resolveTimeRange, rangeExceededResult, MCP_SEARCH_MAX_HOURS } from "@/mcp/lib/time"
+import {
+	resolveTimeRange,
+	rangeExceededResult,
+	timeRangeInvalidResult,
+	MCP_SEARCH_MAX_HOURS,
+} from "@/mcp/lib/time"
 import { clampLimit, clampOffset } from "@/mcp/lib/limits"
 import { formatDurationFromMs, formatTable } from "@/mcp/lib/format"
 import { formatNextSteps } from "@/mcp/lib/next-steps"
@@ -49,6 +54,7 @@ export function registerSearchTracesTool(server: McpToolRegistrar) {
 				maxHours: MCP_SEARCH_MAX_HOURS,
 			})
 			const { st, et } = range
+			if (range.invalid.length > 0) return timeRangeInvalidResult(range, "search_traces")
 			if (range.exceeded) return rangeExceededResult(range, "search_traces")
 			const lim = clampLimit(params.limit, { defaultValue: 20, max: 200 })
 			const off = clampOffset(params.offset, { max: 10_000 })

--- a/apps/api/src/routes/v2/telemetry.http.ts
+++ b/apps/api/src/routes/v2/telemetry.http.ts
@@ -118,6 +118,11 @@ const MAX_SUMMARY_RANGE_SECONDS = 60 * 60 * 24 * 365
  * splice's floor arithmetic used to reject it earlier still with
  * `Cannot parse string '…000' as DateTime`. Whole seconds cost nothing on a
  * window measured in hours.
+ *
+ * Required, deliberately: this used to default to `"millisecond"`, so a handler
+ * reading a rollup only had to omit it to 500 on every call — which is how
+ * `v2ListMetrics` shipped broken against `metric_catalog`. Stating the table's
+ * precision is now the price of calling `parseWindow`.
  */
 type WindowPrecision = "second" | "millisecond"
 
@@ -125,10 +130,10 @@ const parseWindow = (
 	start: string,
 	end: string,
 	options: {
+		readonly precision: WindowPrecision
 		readonly maxSeconds?: number
 		readonly rangeLabel?: string
-		readonly precision?: WindowPrecision
-	} = {},
+	},
 ) =>
 	Effect.gen(function* () {
 		const startMs = Date.parse(start)
@@ -512,6 +517,7 @@ export const HttpV2TracesLive = HttpApiBuilder.group(MapleApiV2, "traces", (hand
 					const window = yield* parseWindow(payload.start_time, payload.end_time, {
 						maxSeconds: MAX_SEARCH_RANGE_SECONDS,
 						rangeLabel: "Trace search",
+						precision: "millisecond",
 					})
 					const limit = payload.limit ?? 20
 					const cursorParts = yield* decodeKeysetCursor(payload.cursor, "trc", 2)
@@ -565,6 +571,7 @@ export const HttpV2TracesLive = HttpApiBuilder.group(MapleApiV2, "traces", (hand
 					const window = yield* parseWindow(payload.start_time, payload.end_time, {
 						maxSeconds: MAX_QUERY_RANGE_SECONDS,
 						rangeLabel: "Trace timeseries",
+						precision: "millisecond",
 					})
 					const bucketSeconds = yield* validateTimeseriesBucket(
 						payload.start_time,
@@ -614,6 +621,7 @@ export const HttpV2TracesLive = HttpApiBuilder.group(MapleApiV2, "traces", (hand
 					const window = yield* parseWindow(payload.start_time, payload.end_time, {
 						maxSeconds: MAX_BREAKDOWN_RANGE_SECONDS,
 						rangeLabel: "Trace breakdown",
+						precision: "millisecond",
 					})
 					yield* validateBreakdownRange(window.rangeSeconds, payload.filters)
 					const request = yield* decodeQueryEngineRequest(
@@ -711,6 +719,7 @@ export const HttpV2LogsLive = HttpApiBuilder.group(MapleApiV2, "logs", (handlers
 					const window = yield* parseWindow(payload.start_time, payload.end_time, {
 						maxSeconds: MAX_SEARCH_RANGE_SECONDS,
 						rangeLabel: "Log search",
+						precision: "millisecond",
 					})
 					const limit = payload.limit ?? 20
 					const cursorParts = yield* decodeKeysetCursor(payload.cursor, "log", 5)
@@ -764,6 +773,7 @@ export const HttpV2LogsLive = HttpApiBuilder.group(MapleApiV2, "logs", (handlers
 					const window = yield* parseWindow(payload.start_time, payload.end_time, {
 						maxSeconds: MAX_QUERY_RANGE_SECONDS,
 						rangeLabel: "Log timeseries",
+						precision: "millisecond",
 					})
 					const bucketSeconds = yield* validateTimeseriesBucket(
 						payload.start_time,
@@ -809,6 +819,7 @@ export const HttpV2LogsLive = HttpApiBuilder.group(MapleApiV2, "logs", (handlers
 					const window = yield* parseWindow(payload.start_time, payload.end_time, {
 						maxSeconds: MAX_BREAKDOWN_RANGE_SECONDS,
 						rangeLabel: "Log breakdown",
+						precision: "millisecond",
 					})
 					yield* validateBreakdownRange(window.rangeSeconds, payload.filters)
 					const request = yield* decodeQueryEngineRequest(
@@ -879,7 +890,11 @@ export const HttpV2MetricsLive = HttpApiBuilder.group(MapleApiV2, "metrics", (ha
 			.handle("list", ({ query }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
-					const window = yield* parseWindow(query.start_time, query.end_time)
+					// `metric_catalog.Hour` is a plain DateTime — a fractional bound is a
+					// hard TYPE_MISMATCH, not a rounding difference.
+					const window = yield* parseWindow(query.start_time, query.end_time, {
+						precision: "second",
+					})
 					const page = yield* paginateOffsetQuery(query, ({ limit, offset }) => {
 						const compiled = CH.compile(
 							CH.listMetricsQuery({
@@ -924,6 +939,7 @@ export const HttpV2MetricsLive = HttpApiBuilder.group(MapleApiV2, "metrics", (ha
 					const window = yield* parseWindow(payload.start_time, payload.end_time, {
 						maxSeconds: MAX_QUERY_RANGE_SECONDS,
 						rangeLabel: "Metric timeseries",
+						precision: "millisecond",
 					})
 					const bucketSeconds = yield* validateTimeseriesBucket(
 						payload.start_time,
@@ -973,6 +989,7 @@ export const HttpV2MetricsLive = HttpApiBuilder.group(MapleApiV2, "metrics", (ha
 					const window = yield* parseWindow(payload.start_time, payload.end_time, {
 						maxSeconds: MAX_BREAKDOWN_RANGE_SECONDS,
 						rangeLabel: "Metric breakdown",
+						precision: "millisecond",
 					})
 					yield* validateBreakdownRange(window.rangeSeconds, payload.filters)
 					const request = yield* decodeQueryEngineRequest(


### PR DESCRIPTION
Fixes five open error issues that turn out to be two instances of one shape: a time string that isn't a valid warehouse `DateTime` gets spliced into SQL and only fails at ClickHouse, as a 500 the caller can't act on.

## 1. MCP tools passed agent garbage straight through

`normalizeTime` returned unparseable input verbatim. An auto-investigation agent sent `start_time="2026-08-47:53"` to `explore_attributes`; that reached ClickHouse as `toDateTime('2026-08-47:53')` and surfaced as an unhandled `McpQueryError` + `WarehouseMalformedQueryError`.

- `normalizeTime` now returns `null` when the input isn't a timestamp.
- `resolveTimeRange` reports the bad bound in a new `invalid` array and substitutes the default window's bound for it, so `st`/`et` are always a well-formed warehouse DateTime — even for a caller that doesn't check the flag. Nothing malformed can reach the warehouse from this path any more.
- The ten tools that already guard `exceeded` now also return `timeRangeInvalidResult`, which names the offending value and states the accepted formats, so the agent gets a retryable tool error instead of a parse failure.
- `invalid` suppresses `exceeded`: a garbage bound collapses to the default window, whose width is under any cap, and reporting "range too large" there would send the agent chasing the wrong fix.

Issues: `55157217-4c27-488e-b944-136c5297c153`, `125b5b63-652f-4ac2-be76-79a78d264770`

## 2. `v2ListMetrics` sent fractional seconds to a plain `DateTime` column

`parseWindow`'s `precision` option defaulted to `"millisecond"`, but the `metrics.list` handler reads `metric_catalog.Hour`, which is a plain `DateTime`. Every call emitted `toDateTime('2026-08-24 22:54:36.000')` and failed with `Cannot parse string … as DateTime`, plus a matching `TYPE_MISMATCH` on the `Hour <= …` bound.

The hazard was already documented in the `WindowPrecision` doc comment — the default just made it opt-in. So:

- The handler now asks for `precision: "second"`.
- `precision` is **required**. The eight raw-signal handlers (traces/logs/metrics on `DateTime64` tables) state `"millisecond"` explicitly, which is exactly their current behaviour — no functional change there. The next rollup-backed handler can no longer inherit the unsafe default by omission.

Issues: `7010ecde-46f5-4835-8ddd-04c4122ae3f2`, `2669196c-efe8-435c-a48c-1005696d6675`, `c66b38fd-3ab9-4cdb-95ad-418f86edd336`

## Testing

- `apps/api` MCP suite: 364 passed
- `time.test.ts`: 26 passed, including the real `2026-08-47:53` input, both-bounds-invalid, and the invalid-beats-exceeded precedence
- `telemetry.http.test.ts`: 11 passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790253476&installation_model_id=427786&pr_number=627&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F627&signature=aa4c2f92c833981b46078d939dc2963f7beecc68ff4f1992275e689888bfd029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->