### PR TITLE
fix(web): agent session detail feedback round two

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-flow.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-flow.tsx
@@ -5,6 +5,7 @@ import {
 	ReactFlow,
 	ReactFlowProvider,
 	useReactFlow,
+	type CoordinateExtent,
 	type Edge,
 	type Node,
 	type NodeProps,
@@ -51,6 +52,10 @@ const WRAP_GAP = 24
 
 const MIN_ZOOM = 0.5
 const MAX_ZOOM = 1.5
+/** How far past the graph the canvas can be panned. Roughly half a viewport:
+ *  enough to pull any node clear of the floor's legend and drawer, while a
+ *  fling can never strand the reader on empty canvas with no node in sight. */
+const PAN_MARGIN = 400
 
 /** Where the hidden ports sit on every card, mirrored by `Ports` below. */
 const STEP_HANDLES: NonNullable<Node["handles"]> = [
@@ -140,6 +145,24 @@ export function SessionFlow({
 		const byId = new Map<string, FlowNode>()
 		for (const lane of lanes) for (const node of lane.nodes) byId.set(node.span.spanId, node)
 		return byId
+	}, [lanes])
+
+	// Panning stays within a margin of the graph itself — the default extent is
+	// infinite, and a stray fling could park the reader on blank canvas with no
+	// way to tell which direction the session went.
+	const translateExtent = useMemo<CoordinateExtent>(() => {
+		let maxX = 0
+		let maxY = 0
+		for (const lane of lanes) {
+			for (const node of lane.nodes) {
+				maxX = Math.max(maxX, node.x + NODE_WIDTH)
+				maxY = Math.max(maxY, node.y + NODE_HEIGHT)
+			}
+		}
+		return [
+			[-PAN_MARGIN, -PAN_MARGIN],
+			[maxX + PAN_MARGIN, maxY + PAN_MARGIN],
+		]
 	}, [lanes])
 
 	// The keyboard's span cursor, over the nodes in reading order — lane by
@@ -279,6 +302,7 @@ export function SessionFlow({
 							}}
 							minZoom={MIN_ZOOM}
 							maxZoom={MAX_ZOOM}
+							translateExtent={translateExtent}
 							nodesDraggable={false}
 							nodesConnectable={false}
 							nodesFocusable={false}

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type ReactNode } from "react"
 
-import { ArrowRightIcon, ChevronDownIcon } from "@/components/icons"
+import { ArrowRightIcon, ChevronDownIcon, ChevronRightIcon } from "@/components/icons"
 import { Button } from "@maple/ui/components/ui/button"
 import { formatNumber, formatPercent } from "@maple/ui/lib/format"
 import { formatSessionDuration } from "@maple/ui/lib/replay-format"
@@ -11,6 +11,7 @@ import {
 	formatCost,
 	type SessionFailureKind,
 	type SessionSummary,
+	type SessionToolUsage,
 } from "@/lib/agent-sessions/session-summary"
 import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
 import { shortTarget } from "@/lib/agent-sessions/span-filters"
@@ -442,15 +443,21 @@ function Rail({ summary }: { summary: SessionSummary }) {
 				<RailSection title="Agents">
 					<div className="flex flex-wrap items-center gap-2">
 						{summary.agentNames.map((name, index) => (
-							<span key={name} className="flex items-center gap-2">
-								{index > 0 && <ArrowRightIcon size={12} className="text-muted-foreground" />}
+							// `min-w-0 max-w-full` + truncate: an agent name is emitter
+							// input, and one long enough would otherwise push the whole
+							// page into a horizontal scroll.
+							<span key={name} className="flex min-w-0 max-w-full items-center gap-2">
+								{index > 0 && (
+									<ArrowRightIcon size={12} className="shrink-0 text-muted-foreground" />
+								)}
 								<span
 									className={cn(
-										"rounded-sm px-2 py-0.5 font-mono text-[11px]",
+										"min-w-0 truncate rounded-sm px-2 py-0.5 font-mono text-[11px]",
 										index === 0
 											? "bg-primary/12 text-primary"
 											: "bg-muted text-muted-foreground",
 									)}
+									title={name}
 								>
 									{name}
 								</span>
@@ -465,24 +472,67 @@ function Rail({ summary }: { summary: SessionSummary }) {
 					<p className="text-muted-foreground text-xs">no tool calls</p>
 				) : (
 					summary.tools.map((tool) => (
-						<div key={tool.name} className="flex items-center gap-2.5">
-							<span className="w-24 shrink-0 truncate font-mono text-xs" title={tool.name}>
-								{tool.name}
-							</span>
-							<span className="h-1 min-w-0 flex-1 overflow-hidden rounded-xs bg-muted">
-								<span
-									className="block h-full bg-chart-4"
-									style={{ width: `${sharePercent(tool.calls, topToolCalls)}%` }}
-								/>
-							</span>
-							<span className="w-6 shrink-0 text-right font-mono text-muted-foreground text-xs tabular-nums">
-								{tool.calls}
-							</span>
-						</div>
+						<ToolUsageRow key={tool.name} tool={tool} topToolCalls={topToolCalls} />
 					))
 				)}
 			</RailSection>
 		</aside>
+	)
+}
+
+/**
+ * One tool in the rail. Where the instrumentation stamped a
+ * `gen_ai.tool.description`, the row discloses it in place — the definition the
+ * model saw is a fact about the session, and the rail is where the tool is
+ * already named. A tool without one has nothing to open and stays a plain row.
+ */
+function ToolUsageRow({ tool, topToolCalls }: { tool: SessionToolUsage; topToolCalls: number }) {
+	const [open, setOpen] = useState(false)
+	const disclosable = tool.description !== undefined
+
+	const row = (
+		<>
+			<span className="flex w-24 shrink-0 items-center gap-1">
+				{disclosable && (
+					<ChevronRightIcon
+						size={10}
+						className={cn("shrink-0 text-muted-foreground transition-transform", open && "rotate-90")}
+					/>
+				)}
+				<span className="min-w-0 truncate font-mono text-xs" title={tool.name}>
+					{tool.name}
+				</span>
+			</span>
+			<span className="h-1 min-w-0 flex-1 overflow-hidden rounded-xs bg-muted">
+				<span
+					className="block h-full bg-chart-4"
+					style={{ width: `${sharePercent(tool.calls, topToolCalls)}%` }}
+				/>
+			</span>
+			<span className="w-6 shrink-0 text-right font-mono text-muted-foreground text-xs tabular-nums">
+				{tool.calls}
+			</span>
+		</>
+	)
+
+	if (!disclosable) return <div className="flex items-center gap-2.5">{row}</div>
+
+	return (
+		<div className="flex flex-col gap-1.5">
+			<button
+				type="button"
+				onClick={() => setOpen((previous) => !previous)}
+				aria-expanded={open}
+				className="-mx-1 flex cursor-pointer items-center gap-2.5 rounded-xs px-1 py-0.5 text-left hover:bg-accent/40"
+			>
+				{row}
+			</button>
+			{open && (
+				<p className="break-words pl-4 text-muted-foreground text-xs leading-relaxed">
+					{tool.description}
+				</p>
+			)}
+		</div>
 	)
 }
 

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -378,7 +378,9 @@ function TurnChapter({
 				</span>
 				{turn.agentName !== undefined && <AgentPill name={turn.agentName} />}
 				{turn.failed && <Pill tone="error">Failed</Pill>}
-				{collapsed && <span className={cn(META, "shrink-0")}>{summariseTurn(row)}</span>}
+				{/* Shrinkable, unlike its neighbours: the summary joins every tool
+				    name in the turn, so it truncates rather than widening the page. */}
+				{collapsed && <span className={META}>{summariseTurn(row)}</span>}
 				<span className="grow" />
 				{/* The AI spans the transcript actually renders, not the turn's raw
 				    time slice: that slice carries the app's own HTTP/DB spans too, and
@@ -435,11 +437,16 @@ function summariseTurn(row: Extract<TranscriptRow, { kind: "turn" }>): string {
 	return parts.join(" · ")
 }
 
+/** Capped and truncating: the name is emitter input, and an unbounded one would
+ *  push its header row — and with it the page — into a horizontal scroll. */
 function AgentPill({ name }: { name: string }) {
 	return (
-		<span className="flex shrink-0 items-center gap-1.5 rounded-sm bg-primary/12 px-1.5 py-px font-mono text-[11px] text-primary">
-			<span aria-hidden className="size-1 rounded-full bg-primary" />
-			{name}
+		<span
+			className="flex max-w-56 shrink-0 items-center gap-1.5 rounded-sm bg-primary/12 px-1.5 py-px font-mono text-[11px] text-primary"
+			title={name}
+		>
+			<span aria-hidden className="size-1 shrink-0 rounded-full bg-primary" />
+			<span className="min-w-0 truncate">{name}</span>
 		</span>
 	)
 }
@@ -458,6 +465,7 @@ function UserBlock({
 	const showHistory = disclosed(openRows, historyKey, false)
 	const rawKey = `${row.key}:raw`
 	const raw = disclosed(openRows, rawKey, false)
+	const textKey = `${row.key}:text`
 
 	return (
 		<Row time={clockOf(row.startMs, timeZone)} depth={row.depth} rail="bg-foreground" className="pt-5">
@@ -487,15 +495,20 @@ function UserBlock({
 						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
 					/>
 				</div>
-				{raw ? (
-					<p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
-						{row.text}
-					</p>
-				) : (
-					<MessageResponse className="text-foreground text-sm leading-relaxed">
-						{row.text}
-					</MessageResponse>
-				)}
+				{/* Clamped like every other long body: a pasted 400-line prompt is one
+				    block of a conversation, not the page. "Show full" opens it. */}
+				<ClampedText
+					text={row.text}
+					body={
+						raw ? undefined : (
+							<MessageResponse className="text-foreground text-sm leading-relaxed">
+								{row.text}
+							</MessageResponse>
+						)
+					}
+					expanded={disclosed(openRows, textKey, false)}
+					onToggleExpanded={() => onToggleRow(textKey)}
+				/>
 				{showHistory && (
 					<div className="flex flex-col gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2.5">
 						{/* The history verbatim, not a diff: dropped and truncated
@@ -852,7 +865,10 @@ function ToolBlock({
 					>
 						<GearIcon size={13} className={cn("shrink-0", tone)} />
 						<span className={cn(LABEL, tone)}>Tool</span>
-						<span className="shrink-0 font-medium font-mono text-foreground text-xs">
+						<span
+							className="min-w-0 truncate font-medium font-mono text-foreground text-xs"
+							title={row.toolName ?? row.span.spanName}
+						>
 							{row.toolName ?? row.span.spanName}
 						</span>
 						<span className={cn(META, "shrink-0")}>
@@ -1142,10 +1158,15 @@ function LaneOpen({
 				<span className={cn(LABEL, "text-chart-1")}>
 					{row.laneKind === "subagent" ? "Subagent" : "Agent"}
 				</span>
-				<span className="shrink-0 font-medium font-mono text-foreground text-xs">
+				{/* Both carry agent names, which are emitter input: capped and
+				    truncating so a long one cannot widen the page. */}
+				<span
+					className="max-w-56 truncate font-medium font-mono text-foreground text-xs"
+					title={row.agentName}
+				>
 					{row.agentName}
 				</span>
-				<span className={cn(META, "shrink-0")}>
+				<span className={META}>
 					{row.laneKind === "subagent" && row.parentAgentName !== undefined
 						? `· invoked by ${row.parentAgentName}`
 						: `· trace ${row.span.traceId.slice(0, 8)}`}{" "}
@@ -1203,7 +1224,8 @@ function ParallelJump({
 		<button
 			type="button"
 			onClick={() => onJump(targetKey)}
-			className="shrink-0 cursor-pointer rounded-sm bg-primary/12 px-2 py-0.5 text-[11px] text-primary hover:bg-primary/20"
+			title={label}
+			className="max-w-72 shrink-0 cursor-pointer truncate rounded-sm bg-primary/12 px-2 py-0.5 text-[11px] text-primary hover:bg-primary/20"
 		>
 			ran in parallel with {label}
 		</button>
@@ -1220,7 +1242,7 @@ function LaneClose({
 		<Row depth={row.depth} className="pt-2">
 			<div className="flex items-center gap-2.5 py-1">
 				<CornerDownLeftIcon size={12} className="shrink-0 text-muted-foreground" />
-				<span className="shrink-0 text-muted-foreground text-xs">
+				<span className="min-w-0 truncate text-muted-foreground text-xs">
 					{row.agentName}
 					{row.parentAgentName === undefined
 						? " finished"
@@ -1272,7 +1294,7 @@ function ParallelMarker({
 				{/* Only a window every lane shared is reported as an overlap. A chain
 				    of pairwise overlaps has none, and the marker then reports the fork's
 				    extent instead of inventing one. */}
-				<span className="shrink-0 text-muted-foreground text-xs">
+				<span className="min-w-0 truncate text-muted-foreground text-xs">
 					{row.forkedBy === undefined ? "This turn" : row.forkedBy} forked {row.lanes.length} lanes
 					—{" "}
 					{row.overlapStartMs !== undefined && row.overlapEndMs !== undefined
@@ -1285,7 +1307,8 @@ function ParallelMarker({
 						key={lane.key}
 						type="button"
 						onClick={() => onJump(lane.key)}
-						className="shrink-0 cursor-pointer font-mono text-[11px] text-primary hover:underline"
+						title={lane.agentName}
+						className="max-w-48 shrink-0 cursor-pointer truncate font-mono text-[11px] text-primary hover:underline"
 					>
 						{lane.agentName}
 					</button>
@@ -1336,7 +1359,8 @@ function ParallelTurnsMarker({
 						key={ref.key}
 						type="button"
 						onClick={() => onJump(ref.key)}
-						className="shrink-0 cursor-pointer font-mono text-[11px] text-primary hover:underline"
+						title={ref.turn.agentName}
+						className="max-w-48 shrink-0 cursor-pointer truncate font-mono text-[11px] text-primary hover:underline"
 					>
 						{turnOrdinal(ref.turn).toUpperCase()}
 						{ref.turn.agentName !== undefined && ` ${ref.turn.agentName}`}
@@ -1398,7 +1422,10 @@ function StructureRow({
 					)}
 				>
 					<Glyph size={13} className={cn("shrink-0", tone)} />
-					<span className="shrink-0 font-medium font-mono text-foreground text-xs">
+					<span
+						className="min-w-0 truncate font-medium font-mono text-foreground text-xs"
+						title={row.label}
+					>
 						{row.label}
 					</span>
 					<span className={META}>{structureMeta(row.span, category)}</span>

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router"
 import { useVirtualizer } from "@tanstack/react-virtual"
 
 import type { AiSessionSpan } from "@maple/domain/http"
-import { ChevronDownIcon, ChevronRightIcon } from "@/components/icons"
+import { ChevronDownIcon, ChevronRightIcon, CircleXmarkIcon } from "@/components/icons"
 import { formatDuration, formatNumber } from "@maple/ui/lib/format"
 import { formatSessionDuration } from "@maple/ui/lib/replay-format"
 import { cn } from "@maple/ui/lib/utils"
@@ -31,13 +31,15 @@ import {
 import { filterSpans, isDelegation, shortTarget } from "@/lib/agent-sessions/span-filters"
 import { Pill } from "./pill"
 import { SpanInlineDetail, type SpanDetailTab } from "./span-expansion"
-import { CATEGORY_FILL } from "./span-visuals"
+import { CATEGORY_FILL, CATEGORY_ICON, CATEGORY_TEXT } from "./span-visuals"
 
 // Row heights are fixed and known, so the virtualizer never has to measure —
 // except the one inline detail row, whose height is its payload's and is
 // measured (`measureElement`) instead.
 const TURN_ROW_HEIGHT = 30
-const ROW_HEIGHT = 26
+/** Two above the old 26: the category glyphs need a touch more air than the
+ *  dots they replaced. */
+const ROW_HEIGHT = 28
 /** Starting guess for the detail row; the measurement replaces it on mount. */
 const DETAIL_ROW_ESTIMATE = 480
 /** Past this the indent eats the span name; deep agent trees are common. */
@@ -534,6 +536,9 @@ function SpanRow({
 	const { span } = row
 	const category = classifyAiSpan(span)
 	const errored = spanFailed(span)
+	// The same glyph vocabulary as the Flow view's nodes: the kind of work reads
+	// by shape, and a failure takes the glyph over outright.
+	const Glyph = errored ? CircleXmarkIcon : CATEGORY_ICON[category]
 	const target = spanTarget(span, category)
 	// Only a model id is a provider path — a tool's target is usually a file path,
 	// whose last segment is not the part worth keeping.
@@ -557,14 +562,12 @@ function SpanRow({
 				className={COL_SPAN}
 				style={{ paddingLeft: Math.min(row.depth, MAX_INDENT_DEPTH) * INDENT_PX }}
 			>
-				<span
+				<Glyph
 					aria-hidden
-					className={cn(
-						"size-1.5 shrink-0 rounded-xs",
-						errored ? "bg-destructive" : CATEGORY_FILL[category],
-					)}
+					size={13}
+					className={cn("shrink-0", errored ? "text-destructive" : CATEGORY_TEXT[category])}
 				/>
-				<span className="shrink-0 truncate font-medium">{span.spanName}</span>
+				<span className="truncate font-medium">{span.spanName}</span>
 				<span className="min-w-0 truncate text-muted-foreground">{spanMeta(span, category)}</span>
 				{errored && <Pill tone="error">{span.genAi.errorType ?? "Error"}</Pill>}
 				{isDelegation(span, spansById) && <Pill tone="outline">Subagent</Pill>}

--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -14,6 +14,7 @@ import {
 	CheckIcon,
 	ChevronDownIcon,
 	ChevronRightIcon,
+	CircleXmarkIcon,
 	CopyIcon,
 	ExternalLinkIcon,
 	XmarkIcon,
@@ -37,7 +38,7 @@ import {
 import { classifyAiSpan, spanFailed, spanModel, spanTtftMs } from "@/lib/agent-sessions/session-turns"
 import { callMetaLine, formatCost } from "@/lib/agent-sessions/session-summary"
 import { ClampedText, firstLine } from "./clamped-text"
-import { CATEGORY_FILL } from "./span-visuals"
+import { CATEGORY_ICON, CATEGORY_TEXT } from "./span-visuals"
 
 /**
  * The payload of one span, expanded in place — under its waterfall row, or in
@@ -183,6 +184,9 @@ export function SpanDrawer({
 }) {
 	const category = classifyAiSpan(span)
 	const errored = spanFailed(span)
+	// The canvas the drawer docks under draws its nodes with these glyphs, so the
+	// drawer names its span in the same vocabulary.
+	const Glyph = errored ? CircleXmarkIcon : CATEGORY_ICON[category]
 	const subtitle = [turnOrdinal, spanModel(span), formatDuration(span.durationMs)]
 		.filter((part): part is string => part !== undefined)
 		.join(" · ")
@@ -201,12 +205,10 @@ export function SpanDrawer({
 				tabsInHeader
 				header={(tabs) => (
 					<div className="sticky top-0 z-10 flex flex-wrap items-center gap-x-3 gap-y-1 bg-background py-2">
-						<span
+						<Glyph
 							aria-hidden
-							className={cn(
-								"size-1.5 shrink-0 rounded-xs",
-								errored ? "bg-destructive" : CATEGORY_FILL[category],
-							)}
+							size={13}
+							className={cn("shrink-0", errored ? "text-destructive" : CATEGORY_TEXT[category])}
 						/>
 						<span className="font-medium font-mono text-sm">{span.spanName}</span>
 						{subtitle !== "" && <span className="text-muted-foreground text-xs">{subtitle}</span>}

--- a/apps/web/src/lab/agent-session-fixture.ts
+++ b/apps/web/src/lab/agent-session-fixture.ts
@@ -221,6 +221,24 @@ function toolArguments(tool: string): Record<string, unknown> {
 	}
 }
 
+/** `gen_ai.tool.description`, on the tools that stamp one — the Overview's
+ *  Tools rail discloses it. run_sql and friends deliberately carry none, so
+ *  the rail also shows the plain, undisclosable row. */
+function toolDescription(tool: string): string | undefined {
+	switch (tool) {
+		case "read_file":
+			return "Read a file from the repository. Returns up to 2000 lines from the given offset."
+		case "grep_repo":
+			return "Search file contents with a regular expression, scoped by a glob."
+		case "run_tests":
+			return "Run a test suite and report per-test pass/fail with captured output for failures."
+		case "write_file":
+			return "Write a file to the repository, overwriting whatever is there."
+		default:
+			return undefined
+	}
+}
+
 function toolResult(tool: string): string | undefined {
 	switch (tool) {
 		case "read_file":
@@ -326,6 +344,7 @@ function buildBaseTurns(): readonly AiSessionSpan[] {
 							toolCallId: `toolu_${index}_${call}`,
 							toolCallArguments: toolArguments(tool),
 							toolCallResult: failedTool ? "exit 1 · 2 failing" : toolResult(tool),
+							toolDescription: toolDescription(tool),
 							errorType: failedTool ? "tool_error" : undefined,
 						},
 					}),

--- a/apps/web/src/lib/agent-sessions/session-summary.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-summary.test.ts
@@ -854,6 +854,25 @@ describe("per-model cost, tools and failure groups", () => {
 		])
 	})
 
+	// The Overview's rail discloses the description, so it rides the usage row.
+	it("keeps the first stamped tool description for the tool's usage row", () => {
+		const summary = summarize([
+			agentSpan({ spanId: "a1", startMs: 0, durationMs: 10 * SECOND }),
+			toolSpan({ spanId: "t1", parentSpanId: "a1", startMs: 0, durationMs: 100 }),
+			toolSpan({
+				spanId: "t2",
+				parentSpanId: "a1",
+				startMs: 200,
+				durationMs: 100,
+				genAi: { toolDescription: "Read a file from the repository." },
+			}),
+		])
+
+		expect(summary.tools).toEqual([
+			{ name: "read_file", calls: 2, description: "Read a file from the repository." },
+		])
+	})
+
 	// The counts and the breakdown are two readings of one list, so a failure
 	// classified as a rate limit must not also appear as a generic error.
 	it("groups failures under the same classification the counts use", () => {

--- a/apps/web/src/lib/agent-sessions/session-summary.ts
+++ b/apps/web/src/lib/agent-sessions/session-summary.ts
@@ -83,6 +83,8 @@ export interface SessionModelUsage {
 export interface SessionToolUsage {
 	readonly name: string
 	readonly calls: number
+	/** `gen_ai.tool.description`, from the first span that stamped one. */
+	readonly description: string | undefined
 }
 
 /** How a failure is named on the page — the bucket it counts in, and the label
@@ -697,14 +699,19 @@ function modelUsage(
  * disappearing from a column whose total says 63.
  */
 function toolUsage(spans: readonly AiSessionSpan[]): readonly SessionToolUsage[] {
-	const calls = new Map<string, number>()
+	const calls = new Map<string, { count: number; description: string | undefined }>()
 	for (const span of spans) {
 		if (classifyAiSpan(span) !== "tool") continue
 		const name = span.genAi.toolName ?? span.spanName
-		calls.set(name, (calls.get(name) ?? 0) + 1)
+		const entry = calls.get(name) ?? { count: 0, description: undefined }
+		entry.count += 1
+		// The first stamped description speaks for the tool: emitters send the
+		// same definition on every call, so later ones only repeat it.
+		entry.description ??= span.genAi.toolDescription
+		calls.set(name, entry)
 	}
 	return [...calls]
-		.map(([name, count]) => ({ name, calls: count }))
+		.map(([name, entry]) => ({ name, calls: entry.count, description: entry.description }))
 		.sort((a, b) => b.calls - a.calls || a.name.localeCompare(b.name))
 }
 

--- a/apps/web/src/routes/agent-sessions/$sessionId.tsx
+++ b/apps/web/src/routes/agent-sessions/$sessionId.tsx
@@ -263,8 +263,11 @@ function SessionDetailBody({
 				    resolve against the padding edge. The top edge is the control bar;
 				    the bottom is the Flow view's floor, whose docked span drawer
 				    otherwise floats a padding's height short of the viewport with the
-				    canvas scrolling visibly beneath it. */}
-				<DashboardLayout.Scroll className="py-0">
+				    canvas scrolling visibly beneath it. `pr-6` keeps the overlay
+				    scrollbar off the right-aligned duration/cost columns, and
+				    `overflow-x-hidden` means a span that escapes its truncation can
+				    never make the whole page scroll sideways. */}
+				<DashboardLayout.Scroll className="overflow-x-hidden py-0 pr-6">
 					{truncated && (
 						<div className="shrink-0 py-4">
 							<Alert variant="warning">

--- a/bun.lock
+++ b/bun.lock
@@ -402,22 +402,6 @@
         "react": ">=19.0.0",
       },
     },
-    "lib/llm": {
-      "name": "@maple/llm",
-      "dependencies": {
-        "@smithy/eventstream-codec": "4.2.14",
-        "@smithy/util-utf8": "4.2.2",
-        "aws4fetch": "1.0.20",
-        "effect": "catalog:effect",
-      },
-      "devDependencies": {
-        "@effect/language-service": "catalog:effect",
-        "@types/node": "catalog:tooling",
-        "typescript": "catalog:tooling",
-        "vite": "catalog:",
-        "vitest": "catalog:",
-      },
-    },
     "lib/otel-helpers": {
       "name": "@maple/otel-helpers",
       "version": "0.1.0",
@@ -1344,8 +1328,6 @@
     "@maple/ingest": ["@maple/ingest@workspace:apps/ingest"],
 
     "@maple/landing": ["@maple/landing@workspace:apps/landing"],
-
-    "@maple/llm": ["@maple/llm@workspace:lib/llm"],
 
     "@maple/local-ui": ["@maple/local-ui@workspace:apps/local-ui"],
 


### PR DESCRIPTION
A second round of feedback fixes on the agent session detail page, verified against the `/lab/agent-session` fixture.

## What changed

**Scrollbar clearance + overflow guard.** The detail page's scroller now carries `pr-6` so the overlay scrollbar sits clear of the right-aligned duration/cost columns, and `overflow-x-hidden` so no stray span can ever put the whole page into a horizontal scroll.

**Long names contained everywhere.** Agent names are emitter input, so every place one rendered unbounded now caps and truncates (full value in `title`): the Overview's Agents rail pills, the transcript's turn-header agent pill, lane open/close rows, "ran in parallel with" jump chips, parallel-marker lane buttons, tool and structure row labels, the collapsed-turn summary (which joins every tool name in the turn), and the waterfall's span-name cell. Stress-tested with a 100-char agent name and a multi-thousand-word prompt: no view overflows.

**Interactable Tools rail.** `SessionToolUsage` now carries `gen_ai.tool.description` (from the first span that stamped one), and an Overview tool row with a description discloses it in place. Tools without one stay plain rows. The lab fixture stamps descriptions on four tools so both shapes render.

**Flow panning constrained.** The canvas gets a `translateExtent` computed from the node bounding box plus a 400px margin — a fling can no longer strand the reader on blank canvas with no node in sight.

**Traces rows read by glyph.** Span rows draw the Flow view's category icons (agent/inference/tool, with error taking the glyph over) instead of colored dots; rows go 26px → 28px for the extra weight. The Flow drawer header names its span with the same glyph.

**User input clamps.** Transcript user blocks render through the shared `ClampedText`: twelve lines with Show full / Show less, in both markdown and raw views, with the disclosure held in `openRows` so it survives virtualization.

Also rides along: `bun.lock` prunes the stale `lib/llm` workspace entry left behind when #626 replaced the vendored copy with `@opencode-ai/ai`.

## Verification

- `apps/web` typecheck clean; all 271 agent-session tests pass, including a new one for the description pickup.
- Every view eyeballed in the lab harness, including a temporary long-name/long-prompt fixture stress patch (reverted before commit).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790274815&installation_model_id=427786&pr_number=633&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F633&signature=4ce283ddeeb87b571906ae10f86445d66f4bef961e21c05748bf0d0b1c2b02ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->