### PR TITLE
fix(web): parallel turns — announce overlap, assign spans by conversation id

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -32,7 +32,6 @@ import { spanModel, type SessionTurn } from "@/lib/agent-sessions/session-turns"
 import {
 	buildTranscript,
 	type CaptureCoverage,
-	type TranscriptLaneRef,
 	type TranscriptPayload,
 	type TranscriptRow,
 } from "@/lib/agent-sessions/session-transcript"
@@ -78,6 +77,7 @@ const ROW_ESTIMATE = {
 	"lane-open": 44,
 	"lane-close": 34,
 	parallel: 46,
+	"parallel-turns": 46,
 	structure: 30,
 	note: 86,
 	divider: 60,
@@ -273,6 +273,8 @@ function TranscriptBlock(props: BlockProps) {
 			return <LaneClose {...props} row={row} />
 		case "parallel":
 			return <ParallelMarker {...props} row={row} />
+		case "parallel-turns":
+			return <ParallelTurnsMarker {...props} row={row} />
 		case "structure":
 			return <StructureRow {...props} row={row} />
 		case "note":
@@ -343,6 +345,7 @@ function TurnChapter({
 	timeZone,
 	collapsed,
 	onToggleTurn,
+	onJump,
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "turn" }> }) {
 	const { turn } = row
 
@@ -377,10 +380,26 @@ function TurnChapter({
 				    time slice: that slice carries the app's own HTTP/DB spans too, and
 				    a count the page cannot account for is worse than no count. */}
 				<span className={cn(META, "shrink-0")}>
-					{turn.traceIds.length} trace{turn.traceIds.length === 1 ? "" : "s"} ·{" "}
-					{row.aiSpanCount} agent spans · {formatDuration(turn.durationMs)}
+					{turn.traceIds.length} trace{turn.traceIds.length === 1 ? "" : "s"} · {row.aiSpanCount}{" "}
+					agent spans · {formatDuration(turn.durationMs)}
 				</span>
 			</button>
+			{/* Outside the toggle, because a chip is a button and buttons do not
+			    nest. It survives collapse for the same reason the header does: a
+			    collapsed chapter still has to say it was not a step in a sequence. */}
+			{row.parallelWith.length > 0 && (
+				<span className="flex shrink-0 items-center gap-2.5 pl-2.5">
+					{row.parallelWith.map((ref) => (
+						<ParallelJump
+							key={ref.key}
+							targetKey={ref.key}
+							// Turns render in index order, so the ordinal is the direction too.
+							label={`${turnOrdinal(ref.turn).toUpperCase()} ${ref.turn.index > turn.index ? "↓" : "↑"}`}
+							onJump={onJump}
+						/>
+					))}
+				</span>
+			)}
 		</h3>
 	)
 }
@@ -475,7 +494,9 @@ function UserBlock({
 									<span className={cn(LABEL, "text-muted-foreground")}>{message.role}</span>
 									<ClampedText
 										text={message.parts
-											.map((part) => (part.kind === "text" ? part.text : `[${part.kind}]`))
+											.map((part) =>
+												part.kind === "text" ? part.text : `[${part.kind}]`,
+											)
 											.join("\n")}
 										clampClass="line-clamp-[6]"
 										expanded={disclosed(openRows, key, false)}
@@ -603,8 +624,8 @@ function AssistantBlock({
 			{!row.failed && row.text === undefined && (
 				<InlineNote className="mt-2.5">
 					The reply isn't captured. This emitter recorded the request but not{" "}
-					<span className="font-mono">gen_ai.output.messages</span>, so the call's text is gone —
-					it did not fail.
+					<span className="font-mono">gen_ai.output.messages</span>, so the call's text is gone — it
+					did not fail.
 				</InlineNote>
 			)}
 		</Row>
@@ -612,10 +633,7 @@ function AssistantBlock({
 }
 
 /** A captured prompt whose reply the emitter never recorded. */
-function PromptBlock({
-	row,
-	timeZone,
-}: BlockProps & { row: Extract<TranscriptRow, { kind: "prompt" }> }) {
+function PromptBlock({ row, timeZone }: BlockProps & { row: Extract<TranscriptRow, { kind: "prompt" }> }) {
 	return (
 		<Row time={clockOf(row.startMs, timeZone)} depth={row.depth} rail="bg-chart-2" className="pt-3">
 			<div className="flex flex-col gap-2.5">
@@ -847,7 +865,11 @@ function PayloadSection({
 					{label}
 				</span>
 				<span className="font-mono text-[10px] text-muted-foreground">
-					{[meta, formatBytes(payload.byteLength), payload.lineCount > 1 && `${payload.lineCount} lines`]
+					{[
+						meta,
+						formatBytes(payload.byteLength),
+						payload.lineCount > 1 && `${payload.lineCount} lines`,
+					]
 						.filter((part): part is string => typeof part === "string")
 						.join(" · ")}
 				</span>
@@ -937,7 +959,12 @@ function LaneOpen({
 					<>
 						<span className="grow" />
 						{row.parallelWith.map((ref) => (
-							<ParallelJump key={ref.key} target={ref} onJump={onJump} />
+							<ParallelJump
+								key={ref.key}
+								targetKey={ref.key}
+								label={ref.agentName}
+								onJump={onJump}
+							/>
 						))}
 					</>
 				)}
@@ -962,20 +989,25 @@ function LaneOpen({
 	)
 }
 
+/** The same chip on a lane header and on a turn header: one visual language for
+ *  concurrency, whichever level announced it. */
 function ParallelJump({
-	target,
+	targetKey,
+	label,
 	onJump,
 }: {
-	target: TranscriptLaneRef
+	targetKey: string
+	/** What the reader is being sent to — an agent's name, or a turn's ordinal. */
+	label: string
 	onJump: (key: string) => void
 }) {
 	return (
 		<button
 			type="button"
-			onClick={() => onJump(target.key)}
+			onClick={() => onJump(targetKey)}
 			className="shrink-0 cursor-pointer rounded-sm bg-primary/12 px-2 py-0.5 text-[11px] text-primary hover:bg-primary/20"
 		>
-			ran in parallel with {target.agentName}
+			ran in parallel with {label}
 		</button>
 	)
 }
@@ -992,8 +1024,10 @@ function LaneClose({
 				<CornerDownLeftIcon size={12} className="shrink-0 text-muted-foreground" />
 				<span className="shrink-0 text-muted-foreground text-xs">
 					{row.agentName}
-					{row.parentAgentName === undefined ? " finished" : ` returned to ${row.parentAgentName}`} ·{" "}
-					{formatDuration(row.durationMs)} · {row.llmCalls} LLM call
+					{row.parentAgentName === undefined
+						? " finished"
+						: ` returned to ${row.parentAgentName}`}{" "}
+					· {formatDuration(row.durationMs)} · {row.llmCalls} LLM call
 					{row.llmCalls === 1 ? "" : "s"} · {row.toolCalls} tool call
 					{row.toolCalls === 1 ? "" : "s"}
 				</span>
@@ -1027,7 +1061,13 @@ function ParallelMarker({
 	onJump,
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "parallel" }> }) {
 	return (
-		<Row time={clockOf(row.startMs, timeZone)} depth={row.depth} timePadding="pt-1.5" className="pt-5" flush>
+		<Row
+			time={clockOf(row.startMs, timeZone)}
+			depth={row.depth}
+			timePadding="pt-1.5"
+			className="pt-5"
+			flush
+		>
 			<div className="flex items-center gap-2.5">
 				<BranchForkIcon size={14} className="shrink-0 text-primary" />
 				<span className={cn(LABEL, "text-primary")}>Parallel</span>
@@ -1035,7 +1075,8 @@ function ParallelMarker({
 				    of pairwise overlaps has none, and the marker then reports the fork's
 				    extent instead of inventing one. */}
 				<span className="shrink-0 text-muted-foreground text-xs">
-					{row.forkedBy === undefined ? "This turn" : row.forkedBy} forked {row.lanes.length} lanes —{" "}
+					{row.forkedBy === undefined ? "This turn" : row.forkedBy} forked {row.lanes.length} lanes
+					—{" "}
 					{row.overlapStartMs !== undefined && row.overlapEndMs !== undefined
 						? `they overlap ${clockOf(row.overlapStartMs, timeZone)} → ${clockOf(row.overlapEndMs, timeZone)}`
 						: `their runs interleave between ${clockOf(row.startMs, timeZone)} and ${clockOf(row.endMs, timeZone)}`}
@@ -1049,6 +1090,58 @@ function ParallelMarker({
 						className="shrink-0 cursor-pointer font-mono text-[11px] text-primary hover:underline"
 					>
 						{lane.agentName}
+					</button>
+				))}
+				<span aria-hidden className="h-px grow bg-border" />
+			</div>
+		</Row>
+	)
+}
+
+/**
+ * Where two chapters ran at once — the lane marker one level up.
+ *
+ * A Maple fan-out gives each sub-agent its own conversation id, and a run
+ * dispatched over a queue roots its own trace, so either way the turn partition
+ * splits the fan-out into sibling chapters. They still read whole and in order;
+ * the marker is what stops "TURN 3, then TURN 4" from reading as a sequence the
+ * timestamps deny.
+ */
+function ParallelTurnsMarker({
+	row,
+	timeZone,
+	onJump,
+}: BlockProps & { row: Extract<TranscriptRow, { kind: "parallel-turns" }> }) {
+	return (
+		<Row
+			time={clockOf(row.startMs, timeZone)}
+			depth={row.depth}
+			timePadding="pt-1.5"
+			className="pt-5"
+			flush
+		>
+			<div className="flex items-center gap-2.5">
+				<BranchForkIcon size={14} className="shrink-0 text-primary" />
+				<span className={cn(LABEL, "text-primary")}>Parallel</span>
+				{/* Only a window every turn shared is reported as an overlap. A chain of
+				    pairwise overlaps has none, and the marker then reports the run's
+				    extent instead of inventing one. */}
+				<span className="shrink-0 text-muted-foreground text-xs">
+					{row.turns.length} turns ran at the same time —{" "}
+					{row.overlapStartMs !== undefined && row.overlapEndMs !== undefined
+						? `they overlap ${clockOf(row.overlapStartMs, timeZone)} → ${clockOf(row.overlapEndMs, timeZone)}`
+						: `their runs interleave between ${clockOf(row.startMs, timeZone)} and ${clockOf(row.endMs, timeZone)}`}
+					. Each turn is shown whole, in order:
+				</span>
+				{row.turns.map((ref) => (
+					<button
+						key={ref.key}
+						type="button"
+						onClick={() => onJump(ref.key)}
+						className="shrink-0 cursor-pointer font-mono text-[11px] text-primary hover:underline"
+					>
+						{turnOrdinal(ref.turn).toUpperCase()}
+						{ref.turn.agentName !== undefined && ` ${ref.turn.agentName}`}
 					</button>
 				))}
 				<span aria-hidden className="h-px grow bg-border" />
@@ -1107,7 +1200,9 @@ function StructureRow({
 					)}
 				>
 					<Glyph size={13} className={cn("shrink-0", tone)} />
-					<span className="shrink-0 font-medium font-mono text-foreground text-xs">{row.label}</span>
+					<span className="shrink-0 font-medium font-mono text-foreground text-xs">
+						{row.label}
+					</span>
 					<span className={META}>{structureMeta(row.span, category)}</span>
 					<span className="grow" />
 					<span className={cn(META, "shrink-0")}>{formatDuration(row.span.durationMs)}</span>
@@ -1144,8 +1239,7 @@ function NoteBlock({ row }: { row: Extract<TranscriptRow, { kind: "note" }> }) {
 
 	// The same absence, said at the scope it was measured at: a session-wide
 	// banner must not read as a claim about one turn, or the other way round.
-	const scope =
-		row.scope === "session" ? `${row.anyCaptured ? "most of " : ""}this session` : "this turn"
+	const scope = row.scope === "session" ? `${row.anyCaptured ? "most of " : ""}this session` : "this turn"
 
 	return (
 		<div className="flex items-start gap-3 rounded-md border border-border bg-card px-4 py-3">
@@ -1163,10 +1257,7 @@ function NoteBlock({ row }: { row: Extract<TranscriptRow, { kind: "note" }> }) {
 	)
 }
 
-function DividerBlock({
-	row,
-	timeZone,
-}: BlockProps & { row: Extract<TranscriptRow, { kind: "divider" }> }) {
+function DividerBlock({ row, timeZone }: BlockProps & { row: Extract<TranscriptRow, { kind: "divider" }> }) {
 	if (row.dividerKind === "compaction") {
 		return (
 			<Row
@@ -1180,8 +1271,8 @@ function DividerBlock({
 					<CompactLinesIcon size={14} className="shrink-0 text-chart-4" />
 					<span className={cn(LABEL, "text-chart-4")}>Context compacted</span>
 					<span className="shrink-0 text-muted-foreground text-xs">
-						the agent replaced its history with a summary — earlier messages above are still shown,
-						but the model no longer had them
+						the agent replaced its history with a summary — earlier messages above are still
+						shown, but the model no longer had them
 					</span>
 					<span aria-hidden className="h-px grow bg-chart-4/30" />
 				</div>

--- a/apps/web/src/lab/agent-session-fixture.ts
+++ b/apps/web/src/lab/agent-session-fixture.ts
@@ -4,9 +4,10 @@
 // tidy: fourteen turns so the Overview's digest elides its middle, idle gaps of
 // wildly different lengths, two models, five tools, per-call usage and cost, a
 // sub-agent handoff, and a final turn that dies on a context-window error
-// reported at two levels — the roll-up the counting rules exist for. Three more
+// reported at two levels — the roll-up the counting rules exist for. Six more
 // turns after those carry what the Transcript view needs and the fourteen do
-// not produce (see `buildTranscriptTurns`).
+// not produce (see `buildTranscriptTurns`) — the last three a dispatched
+// fan-out that overlaps in time and so lands as concurrent CHAPTERS.
 
 import type { AiSessionGenAiValues, AiSessionSpan } from "@maple/domain/http"
 
@@ -430,6 +431,7 @@ function buildTranscriptTurns(startMs: number): readonly AiSessionSpan[] {
 		...richTurn(startMs),
 		...captureOffTurn(startMs + 3 * MINUTE),
 		...mixedCaptureTurn(startMs + 5 * MINUTE),
+		...parallelTurns(startMs + 7 * MINUTE),
 	]
 }
 
@@ -873,6 +875,218 @@ function mixedCaptureTurn(t: number): readonly AiSessionSpan[] {
 				conversationCompacted: true,
 				outputMessages: assistantText(
 					"Shard 3 is at 61% with the raised timeout and no lock contention since the retry. I've replaced the earlier tool dumps with this summary to keep the window open.",
+				),
+				responseFinishReasons: ["end_turn"],
+			},
+		}),
+	]
+}
+
+/**
+ * A fan-out that the turn partition splits into SIBLING turns, not lanes.
+ *
+ * `release-triage` dispatches two checks onto a queue and waits. The queue hop
+ * loses the span link, so each dispatched run roots its own trace and
+ * `buildSessionTurns` reads all three as agent roots — one chapter each. The
+ * dispatcher is still open while both run, so the three genuinely overlap and
+ * the transcript's chapter marker has something true to report.
+ *
+ * Deliberately NOT keyed on `gen_ai.conversation.id`, which is the other way
+ * Maple produces this shape: `findAnchors` prefers conversation ids over agent
+ * roots for the WHOLE session as soon as two distinct ids exist, so stamping
+ * them here would repartition the other seventeen turns into three and gut the
+ * rest of the lab.
+ *
+ * The timings are staggered so each turn's spans all START before the next
+ * turn's anchor. Turn assignment is by time, and truly interleaved emission
+ * would scatter one run's later spans into its neighbour's chapter — a real
+ * property of the partition, but not the one this fixture is here to show.
+ */
+function parallelTurns(t: number): readonly AiSessionSpan[] {
+	return [
+		// The dispatcher, open across both dispatched runs — it is waiting on them.
+		agentSpan({
+			spanId: "fan-agent",
+			traceId: "trace-fan",
+			startMs: t,
+			durationMs: 46 * SECOND,
+			agentName: "release-triage",
+		}),
+		llmSpan({
+			spanId: "fan-l1",
+			parentSpanId: "fan-agent",
+			traceId: "trace-fan",
+			startMs: t,
+			durationMs: 3 * SECOND,
+			spanName: "chat claude-opus-5",
+			model: "claude-opus-5",
+			ttftSeconds: 0.71,
+			genAi: {
+				...usage(8_200, 410, 0.13),
+				inputMessages: userMessages(
+					"the 14:20 release is still suspect — check the logs and the metrics at the same time, don't serialise them",
+				),
+				outputMessages: assistantText(
+					"Neither check needs the other's answer, so I'll dispatch both now and read them together: log-lane takes the error stream either side of 14:20, metric-lane takes the saturation counters. Whichever comes back first, I wait for both before concluding.",
+				),
+				responseFinishReasons: ["tool_use"],
+			},
+		}),
+		toolSpan({
+			spanId: "fan-t1",
+			parentSpanId: "fan-agent",
+			traceId: "trace-fan",
+			startMs: t + 4 * SECOND,
+			durationMs: 380,
+			serviceName: "agent-dispatch",
+			toolName: "dispatch_agent",
+			genAi: {
+				toolCallId: "toolu_01Fan1",
+				toolCallArguments: { agent: "log-lane", question: "error-rate shape either side of 14:20" },
+				toolCallResult: '{"queued":true,"run_id":"run_9f21"}',
+			},
+		}),
+		toolSpan({
+			spanId: "fan-t2",
+			parentSpanId: "fan-agent",
+			traceId: "trace-fan",
+			startMs: t + 4_600,
+			durationMs: 340,
+			serviceName: "agent-dispatch",
+			toolName: "dispatch_agent",
+			genAi: {
+				toolCallId: "toolu_01Fan2",
+				toolCallArguments: { agent: "metric-lane", question: "connection-pool saturation at 14:20" },
+				toolCallResult: '{"queued":true,"run_id":"run_9f22"}',
+			},
+		}),
+
+		// Dispatched run 1 — its own trace, no parent span: the queue hop lost it.
+		agentSpan({
+			spanId: "log-agent",
+			traceId: "trace-log",
+			startMs: t + 6 * SECOND,
+			durationMs: 22 * SECOND,
+			agentName: "log-lane",
+			serviceName: "log-worker",
+		}),
+		llmSpan({
+			spanId: "log-l1",
+			parentSpanId: "log-agent",
+			traceId: "trace-log",
+			startMs: t + 6_500,
+			durationMs: 2 * SECOND,
+			spanName: "chat claude-haiku-4-5",
+			model: "claude-haiku-4-5",
+			ttftSeconds: 0.31,
+			serviceName: "log-worker",
+			genAi: {
+				...usage(2_900, 240, 0.01),
+				outputMessages: assistantText(
+					"Counting ERROR-level lines per minute for checkout-api across 13:50–14:50, grouped by logger, so a new message type shows up as its own series instead of vanishing into the total.",
+				),
+				responseFinishReasons: ["tool_use"],
+			},
+		}),
+		toolSpan({
+			spanId: "log-t1",
+			parentSpanId: "log-agent",
+			traceId: "trace-log",
+			startMs: t + 9 * SECOND,
+			durationMs: 6 * SECOND,
+			serviceName: "maple-mcp",
+			toolName: "search_logs",
+			genAi: {
+				toolCallId: "toolu_01Log1",
+				toolCallArguments: {
+					query: "service:checkout-api level:ERROR",
+					from: "2026-08-25T13:50:00Z",
+					to: "2026-08-25T14:50:00Z",
+					group_by: "logger",
+				},
+				toolCallResult:
+					"logger                          before  after\ncarts.pool.ConnectionPool           0    1841\ncheckout.api.RequestHandler        12      14",
+			},
+		}),
+		llmSpan({
+			spanId: "log-l2",
+			parentSpanId: "log-agent",
+			traceId: "trace-log",
+			startMs: t + 16 * SECOND,
+			durationMs: 2 * SECOND,
+			spanName: "chat claude-haiku-4-5",
+			model: "claude-haiku-4-5",
+			ttftSeconds: 0.28,
+			serviceName: "log-worker",
+			genAi: {
+				...usage(4_100, 198, 0.02),
+				outputMessages: assistantText(
+					"1,841 ConnectionPool errors after 14:20 against none before, while the request handler's own error count barely moves. The failure is in getting a connection, not in the request.",
+				),
+				responseFinishReasons: ["end_turn"],
+			},
+		}),
+
+		// Dispatched run 2 — starts while run 1 is still open, and outlives it.
+		agentSpan({
+			spanId: "met-agent",
+			traceId: "trace-met",
+			startMs: t + 17 * SECOND,
+			durationMs: 20 * SECOND,
+			agentName: "metric-lane",
+			serviceName: "metric-worker",
+		}),
+		llmSpan({
+			spanId: "met-l1",
+			parentSpanId: "met-agent",
+			traceId: "trace-met",
+			startMs: t + 17_500,
+			durationMs: 2 * SECOND,
+			spanName: "chat claude-haiku-4-5",
+			model: "claude-haiku-4-5",
+			ttftSeconds: 0.33,
+			serviceName: "metric-worker",
+			genAi: {
+				...usage(3_300, 216, 0.01),
+				outputMessages: assistantText(
+					"Reading pool utilisation and wait time for the carts datasource on either side of the boundary. If utilisation pins at 1.0 the pool is the ceiling; if it doesn't, the slowness is downstream of it.",
+				),
+				responseFinishReasons: ["tool_use"],
+			},
+		}),
+		toolSpan({
+			spanId: "met-t1",
+			parentSpanId: "met-agent",
+			traceId: "trace-met",
+			startMs: t + 21 * SECOND,
+			durationMs: 7 * SECOND,
+			serviceName: "maple-mcp",
+			toolName: "query_data",
+			genAi: {
+				toolCallId: "toolu_01Met1",
+				toolCallArguments: {
+					metric: "db.client.connection.pool.utilization",
+					filters: { "pool.name": "carts" },
+					step: "1m",
+				},
+				toolCallResult:
+					"t       utilization  wait_ms_p95\n14:18          0.41          2\n14:22          1.00        780\n14:40          1.00        812",
+			},
+		}),
+		llmSpan({
+			spanId: "met-l2",
+			parentSpanId: "met-agent",
+			traceId: "trace-met",
+			startMs: t + 30 * SECOND,
+			durationMs: 2_400,
+			spanName: "chat claude-haiku-4-5",
+			model: "claude-haiku-4-5",
+			ttftSeconds: 0.3,
+			serviceName: "metric-worker",
+			genAi: {
+				...usage(5_600, 262, 0.02),
+				outputMessages: assistantText(
+					"Pool utilisation goes to 1.00 at 14:22 and stays there, with p95 wait climbing from 2ms to 780ms. The carts pool is saturated from the release onward.",
 				),
 				responseFinishReasons: ["end_turn"],
 			},

--- a/apps/web/src/lib/agent-sessions/session-transcript.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-transcript.test.ts
@@ -84,10 +84,16 @@ describe("buildTranscript — turn shape", () => {
 					genAi: {
 						systemInstructions: "you are the investigation planner",
 						inputMessages: [
-							{ role: "user", parts: [{ type: "text", content: "p95 tripled — find what changed" }] },
+							{
+								role: "user",
+								parts: [{ type: "text", content: "p95 tripled — find what changed" }],
+							},
 						],
 						outputMessages: [
-							{ role: "assistant", parts: [{ type: "text", content: "reading the traces first" }] },
+							{
+								role: "assistant",
+								parts: [{ type: "text", content: "reading the traces first" }],
+							},
 						],
 					},
 				}),
@@ -97,7 +103,11 @@ describe("buildTranscript — turn shape", () => {
 					startMs: 3 * SECOND,
 					durationMs: SECOND,
 					toolName: "run_sql",
-					genAi: { toolCallId: "toolu_1", toolCallArguments: { sql: "SELECT 1" }, toolCallResult: "1" },
+					genAi: {
+						toolCallId: "toolu_1",
+						toolCallArguments: { sql: "SELECT 1" },
+						toolCallResult: "1",
+					},
 				}),
 			],
 		})
@@ -158,7 +168,13 @@ describe("buildTranscript — turn shape", () => {
 				durationMs: 20 * SECOND,
 				agentName: "trace-lane",
 			}),
-			toolSpan({ spanId: "a1", parentSpanId: "lane-a", startMs: 3 * SECOND, durationMs: 500, toolName: "run_sql" }),
+			toolSpan({
+				spanId: "a1",
+				parentSpanId: "lane-a",
+				startMs: 3 * SECOND,
+				durationMs: 500,
+				toolName: "run_sql",
+			}),
 			toolSpan({
 				spanId: "b1",
 				parentSpanId: "lane-b",
@@ -166,7 +182,13 @@ describe("buildTranscript — turn shape", () => {
 				durationMs: 500,
 				toolName: "inspect_trace",
 			}),
-			toolSpan({ spanId: "a2", parentSpanId: "lane-a", startMs: 5 * SECOND, durationMs: 500, toolName: "run_sql" }),
+			toolSpan({
+				spanId: "a2",
+				parentSpanId: "lane-a",
+				startMs: 5 * SECOND,
+				durationMs: 500,
+				toolName: "run_sql",
+			}),
 			toolSpan({
 				spanId: "b2",
 				parentSpanId: "lane-b",
@@ -263,8 +285,20 @@ describe("buildTranscript — lanes and parallel markers", () => {
 			startMs: 0,
 			durationMs: 10 * SECOND,
 			children: [
-				toolSpan({ spanId: "t1", parentSpanId: "agent", startMs: 0, durationMs: 5 * SECOND, toolName: "a" }),
-				toolSpan({ spanId: "t2", parentSpanId: "agent", startMs: SECOND, durationMs: 5 * SECOND, toolName: "b" }),
+				toolSpan({
+					spanId: "t1",
+					parentSpanId: "agent",
+					startMs: 0,
+					durationMs: 5 * SECOND,
+					toolName: "a",
+				}),
+				toolSpan({
+					spanId: "t2",
+					parentSpanId: "agent",
+					startMs: SECOND,
+					durationMs: 5 * SECOND,
+					toolName: "b",
+				}),
 			],
 		})
 		expect(kinds(transcript(spans))).not.toContain("parallel")
@@ -321,8 +355,20 @@ describe("buildTranscript — lanes and parallel markers", () => {
 				agentName: "db-lane",
 			}),
 			llmSpan({ spanId: "l1", parentSpanId: "lane", startMs: SECOND, durationMs: SECOND, model: "m" }),
-			llmSpan({ spanId: "l2", parentSpanId: "lane", startMs: 3 * SECOND, durationMs: SECOND, model: "m" }),
-			toolSpan({ spanId: "t1", parentSpanId: "lane", startMs: 5 * SECOND, durationMs: SECOND, toolName: "run_sql" }),
+			llmSpan({
+				spanId: "l2",
+				parentSpanId: "lane",
+				startMs: 3 * SECOND,
+				durationMs: SECOND,
+				model: "m",
+			}),
+			toolSpan({
+				spanId: "t1",
+				parentSpanId: "lane",
+				startMs: 5 * SECOND,
+				durationMs: SECOND,
+				toolName: "run_sql",
+			}),
 		]
 
 		const rows = transcript(spans)
@@ -351,7 +397,10 @@ describe("buildTranscript — message extraction", () => {
 					parentSpanId: "agent",
 					startMs: 0,
 					durationMs: SECOND,
-					genAi: { inputMessages: history, outputMessages: [{ role: "assistant", parts: [{ type: "text", content: "ok" }] }] },
+					genAi: {
+						inputMessages: history,
+						outputMessages: [{ role: "assistant", parts: [{ type: "text", content: "ok" }] }],
+					},
 				}),
 				llmSpan({
 					spanId: "l2",
@@ -359,7 +408,10 @@ describe("buildTranscript — message extraction", () => {
 					startMs: 2 * SECOND,
 					durationMs: SECOND,
 					genAi: {
-						inputMessages: [...history, { role: "user", parts: [{ type: "text", content: "re-sent" }] }],
+						inputMessages: [
+							...history,
+							{ role: "user", parts: [{ type: "text", content: "re-sent" }] },
+						],
 						outputMessages: [{ role: "assistant", parts: [{ type: "text", content: "done" }] }],
 					},
 				}),
@@ -464,7 +516,9 @@ describe("buildTranscript — message extraction", () => {
 					startMs: 0,
 					durationMs: SECOND,
 					genAi: {
-						inputMessages: [{ role: "user", parts: [{ type: "text", content: "the turn prompt" }] }],
+						inputMessages: [
+							{ role: "user", parts: [{ type: "text", content: "the turn prompt" }] },
+						],
 						outputMessages: [{ role: "assistant", parts: [{ type: "text", content: "reply" }] }],
 					},
 				}),
@@ -475,7 +529,9 @@ describe("buildTranscript — message extraction", () => {
 					durationMs: SECOND,
 					serviceName: "search-service",
 					genAi: {
-						inputMessages: [{ role: "user", parts: [{ type: "text", content: "summarise progress" }] }],
+						inputMessages: [
+							{ role: "user", parts: [{ type: "text", content: "summarise progress" }] },
+						],
 					},
 				}),
 			],
@@ -505,7 +561,9 @@ describe("buildTranscript — message extraction", () => {
 					startMs: 0,
 					durationMs: SECOND,
 					genAi: {
-						inputMessages: [{ role: "user", parts: [{ type: "text", content: "the only prompt" }] }],
+						inputMessages: [
+							{ role: "user", parts: [{ type: "text", content: "the only prompt" }] },
+						],
 					},
 				}),
 			],
@@ -618,7 +676,12 @@ describe("buildTranscript — tool calls", () => {
 								role: "assistant",
 								parts: [
 									{ type: "text", content: "calling out" },
-									{ type: "tool_call", id: "toolu_9", name: "web_search", arguments: { q: "x" } },
+									{
+										type: "tool_call",
+										id: "toolu_9",
+										name: "web_search",
+										arguments: { q: "x" },
+									},
 								],
 							},
 						],
@@ -810,8 +873,12 @@ describe("buildTranscript — structural fallback and notes", () => {
 						startMs: index * 60 * SECOND,
 						durationMs: SECOND,
 						genAi: {
-							inputMessages: [{ role: "user", parts: [{ type: "text", content: `q${index}` }] }],
-							outputMessages: [{ role: "assistant", parts: [{ type: "text", content: `a${index}` }] }],
+							inputMessages: [
+								{ role: "user", parts: [{ type: "text", content: `q${index}` }] },
+							],
+							outputMessages: [
+								{ role: "assistant", parts: [{ type: "text", content: `a${index}` }] },
+							],
 						},
 					}),
 				],
@@ -822,7 +889,12 @@ describe("buildTranscript — structural fallback and notes", () => {
 			startMs: 600 * SECOND,
 			durationMs: 10 * SECOND,
 			children: [
-				llmSpan({ spanId: "l-9", parentSpanId: "agent-9", startMs: 600 * SECOND, durationMs: SECOND }),
+				llmSpan({
+					spanId: "l-9",
+					parentSpanId: "agent-9",
+					startMs: 600 * SECOND,
+					durationMs: SECOND,
+				}),
 			],
 		})
 
@@ -862,7 +934,9 @@ describe("buildTranscript — session-level states", () => {
 	})
 
 	it("renders nothing at all for a session with no AI spans", () => {
-		const spans = [makeSpan({ spanId: "http", spanName: "GET /checkout", startMs: 0, durationMs: SECOND })]
+		const spans = [
+			makeSpan({ spanId: "http", spanName: "GET /checkout", startMs: 0, durationMs: SECOND }),
+		]
 		expect(transcript(spans)).toHaveLength(0)
 	})
 
@@ -876,7 +950,9 @@ describe("buildTranscript — session-level states", () => {
 					parentSpanId: "agent",
 					startMs: 0,
 					durationMs: SECOND,
-					genAi: { outputMessages: [{ role: "assistant", parts: [{ type: "text", content: "a" }] }] },
+					genAi: {
+						outputMessages: [{ role: "assistant", parts: [{ type: "text", content: "a" }] }],
+					},
 				}),
 				llmSpan({
 					spanId: "l2",
@@ -918,7 +994,9 @@ describe("buildTranscript — session-level states", () => {
 					startMs: 3 * SECOND,
 					durationMs: SECOND,
 					genAi: {
-						outputMessages: [{ role: "assistant", parts: [{ type: "text", content: "retried fine" }] }],
+						outputMessages: [
+							{ role: "assistant", parts: [{ type: "text", content: "retried fine" }] },
+						],
 					},
 				}),
 			],
@@ -941,7 +1019,13 @@ describe("buildTranscript — session-level states", () => {
 		})
 		const spans = [
 			...turnSpans({ startMs: 0, durationMs: 5 * SECOND, children: [tool, tool] }),
-			makeSpan({ spanId: "http", parentSpanId: "agent", spanName: "SELECT carts", startMs: 0, durationMs: SECOND }),
+			makeSpan({
+				spanId: "http",
+				parentSpanId: "agent",
+				spanName: "SELECT carts",
+				startMs: 0,
+				durationMs: SECOND,
+			}),
 		]
 		expect(transcript(spans).filter((row) => row.kind === "tool")).toHaveLength(1)
 	})
@@ -959,7 +1043,10 @@ describe("buildTranscript — filter and collapse", () => {
 				durationMs: SECOND,
 				genAi: {
 					outputMessages: [
-						{ role: "assistant", parts: [{ type: "text", content: "the carts lookup is the outlier" }] },
+						{
+							role: "assistant",
+							parts: [{ type: "text", content: "the carts lookup is the outlier" }],
+						},
 					],
 				},
 			}),
@@ -1163,7 +1250,9 @@ describe("buildTranscript — what counts as a captured reply", () => {
 					statusMessage: "stream closed",
 					genAi: {
 						errorType: "stream_error",
-						outputMessages: [{ role: "assistant", parts: [{ type: "text", content: "reading the" }] }],
+						outputMessages: [
+							{ role: "assistant", parts: [{ type: "text", content: "reading the" }] },
+						],
 					},
 				}),
 			],
@@ -1293,7 +1382,9 @@ describe("buildTranscript — capture notes", () => {
 					startMs: index * 60 * SECOND,
 					durationMs: SECOND,
 					genAi: {
-						outputMessages: [{ role: "assistant", parts: [{ type: "text", content: `a${index}` }] }],
+						outputMessages: [
+							{ role: "assistant", parts: [{ type: "text", content: `a${index}` }] },
+						],
 					},
 				}),
 			],
@@ -1365,9 +1456,7 @@ describe("buildTranscript — delegation payloads", () => {
 		]
 
 		const rows = transcript(spans)
-		expect(findRow(rows, "lane-open").args?.text).toBe(
-			'{"prompt":"verify the plan against the schema"}',
-		)
+		expect(findRow(rows, "lane-open").args?.text).toBe('{"prompt":"verify the plan against the schema"}')
 		expect(findRow(rows, "lane-close").result?.text).toBe("the plan checks out")
 	})
 })
@@ -1505,5 +1594,229 @@ describe("buildTranscript — row keys", () => {
 		})
 		expect(rows.length).toBeGreaterThan(20)
 		expect(new Set(rows.map((row) => row.key)).size).toBe(rows.length)
+	})
+})
+
+describe("buildTranscript — parallel turns", () => {
+	/**
+	 * One turn per conversation id, the partition a Maple fan-out produces: the
+	 * parent and each sub-agent carry their own id, so they arrive as siblings
+	 * rather than as lanes inside one turn.
+	 */
+	function conversationTurn(input: {
+		readonly id: string
+		readonly agentName: string
+		readonly startMs: number
+		readonly durationMs: number
+		readonly text?: string
+	}): readonly AiSessionSpan[] {
+		const conversationId = `conv-${input.id}`
+		return [
+			agentSpan({
+				spanId: `${input.id}-agent`,
+				traceId: `trace-${input.id}`,
+				startMs: input.startMs,
+				durationMs: input.durationMs,
+				agentName: input.agentName,
+				genAi: { conversationId },
+			}),
+			llmSpan({
+				spanId: `${input.id}-l1`,
+				parentSpanId: `${input.id}-agent`,
+				traceId: `trace-${input.id}`,
+				startMs: input.startMs,
+				durationMs: SECOND,
+				genAi: {
+					conversationId,
+					outputMessages: [
+						{
+							role: "assistant",
+							parts: [{ type: "text", content: input.text ?? input.agentName }],
+						},
+					],
+				},
+			}),
+		]
+	}
+
+	/** Two turns open at once: B starts while A is still running. */
+	const twoTurns = [
+		...conversationTurn({ id: "a", agentName: "log-lane", startMs: 0, durationMs: 20 * SECOND }),
+		...conversationTurn({
+			id: "b",
+			agentName: "metric-lane",
+			startMs: 5 * SECOND,
+			durationMs: 20 * SECOND,
+		}),
+	]
+
+	it("splits a fan-out into sibling turns and marks the pair", () => {
+		const rows = transcript(twoTurns)
+		expect(kinds(rows).slice(0, 2)).toEqual(["parallel-turns", "turn"])
+
+		const marker = findRow(rows, "parallel-turns")
+		expect(marker.depth).toBe(0)
+		expect(marker.turns.map((ref) => ref.turn.agentName)).toEqual(["log-lane", "metric-lane"])
+		// The run's extent, and the window both turns really were open in.
+		expect(marker.startMs).toBe(T0)
+		expect(marker.endMs).toBe(T0 + 25 * SECOND)
+		expect(marker.overlapStartMs).toBe(T0 + 5 * SECOND)
+		expect(marker.overlapEndMs).toBe(T0 + 20 * SECOND)
+	})
+
+	it("gives each member turn header reciprocal jump data", () => {
+		const rows = transcript(twoTurns)
+		const headers = findRows(rows, "turn")
+		expect(headers.map((row) => row.turn.agentName)).toEqual(["log-lane", "metric-lane"])
+		expect(headers[0]!.parallelWith.map((ref) => ref.turn.agentName)).toEqual(["metric-lane"])
+		expect(headers[1]!.parallelWith.map((ref) => ref.turn.agentName)).toEqual(["log-lane"])
+		// The links point at the other turn's own header row key.
+		expect(headers[0]!.parallelWith[0]!.key).toBe(headers[1]!.key)
+		expect(headers[1]!.parallelWith[0]!.key).toBe(headers[0]!.key)
+	})
+
+	// The marker's jump targets have to be row keys, not turn-shaped lookalikes:
+	// a key that resolves to nothing scrolls nowhere and reports no error.
+	it("resolves every jump key to a row that is on the page", () => {
+		const rows = transcript(twoTurns)
+		const keys = new Set(rows.map((row) => row.key))
+		const marker = findRow(rows, "parallel-turns")
+		for (const ref of marker.turns) expect(keys.has(ref.key)).toBe(true)
+		for (const header of findRows(rows, "turn")) {
+			for (const ref of header.parallelWith) expect(keys.has(ref.key)).toBe(true)
+		}
+	})
+
+	it("keeps the marker and the chip data on a collapsed member", () => {
+		const rows = transcript(twoTurns, { collapsedTurns: new Set(["conversation:conv-a"]) })
+		// Collapse hides a turn's body, never its header — so the chapter-level
+		// concurrency survives it.
+		expect(kinds(rows)).toEqual(["parallel-turns", "turn", "turn", "assistant"])
+		const collapsed = findRows(rows, "turn")[0]!
+		expect(collapsed.parallelWith.map((ref) => ref.turn.agentName)).toEqual(["metric-lane"])
+	})
+
+	it("keeps a staggered run in one cluster and links only the pairs that overlapped", () => {
+		const staggered = [
+			...conversationTurn({ id: "a", agentName: "a-lane", startMs: 0, durationMs: 10 * SECOND }),
+			...conversationTurn({
+				id: "b",
+				agentName: "b-lane",
+				startMs: 5 * SECOND,
+				durationMs: 10 * SECOND,
+			}),
+			...conversationTurn({
+				id: "c",
+				agentName: "c-lane",
+				startMs: 12 * SECOND,
+				durationMs: 8 * SECOND,
+			}),
+		]
+		const rows = transcript(staggered)
+		expect(findRows(rows, "parallel-turns")).toHaveLength(1)
+
+		const marker = findRow(rows, "parallel-turns")
+		expect(marker.turns.map((ref) => ref.turn.agentName)).toEqual(["a-lane", "b-lane", "c-lane"])
+		expect(marker.startMs).toBe(T0)
+		expect(marker.endMs).toBe(T0 + 20 * SECOND)
+		// A chain has no window all three shared, and the marker says so rather
+		// than reporting one that runs backwards.
+		expect(marker.overlapStartMs).toBeUndefined()
+		expect(marker.overlapEndMs).toBeUndefined()
+
+		expect(
+			findRows(rows, "turn").map((row) => row.parallelWith.map((ref) => ref.turn.agentName)),
+		).toEqual([["b-lane"], ["a-lane", "c-lane"], ["b-lane"]])
+	})
+
+	// The turn that breaks the run under a "previous member" rule: it ends before
+	// the next one starts, while the long turn above it is still open.
+	it("clusters a short turn nested inside a long one", () => {
+		const nested = [
+			...conversationTurn({ id: "long", agentName: "long-lane", startMs: 0, durationMs: 30 * SECOND }),
+			...conversationTurn({
+				id: "x",
+				agentName: "x-lane",
+				startMs: 3 * SECOND,
+				durationMs: 3 * SECOND,
+			}),
+			...conversationTurn({
+				id: "y",
+				agentName: "y-lane",
+				startMs: 12 * SECOND,
+				durationMs: 4 * SECOND,
+			}),
+		]
+		const rows = transcript(nested)
+		expect(findRows(rows, "parallel-turns")).toHaveLength(1)
+
+		const marker = findRow(rows, "parallel-turns")
+		expect(marker.turns).toHaveLength(3)
+		expect(marker.startMs).toBeLessThan(marker.endMs)
+		// The two short turns never met each other, so only the long one is shared.
+		expect(marker.overlapStartMs).toBeUndefined()
+		expect(marker.overlapEndMs).toBeUndefined()
+
+		expect(
+			findRows(rows, "turn").map((row) => row.parallelWith.map((ref) => ref.turn.agentName)),
+		).toEqual([["x-lane", "y-lane"], ["long-lane"], ["long-lane"]])
+	})
+
+	it("says nothing about turns that ran one after the other", () => {
+		const sequential = [
+			...conversationTurn({ id: "a", agentName: "a-lane", startMs: 0, durationMs: 5 * SECOND }),
+			...conversationTurn({
+				id: "b",
+				agentName: "b-lane",
+				startMs: 10 * SECOND,
+				durationMs: 5 * SECOND,
+			}),
+		]
+		const rows = transcript(sequential)
+		expect(kinds(rows)).not.toContain("parallel-turns")
+		for (const header of findRows(rows, "turn")) expect(header.parallelWith).toStrictEqual([])
+	})
+
+	// An `empty-turn` stub is HTTP/DB work with no agent activity in it. Pairing
+	// one with a real turn would announce a concurrency the reader cannot see.
+	it("leaves turns with no AI activity out of a cluster", () => {
+		const spans = [
+			...conversationTurn({ id: "a", agentName: "a-lane", startMs: 0, durationMs: 20 * SECOND }),
+			makeSpan({
+				spanId: "http",
+				traceId: "trace-http",
+				spanName: "GET /checkout",
+				startMs: 5 * SECOND,
+				durationMs: 10 * SECOND,
+				genAi: { conversationId: "conv-http" },
+				isAiSpan: false,
+			}),
+		]
+		const rows = transcript(spans)
+		expect(kinds(rows)).toEqual(["turn", "assistant", "empty-turn"])
+		expect(findRow(rows, "turn").parallelWith).toStrictEqual([])
+	})
+
+	// Structural chrome, like the lane markers: the filtered view no longer has
+	// the ordering the marker describes.
+	it("drops the marker and the chips while a query is active", () => {
+		const rows = transcript(twoTurns, { query: "metric-lane" })
+		expect(kinds(rows)).toEqual(["turn", "assistant"])
+		expect(findRow(rows, "turn").parallelWith).toStrictEqual([])
+	})
+
+	it("marks the lab fixture's dispatched fan-out", () => {
+		const spans = buildAgentSessionFixture()
+		const rows = transcript(spans)
+		const marker = findRow(rows, "parallel-turns")
+		expect(marker.turns.map((ref) => ref.turn.agentName)).toEqual([
+			"release-triage",
+			"log-lane",
+			"metric-lane",
+		])
+		// All three really were open together, so the window is reported.
+		expect(marker.overlapStartMs).toBeDefined()
+		expect(marker.overlapEndMs).toBeDefined()
+		expect(marker.overlapStartMs!).toBeLessThan(marker.overlapEndMs!)
 	})
 })

--- a/apps/web/src/lib/agent-sessions/session-transcript.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-transcript.test.ts
@@ -1820,3 +1820,159 @@ describe("buildTranscript — parallel turns", () => {
 		expect(marker.overlapStartMs!).toBeLessThan(marker.overlapEndMs!)
 	})
 })
+
+/**
+ * The two halves together: the turn partition files each concurrent lane's
+ * spans into its own chapter, and the chapter marker then announces that the
+ * chapters ran at once.
+ *
+ * Shaped like Maple's investigation fan-out — a planner pass, three hypothesis
+ * lanes launched together with their own `gen_ai.conversation.id`, a validator
+ * pass. Each lane ends on a final chat and an `execute_tool submit_candidate`
+ * long after the last lane anchored: the spans a time-ordered partition used to
+ * dump into whichever lane started last, where they rendered at depth 0 under a
+ * chapter that never ran them.
+ */
+describe("buildTranscript — investigation fan-out", () => {
+	const LANES = ["hypothesis-0", "hypothesis-1", "hypothesis-2"] as const
+
+	function fanout(): readonly AiSessionSpan[] {
+		const reply = (content: string) => [{ role: "assistant", parts: [{ type: "text", content }] }]
+		return [
+			agentSpan({
+				spanId: "planner-agent",
+				traceId: "trace-inv",
+				startMs: 0,
+				durationMs: 8 * SECOND,
+				agentName: "planner",
+				genAi: { conversationId: "inv_1_planner" },
+			}),
+			...LANES.flatMap((lane, index) => {
+				const conversationId = `inv_1_${lane}`
+				const opensAt = 10 * SECOND + index * 300
+				return [
+					agentSpan({
+						spanId: `${lane}-agent`,
+						traceId: "trace-inv",
+						startMs: opensAt,
+						durationMs: 120 * SECOND,
+						agentName: lane,
+						genAi: { conversationId },
+					}),
+					llmSpan({
+						spanId: `${lane}-chat-1`,
+						parentSpanId: `${lane}-agent`,
+						traceId: "trace-inv",
+						startMs: opensAt + SECOND,
+						durationMs: 3 * SECOND,
+						genAi: { conversationId, outputMessages: reply(`${lane} opening read`) },
+					}),
+					llmSpan({
+						spanId: `${lane}-chat-2`,
+						parentSpanId: `${lane}-agent`,
+						traceId: "trace-inv",
+						startMs: opensAt + 100 * SECOND,
+						durationMs: 4 * SECOND,
+						genAi: { conversationId, outputMessages: reply(`${lane} final answer`) },
+					}),
+					toolSpan({
+						spanId: `${lane}-submit`,
+						parentSpanId: `${lane}-agent`,
+						traceId: "trace-inv",
+						startMs: opensAt + 110 * SECOND,
+						durationMs: SECOND,
+						toolName: "submit_candidate",
+						genAi: {
+							conversationId,
+							toolCallId: `call-${lane}`,
+							toolCallResult: `${lane} filed`,
+						},
+					}),
+				]
+			}),
+			agentSpan({
+				spanId: "validator-agent",
+				traceId: "trace-inv",
+				startMs: 140 * SECOND,
+				durationMs: 10 * SECOND,
+				agentName: "validator",
+				genAi: { conversationId: "inv_1_validator" },
+			}),
+		]
+	}
+
+	it("announces the concurrent lanes as chapters that ran at once", () => {
+		const rows = transcript(fanout())
+		const marker = findRow(rows, "parallel-turns")
+
+		expect(marker.turns.map((ref) => ref.turn.agentName)).toEqual([...LANES])
+		// All three really were open together, so a window is reported — and it
+		// runs forwards.
+		expect(marker.overlapStartMs).toBeDefined()
+		expect(marker.overlapEndMs).toBeDefined()
+		expect(marker.overlapStartMs!).toBeLessThan(marker.overlapEndMs!)
+
+		// The marker opens the cluster: it sits directly before the first lane's
+		// header, and the planner's chapter is untouched ahead of it.
+		const markerAt = rows.indexOf(marker)
+		const next = rows[markerAt + 1]!
+		expect(next.kind).toBe("turn")
+		expect(next.kind === "turn" && next.turn.agentName).toBe("hypothesis-0")
+	})
+
+	// The heart of it: a lane's final chat and its submit call belong to the lane
+	// that ran them, not to whichever lane happened to anchor last.
+	it("keeps every lane's tail spans inside that lane's own chapter", () => {
+		const rows = transcript(fanout())
+
+		// Walk the flat row list, attributing each span-bearing row to the chapter
+		// heading it sits under.
+		let chapter: string | undefined
+		const byChapter = new Map<string, string[]>()
+		for (const row of rows) {
+			if (row.kind === "turn") {
+				chapter = row.turn.agentName
+				byChapter.set(chapter!, [])
+				continue
+			}
+			if (!("span" in row) || chapter === undefined) continue
+			byChapter.get(chapter)!.push(row.span.spanId)
+		}
+
+		for (const lane of LANES) {
+			// The anchor is absorbed into the header, so what renders is the work.
+			expect(byChapter.get(lane)).toStrictEqual([`${lane}-chat-1`, `${lane}-chat-2`, `${lane}-submit`])
+		}
+		// And nothing from a lane leaked into the planner's or validator's chapter.
+		expect(byChapter.get("planner")).toStrictEqual([])
+		expect(byChapter.get("validator")).toStrictEqual([])
+	})
+
+	// The failure mode the mis-partition produced: a tail span whose parent lives
+	// in another turn becomes a forest root and renders at depth 0, unattributed,
+	// under a chapter that never ran it.
+	it("leaves no span rendering under a chapter that did not run it", () => {
+		const rows = transcript(fanout())
+
+		let chapter: string | undefined
+		for (const row of rows) {
+			if (row.kind === "turn") {
+				chapter = row.turn.agentName
+				continue
+			}
+			if (!("span" in row)) continue
+			// Every lane span's id is prefixed with the lane that ran it.
+			const owner = LANES.find((lane) => row.span.spanId.startsWith(`${lane}-`))
+			if (owner !== undefined) expect(chapter).toBe(owner)
+		}
+	})
+
+	// Within-turn lane clustering is a different mechanism on a different shape;
+	// the fan-out must not start producing lane rows instead of chapters.
+	it("does not turn sibling chapters back into lanes inside one turn", () => {
+		const rows = transcript(fanout())
+		expect(kinds(rows)).not.toContain("lane-open")
+		expect(kinds(rows)).not.toContain("parallel")
+		expect(findRows(rows, "turn")).toHaveLength(5)
+	})
+})

--- a/apps/web/src/lib/agent-sessions/session-transcript.ts
+++ b/apps/web/src/lib/agent-sessions/session-transcript.ts
@@ -65,6 +65,19 @@ export interface TranscriptLaneRef {
 	readonly agentName: string
 }
 
+/**
+ * One turn the reader can be sent to, for a chapter marker's jump link.
+ *
+ * The turn rides along rather than a formatted label: the ordinal the page
+ * prints ("Turn 4" / "Segment 2") is the view's wording, and re-deriving it here
+ * would put the same rule in two places.
+ */
+export interface TranscriptTurnRef {
+	/** The turn header row's own key, so a jump resolves against the row list. */
+	readonly key: string
+	readonly turn: SessionTurn
+}
+
 /** The payload of a tool call or its result, with what the emitter did to it. */
 export interface TranscriptPayload {
 	/** Empty where the emitter recorded that it truncated but kept no prefix. */
@@ -101,6 +114,8 @@ export type TranscriptRow =
 			/** AI spans the turn actually renders — deduped, app spans excluded. */
 			readonly aiSpanCount: number
 			readonly toolNames: readonly string[]
+			/** Sibling turns this one genuinely overlapped — see `markParallelTurns`. */
+			readonly parallelWith: readonly TranscriptTurnRef[]
 	  })
 	/** A turn the transcript has nothing to say about, holding its ordinal open. */
 	| (RowBase & { readonly kind: "empty-turn"; readonly turn: SessionTurn })
@@ -179,6 +194,18 @@ export type TranscriptRow =
 			readonly overlapEndMs: number | undefined
 			readonly lanes: readonly TranscriptLaneRef[]
 	  })
+	/** The same announcement one level up: turns that ran at the same time. */
+	| (RowBase & {
+			readonly kind: "parallel-turns"
+			/** The cluster: from the first turn starting to the last one ending. */
+			readonly startMs: number
+			readonly endMs: number
+			/** The window every turn in the cluster was open in, where there is one.
+			 *  A chain of pairwise overlaps has none. */
+			readonly overlapStartMs: number | undefined
+			readonly overlapEndMs: number | undefined
+			readonly turns: readonly TranscriptTurnRef[]
+	  })
 	/** A model call, or a tool call, that captured no content at all. */
 	| (SpanRowBase & {
 			readonly kind: "structure"
@@ -243,13 +270,15 @@ export function buildTranscript(input: TranscriptInput): readonly TranscriptRow[
 
 	const filtering = input.query.trim() !== ""
 	const turnRows = input.turns.map((turn) => buildTurn(turn, input, categoryOf))
+	// Structural chrome, like the lane markers: a filtered view no longer has the
+	// ordering the marker describes, so it is not built at all.
+	const concurrent = filtering ? new Map<string, TurnMarking>() : markParallelTurns(turnRows)
 
 	// Capture coverage is a fact about the session, so it is counted over every
 	// turn before the first row is emitted.
 	const llmSpans = turnRows.flatMap((entry) => entry.llmSpans)
 	const capturedCalls = llmSpans.filter(hasCapturedContent).length
-	const bannerUp =
-		llmSpans.length > 0 && capturedCalls / llmSpans.length < CAPTURE_BANNER_THRESHOLD
+	const bannerUp = llmSpans.length > 0 && capturedCalls / llmSpans.length < CAPTURE_BANNER_THRESHOLD
 	// A session of pure HTTP/DB work has no transcript at all; only one that DOES
 	// have agent work keeps placeholders for the turns without it.
 	const anyAiActivity = turnRows.some((entry) => entry.aiSpanCount > 0)
@@ -270,7 +299,10 @@ export function buildTranscript(input: TranscriptInput): readonly TranscriptRow[
 		// a header over nothing is worse than no header. Collapse does not change
 		// that: the filter judges both states by the same rows.
 		if (filtering && entry.rows.length === 0) continue
-		body.push(entry.header)
+		const marking = concurrent.get(entry.turn.id)
+		// The marker opens the cluster, so it is carried by its first member.
+		if (marking?.marker !== undefined) body.push(marking.marker)
+		body.push(marking?.header ?? entry.header)
 		// Per-turn only where the session-level banner is not already up.
 		if (
 			!bannerUp &&
@@ -326,7 +358,7 @@ export function buildTranscript(input: TranscriptInput): readonly TranscriptRow[
 
 interface TurnRows {
 	readonly turn: SessionTurn
-	readonly header: TranscriptRow
+	readonly header: Extract<TranscriptRow, { kind: "turn" }>
 	readonly rows: readonly TranscriptRow[]
 	/** The turn's model calls, for the session's capture coverage. */
 	readonly llmSpans: readonly AiSessionSpan[]
@@ -345,7 +377,7 @@ function buildTurn(
 	const llmSpans = spans.filter(isLlmCall)
 	const toolSpans = spans.filter((span) => categoryOf(span) === "tool")
 
-	const header: TranscriptRow = {
+	const header: Extract<TranscriptRow, { kind: "turn" }> = {
 		kind: "turn",
 		key: turn.id,
 		depth: 0,
@@ -357,6 +389,9 @@ function buildTurn(
 		toolNames: distinct(
 			toolSpans.map((span) => span.genAi.toolName).filter((name): name is string => name !== undefined),
 		),
+		// Filled in by `markParallelTurns`, which needs every turn to be built
+		// before it can tell which of them overlapped.
+		parallelWith: [],
 	}
 
 	// A collapsed turn renders its header and nothing else, so none of the work
@@ -737,30 +772,13 @@ function markParallelLanes(
 	lanes: readonly LaneBlock[],
 	scope: LaneScope,
 ): readonly TranscriptRow[] {
-	if (lanes.length < 2) return rows
-
-	// Clustered against a RUNNING maximum end, never against the previous lane's
-	// own: two short lanes nested inside one long one are a single fork, and
-	// reading only the last member would break the run at the first lane that
-	// happened to finish early.
-	const clusters: LaneBlock[][] = []
-	let clusterEnd = Number.NEGATIVE_INFINITY
-	for (const lane of lanes) {
-		const cluster = clusters.at(-1)
-		if (cluster !== undefined && lane.startMs < clusterEnd) {
-			cluster.push(lane)
-			clusterEnd = Math.max(clusterEnd, lane.endMs)
-		} else {
-			clusters.push([lane])
-			clusterEnd = lane.endMs
-		}
-	}
+	const clusters = clusterByOverlap(lanes)
+	if (clusters.length === 0) return rows
 
 	const out = [...rows]
 	const markers: { at: number; row: TranscriptRow }[] = []
 	for (const cluster of clusters) {
-		if (cluster.length < 2) continue
-		for (const lane of cluster) {
+		for (const lane of cluster.members) {
 			// `at` is where the lane's rows were pushed and its opening row is the
 			// first of them — a search by key would find the same row more slowly.
 			const row = out[lane.at]
@@ -770,25 +788,24 @@ function markParallelLanes(
 			// same invention the marker exists to prevent.
 			out[lane.at] = {
 				...row,
-				parallelWith: cluster.filter((other) => overlaps(lane, other)).map((other) => other.ref),
+				parallelWith: cluster.members
+					.filter((other) => overlaps(lane, other))
+					.map((other) => other.ref),
 			}
 		}
-		// The window every lane in the cluster was open in, where there is one.
-		const sharedStart = Math.max(...cluster.map((lane) => lane.startMs))
-		const sharedEnd = Math.min(...cluster.map((lane) => lane.endMs))
-		const shared = sharedStart < sharedEnd
+		const first = cluster.members[0]!
 		markers.push({
-			at: cluster[0]!.at,
+			at: first.at,
 			row: {
 				kind: "parallel",
-				key: `${cluster[0]!.ref.key}:parallel`,
+				key: `${first.ref.key}:parallel`,
 				depth: scope.depth,
 				forkedBy: scope.agentName,
-				startMs: Math.min(...cluster.map((lane) => lane.startMs)),
-				endMs: Math.max(...cluster.map((lane) => lane.endMs)),
-				overlapStartMs: shared ? sharedStart : undefined,
-				overlapEndMs: shared ? sharedEnd : undefined,
-				lanes: cluster.map((lane) => lane.ref),
+				startMs: cluster.startMs,
+				endMs: cluster.endMs,
+				overlapStartMs: cluster.overlapStartMs,
+				overlapEndMs: cluster.overlapEndMs,
+				lanes: cluster.members.map((lane) => lane.ref),
 			},
 		})
 	}
@@ -798,9 +815,149 @@ function markParallelLanes(
 	return out
 }
 
-/** Two lanes open at the same moment. */
-function overlaps(a: LaneBlock, b: LaneBlock): boolean {
+/* -------------------------------------------------------------------------- */
+/* Overlap clustering                                                         */
+/* -------------------------------------------------------------------------- */
+
+/** Anything the transcript can announce as concurrent: a lane, or a turn. */
+interface Interval {
+	readonly startMs: number
+	readonly endMs: number
+}
+
+interface OverlapCluster<T> {
+	/** Two or more, in start order. */
+	readonly members: readonly T[]
+	/** The run's extent: first member starting to last member ending. */
+	readonly startMs: number
+	readonly endMs: number
+	/**
+	 * The window every member was open in, where there is one. A chain of
+	 * pairwise overlaps has none, and claiming a window there would be the
+	 * invention the marker exists to prevent — so both ends are `undefined`
+	 * together rather than reported backwards.
+	 */
+	readonly overlapStartMs: number | undefined
+	readonly overlapEndMs: number | undefined
+}
+
+/**
+ * Group items that ran at the same time.
+ *
+ * Clustered against a RUNNING maximum end, never against the previous item's
+ * own: two short runs nested inside one long one are a single cluster, and
+ * reading only the last member would break the run at the first item that
+ * happened to finish early. A cluster of one is a sequence and is dropped.
+ *
+ * The input is sorted defensively. A thread's lanes arrive in start order
+ * already, but a turn is ordered by its ANCHOR while its own `startMs` is the
+ * minimum over every span the time partition gave it, and the two can disagree.
+ */
+function clusterByOverlap<T extends Interval>(items: readonly T[]): readonly OverlapCluster<T>[] {
+	if (items.length < 2) return []
+
+	const groups: T[][] = []
+	let clusterEnd = Number.NEGATIVE_INFINITY
+	for (const item of [...items].sort((a, b) => a.startMs - b.startMs)) {
+		const group = groups.at(-1)
+		if (group !== undefined && item.startMs < clusterEnd) {
+			group.push(item)
+			clusterEnd = Math.max(clusterEnd, item.endMs)
+		} else {
+			groups.push([item])
+			clusterEnd = item.endMs
+		}
+	}
+
+	return groups
+		.filter((group) => group.length > 1)
+		.map((members) => {
+			const sharedStart = Math.max(...members.map((item) => item.startMs))
+			const sharedEnd = Math.min(...members.map((item) => item.endMs))
+			const shared = sharedStart < sharedEnd
+			return {
+				members,
+				startMs: members[0]!.startMs,
+				endMs: Math.max(...members.map((item) => item.endMs)),
+				overlapStartMs: shared ? sharedStart : undefined,
+				overlapEndMs: shared ? sharedEnd : undefined,
+			}
+		})
+}
+
+/** Two intervals open at the same moment. Identity, not keys: the members are
+ *  the very objects handed to `clusterByOverlap`. */
+function overlaps<T extends Interval>(a: T, b: T): boolean {
 	return a !== b && a.startMs < b.endMs && b.startMs < a.endMs
+}
+
+/** What a cluster does to one of its member turns. */
+interface TurnMarking {
+	/** The header again, carrying the turns this one overlapped. */
+	readonly header: Extract<TranscriptRow, { kind: "turn" }>
+	/** The cluster's marker, on its first member only. */
+	readonly marker: TranscriptRow | undefined
+}
+
+/**
+ * Chapter-level parallelism: turns that ran at the same time.
+ *
+ * `buildSessionTurns` partitions on `gen_ai.conversation.id` where there is one,
+ * and a Maple sub-agent or workflow lane carries its own — so a fan-out the
+ * parent dispatched arrives here as SIBLING turns rather than as lanes inside
+ * one, and reads as "turn 3, then turn 4": the one thing the timestamps deny.
+ * A dispatched run whose queue hop lost the span link lands the same way,
+ * through the agent-root rule.
+ *
+ * Only turns the transcript actually renders take part. An `empty-turn` stub is
+ * a placeholder for HTTP/DB work with no agent activity in it, and pairing one
+ * with a real turn would announce a concurrency the reader cannot see.
+ */
+function markParallelTurns(entries: readonly TurnRows[]): ReadonlyMap<string, TurnMarking> {
+	const items = entries
+		.filter((entry) => entry.aiSpanCount > 0)
+		.map((entry, order) => ({
+			entry,
+			// Where this turn sits on the PAGE. Turns are ordered by their anchor and
+			// a turn's `startMs` is the minimum over its spans, so the two can
+			// disagree — and the marker has to open the cluster wherever it renders.
+			order,
+			startMs: entry.turn.startMs,
+			endMs: entry.turn.endMs,
+			ref: { key: entry.turn.id, turn: entry.turn } satisfies TranscriptTurnRef,
+		}))
+
+	const marked = new Map<string, TurnMarking>()
+	for (const cluster of clusterByOverlap(items)) {
+		for (const item of cluster.members) {
+			marked.set(item.entry.turn.id, {
+				header: {
+					...item.entry.header,
+					// Only the turns this one GENUINELY overlapped: a cluster can be a
+					// chain (A with B, B with C, A never with C).
+					parallelWith: cluster.members
+						.filter((other) => overlaps(item, other))
+						.map((other) => other.ref),
+				},
+				marker: undefined,
+			})
+		}
+		const first = cluster.members.reduce((a, b) => (a.order <= b.order ? a : b))
+		marked.set(first.entry.turn.id, {
+			...marked.get(first.entry.turn.id)!,
+			marker: {
+				kind: "parallel-turns",
+				key: `${first.ref.key}:parallel-turns`,
+				depth: 0,
+				startMs: cluster.startMs,
+				endMs: cluster.endMs,
+				overlapStartMs: cluster.overlapStartMs,
+				overlapEndMs: cluster.overlapEndMs,
+				turns: cluster.members.map((item) => item.ref),
+			},
+		})
+	}
+	return marked
 }
 
 /* -------------------------------------------------------------------------- */
@@ -1040,7 +1197,13 @@ function outputRows(
 		// This call captured something — so the reply is missing, not merely
 		// unrecorded like every call in a capture-off session.
 		return [
-			{ ...base, kind: "assistant", key: rowKey(scope, span, "no-reply"), text: undefined, failed: false },
+			{
+				...base,
+				kind: "assistant",
+				key: rowKey(scope, span, "no-reply"),
+				text: undefined,
+				failed: false,
+			},
 		]
 	}
 	return [
@@ -1055,10 +1218,7 @@ function outputRows(
 }
 
 /** Does a tool span already account for this `tool_call` part? */
-function coveredBySpan(
-	part: Extract<SpanMessagePart, { kind: "tool_call" }>,
-	context: TurnContext,
-): boolean {
+function coveredBySpan(part: Extract<SpanMessagePart, { kind: "tool_call" }>, context: TurnContext): boolean {
 	// A tool span for the same call carries the duration, the service and the
 	// error; the message-only row exists only where there is no such span.
 	if (part.id !== undefined) return context.coveredCallIds.has(part.id)

--- a/apps/web/src/lib/agent-sessions/session-turns.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-turns.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
 
+import type { AiSessionSpan } from "@maple/domain/http"
+
 import { agentSpan, llmSpan, makeSpan, toolSpan, userMessages } from "./span-test-support"
 import { buildSessionTurns, classifyAiSpan, isLlmCall, spanTtftMs } from "./session-turns"
 
@@ -449,5 +451,213 @@ describe("turn labels", () => {
 		expect(labelFor("a plain string")).toBeUndefined()
 		expect(labelFor([{ role: "assistant", content: "hi" }])).toBeUndefined()
 		expect(labelFor([{ role: "user", content: [{ type: "image" }] }])).toBeUndefined()
+	})
+})
+
+/**
+ * Maple's investigation fan-out: a planner pass, N hypothesis lanes launched
+ * together, then a validator pass. Every pass stamps its own
+ * `maple_ai.turn.id`, which the maple vendor integration lifts into
+ * `gen_ai.conversation.id`, so the lanes are concurrent CONVERSATION ids.
+ *
+ * Each lane opens on an `invoke_agent` root a few hundred ms after the one
+ * before it, runs for two minutes, and ends on a final chat plus an
+ * `execute_tool submit_candidate` — the tail spans a time-ordered partition
+ * files into whichever lane anchored last.
+ */
+function fanoutSpans(laneCount: number): readonly AiSessionSpan[] {
+	const lanes = Array.from({ length: laneCount }, (_, index) => index)
+	const laneOpensAt = (index: number) => 10 * SECOND + index * 300
+
+	return [
+		agentSpan({
+			spanId: "planner",
+			traceId: "trace-inv",
+			startMs: 0,
+			durationMs: 8 * SECOND,
+			agentName: "planner",
+			genAi: { conversationId: "inv_1_planner" },
+		}),
+		...lanes.flatMap((index) => {
+			const lane = `hypothesis-${index}`
+			const conversationId = `inv_1_${lane}`
+			const opensAt = laneOpensAt(index)
+			return [
+				agentSpan({
+					spanId: `${lane}-agent`,
+					traceId: "trace-inv",
+					startMs: opensAt,
+					durationMs: 120 * SECOND,
+					agentName: lane,
+					genAi: { conversationId },
+				}),
+				llmSpan({
+					spanId: `${lane}-chat-1`,
+					parentSpanId: `${lane}-agent`,
+					traceId: "trace-inv",
+					startMs: opensAt + SECOND,
+					durationMs: 3 * SECOND,
+					genAi: { conversationId },
+				}),
+				// The tail: both start long after the LAST lane's anchor.
+				llmSpan({
+					spanId: `${lane}-chat-2`,
+					parentSpanId: `${lane}-agent`,
+					traceId: "trace-inv",
+					startMs: opensAt + 100 * SECOND,
+					durationMs: 4 * SECOND,
+					genAi: { conversationId },
+				}),
+				toolSpan({
+					spanId: `${lane}-submit`,
+					parentSpanId: `${lane}-agent`,
+					traceId: "trace-inv",
+					startMs: opensAt + 110 * SECOND,
+					durationMs: SECOND,
+					toolName: "submit_candidate",
+					genAi: { conversationId },
+				}),
+			]
+		}),
+		agentSpan({
+			spanId: "validator",
+			traceId: "trace-inv",
+			startMs: 140 * SECOND,
+			durationMs: 10 * SECOND,
+			agentName: "validator",
+			genAi: { conversationId: "inv_1_validator" },
+		}),
+	]
+}
+
+describe("buildSessionTurns — concurrent conversation ids", () => {
+	// The regression: a time cursor gives each lane only the sliver before the
+	// next lane anchored, and dumps every lane's tail into the last one.
+	it("keeps each lane's own tail spans in its own turn", () => {
+		const turns = buildSessionTurns(fanoutSpans(4))
+
+		expect(turns.map((turn) => turn.anchorKind)).toEqual(Array(6).fill("conversation"))
+		expect(turns.map((turn) => turn.id)).toEqual([
+			"conversation:inv_1_planner",
+			"conversation:inv_1_hypothesis-0",
+			"conversation:inv_1_hypothesis-1",
+			"conversation:inv_1_hypothesis-2",
+			"conversation:inv_1_hypothesis-3",
+			"conversation:inv_1_validator",
+		])
+
+		for (const index of [0, 1, 2, 3]) {
+			const lane = `hypothesis-${index}`
+			const turn = turns.find((candidate) => candidate.id === `conversation:inv_1_${lane}`)!
+			expect(turn.spans.map((span) => span.spanId)).toEqual([
+				`${lane}-agent`,
+				`${lane}-chat-1`,
+				`${lane}-chat-2`,
+				`${lane}-submit`,
+			])
+		}
+	})
+
+	it("measures each lane over its own spans, so the lanes overlap", () => {
+		const turns = buildSessionTurns(fanoutSpans(3))
+		const lanes = turns.filter((turn) => turn.id.includes("hypothesis"))
+
+		expect(lanes).toHaveLength(3)
+		for (const lane of lanes) expect(lane.durationMs).toBeGreaterThan(100 * SECOND)
+		// Every lane is still open when the last one starts: concurrent, not serial.
+		const lastStart = Math.max(...lanes.map((lane) => lane.startMs))
+		for (const lane of lanes) expect(lane.endMs).toBeGreaterThan(lastStart)
+	})
+
+	// Two lanes dispatched inside one millisecond used to leave the earlier
+	// bucket empty, and the turn was dropped. Its anchor carries its own id, so
+	// it now keeps its turn.
+	it("keeps both turns when two anchors share a millisecond", () => {
+		const turns = buildSessionTurns([
+			llmSpan({ spanId: "a", startMs: 0, durationMs: 30 * SECOND, genAi: { conversationId: "t1" } }),
+			llmSpan({ spanId: "b", startMs: 0, durationMs: 30 * SECOND, genAi: { conversationId: "t2" } }),
+		])
+
+		expect(turns.map((turn) => turn.spans.map((span) => span.spanId))).toEqual([["a"], ["b"]])
+	})
+
+	// An untagged span is usually the app's own HTTP or database work sharing the
+	// agent's trace. Its parent names the turn, and following that beats the time
+	// cursor, which would file it into whichever lane anchored last.
+	it("follows parentage to place an untagged child in its parent's turn", () => {
+		const turns = buildSessionTurns([
+			agentSpan({
+				spanId: "lane-a",
+				startMs: 0,
+				durationMs: 60 * SECOND,
+				genAi: { conversationId: "t1" },
+			}),
+			agentSpan({
+				spanId: "lane-b",
+				startMs: SECOND,
+				durationMs: 60 * SECOND,
+				genAi: { conversationId: "t2" },
+			}),
+			// No conversation id: a database span the app emitted under lane A, long
+			// after lane B anchored.
+			makeSpan({
+				spanId: "db",
+				parentSpanId: "lane-a",
+				startMs: 30 * SECOND,
+				durationMs: SECOND,
+				spanName: "SELECT carts",
+				isAiSpan: false,
+			}),
+		])
+
+		expect(turns[0]!.spans.map((span) => span.spanId)).toEqual(["lane-a", "db"])
+		expect(turns[1]!.spans.map((span) => span.spanId)).toEqual(["lane-b"])
+	})
+
+	// Parentage only reaches so far: `parentSpanId` is intra-trace, and a span
+	// with no tagged ancestor has no link to any turn at all.
+	it("falls back to the time cursor for a span with no tagged ancestor", () => {
+		const turns = buildSessionTurns([
+			llmSpan({ spanId: "a", startMs: 0, durationMs: 10 * SECOND, genAi: { conversationId: "t1" } }),
+			llmSpan({
+				spanId: "b",
+				startMs: 30 * SECOND,
+				durationMs: 10 * SECOND,
+				genAi: { conversationId: "t2" },
+			}),
+			makeSpan({
+				spanId: "orphan",
+				traceId: "trace-other",
+				startMs: 35 * SECOND,
+				durationMs: SECOND,
+				isAiSpan: false,
+			}),
+		])
+
+		expect(turns[1]!.spans.map((span) => span.spanId)).toEqual(["b", "orphan"])
+	})
+
+	// The session-id exclusion has to survive the new path: for the six vendors
+	// that derive the session id from the conversation id, the id names the
+	// session and must not claim spans for turn 1.
+	it("still ignores a conversation id that only names the session", () => {
+		const turns = buildSessionTurns([
+			agentSpan({
+				spanId: "agent-1",
+				startMs: 0,
+				durationMs: 10 * SECOND,
+				sessionId: "sess-1",
+				genAi: { conversationId: "sess-1" },
+			}),
+			agentSpan({
+				spanId: "agent-2",
+				startMs: 60 * SECOND,
+				durationMs: 10 * SECOND,
+				sessionId: "sess-1",
+				genAi: { conversationId: "sess-1" },
+			}),
+		])
+
+		expect(turns.map((turn) => turn.anchorKind)).toEqual(["agent-root", "agent-root"])
 	})
 })

--- a/apps/web/src/lib/agent-sessions/session-turns.ts
+++ b/apps/web/src/lib/agent-sessions/session-turns.ts
@@ -150,6 +150,9 @@ interface TurnAnchor {
 	readonly span: AiSessionSpan
 	readonly kind: TurnAnchorKind
 	readonly id: string
+	/** The `gen_ai.conversation.id` this anchor owns, on the conversation rule
+	 *  only. It is also how member spans find their way to this turn. */
+	readonly conversationId: string | undefined
 }
 
 /**
@@ -161,17 +164,21 @@ interface TurnAnchor {
  * 1. `gen_ai.conversation.id` — the only turn key the convention has, and the
  *    one eve stamps with its turn id. One id, one turn. `findAnchors` requires
  *    more than one distinct id, and ignores vendors that derive the session id
- *    from it; it does not check that the ids are non-interleaved in time, so a
- *    vendor stamping one per concurrent sub-agent would mis-partition here.
+ *    from it. The ids may INTERLEAVE in time: Maple's investigation fan-out
+ *    stamps one per hypothesis lane and launches the lanes together.
  * 2. Agent invocations with no agent above them — a session with no usable
  *    conversation id still opens each turn by invoking the agent.
  * 3. One turn per trace — the floor. Wrong for a trace holding several turns,
  *    but it never merges two traces into one turn, and it always renders.
  *
- * Assignment is by time, not by parentage: a turn owns every span that started
- * before the next turn did, whatever trace or service it came from. Spans that
- * start before the first anchor (a gateway span that opens the trace, say) join
- * turn 1 rather than becoming a turn of their own.
+ * Assignment then depends on which rule fired. On rule 1 the id a span CARRIES
+ * decides, because concurrent turns make time meaningless as an owner: a pure
+ * time cursor gives each lane only the sliver before the next lane anchored and
+ * dumps every lane's tail into whichever anchored last. On rules 2 and 3 — and
+ * for any span carrying no id — a turn owns every span that started before the
+ * next turn did, whatever trace or service it came from. Spans that start before
+ * the first anchor (a gateway span that opens the trace, say) join turn 1 rather
+ * than becoming a turn of their own.
  */
 export function buildSessionTurns(spans: readonly AiSessionSpan[]): readonly SessionTurn[] {
 	if (spans.length === 0) return []
@@ -184,16 +191,21 @@ export function buildSessionTurns(spans: readonly AiSessionSpan[]): readonly Ses
 	const anchors = findAnchors(ordered.map((entry) => entry.span))
 	const anchorStarts = anchors.map((anchor) => spanStartMs(anchor.span))
 	const buckets: AiSessionSpan[][] = anchors.map(() => [])
+	const turnOf = conversationTurnResolver(spans, anchors)
 
-	// Both lists are in start order, so one forward cursor assigns every span.
+	// Both lists are in start order, so one forward cursor assigns every span that
+	// names no turn of its own.
 	let cursor = 0
 	for (const { span, startMs } of ordered) {
 		while (cursor + 1 < anchors.length && anchorStarts[cursor + 1]! <= startMs) cursor++
-		buckets[cursor]!.push(span)
+		buckets[turnOf(span) ?? cursor]!.push(span)
 	}
 
-	// Two anchors starting in the same millisecond leave the earlier one's bucket
-	// empty, and a turn with no spans has no start, no end and nothing to draw.
+	// A turn with no spans has no start, no end and nothing to draw. Rule 1 can no
+	// longer produce one — an anchor always carries its own id, so it lands in its
+	// own bucket even when another anchor shares its millisecond — but two
+	// agent-root or trace anchors in one millisecond still leave the earlier bucket
+	// empty.
 	return anchors
 		.map((anchor, index) => ({ anchor, turnSpans: buckets[index]! }))
 		.filter((entry) => entry.turnSpans.length > 0)
@@ -230,6 +242,55 @@ export function buildSessionTurns(spans: readonly AiSessionSpan[]): readonly Ses
 		})
 }
 
+/**
+ * Which turn a span names, by the conversation id it carries or its nearest
+ * tagged ancestor's — or `undefined`, leaving it to the caller's time cursor.
+ *
+ * Only the conversation rule assigns this way, so on rules 2 and 3 this is
+ * `undefined` for every span and the partition keeps its existing behaviour.
+ *
+ * Parentage is followed because a lane's own children are often untagged: the
+ * app's HTTP and database spans share the agent's trace and carry no
+ * `gen_ai.conversation.id`, and the time cursor would file them into whichever
+ * concurrent lane anchored last — the very mis-assignment this exists to stop.
+ * `parentSpanId` is intra-trace, so the walk ends at the trace root and the time
+ * cursor takes the spans it could not place, which is the best available guess
+ * for a span with no link to any turn.
+ */
+function conversationTurnResolver(
+	spans: readonly AiSessionSpan[],
+	anchors: readonly TurnAnchor[],
+): (span: AiSessionSpan) => number | undefined {
+	const turnByConversation = new Map<string, number>()
+	anchors.forEach((anchor, turn) => {
+		if (anchor.conversationId !== undefined) turnByConversation.set(anchor.conversationId, turn)
+	})
+	if (turnByConversation.size === 0) return () => undefined
+
+	const byId = new Map(spans.map((span) => [span.spanId, span]))
+	const memo = new Map<string, number | undefined>()
+
+	const resolve = (span: AiSessionSpan): number | undefined => {
+		if (memo.has(span.spanId)) return memo.get(span.spanId)
+		// Seeded before the walk so a malformed parent cycle ends here instead of
+		// recursing forever — the same guard `findAnchors` makes when it walks up.
+		memo.set(span.spanId, undefined)
+
+		// The same exclusion `findAnchors` makes: six vendors derive the session id
+		// FROM the conversation id, and for them the id names the session, not a
+		// turn — so it must not claim the span for turn 1.
+		const own = span.genAi.conversationId
+		let turn = own !== undefined && own !== span.sessionId ? turnByConversation.get(own) : undefined
+		if (turn === undefined) {
+			const parent = byId.get(span.parentSpanId)
+			if (parent !== undefined) turn = resolve(parent)
+		}
+		memo.set(span.spanId, turn)
+		return turn
+	}
+	return resolve
+}
+
 function findAnchors(ordered: readonly AiSessionSpan[]): readonly TurnAnchor[] {
 	const byConversation = new Map<string, AiSessionSpan>()
 	for (const span of ordered) {
@@ -246,6 +307,7 @@ function findAnchors(ordered: readonly AiSessionSpan[]): readonly TurnAnchor[] {
 			span,
 			kind: "conversation" as const,
 			id: `conversation:${conversationId}`,
+			conversationId,
 		}))
 	}
 
@@ -271,12 +333,22 @@ function findAnchors(ordered: readonly AiSessionSpan[]): readonly TurnAnchor[] {
 		(span) => span.isAiSpan && classifyAiSpan(span) === "agent" && !underAiSpan(span),
 	)
 	if (agentRoots.length > 0) {
-		return agentRoots.map((span) => ({ span, kind: "agent-root" as const, id: `span:${span.spanId}` }))
+		return agentRoots.map((span) => ({
+			span,
+			kind: "agent-root" as const,
+			id: `span:${span.spanId}`,
+			conversationId: undefined,
+		}))
 	}
 
 	const byTrace = new Map<string, AiSessionSpan>()
 	for (const span of ordered) if (!byTrace.has(span.traceId)) byTrace.set(span.traceId, span)
-	return [...byTrace].map(([traceId, span]) => ({ span, kind: "trace" as const, id: `trace:${traceId}` }))
+	return [...byTrace].map(([traceId, span]) => ({
+		span,
+		kind: "trace" as const,
+		id: `trace:${traceId}`,
+		conversationId: undefined,
+	}))
 }
 
 /**


### PR DESCRIPTION
Two related fixes for concurrent agent work that lands as sibling *turns* rather than lanes inside one turn — the shape Maple's own investigation fan-out produces, since every pass stamps its own turn id.

## Announce turns that ran in parallel

The transcript's parallelism treatment stopped at lane level: overlapping lanes inside one turn got a fork marker and jump chips, but overlapping turn *chapters* rendered as silently sequential. Turn-level overlap now gets the same treatment — the lane clustering (running max-end, honest overlap window only when a shared window exists) is lifted into a generic `clusterByOverlap` used by both levels. A `parallel-turns` marker row precedes the cluster ("3 turns ran at the same time — they overlap 12:31:51 → 12:32:02. Each turn is shown whole, in order: …") and each member's header carries reciprocal "ran in parallel with TURN n" jump chips, collapsed or not. Markers stay structural chrome: dropped under an active filter, excluded for no-AI chapter stubs.

## Assign spans to conversation turns by the id they carry

`buildSessionTurns`' conversation-id partition assigned spans by a pure time cursor, so N concurrent turn ids interleaved: every lane's tail spans — its final answer, its submit tool call — landed in whichever lane started last, and the transcript rendered them unattributed in the wrong chapter (its parentage re-threading is per-turn and could not repair a cross-turn split).

The conversation partition now assigns each span to the turn whose id it **carries**; untagged spans (the app's own HTTP/DB children) follow `parentSpanId` to the nearest tagged ancestor, and only spans with no link to any turn fall back to the time cursor. The session-id-derived exclusion, the agent-root and trace partitions, and pre-first-anchor behavior are all unchanged, and turn bounds/traces/failure/label still derive from the member sets. Same-millisecond anchors no longer drop the earlier turn on this path — an anchor carries its own id.

The two fixes compose: once each lane owns its spans, the fan-out reads as correctly-attributed sibling chapters, and the marker is what says they ran together.

Tests: +20 (fan-out regression proving each lane keeps its tail spans — fails on the old assignment; transitive/staggered/nested turn clustering with honest windows; the end-to-end fan-out → sibling chapters → marker combination; within-turn lane clustering anti-regression). 270 scoped tests and web typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790261253&installation_model_id=427786&pr_number=632&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F632&signature=80f3ba4043f6ce410a8dc4e51f744a8e1a6b326f3422ba2607ea06290d8fd70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->