### PR TITLE
feat(slack-agent): emit model cost, reasoning tokens, and TTFT to Maple

### DIFF
--- a/apps/slack-agent/agent/agent.ts
+++ b/apps/slack-agent/agent/agent.ts
@@ -42,7 +42,12 @@ const contextWindowTokens = Number(process.env.OPENROUTER_CONTEXT_WINDOW ?? 400_
 const workflowWorld = process.env.EVE_WORKFLOW_WORLD
 
 export default defineAgent({
-	model: openrouter(modelId),
+	// `usage.include` turns on OpenRouter usage accounting: every response then
+	// carries the actual amount charged (`usage.cost`, in USD credits), which the
+	// telemetry pipeline lifts into `gen_ai.usage.cost` (see
+	// `lib/genai-cost.ts`). Without it OpenRouter omits cost and per-session
+	// spend in Maple would have to be inferred from token prices.
+	model: openrouter(modelId, { usage: { include: true } }),
 	modelContextWindowTokens: contextWindowTokens,
 	...(workflowWorld ? { experimental: { workflow: { world: workflowWorld } } } : undefined),
 })

--- a/apps/slack-agent/agent/instrumentation.ts
+++ b/apps/slack-agent/agent/instrumentation.ts
@@ -5,9 +5,11 @@ import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici"
 import { resourceFromAttributes } from "@opentelemetry/resources"
 import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs"
 import { NodeSDK } from "@opentelemetry/sdk-node"
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base"
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
 import { defineInstrumentation, isChannel } from "eve/instrumentation"
 import slackChannel from "#channels/slack.js"
+import { GenAiCostSpanProcessor } from "#lib/genai-cost.js"
 import { markAgentTelemetryActive } from "#lib/telemetry-log.js"
 
 /**
@@ -97,10 +99,19 @@ function setupTelemetry(): void {
 		// recurse into the exporters below: the Node OTLP exporters use
 		// `node:http`, not fetch.
 		instrumentations: [new UndiciInstrumentation()],
-		traceExporter: new OTLPTraceExporter({
-			url: `${endpoint}/v1/traces`,
-			headers,
-		}),
+		// Explicit processor list instead of `traceExporter` (which would build
+		// just the batch processor): the cost processor must see each span before
+		// the batch processor serializes it, so it can lift OpenRouter's charged
+		// cost from `ai.response.providerMetadata` into `gen_ai.usage.cost`.
+		spanProcessors: [
+			new GenAiCostSpanProcessor(),
+			new BatchSpanProcessor(
+				new OTLPTraceExporter({
+					url: `${endpoint}/v1/traces`,
+					headers,
+				}),
+			),
+		],
 		// Logs, not just spans: agent/hooks/outcome-log.ts is the primary signal
 		// for the "agent did nothing" failure mode, and without a log pipeline it
 		// never leaves the container. NodeSDK builds the LoggerProvider from these

--- a/apps/slack-agent/agent/lib/eve-patch.test.ts
+++ b/apps/slack-agent/agent/lib/eve-patch.test.ts
@@ -107,3 +107,44 @@ describe("eve __maple_ui strip patch", () => {
 		expect(strip!(null)).toBe(null)
 	})
 })
+
+describe("eve otel supplemental-attributes patch", () => {
+	/**
+	 * Canary for the third hunk of `patches/eve@0.25.3.patch`: eve hard-codes
+	 * `new OpenTelemetry({runtimeContext:!0})`, which leaves the integration's
+	 * `providerMetadata` and `usage` supplemental span attributes off. The patch
+	 * turns both on — `ai.response.providerMetadata` is where OpenRouter's cost
+	 * accounting reaches the span (lifted into `gen_ai.usage.cost` by
+	 * `lib/genai-cost.ts`), and the usage supplemental carries
+	 * `ai.usage.outputTokenDetails.reasoningTokens`, which Maple's read side
+	 * decodes as reasoning output tokens.
+	 *
+	 * Fails silently when it stops applying: spans simply arrive without cost
+	 * or reasoning tokens. So the test registers the real integration and reads
+	 * the flags it resolved.
+	 */
+	const require_ = createRequire(import.meta.url)
+	const eveRoot = new URL(".", `file://${require_.resolve("eve/package.json")}`).href
+
+	test("registered integration has providerMetadata + usage supplementals on", async () => {
+		const module_ = (await import(`${eveRoot}dist/src/harness/otel-integration.js`)) as {
+			ensureOtelIntegration: () => void
+		}
+		module_.ensureOtelIntegration()
+
+		const integrations = (
+			globalThis as {
+				AI_SDK_TELEMETRY_INTEGRATIONS?: Array<{
+					supplementalAttributes?: Record<string, boolean>
+				}>
+			}
+		).AI_SDK_TELEMETRY_INTEGRATIONS
+		const otel = integrations?.find((entry) => entry.supplementalAttributes !== undefined)
+		expect(otel, "eve did not register its OpenTelemetry integration").toBeDefined()
+		expect(otel!.supplementalAttributes).toMatchObject({
+			runtimeContext: true,
+			providerMetadata: true,
+			usage: true,
+		})
+	})
+})

--- a/apps/slack-agent/agent/lib/genai-cost.test.ts
+++ b/apps/slack-agent/agent/lib/genai-cost.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import type { Attributes } from "@opentelemetry/api"
+import {
+	extractOpenRouterCost,
+	GENAI_USAGE_COST_ATTR,
+	PROVIDER_METADATA_ATTR,
+	stampGenAiCost,
+} from "#lib/genai-cost.js"
+
+/** Provider metadata as eve's OTel integration serializes it onto spans. */
+const metadataJson = (usage: Record<string, unknown>): string =>
+	JSON.stringify({ openrouter: { provider: "openai", usage } })
+
+describe("extractOpenRouterCost", () => {
+	test("reads the charged cost", () => {
+		expect(extractOpenRouterCost(metadataJson({ cost: 0.01275 }))).toBe(0.01275)
+	})
+
+	test("adds the BYOK upstream inference cost to OpenRouter's fee", () => {
+		expect(
+			extractOpenRouterCost(
+				metadataJson({ cost: 0.0005, costDetails: { upstreamInferenceCost: 0.01 } }),
+			),
+		).toBeCloseTo(0.0105, 10)
+	})
+
+	test("zero cost is real accounting (free-tier model), not absence", () => {
+		expect(extractOpenRouterCost(metadataJson({ cost: 0 }))).toBe(0)
+	})
+
+	test("no cost field (accounting disabled) yields undefined", () => {
+		expect(extractOpenRouterCost(metadataJson({ promptTokens: 12 }))).toBeUndefined()
+	})
+
+	test("non-OpenRouter metadata yields undefined", () => {
+		expect(
+			extractOpenRouterCost(JSON.stringify({ anthropic: { cacheCreationInputTokens: 5 } })),
+		).toBeUndefined()
+	})
+
+	test("malformed JSON and non-numeric cost yield undefined", () => {
+		expect(extractOpenRouterCost("{not json")).toBeUndefined()
+		expect(extractOpenRouterCost(metadataJson({ cost: "0.01" }))).toBeUndefined()
+		expect(extractOpenRouterCost(metadataJson({ cost: Number.NaN }))).toBeUndefined()
+	})
+})
+
+describe("stampGenAiCost", () => {
+	test("stamps gen_ai.usage.cost on attributes carrying costed provider metadata", () => {
+		const attributes: Attributes = {
+			[PROVIDER_METADATA_ATTR]: metadataJson({ cost: 0.002 }),
+		}
+		stampGenAiCost(attributes)
+		expect(attributes[GENAI_USAGE_COST_ATTR]).toBe(0.002)
+	})
+
+	test("leaves attributes without provider metadata or without cost untouched", () => {
+		const plain: Attributes = { "gen_ai.operation.name": "chat" }
+		const uncosted: Attributes = {
+			[PROVIDER_METADATA_ATTR]: metadataJson({ promptTokens: 3 }),
+		}
+		stampGenAiCost(plain)
+		stampGenAiCost(uncosted)
+		expect(plain[GENAI_USAGE_COST_ATTR]).toBeUndefined()
+		expect(uncosted[GENAI_USAGE_COST_ATTR]).toBeUndefined()
+	})
+})

--- a/apps/slack-agent/agent/lib/genai-cost.ts
+++ b/apps/slack-agent/agent/lib/genai-cost.ts
@@ -1,0 +1,105 @@
+import type { Attributes, Context } from "@opentelemetry/api"
+import type { ReadableSpan, Span, SpanProcessor } from "@opentelemetry/sdk-trace-base"
+
+/**
+ * Lifts the OpenRouter cost accounting into `gen_ai.usage.cost`.
+ *
+ * The chain that makes this necessary: OpenRouter reports the charged amount in
+ * the response (`usage.cost`, enabled per-request via `usage.include` in
+ * `agent.ts`), the AI SDK provider surfaces it as
+ * `providerMetadata.openrouter.usage`, and eve's OTel integration serializes
+ * that object onto the model-call spans as `ai.response.providerMetadata`
+ * (enabled by the `providerMetadata` supplemental in
+ * `patches/eve@0.25.3.patch`). No emitter in that chain writes the
+ * OpenLLMetry-convention `gen_ai.usage.cost` key Maple decodes, and eve's
+ * instrumentation events offer no post-response hook to add it — so the lift
+ * happens here, in a span processor, just before export.
+ *
+ * The canonical key (rather than a read-side integration alias in
+ * `@maple/query-engine-integrations`) is deliberate: a flat numeric attribute
+ * is directly aggregatable in warehouse SQL, where a value buried in
+ * providerMetadata JSON is not. Maple's session views count cost per
+ * deepest-reporting span, so the same value appearing on the step and root
+ * spans does not double-count.
+ */
+
+/** Stringified provider metadata, stamped by eve's OTel integration. */
+export const PROVIDER_METADATA_ATTR = "ai.response.providerMetadata"
+
+/** The cost key Maple's GenAI catalog decodes (`usageCost` in gen-ai.ts). */
+export const GENAI_USAGE_COST_ATTR = "gen_ai.usage.cost"
+
+/**
+ * Total cost in USD from an `ai.response.providerMetadata` JSON payload, or
+ * undefined when the payload carries no cost (accounting disabled, another
+ * provider, or malformed JSON — all left unstamped rather than guessed).
+ *
+ * `usage.cost` is what OpenRouter charged; with BYOK keys it is only
+ * OpenRouter's fee and the upstream charge arrives separately as
+ * `usage.costDetails.upstreamInferenceCost`, so the two are summed. A zero
+ * cost (free-tier model) is real accounting and is returned, not dropped.
+ */
+export function extractOpenRouterCost(providerMetadataJson: string): number | undefined {
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(providerMetadataJson)
+	} catch {
+		return undefined
+	}
+	const usage = readObjectPath(parsed, "openrouter", "usage")
+	if (usage === undefined) return undefined
+	const cost = readFiniteNumber(usage["cost"])
+	if (cost === undefined) return undefined
+	const upstream = readFiniteNumber(readObjectPath(usage, "costDetails")?.["upstreamInferenceCost"])
+	return cost + (upstream ?? 0)
+}
+
+function readObjectPath(value: unknown, ...path: string[]): Record<string, unknown> | undefined {
+	let current = value
+	for (const key of path) {
+		if (current === null || typeof current !== "object") return undefined
+		current = (current as Record<string, unknown>)[key]
+	}
+	return current !== null && typeof current === "object"
+		? (current as Record<string, unknown>)
+		: undefined
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+/**
+ * Stamps {@link GENAI_USAGE_COST_ATTR} into an attribute record whose
+ * provider metadata carries cost accounting; leaves every other record
+ * untouched.
+ */
+export function stampGenAiCost(attributes: Attributes): void {
+	const raw = attributes[PROVIDER_METADATA_ATTR]
+	if (typeof raw !== "string") return
+	const cost = extractOpenRouterCost(raw)
+	if (cost === undefined) return
+	attributes[GENAI_USAGE_COST_ATTR] = cost
+}
+
+/**
+ * Span processor applying {@link stampGenAiCost} to every ended span.
+ * Registered ahead of the batch processor in `instrumentation.ts`; mutating
+ * `span.attributes` in `onEnd` is visible to the exporter because the batch
+ * processor serializes the same span object later.
+ */
+export class GenAiCostSpanProcessor implements SpanProcessor {
+	onStart(_span: Span, _parentContext: Context): void {}
+
+	onEnd(span: ReadableSpan): void {
+		stampGenAiCost(span.attributes)
+	}
+
+	forceFlush(): Promise<void> {
+		return Promise.resolve()
+	}
+
+	shutdown(): Promise<void> {
+		return Promise.resolve()
+	}
+}

--- a/apps/slack-agent/bun.lock
+++ b/apps/slack-agent/bun.lock
@@ -15,6 +15,7 @@
         "@opentelemetry/resources": "^2.0.0",
         "@opentelemetry/sdk-logs": "^0.205.0",
         "@opentelemetry/sdk-node": "^0.205.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.36.0",
         "@resvg/resvg-js": "^2.6.2",
         "@workflow/world-postgres": "5.0.0-beta.27",

--- a/apps/slack-agent/package.json
+++ b/apps/slack-agent/package.json
@@ -26,6 +26,7 @@
 		"@opentelemetry/resources": "^2.0.0",
 		"@opentelemetry/sdk-logs": "^0.205.0",
 		"@opentelemetry/sdk-node": "^0.205.0",
+		"@opentelemetry/sdk-trace-base": "^2.0.0",
 		"@opentelemetry/semantic-conventions": "^1.36.0",
 		"@resvg/resvg-js": "^2.6.2",
 		"@workflow/world-postgres": "5.0.0-beta.27",

--- a/apps/slack-agent/patches/eve@0.25.3.patch
+++ b/apps/slack-agent/patches/eve@0.25.3.patch
@@ -83,3 +83,12 @@ index 6a39d25b7eb76799ab266509b388e9158d9e3f24..e8132a86815bcc725598da508cf65dfc
 +function stripMapleUiContent(result){if(result===null||typeof result!==`object`||!Array.isArray(result.content))return result;const content=result.content.filter(entry=>{if(entry===null||typeof entry!==`object`||entry.type!==`text`||typeof entry.text!==`string`)return true;const text=entry.text;if(!text.startsWith(`{`)||!text.includes(`"__maple_ui"`))return true;try{const parsed=JSON.parse(text);return!(parsed!==null&&typeof parsed===`object`&&parsed.__maple_ui===true)}catch{return true}});return content.length===result.content.length?result:{...result,content}}
 +export{stripMapleUiContent,McpConnectionClient,isMcpAuthRequiredError,passesToolFilter,resolveHeaders};
 \ No newline at end of file
+diff --git a/dist/src/harness/otel-integration.js b/dist/src/harness/otel-integration.js
+index 4768fefb5d0d65ef4137c4f50f40e73ea91e339c..18f2bffe5793f45f854caeaf16699376f64e3d6d 100644
+--- a/dist/src/harness/otel-integration.js
++++ b/dist/src/harness/otel-integration.js
+@@ -1 +1 @@
+-import{registerTelemetry}from"ai";import{OpenTelemetry}from"#compiled/@ai-sdk/otel/index.js";let registered=!1;function ensureOtelIntegration(){registered||(registered=!0,registerTelemetry(new OpenTelemetry({runtimeContext:!0})))}export{ensureOtelIntegration};
+\ No newline at end of file
++import{registerTelemetry}from"ai";import{OpenTelemetry}from"#compiled/@ai-sdk/otel/index.js";let registered=!1;function ensureOtelIntegration(){registered||(registered=!0,registerTelemetry(new OpenTelemetry({runtimeContext:!0,providerMetadata:!0,usage:!0})))}export{ensureOtelIntegration};
+\ No newline at end of file

--- a/packages/query-engine-integrations/src/ai/ai-vendors.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-vendors.test.ts
@@ -80,6 +80,23 @@ describe("vercel_ai_sdk", () => {
 		).toBe("triage")
 	})
 
+	it("reads TTFT from the v7 client.operation key, in seconds", () => {
+		const mapped = mapAiSpan(
+			row("vercel_ai_sdk", { "gen_ai.client.operation.time_to_first_chunk": "1.84" }),
+		)
+
+		expect(mapped.genAi.responseTimeToFirstChunk).toBe(1.84)
+
+		// The canonical key still wins when both appear on one span.
+		const both = mapAiSpan(
+			row("vercel_ai_sdk", {
+				"gen_ai.response.time_to_first_chunk": "0.5",
+				"gen_ai.client.operation.time_to_first_chunk": "1.84",
+			}),
+		)
+		expect(both.genAi.responseTimeToFirstChunk).toBe(0.5)
+	})
+
 	it("leaves fields it does not mention on the default source list", () => {
 		// The merge is per field: `requestSeed` is not in the override, so it
 		// keeps the default's canonical key AND the default's legacy alias.

--- a/packages/query-engine-integrations/src/ai/ai-vendors.ts
+++ b/packages/query-engine-integrations/src/ai/ai-vendors.ts
@@ -27,6 +27,10 @@ import { MAPLE_NATIVE_TURN_ID_ATTR, type MutableAiGenAiValues } from "@maple/dom
  * `ai.response.msToFirstChunk` (milliseconds, where
  * `gen_ai.response.time_to_first_chunk` is seconds — silently mixing units is
  * worse than not having the field).
+ *
+ * `gen_ai.client.operation.time_to_first_chunk` is where AI SDK v7 puts TTFT
+ * — already in seconds, so unlike `msToFirstChunk` it aliases cleanly onto
+ * the catalog's `responseTimeToFirstChunk`.
  */
 const vercelAiSdkIntegration: AiIntegration = {
 	id: "vercel_ai_sdk",
@@ -47,6 +51,7 @@ const vercelAiSdkIntegration: AiIntegration = {
 			"ai.usage.reasoningTokens",
 			"ai.usage.outputTokenDetails.reasoningTokens",
 		],
+		responseTimeToFirstChunk: ["gen_ai.client.operation.time_to_first_chunk"],
 		inputMessages: ["ai.prompt.messages", "ai.prompt"],
 		toolName: ["ai.toolCall.name"],
 		toolCallId: ["ai.toolCall.id"],


### PR DESCRIPTION
## Summary

- **Cost** (`gen_ai.usage.cost`): the slack agent now reports the actual charged amount per model call instead of leaving spend to be inferred from token prices. OpenRouter usage accounting is enabled per request (`usage.include`), eve's OTel integration is patched to emit its `providerMetadata` + `usage` supplemental span attributes, and a span processor lifts `openrouter.usage.cost` (plus BYOK upstream inference cost) into the canonical `gen_ai.usage.cost` key the GenAI catalog already decodes. Emitter-side stamping keeps the value a flat numeric attribute, so it stays aggregatable in warehouse SQL; deepest-reporter counting on the read side makes multi-level stamping safe.
- **Reasoning tokens**: the `usage` supplemental emits `ai.usage.outputTokenDetails.reasoningTokens`, which the `vercel_ai_sdk` integration already maps to `usageReasoningOutputTokens` — no read-side change needed.
- **TTFT**: closes the attribute-key gap by aliasing `gen_ai.client.operation.time_to_first_chunk` (AI SDK v7's key, already in seconds) onto `responseTimeToFirstChunk` in the `vercel_ai_sdk` integration. `ai.response.msToFirstChunk` stays unmapped because it is milliseconds.
- The raw provider metadata on model spans also records which upstream provider served each request — useful when debugging latency variance.
- New canary test guards the third patch hunk, which otherwise fails silently (spans simply arrive without cost or reasoning tokens).

## Test plan

- `apps/slack-agent`: `bun test` (298 pass, including new `genai-cost` unit tests and the patch canary), `tsc --noEmit` clean, oxlint clean; fresh `bun install` confirmed all three patch hunks apply.
- `packages/query-engine-integrations`: `bun run test` (293 pass, including new TTFT alias coverage), `tsc --noEmit` clean.
- End-to-end cost visibility still needs a Railway deploy plus one real Slack turn; not exercisable locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790277832&installation_model_id=427786&pr_number=634&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F634&signature=3b1e3210b69f55e24ef68ce902c4f70bcbf0fe0650990ac95d262a652b87bf9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->