### PR TITLE
test(cli): give each complete-journal invariant case its own test

### DIFF
--- a/apps/cli/test/archive-generation.test.ts
+++ b/apps/cli/test/archive-generation.test.ts
@@ -225,6 +225,69 @@ const seedPublishedOperation = async (
 	}
 }
 
+/**
+ * Reconcile must refuse to retire a complete operation's journal while any one of the durable
+ * invariants it implies is inexact — and each of these is a distinct way to be inexact.
+ *
+ * One `it` per scenario rather than a loop inside one: each case seeds a whole archive on disk, so
+ * a single test's wall time was the sum of all seven against one 5s budget, and it timed out on a
+ * loaded CI runner at 5002ms. Per-case tests also name the scenario that failed in the test name.
+ */
+const COMPLETE_JOURNAL_CASES: ReadonlyArray<{
+	name: string
+	mutate: (seeded: Awaited<ReturnType<typeof seedPublishedOperation>>) => void
+	error: RegExp
+}> = [
+	{
+		name: "manifest",
+		mutate: (s) => writeFileSync(s.finalManifestPath, "{}\n"),
+		error: /manifest SHA-256 mismatch/,
+	},
+	{
+		name: "shard",
+		mutate: (s) => writeFileSync(s.finalShardPath, "tampered"),
+		error: /shard 00\.parquet (byte size|SHA-256) mismatch/,
+	},
+	{
+		name: "pointer",
+		mutate: (s) => rmSync(activePointerPath(s.archiveDir, "traces", "2026-06-01")),
+		error: /pointer mismatch/,
+	},
+	{
+		name: "catalog",
+		mutate: (s) => writeFileSync(catalogPath(s.archiveDir, "traces"), "{}\n"),
+		error: /catalog does not exactly match/,
+	},
+	{
+		name: "pin",
+		mutate: (s) => {
+			const pinPath = join(checkpointPinsRoot(s.dataDir), s.checkpointId, `${s.pinId}.json`)
+			mkdirSync(join(pinPath, ".."), { recursive: true })
+			writeFileSync(
+				pinPath,
+				`${JSON.stringify({
+					formatVersion: 1,
+					pinId: s.pinId,
+					checkpointId: s.checkpointId,
+					purpose: `archive:${s.generationId}`,
+					createdAt: new Date().toISOString(),
+				})}\n`,
+			)
+		},
+		error: /requires its exact owned pin to be absent/,
+	},
+	{
+		name: "scratch",
+		mutate: (s) => mkdirSync(join(s.scratchRoot, `archive-${s.operationId}`), { recursive: true }),
+		error: /requires its exact owned scratch to be absent/,
+	},
+	{
+		name: "building",
+		mutate: (s) => mkdirSync(buildingGenerationRoot(s.archiveDir, s.generationId), { recursive: true }),
+		error: /both building and final generation state/,
+	},
+]
+
 describe("archive generation promotion", () => {
 	it("preflights archive and scratch independently on separate devices", () => {
 		assertArchiveScratchFreeSpace(
@@ -693,67 +756,10 @@ describe("archive generation promotion", () => {
 		})
 	})
 
-	it("retains a complete journal unless every implied durable invariant is exact", async () => {
-		await withArchive(async (outerArchiveDir) => {
-			const root = join(outerArchiveDir, "..")
-			const cases: ReadonlyArray<{
-				name: string
-				mutate: (seeded: Awaited<ReturnType<typeof seedPublishedOperation>>) => void
-				error: RegExp
-			}> = [
-				{
-					name: "manifest",
-					mutate: (s) => writeFileSync(s.finalManifestPath, "{}\n"),
-					error: /manifest SHA-256 mismatch/,
-				},
-				{
-					name: "shard",
-					mutate: (s) => writeFileSync(s.finalShardPath, "tampered"),
-					error: /shard 00\.parquet (byte size|SHA-256) mismatch/,
-				},
-				{
-					name: "pointer",
-					mutate: (s) => rmSync(activePointerPath(s.archiveDir, "traces", "2026-06-01")),
-					error: /pointer mismatch/,
-				},
-				{
-					name: "catalog",
-					mutate: (s) => writeFileSync(catalogPath(s.archiveDir, "traces"), "{}\n"),
-					error: /catalog does not exactly match/,
-				},
-				{
-					name: "pin",
-					mutate: (s) => {
-						const pinPath = join(checkpointPinsRoot(s.dataDir), s.checkpointId, `${s.pinId}.json`)
-						mkdirSync(join(pinPath, ".."), { recursive: true })
-						writeFileSync(
-							pinPath,
-							`${JSON.stringify({
-								formatVersion: 1,
-								pinId: s.pinId,
-								checkpointId: s.checkpointId,
-								purpose: `archive:${s.generationId}`,
-								createdAt: new Date().toISOString(),
-							})}\n`,
-						)
-					},
-					error: /requires its exact owned pin to be absent/,
-				},
-				{
-					name: "scratch",
-					mutate: (s) =>
-						mkdirSync(join(s.scratchRoot, `archive-${s.operationId}`), { recursive: true }),
-					error: /requires its exact owned scratch to be absent/,
-				},
-				{
-					name: "building",
-					mutate: (s) =>
-						mkdirSync(buildingGenerationRoot(s.archiveDir, s.generationId), { recursive: true }),
-					error: /both building and final generation state/,
-				},
-			]
-			for (const scenario of cases) {
-				const archiveDir = join(root, `complete-${scenario.name}`, "archive")
+	for (const scenario of COMPLETE_JOURNAL_CASES) {
+		it(`retains a complete journal when the ${scenario.name} invariant is inexact`, async () => {
+			await withArchive(async (outerArchiveDir) => {
+				const archiveDir = join(outerArchiveDir, "..", `complete-${scenario.name}`, "archive")
 				mkdirSync(archiveDir, { recursive: true })
 				const seeded = await seedPublishedOperation(archiveDir, "complete", {
 					pointer: true,
@@ -764,13 +770,10 @@ describe("archive generation promotion", () => {
 					reconcileArchiveGeneration(seeded.dataDir, archiveDir, seeded.scratchRoot),
 					scenario.error,
 				)
-				ok(
-					existsSync(operationDir(archiveDir, seeded.operationId)),
-					`${scenario.name}: active journal retained`,
-				)
-			}
+				ok(existsSync(operationDir(archiveDir, seeded.operationId)), "active journal retained")
+			})
 		})
-	})
+	}
 })
 
 describe("archive catalog append", () => {


### PR DESCRIPTION
Stacked on #626.

## Why

`retains a complete journal unless every implied durable invariant is exact` in `apps/cli/test/archive-generation.test.ts` looped a table of **seven** scenarios inside a single `it`. Each case seeds a whole archive on disk — manifest, shard, pointer, catalog, pin, scratch, building — so one 5s budget had to cover the sum of all seven.

It timed out on a loaded CI runner at **5002.38ms**, a 2ms margin, and took #626 red with it. That PR touches nothing in `apps/cli`; a re-run of the same commit went green, which is what identified this as structural rather than a real failure.

## What changed

The scenario table is hoisted to `COMPLETE_JOURNAL_CASES` and emitted as one `it` per case.

- **Each case gets its own budget.** Locally the seven cost ~6-8ms each; previously their sum raced a single 5s timeout, now none of them is near one.
- **A failure names the invariant.** `retains a complete journal when the pin invariant is inexact` instead of one test name plus an assertion message identifying the iteration.
- **Better isolation.** Each case gets its own temp archive via `withArchive` rather than sharing one parent directory across all seven.

Nothing under test changes: same seven mutations, same expected rejection patterns, same retained-journal assertion.

## Note on scope

This removes the amplification — seven cases sharing one budget — which is the part that made a marginal runner stall fatal. It is not a claim that the underlying CI slowness is explained: the aggregate is ~48ms locally against 5002ms on CI, and I did not chase that gap. I deliberately did **not** raise the timeout, since an explicit bump would mask a genuine hang rather than fix the shape of the test.

## Verification

- `bun run --cwd apps/cli test` — 517 pass, 0 fail (was 511; +7 cases, −1 combined)
- `bun run --cwd apps/cli typecheck`, `bun run lint`, `oxfmt --list-different` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790254097&installation_model_id=427786&pr_number=628&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F628&signature=ebf2a835218c01d2f95e35aa81d964cd48ae0e861c73b3b8b3577bb334b08e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->