### PR TITLE
feat(web): render transcript text as markdown and payloads as JSON

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/clamped-text.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/clamped-text.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react"
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react"
 
 import { cn } from "@maple/ui/lib/utils"
 
@@ -19,6 +19,12 @@ const CLAMP_CLASS = "line-clamp-[12]"
  */
 export function ClampedText({
 	text,
+	/** Pre-highlighted markup for the body (sugar-high output). `text` stays the
+	 *  source of truth — it is what overflows measurement and copies see. */
+	html,
+	/** A rendered body (markdown, say) that clamps in place of the raw text.
+	 *  Wins over `html`; the clamp still measures whatever actually rendered. */
+	body,
 	mono = false,
 	/** Lines before clamping; the default is the expansion's twelve. */
 	clampClass = CLAMP_CLASS,
@@ -28,6 +34,8 @@ export function ClampedText({
 	onToggleExpanded,
 }: {
 	text: string
+	html?: string
+	body?: ReactNode
 	mono?: boolean
 	clampClass?: string
 	toneClass?: string
@@ -51,16 +59,21 @@ export function ClampedText({
 			<div
 				ref={bodyRef}
 				className={cn(
-					"whitespace-pre-wrap break-words",
+					// A rendered body lays out its own blocks; pre-wrap is for raw text.
+					body === undefined && "whitespace-pre-wrap",
+					"break-words",
 					mono
 						? "font-mono text-muted-foreground text-xs leading-relaxed"
 						: "max-w-[70rem] text-foreground text-sm leading-relaxed",
 					toneClass,
 					!expanded && clampClass,
 				)}
-			>
-				{text}
-			</div>
+				{...(body !== undefined
+					? { children: body }
+					: html === undefined
+						? { children: text }
+						: { dangerouslySetInnerHTML: { __html: html } })}
+			/>
 			{(clamped || expanded) && (
 				<button
 					type="button"

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -4,9 +4,12 @@ import { useVirtualizer } from "@tanstack/react-virtual"
 
 import type { AiSessionSpan } from "@maple/domain/http"
 import { Button } from "@maple/ui/components/ui/button"
+import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { formatBytes, formatDuration, formatNumber } from "@maple/ui/lib/format"
 import { cn } from "@maple/ui/lib/utils"
 
+import { MessageResponse } from "@/components/ai-elements/message-response"
+import { tryParseJson } from "@/components/attributes"
 import {
 	AlertWarningIcon,
 	BranchForkIcon,
@@ -21,6 +24,7 @@ import {
 	ExternalLinkIcon,
 	FaceRobotIcon,
 	GearIcon,
+	PixelBracketsCurlyIcon,
 	PixelSparkleIcon,
 	UserIcon,
 	type IconComponent,
@@ -37,6 +41,7 @@ import {
 	type TranscriptRow,
 } from "@/lib/agent-sessions/session-transcript"
 import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
+import { highlightCode } from "@/lib/sugar-high"
 import { formatClockInTimezone } from "@/lib/timezone-format"
 import { ClampedText, firstLine } from "./clamped-text"
 import { Pill } from "./pill"
@@ -433,6 +438,8 @@ function UserBlock({
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "user" }> }) {
 	const historyKey = `${row.key}:history`
 	const showHistory = disclosed(openRows, historyKey, false)
+	const rawKey = `${row.key}:raw`
+	const raw = disclosed(openRows, rawKey, false)
 
 	return (
 		<Row time={clockOf(row.startMs, timeZone)} depth={row.depth} rail="bg-foreground" className="pt-5">
@@ -456,10 +463,17 @@ function UserBlock({
 							{showHistory ? "hide full history" : "show full history"}
 						</button>
 					)}
+					<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} className="-my-1" />
 				</div>
-				<p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
-					{row.text}
-				</p>
+				{raw ? (
+					<p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
+						{row.text}
+					</p>
+				) : (
+					<MessageResponse className="text-foreground text-sm leading-relaxed">
+						{row.text}
+					</MessageResponse>
+				)}
 				{showHistory && (
 					<div className="flex flex-col gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2.5">
 						{/* The history verbatim, not a diff: dropped and truncated
@@ -500,6 +514,8 @@ function SystemBlock({
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "system" }> }) {
 	const open = disclosed(openRows, row.key, false)
 	const textKey = `${row.key}:text`
+	const rawKey = `${row.key}:raw`
+	const raw = disclosed(openRows, rawKey, false)
 
 	return (
 		<Row depth={row.depth} rail="bg-muted-foreground/40" className="pt-3.5">
@@ -532,12 +548,18 @@ function SystemBlock({
 				)}
 			</button>
 			{open && (
-				<div className="pb-2 pl-6">
-					<ClampedText
-						text={row.text}
-						expanded={disclosed(openRows, textKey, false)}
-						onToggleExpanded={() => onToggleRow(textKey)}
-					/>
+				<div className="flex items-start gap-1.5 pb-2 pl-6">
+					<div className="min-w-0 grow">
+						<ClampedText
+							text={row.text}
+							body={raw ? undefined : <MessageResponse className="text-sm">{row.text}</MessageResponse>}
+							expanded={disclosed(openRows, textKey, false)}
+							onToggleExpanded={() => onToggleRow(textKey)}
+						/>
+					</div>
+					<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} className="-my-1" />
+					{/* Copies the prompt as captured, not its rendering. */}
+					<CopyButton value={row.text} label="system prompt" className="-my-1 shrink-0" />
 				</div>
 			)}
 		</Row>
@@ -547,12 +569,22 @@ function SystemBlock({
 function AssistantBlock({
 	row,
 	timeZone,
+	openRows,
+	onToggleRow,
 	selected,
 	onSelectSpan,
 	onOpenTraceView,
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "assistant" }> }) {
 	const tone = row.failed ? "text-destructive" : "text-chart-2"
 	const Glyph = row.failed ? CircleWarningIcon : PixelSparkleIcon
+	// The failure payload some providers put in the status message — often a
+	// whole JSON error envelope, so it gets the same JSON treatment as a tool
+	// payload. Empty where the call succeeded, and the hook is cheap on "".
+	const error = useJsonPayload(row.failed ? row.span.statusMessage : "")
+	const rawKey = `${row.key}:raw`
+	const raw = disclosed(openRows, rawKey, false)
+	const errorRawKey = `${row.key}:error-raw`
+	const errorRaw = disclosed(openRows, errorRawKey, false)
 
 	return (
 		<Row
@@ -581,19 +613,49 @@ function AssistantBlock({
 						error.type {row.span.genAi.errorType}
 					</Pill>
 				)}
+				{row.text !== undefined && (
+					<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} className="-my-1" />
+				)}
 				{selected && <OpenInTraces span={row.span} onOpenTraceView={onOpenTraceView} />}
 			</div>
-			{row.text !== undefined && (
-				<p className="whitespace-pre-wrap break-words pt-2.5 text-foreground text-sm leading-relaxed">
-					{row.text}
-				</p>
-			)}
+			{row.text !== undefined &&
+				(raw ? (
+					<p className="whitespace-pre-wrap break-words pt-2.5 text-foreground text-sm leading-relaxed">
+						{row.text}
+					</p>
+				) : (
+					<MessageResponse className="pt-2.5 text-foreground text-sm leading-relaxed">
+						{row.text}
+					</MessageResponse>
+				))}
 			{row.failed && (
 				<div className="flex flex-col gap-1.5 pt-2.5">
 					{row.span.statusMessage !== "" && (
-						<p className="whitespace-pre-wrap break-words font-mono text-[13px] text-destructive/90 leading-relaxed">
-							{row.span.statusMessage}
-						</p>
+						<div className="flex items-start gap-1.5">
+							<div className="min-w-0 grow">
+								<ClampedText
+									text={errorRaw ? row.span.statusMessage : error.formatted}
+									html={errorRaw ? undefined : error.highlighted}
+									mono
+									clampClass="line-clamp-[14]"
+									toneClass="text-[13px] text-destructive/90"
+									expanded={disclosed(openRows, `${row.key}:error-text`, false)}
+									onToggleExpanded={() => onToggleRow(`${row.key}:error-text`)}
+								/>
+							</div>
+							{error.highlighted !== undefined && (
+								<RawToggle
+									raw={errorRaw}
+									onToggle={() => onToggleRow(errorRawKey)}
+									className="-my-1"
+								/>
+							)}
+							<CopyButton
+								value={errorRaw ? row.span.statusMessage : error.formatted}
+								label="error message"
+								className="-my-1 shrink-0"
+							/>
+						</div>
 					)}
 					{/* Never "the agent gave up": what the span supports is that this
 					    call produced nothing. A retry, if there was one, is its own row. */}
@@ -615,7 +677,12 @@ function AssistantBlock({
 function PromptBlock({
 	row,
 	timeZone,
+	openRows,
+	onToggleRow,
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "prompt" }> }) {
+	const rawKey = `${row.key}:raw`
+	const raw = disclosed(openRows, rawKey, false)
+
 	return (
 		<Row time={clockOf(row.startMs, timeZone)} depth={row.depth} rail="bg-chart-2" className="pt-3">
 			<div className="flex flex-col gap-2.5">
@@ -625,10 +692,17 @@ function PromptBlock({
 					<span className={META}>{callMetaLine(row.span)}</span>
 					<span className="grow" />
 					<span className={cn(META, "shrink-0")}>{row.span.serviceName}</span>
+					<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} className="-my-1" />
 				</div>
-				<p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
-					{row.text}
-				</p>
+				{raw ? (
+					<p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
+						{row.text}
+					</p>
+				) : (
+					<MessageResponse className="text-foreground text-sm leading-relaxed">
+						{row.text}
+					</MessageResponse>
+				)}
 				<InlineNote>
 					The reply isn't captured. This emitter records{" "}
 					<span className="font-mono">gen_ai.input.messages</span> but not{" "}
@@ -821,6 +895,59 @@ function payloadSummary(row: Extract<TranscriptRow, { kind: "tool" }>): string {
 	return ` · ${parts.join(" · ")}`
 }
 
+/**
+ * A payload body, pretty-printed and highlighted where it parses as JSON
+ * (object or array — same test as the log body), verbatim otherwise. An
+ * emitter-truncated prefix fails the parse and stays verbatim, which is right:
+ * pretty-printing a fragment would dress it up as a whole document.
+ */
+function useJsonPayload(text: string): { formatted: string; highlighted: string | undefined } {
+	return useMemo(() => {
+		const parsed = tryParseJson(text)
+		if (parsed === null) return { formatted: text, highlighted: undefined }
+		const formatted = JSON.stringify(parsed, null, 2)
+		return { formatted, highlighted: highlightCode(formatted) }
+	}, [text])
+}
+
+/**
+ * The rendered ↔ raw switch. Markdown layout and pretty-printed JSON are
+ * readings of the capture, and a reading can hide things — whitespace, key
+ * order, a literal `**` — so every rendered body keeps a way back to the
+ * captured bytes. Held in `openRows` like every other flipped default, so the
+ * choice survives the row scrolling out of the virtualizer.
+ */
+function RawToggle({
+	raw,
+	onToggle,
+	className,
+}: {
+	raw: boolean
+	onToggle: () => void
+	className?: string
+}) {
+	return (
+		<Button
+			variant="ghost"
+			size="icon-xs"
+			aria-pressed={raw}
+			aria-label={raw ? "Show rendered" : "Show raw text"}
+			title={raw ? "Show rendered" : "Show raw text"}
+			onClick={(event) => {
+				event.stopPropagation()
+				onToggle()
+			}}
+			className={cn(
+				"shrink-0 text-muted-foreground hover:text-foreground",
+				raw && "bg-accent text-foreground",
+				className,
+			)}
+		>
+			<PixelBracketsCurlyIcon />
+		</Button>
+	)
+}
+
 function PayloadSection({
 	label,
 	payload,
@@ -840,6 +967,10 @@ function PayloadSection({
 	onToggleRow: (key: string) => void
 	textKey: string
 }) {
+	const { formatted, highlighted } = useJsonPayload(payload.text)
+	const rawKey = `${textKey}:raw`
+	const raw = disclosed(openRows, rawKey, false)
+
 	return (
 		<div className={cn("flex flex-col gap-2 px-3 pt-2.5 pb-3", bordered && "border-border/60 border-t")}>
 			<div className="flex flex-wrap items-center gap-2">
@@ -858,12 +989,23 @@ function PayloadSection({
 						truncated by the emitter
 					</Pill>
 				)}
+				{/* Copies what is displayed: the pretty-printed JSON, or the raw text.
+				    The switch only appears where the two differ. */}
+				{payload.text !== "" && (
+					<span className="-my-1 ml-auto flex items-center">
+						{highlighted !== undefined && (
+							<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} />
+						)}
+						<CopyButton value={raw ? payload.text : formatted} label={label.toLowerCase()} />
+					</span>
+				)}
 			</div>
 			{/* An emitter that recorded the truncation but kept no prefix leaves
 			    nothing to show; an empty card would read as an empty payload. */}
 			{payload.text !== "" && (
 				<ClampedText
-					text={payload.text}
+					text={raw ? payload.text : formatted}
+					html={raw ? undefined : highlighted}
 					mono
 					clampClass="line-clamp-[14]"
 					toneClass={tone}

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -24,7 +24,6 @@ import {
 	ExternalLinkIcon,
 	FaceRobotIcon,
 	GearIcon,
-	PixelBracketsCurlyIcon,
 	PixelSparkleIcon,
 	UserIcon,
 	type IconComponent,
@@ -463,7 +462,11 @@ function UserBlock({
 							{showHistory ? "hide full history" : "show full history"}
 						</button>
 					)}
-					<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} className="-my-1" />
+					<ViewSwitch
+						rendered="md"
+						raw={raw}
+						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
+					/>
 				</div>
 				{raw ? (
 					<p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
@@ -557,7 +560,11 @@ function SystemBlock({
 							onToggleExpanded={() => onToggleRow(textKey)}
 						/>
 					</div>
-					<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} className="-my-1" />
+					<ViewSwitch
+						rendered="md"
+						raw={raw}
+						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
+					/>
 					{/* Copies the prompt as captured, not its rendering. */}
 					<CopyButton value={row.text} label="system prompt" className="-my-1 shrink-0" />
 				</div>
@@ -614,7 +621,11 @@ function AssistantBlock({
 					</Pill>
 				)}
 				{row.text !== undefined && (
-					<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} className="-my-1" />
+					<ViewSwitch
+						rendered="md"
+						raw={raw}
+						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
+					/>
 				)}
 				{selected && <OpenInTraces span={row.span} onOpenTraceView={onOpenTraceView} />}
 			</div>
@@ -644,10 +655,11 @@ function AssistantBlock({
 								/>
 							</div>
 							{error.highlighted !== undefined && (
-								<RawToggle
+								<ViewSwitch
+									rendered="json"
 									raw={errorRaw}
-									onToggle={() => onToggleRow(errorRawKey)}
-									className="-my-1"
+									onRawChange={(next) => next !== errorRaw && onToggleRow(errorRawKey)}
+									className="self-start"
 								/>
 							)}
 							<CopyButton
@@ -692,7 +704,11 @@ function PromptBlock({
 					<span className={META}>{callMetaLine(row.span)}</span>
 					<span className="grow" />
 					<span className={cn(META, "shrink-0")}>{row.span.serviceName}</span>
-					<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} className="-my-1" />
+					<ViewSwitch
+						rendered="md"
+						raw={raw}
+						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
+					/>
 				</div>
 				{raw ? (
 					<p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
@@ -911,40 +927,72 @@ function useJsonPayload(text: string): { formatted: string; highlighted: string 
 }
 
 /**
- * The rendered ↔ raw switch. Markdown layout and pretty-printed JSON are
+ * The rendered ↔ raw selector. Markdown layout and pretty-printed JSON are
  * readings of the capture, and a reading can hide things — whitespace, key
  * order, a literal `**` — so every rendered body keeps a way back to the
- * captured bytes. Held in `openRows` like every other flipped default, so the
- * choice survives the row scrolling out of the virtualizer.
+ * captured bytes. Two labelled segments where the selected one is the view the
+ * reader is IN: a lone pressed icon named either the current view or the one a
+ * click would bring, depending on who read it. Held in `openRows` like every
+ * other flipped default, so the choice survives the row scrolling out of the
+ * virtualizer.
  */
-function RawToggle({
+function ViewSwitch({
+	rendered,
 	raw,
-	onToggle,
+	onRawChange,
 	className,
 }: {
+	/** The rendered segment's label — what the rendering IS: "md" or "json". */
+	rendered: string
 	raw: boolean
-	onToggle: () => void
+	onRawChange: (raw: boolean) => void
 	className?: string
 }) {
 	return (
-		<Button
-			variant="ghost"
-			size="icon-xs"
-			aria-pressed={raw}
-			aria-label={raw ? "Show rendered" : "Show raw text"}
-			title={raw ? "Show rendered" : "Show raw text"}
-			onClick={(event) => {
-				event.stopPropagation()
-				onToggle()
-			}}
+		<span
+			role="group"
+			aria-label="Body view"
 			className={cn(
-				"shrink-0 text-muted-foreground hover:text-foreground",
-				raw && "bg-accent text-foreground",
+				"flex shrink-0 items-center self-center overflow-hidden rounded-sm border border-border",
 				className,
 			)}
 		>
-			<PixelBracketsCurlyIcon />
-		</Button>
+			<ViewSegment active={!raw} onSelect={() => onRawChange(false)}>
+				{rendered}
+			</ViewSegment>
+			<ViewSegment active={raw} onSelect={() => onRawChange(true)}>
+				raw
+			</ViewSegment>
+		</span>
+	)
+}
+
+function ViewSegment({
+	active,
+	onSelect,
+	children,
+}: {
+	active: boolean
+	onSelect: () => void
+	children: string
+}) {
+	return (
+		<button
+			type="button"
+			aria-pressed={active}
+			onClick={(event) => {
+				event.stopPropagation()
+				onSelect()
+			}}
+			className={cn(
+				"cursor-pointer px-1.5 py-px font-mono text-[10px] uppercase tracking-[0.08em]",
+				active
+					? "bg-accent text-foreground"
+					: "text-muted-foreground hover:text-foreground",
+			)}
+		>
+			{children}
+		</button>
 	)
 }
 
@@ -994,7 +1042,12 @@ function PayloadSection({
 				{payload.text !== "" && (
 					<span className="-my-1 ml-auto flex items-center">
 						{highlighted !== undefined && (
-							<RawToggle raw={raw} onToggle={() => onToggleRow(rawKey)} />
+							<ViewSwitch
+								rendered="json"
+								raw={raw}
+								onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
+								className="mr-1"
+							/>
 						)}
 						<CopyButton value={raw ? payload.text : formatted} label={label.toLowerCase()} />
 					</span>

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -65,7 +65,7 @@ export function SessionViews({
 	const [collapseIdle, setCollapseIdle] = useState(true)
 	const [mergeRepeats, setMergeRepeats] = useState(false)
 	const [showThinking, setShowThinking] = useState(true)
-	const [showPayloads, setShowPayloads] = useState(true)
+	const [showPayloads, setShowPayloads] = useState(false)
 	// The views unmount when the view changes, so what the reader opened,
 	// collapsed or zoomed lives here — otherwise a look at Flow and back costs
 	// them the place they had found in a 600-span session.

--- a/apps/web/src/lab/agent-session-fixture.ts
+++ b/apps/web/src/lab/agent-session-fixture.ts
@@ -130,6 +130,21 @@ const TURNS: readonly TurnPlan[] = [
 
 const CONTEXT_ERROR = "prompt is too long: 214832 tokens > 200000 maximum"
 
+/** A turn's closing reply, in markdown — the transcript renders assistant text
+ *  through the markdown pipeline, so the lab has to show it some. */
+const CLOSING_REPLY = [
+	"The backoff is fixed at 30s with **no jitter** — that window is exactly where the duplicate charges land. Two changes:",
+	"",
+	"1. Exponential backoff with full jitter",
+	"2. An idempotency key on the charge call itself",
+	"",
+	"```ts",
+	"const delay = Math.random() * Math.min(cap, base * 2 ** attempt)",
+	"```",
+	"",
+	"The `webhooks` suite passes with the regression test included.",
+].join("\n")
+
 /**
  * One model call's attributes: usage that grows with the conversation the way a
  * real context window does, plus the things only some calls carry — the
@@ -162,8 +177,12 @@ function callAttributes(input: {
 						parts: [
 							{
 								type: "text",
+								// The closing call answers in markdown; the ones that go on
+								// to dispatch a tool stay one plain sentence.
 								content:
-									"I'll read the retry handler before changing anything — the fixed delay is only half the story, the idempotency key is what decides whether a duplicate delivery is charged twice.",
+									input.tool === undefined
+										? CLOSING_REPLY
+										: "I'll read the retry handler before changing anything — the fixed delay is only half the story, the idempotency key is what decides whether a duplicate delivery is charged twice.",
 							},
 							...(input.tool === undefined
 								? []
@@ -383,8 +402,17 @@ function buildBaseTurns(): readonly AiSessionSpan[] {
 // through a later call's history, a turn with no captured content at all, a
 // turn whose capture changes emitter mid-way, and a compaction.
 
-const INVESTIGATION_SYSTEM =
-	"You are the Maple investigation planner. You have read-only access to this org's traces, logs and metrics. Prefer evidence from spans over inference from code. Never state a cause you cannot point at a query for."
+// Markdown on purpose: system prompts are usually authored as it, and the
+// transcript's expanded System block renders them through the markdown pipeline.
+const INVESTIGATION_SYSTEM = [
+	"You are the **Maple investigation planner**. You have read-only access to this org's traces, logs and metrics.",
+	"",
+	"## Rules",
+	"",
+	"- Prefer evidence from spans over inference from code.",
+	"- Never state a cause you cannot point at a query for.",
+	"- Quote span attributes verbatim, e.g. `db.query.fingerprint`.",
+].join("\n")
 
 const INVESTIGATION_PROMPT =
 	"p95 checkout latency tripled after the 14:20 deploy — find what changed. Don't guess from the deploy diff, read the traces."


### PR DESCRIPTION
Follow-up to #624: the Transcript view rendered every captured body as plain pre-wrapped text. This gives each kind of body the reading it deserves, while keeping the captured bytes one click away.

## What changed

**Markdown for message text.** User, assistant, prompt and (expanded) system bodies render through the existing `MessageResponse` pipeline (Streamdown + Shiki/KaTeX/Mermaid), so replies with code fences, lists and inline code read the way the chat surfaces already do. The collapsed system preview stays the plain first line — a one-line elision of markdown source reads better raw.

**JSON detection for payloads.** Tool arguments/results, subagent task prompts/returns and failed-call status messages go through a shared `useJsonPayload` hook: the same `tryParseJson` object/array test the log body uses, then pretty-print + sugar-high highlighting on a hit. Everything else stays verbatim — including an emitter-truncated prefix, which fails the parse on purpose rather than being dressed up as a whole document. Each payload gets a copy button that copies what is displayed.

**A rendered ↔ raw selector on every rendered body.** Rendering is a reading of the capture, and a reading can hide things — whitespace, key order, a literal `**`. Each rendered body carries a small segment pair (`md | raw` on message text, `json | raw` on payloads) where the selected segment is the view you are in; switching to raw shows the captured text verbatim and points the copy button at it. The pair only appears where the two views actually differ, and the choice lives in the existing `openRows` set so it survives the row scrolling out of the virtualizer.

**Tool payloads start collapsed.** The "Tool payloads" chip now defaults off; every card opens on its one-line size summary.

`ClampedText` gained `html` (highlighted markup) and `body` (rendered node) modes so all of the above still clamps and "Show full"s identically; `text` remains the measurement source. The lab fixture's closing replies and investigation system prompt are now markdown so `/lab/agent-session` exercises the new paths.

## Verification

- All 250 agent-session tests and `tsc` pass.
- Verified in the lab harness: markdown replies render and switch to raw source, JSON arguments pretty-print/highlight and switch to the captured one-liner, plain-text payloads show no selector, the failed-call error renders with its copy button, and virtualized rows re-measure cleanly through every switch.

## Known trade-off

JSON pretty-printing goes through `JSON.parse`/`stringify` — the same accepted pattern as the log body viewer — so an integer above 2^53 inside a payload displays and copies with precision loss. The raw view is the escape hatch; a lexeme-preserving re-indenter is the fix if this bites in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)