### PR TITLE
fix(web): agent session detail feedback round three

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from "react"
+
+import { cn } from "@maple/ui/lib/utils"
+
+import { tryParseJson } from "@/components/attributes"
+import { highlightCode } from "@/lib/sugar-high"
+
+/**
+ * The rendered ↔ raw affordances every captured body shares, wherever it is
+ * opened — a transcript block, the Traces expansion, the Flow drawer. Markdown
+ * layout and pretty-printed JSON are readings of the capture, and a reading can
+ * hide things — whitespace, key order, a literal `**` — so every rendered body
+ * keeps a way back to the captured bytes.
+ */
+
+/**
+ * A payload body, pretty-printed and highlighted where it parses as JSON
+ * (object or array — same test as the log body), verbatim otherwise. An
+ * emitter-truncated prefix fails the parse and stays verbatim, which is right:
+ * pretty-printing a fragment would dress it up as a whole document.
+ */
+export function useJsonPayload(text: string): { formatted: string; highlighted: string | undefined } {
+	return useMemo(() => {
+		const parsed = tryParseJson(text)
+		if (parsed === null) return { formatted: text, highlighted: undefined }
+		const formatted = JSON.stringify(parsed, null, 2)
+		return { formatted, highlighted: highlightCode(formatted) }
+	}, [text])
+}
+
+/**
+ * The rendered ↔ raw selector: two labelled segments where the selected one is
+ * the view the reader is IN — a lone pressed icon named either the current view
+ * or the one a click would bring, depending on who read it.
+ */
+export function ViewSwitch({
+	rendered,
+	raw,
+	onRawChange,
+	className,
+}: {
+	/** The rendered segment's label — what the rendering IS: "md" or "json". */
+	rendered: string
+	raw: boolean
+	onRawChange: (raw: boolean) => void
+	className?: string
+}) {
+	return (
+		<span
+			role="group"
+			aria-label="Body view"
+			className={cn(
+				"flex shrink-0 items-center self-center overflow-hidden rounded-sm border border-border",
+				className,
+			)}
+		>
+			<ViewSegment active={!raw} onSelect={() => onRawChange(false)}>
+				{rendered}
+			</ViewSegment>
+			<ViewSegment active={raw} onSelect={() => onRawChange(true)}>
+				raw
+			</ViewSegment>
+		</span>
+	)
+}
+
+/** One segment of a two-state switch; shared so a tool card's arguments ↔
+ *  result selector reads exactly like the rendered ↔ raw one beside it. */
+export function ViewSegment({
+	active,
+	onSelect,
+	children,
+}: {
+	active: boolean
+	onSelect: () => void
+	children: string
+}) {
+	return (
+		<button
+			type="button"
+			aria-pressed={active}
+			onClick={(event) => {
+				event.stopPropagation()
+				onSelect()
+			}}
+			className={cn(
+				"cursor-pointer px-1.5 py-px font-mono text-[10px] uppercase tracking-[0.08em]",
+				active ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground",
+			)}
+		>
+			{children}
+		</button>
+	)
+}

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -536,6 +536,39 @@ describe("SessionWaterfall", () => {
 		expect(view.container.querySelectorAll('[data-slot="span-inline-detail"]')).toHaveLength(1)
 	})
 
+	// A call and its result are one event: the expansion shows them as one card
+	// whose selector flips between the halves, instead of two stacked cards the
+	// reader has to pair by eye.
+	it("groups a tool call and its result into one card behind a selector", () => {
+		const { turns: toolTurns, summary: toolSummary } = sessionOf([
+			agentSpan({ spanId: "tc-agent", startMs: 0, durationMs: 4 * SECOND }),
+			toolSpan({
+				spanId: "tc-tool",
+				parentSpanId: "tc-agent",
+				startMs: SECOND,
+				durationMs: SECOND,
+				toolName: "run_sql",
+				genAi: {
+					toolCallId: "call_9",
+					toolCallArguments: { sql: "select 1" },
+					toolCallResult: { rows: [1] },
+				},
+			}),
+		])
+		const view = render(
+			<Waterfall turns={toolTurns} summary={toolSummary} selectedSpanId="tc-tool" spanTab="tools" />,
+		)
+
+		// Arguments first, pretty-printed; the result is a click away, not a scroll.
+		const detail = view.container.querySelector('[data-slot="span-inline-detail"]') as HTMLElement
+		expect(detail.textContent).toContain('"sql"')
+		expect(detail.textContent).not.toContain('"rows"')
+
+		fireEvent.click(within(detail).getByRole("button", { name: "result" }))
+		expect(detail.textContent).toContain('"rows"')
+		expect(detail.textContent).not.toContain('"sql"')
+	})
+
 	it("moves the span cursor with the arrows, expands on Enter, collapses on Esc", () => {
 		const onSelectSpan = vi.fn()
 		const view = render(<Waterfall onSelectSpan={onSelectSpan} />)

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -517,6 +517,39 @@ describe("SessionWaterfall", () => {
 		expect(labels.some((label) => label.includes("Timing"))).toBe(false)
 	})
 
+	// A failed tool call must show its failure on Details — the tab a reader
+	// opens first — even when the span carries no status message: the evidence
+	// attributes and the captured result are what there is to show.
+	it("shows a message-less tool failure on Details, captured result included", () => {
+		const { turns: failTurns, summary: failSummary } = sessionOf([
+			agentSpan({ spanId: "ft-agent", startMs: 0, durationMs: 4 * SECOND }),
+			toolSpan({
+				spanId: "ft-tool",
+				parentSpanId: "ft-agent",
+				startMs: SECOND,
+				durationMs: SECOND,
+				toolName: "run_sql",
+				genAi: {
+					errorType: "tool_error",
+					toolCallId: "call_f",
+					toolCallArguments: { sql: "select 1" },
+					toolCallResult: { error: "relation missing" },
+				},
+			}),
+		])
+		const view = render(<Waterfall turns={failTurns} summary={failSummary} selectedSpanId="ft-tool" />)
+
+		const detail = view.container.querySelector('[data-slot="span-inline-detail"]') as HTMLElement
+		// A failed span opens on Details by default.
+		expect(within(detail).getByRole("button", { name: "Details" }).getAttribute("aria-pressed")).toBe(
+			"true",
+		)
+		expect(within(detail).getByText("This call failed")).toBeTruthy()
+		expect(within(detail).getByText(/tool_error/)).toBeTruthy()
+		// The captured result — where the actual error text lives — is on the tab.
+		expect(detail.textContent).toContain('"relation missing"')
+	})
+
 	it("opens an errored span on Details, where the error and the ids are", () => {
 		const view = render(<Waterfall selectedSpanId="tool-3" />)
 

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -9,7 +9,6 @@ import { formatBytes, formatDuration, formatNumber } from "@maple/ui/lib/format"
 import { cn } from "@maple/ui/lib/utils"
 
 import { MessageResponse } from "@/components/ai-elements/message-response"
-import { tryParseJson } from "@/components/attributes"
 import {
 	AlertWarningIcon,
 	BranchForkIcon,
@@ -39,9 +38,9 @@ import {
 	type TranscriptRow,
 } from "@/lib/agent-sessions/session-transcript"
 import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
-import { highlightCode } from "@/lib/sugar-high"
 import { formatClockInTimezone } from "@/lib/timezone-format"
 import { ClampedText, firstLine } from "./clamped-text"
+import { useJsonPayload, ViewSwitch } from "./payload-view"
 import { Pill } from "./pill"
 
 /**
@@ -317,11 +316,7 @@ function Row({
 	return (
 		<div className={cn("flex", className)}>
 			<span className={cn(GUTTER, timePadding)}>{time}</span>
-			{Array.from({ length: Math.min(depth, MAX_INDENT_DEPTH) }, (_, index) => (
-				<span key={index} aria-hidden className={INDENT}>
-					<span className="w-px bg-border" />
-				</span>
-			))}
+			<IndentLanes depth={depth} />
 			{rail !== undefined && (
 				<span
 					aria-hidden
@@ -330,6 +325,20 @@ function Row({
 			)}
 			<div className={flush ? "min-w-0 grow" : BODY}>{children}</div>
 		</div>
+	)
+}
+
+/** The nesting hairlines, one lane each — `self-stretch` so they still span the
+ *  row inside an `items-center` header like the turn chapter's. */
+function IndentLanes({ depth }: { depth: number }) {
+	return (
+		<>
+			{Array.from({ length: Math.min(depth, MAX_INDENT_DEPTH) }, (_, index) => (
+				<span key={index} aria-hidden className={cn(INDENT, "self-stretch")}>
+					<span className="w-px bg-border" />
+				</span>
+			))}
+		</>
 	)
 }
 
@@ -349,13 +358,13 @@ function TurnChapter({
 	timeZone,
 	collapsed,
 	onToggleTurn,
-	onJump,
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "turn" }> }) {
 	const { turn } = row
 
 	return (
 		<h3 className="mt-5 flex items-center border-border border-b pb-2 font-normal text-base">
 			<span className={cn(GUTTER, "pt-0")}>{clockOf(turn.startMs, timeZone)}</span>
+			<IndentLanes depth={row.depth} />
 			<button
 				type="button"
 				onClick={() => onToggleTurn(turn.id)}
@@ -378,6 +387,19 @@ function TurnChapter({
 				</span>
 				{turn.agentName !== undefined && <AgentPill name={turn.agentName} />}
 				{turn.failed && <Pill tone="error">Failed</Pill>}
+				{/* The cluster's banner and the indentation carry the explanation; the
+				    pill is the glanceable trace of it that survives collapse. Bounded,
+				    unlike the old per-turn jump chips, whose row of unshrinkable
+				    buttons was one of the things pushing the page sideways. */}
+				{row.parallelWith.length > 0 && (
+					<span
+						className="flex shrink-0 items-center gap-1 rounded-sm bg-primary/12 px-1.5 py-px font-mono text-[10px] text-primary uppercase tracking-[0.08em]"
+						title={`ran in parallel with ${row.parallelWith.map((ref) => turnOrdinal(ref.turn)).join(", ")}`}
+					>
+						<BranchForkIcon size={10} className="shrink-0" />
+						parallel
+					</span>
+				)}
 				{/* Shrinkable, unlike its neighbours: the summary joins every tool
 				    name in the turn, so it truncates rather than widening the page. */}
 				{collapsed && <span className={META}>{summariseTurn(row)}</span>}
@@ -390,22 +412,6 @@ function TurnChapter({
 					agent spans · {formatDuration(turn.durationMs)}
 				</span>
 			</button>
-			{/* Outside the toggle, because a chip is a button and buttons do not
-			    nest. It survives collapse for the same reason the header does: a
-			    collapsed chapter still has to say it was not a step in a sequence. */}
-			{row.parallelWith.length > 0 && (
-				<span className="flex shrink-0 items-center gap-2.5 pl-2.5">
-					{row.parallelWith.map((ref) => (
-						<ParallelJump
-							key={ref.key}
-							targetKey={ref.key}
-							// Turns render in index order, so the ordinal is the direction too.
-							label={`${turnOrdinal(ref.turn).toUpperCase()} ${ref.turn.index > turn.index ? "↓" : "↑"}`}
-							onJump={onJump}
-						/>
-					))}
-				</span>
-			)}
 		</h3>
 	)
 }
@@ -948,91 +954,6 @@ function payloadSummary(row: Extract<TranscriptRow, { kind: "tool" }>): string {
 	return ` · ${parts.join(" · ")}`
 }
 
-/**
- * A payload body, pretty-printed and highlighted where it parses as JSON
- * (object or array — same test as the log body), verbatim otherwise. An
- * emitter-truncated prefix fails the parse and stays verbatim, which is right:
- * pretty-printing a fragment would dress it up as a whole document.
- */
-function useJsonPayload(text: string): { formatted: string; highlighted: string | undefined } {
-	return useMemo(() => {
-		const parsed = tryParseJson(text)
-		if (parsed === null) return { formatted: text, highlighted: undefined }
-		const formatted = JSON.stringify(parsed, null, 2)
-		return { formatted, highlighted: highlightCode(formatted) }
-	}, [text])
-}
-
-/**
- * The rendered ↔ raw selector. Markdown layout and pretty-printed JSON are
- * readings of the capture, and a reading can hide things — whitespace, key
- * order, a literal `**` — so every rendered body keeps a way back to the
- * captured bytes. Two labelled segments where the selected one is the view the
- * reader is IN: a lone pressed icon named either the current view or the one a
- * click would bring, depending on who read it. Held in `openRows` like every
- * other flipped default, so the choice survives the row scrolling out of the
- * virtualizer.
- */
-function ViewSwitch({
-	rendered,
-	raw,
-	onRawChange,
-	className,
-}: {
-	/** The rendered segment's label — what the rendering IS: "md" or "json". */
-	rendered: string
-	raw: boolean
-	onRawChange: (raw: boolean) => void
-	className?: string
-}) {
-	return (
-		<span
-			role="group"
-			aria-label="Body view"
-			className={cn(
-				"flex shrink-0 items-center self-center overflow-hidden rounded-sm border border-border",
-				className,
-			)}
-		>
-			<ViewSegment active={!raw} onSelect={() => onRawChange(false)}>
-				{rendered}
-			</ViewSegment>
-			<ViewSegment active={raw} onSelect={() => onRawChange(true)}>
-				raw
-			</ViewSegment>
-		</span>
-	)
-}
-
-function ViewSegment({
-	active,
-	onSelect,
-	children,
-}: {
-	active: boolean
-	onSelect: () => void
-	children: string
-}) {
-	return (
-		<button
-			type="button"
-			aria-pressed={active}
-			onClick={(event) => {
-				event.stopPropagation()
-				onSelect()
-			}}
-			className={cn(
-				"cursor-pointer px-1.5 py-px font-mono text-[10px] uppercase tracking-[0.08em]",
-				active
-					? "bg-accent text-foreground"
-					: "text-muted-foreground hover:text-foreground",
-			)}
-		>
-			{children}
-		</button>
-	)
-}
-
 function PayloadSection({
 	label,
 	payload,
@@ -1153,7 +1074,9 @@ function LaneOpen({
 			timePadding="pt-2"
 			className="pt-2.5"
 		>
-			<div className="flex items-center gap-2.5 py-1.5">
+			{/* Wraps: the parallel chips are one per sibling lane, and a fan-out wide
+			    enough to overflow the line belongs on a second one, not off-page. */}
+			<div className="flex flex-wrap items-center gap-2.5 py-1.5">
 				<FaceRobotIcon size={14} className="shrink-0 text-chart-1" />
 				<span className={cn(LABEL, "text-chart-1")}>
 					{row.laneKind === "subagent" ? "Subagent" : "Agent"}
@@ -1272,6 +1195,67 @@ function LaneClose({
 }
 
 /**
+ * The fork banner both parallel markers share: a bordered, tinted block whose
+ * every line WRAPS. The old markers were one flex line of unshrinkable text and
+ * chips, which is exactly the shape that pushes a page into sideways clipping —
+ * a marker about concurrency must never cost the reader the right edge.
+ */
+function ParallelBanner({
+	title,
+	description,
+	refs,
+	onJump,
+}: {
+	title: string
+	description: string
+	/** The forked threads, as jump chips. */
+	refs: readonly { key: string; label: string }[]
+	onJump: (key: string) => void
+}) {
+	return (
+		<div className="flex min-w-0 flex-col gap-1.5 rounded-md border border-primary/25 bg-primary/6 px-3 py-2.5">
+			<div className="flex items-center gap-2.5">
+				<BranchForkIcon size={14} className="shrink-0 text-primary" />
+				<span className={cn(LABEL, "text-primary")}>{title}</span>
+			</div>
+			<p className="min-w-0 break-words pl-6 text-muted-foreground text-xs leading-relaxed">
+				{description}
+			</p>
+			<div className="flex flex-wrap items-center gap-1.5 pl-6">
+				{refs.map((ref) => (
+					<button
+						key={ref.key}
+						type="button"
+						onClick={() => onJump(ref.key)}
+						title={ref.label}
+						className="max-w-72 cursor-pointer truncate rounded-sm bg-primary/12 px-2 py-0.5 font-mono text-[11px] text-primary hover:bg-primary/20"
+					>
+						{ref.label}
+					</button>
+				))}
+			</div>
+		</div>
+	)
+}
+
+/** Only a window every member shared is reported as an overlap. A chain of
+ *  pairwise overlaps has none, and the sentence then reports the run's extent
+ *  instead of inventing one. */
+function overlapSentence(
+	row: {
+		startMs: number
+		endMs: number
+		overlapStartMs: number | undefined
+		overlapEndMs: number | undefined
+	},
+	timeZone: string,
+): string {
+	return row.overlapStartMs !== undefined && row.overlapEndMs !== undefined
+		? `they overlap ${clockOf(row.overlapStartMs, timeZone)} → ${clockOf(row.overlapEndMs, timeZone)}`
+		: `their runs interleave between ${clockOf(row.startMs, timeZone)} and ${clockOf(row.endMs, timeZone)}`
+}
+
+/**
  * Where a thread forked. Each lane below still reads whole and in order — the
  * marker is what stops "db-lane, then trace-lane" from reading as a sequence.
  */
@@ -1284,37 +1268,16 @@ function ParallelMarker({
 		<Row
 			time={clockOf(row.startMs, timeZone)}
 			depth={row.depth}
-			timePadding="pt-1.5"
+			timePadding="pt-3"
 			className="pt-5"
 			flush
 		>
-			<div className="flex items-center gap-2.5">
-				<BranchForkIcon size={14} className="shrink-0 text-primary" />
-				<span className={cn(LABEL, "text-primary")}>Parallel</span>
-				{/* Only a window every lane shared is reported as an overlap. A chain
-				    of pairwise overlaps has none, and the marker then reports the fork's
-				    extent instead of inventing one. */}
-				<span className="min-w-0 truncate text-muted-foreground text-xs">
-					{row.forkedBy === undefined ? "This turn" : row.forkedBy} forked {row.lanes.length} lanes
-					—{" "}
-					{row.overlapStartMs !== undefined && row.overlapEndMs !== undefined
-						? `they overlap ${clockOf(row.overlapStartMs, timeZone)} → ${clockOf(row.overlapEndMs, timeZone)}`
-						: `their runs interleave between ${clockOf(row.startMs, timeZone)} and ${clockOf(row.endMs, timeZone)}`}
-					. Each lane is shown whole, in order:
-				</span>
-				{row.lanes.map((lane) => (
-					<button
-						key={lane.key}
-						type="button"
-						onClick={() => onJump(lane.key)}
-						title={lane.agentName}
-						className="max-w-48 shrink-0 cursor-pointer truncate font-mono text-[11px] text-primary hover:underline"
-					>
-						{lane.agentName}
-					</button>
-				))}
-				<span aria-hidden className="h-px grow bg-border" />
-			</div>
+			<ParallelBanner
+				title={`Parallel — ${row.forkedBy === undefined ? "this turn" : row.forkedBy} forked ${row.lanes.length} lanes`}
+				description={`${overlapSentence(row, timeZone)}. Each lane is shown whole and in order below:`}
+				refs={row.lanes.map((lane) => ({ key: lane.key, label: lane.agentName }))}
+				onJump={onJump}
+			/>
 		</Row>
 	)
 }
@@ -1326,7 +1289,8 @@ function ParallelMarker({
  * dispatched over a queue roots its own trace, so either way the turn partition
  * splits the fan-out into sibling chapters. They still read whole and in order;
  * the marker is what stops "TURN 3, then TURN 4" from reading as a sequence the
- * timestamps deny.
+ * timestamps deny — and the member turns render indented one lane under it, so
+ * the fork is visible even from the middle of a long chapter.
  */
 function ParallelTurnsMarker({
 	row,
@@ -1337,37 +1301,19 @@ function ParallelTurnsMarker({
 		<Row
 			time={clockOf(row.startMs, timeZone)}
 			depth={row.depth}
-			timePadding="pt-1.5"
+			timePadding="pt-3"
 			className="pt-5"
 			flush
 		>
-			<div className="flex items-center gap-2.5">
-				<BranchForkIcon size={14} className="shrink-0 text-primary" />
-				<span className={cn(LABEL, "text-primary")}>Parallel</span>
-				{/* Only a window every turn shared is reported as an overlap. A chain of
-				    pairwise overlaps has none, and the marker then reports the run's
-				    extent instead of inventing one. */}
-				<span className="shrink-0 text-muted-foreground text-xs">
-					{row.turns.length} turns ran at the same time —{" "}
-					{row.overlapStartMs !== undefined && row.overlapEndMs !== undefined
-						? `they overlap ${clockOf(row.overlapStartMs, timeZone)} → ${clockOf(row.overlapEndMs, timeZone)}`
-						: `their runs interleave between ${clockOf(row.startMs, timeZone)} and ${clockOf(row.endMs, timeZone)}`}
-					. Each turn is shown whole, in order:
-				</span>
-				{row.turns.map((ref) => (
-					<button
-						key={ref.key}
-						type="button"
-						onClick={() => onJump(ref.key)}
-						title={ref.turn.agentName}
-						className="max-w-48 shrink-0 cursor-pointer truncate font-mono text-[11px] text-primary hover:underline"
-					>
-						{turnOrdinal(ref.turn).toUpperCase()}
-						{ref.turn.agentName !== undefined && ` ${ref.turn.agentName}`}
-					</button>
-				))}
-				<span aria-hidden className="h-px grow bg-border" />
-			</div>
+			<ParallelBanner
+				title={`Parallel — ${row.turns.length} turns ran at the same time`}
+				description={`${overlapSentence(row, timeZone)}. Each turn is shown whole and in order, indented below:`}
+				refs={row.turns.map((ref) => ({
+					key: ref.key,
+					label: `${turnOrdinal(ref.turn).toUpperCase()}${ref.turn.agentName === undefined ? "" : ` ${ref.turn.agentName}`}`,
+				}))}
+				onJump={onJump}
+			/>
 		</Row>
 	)
 }
@@ -1453,7 +1399,7 @@ function NoteBlock({ row }: { row: Extract<TranscriptRow, { kind: "note" }> }) {
 				<div className="flex items-center gap-2.5">
 					<CircleInfoIcon size={13} className="shrink-0 text-muted-foreground" />
 					<span className={cn(LABEL, "text-muted-foreground")}>Capture changes here</span>
-					<span className="shrink-0 text-muted-foreground text-xs">
+					<span className="min-w-0 text-muted-foreground text-xs">
 						spans below come from {row.serviceName} — it records {CAPTURES_LABEL[row.captures]}
 					</span>
 					<span aria-hidden className="h-px grow bg-border" />
@@ -1495,7 +1441,7 @@ function DividerBlock({ row, timeZone }: BlockProps & { row: Extract<TranscriptR
 				<div className="flex items-center gap-2.5">
 					<CompactLinesIcon size={14} className="shrink-0 text-chart-4" />
 					<span className={cn(LABEL, "text-chart-4")}>Context compacted</span>
-					<span className="shrink-0 text-muted-foreground text-xs">
+					<span className="min-w-0 text-muted-foreground text-xs">
 						the agent replaced its history with a summary — earlier messages above are still
 						shown, but the model no longer had them
 					</span>

--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -6,6 +6,7 @@ import { SpanId, TraceId } from "@maple/domain"
 import type { AiSessionSpan } from "@maple/domain/http"
 import { ErrorSection } from "@maple/ui/components/error-section"
 import { Button } from "@maple/ui/components/ui/button"
+import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { formatDuration, formatNumber } from "@maple/ui/lib/format"
 import { cn } from "@maple/ui/lib/utils"
@@ -19,6 +20,7 @@ import {
 	ExternalLinkIcon,
 	XmarkIcon,
 } from "@/components/icons"
+import { MessageResponse } from "@/components/ai-elements/message-response"
 import { AttributesSection, CopyableValue, ResourceAttributesSection } from "@/components/attributes"
 import { SpanLogs } from "@/components/traces/span-detail-panel"
 import type { SpanDetailResult } from "@/api/warehouse/traces"
@@ -38,6 +40,7 @@ import {
 import { classifyAiSpan, spanFailed, spanModel, spanTtftMs } from "@/lib/agent-sessions/session-turns"
 import { callMetaLine, formatCost } from "@/lib/agent-sessions/session-summary"
 import { ClampedText, firstLine } from "./clamped-text"
+import { useJsonPayload, ViewSegment, ViewSwitch } from "./payload-view"
 import { CATEGORY_ICON, CATEGORY_TEXT } from "./span-visuals"
 
 /**
@@ -411,6 +414,7 @@ function MessagesSection({ messages, span }: { messages: readonly SpanMessage[];
  *  rarely what the reader came for. */
 function SystemMessageRow({ message }: { message: SpanMessage }) {
 	const [open, setOpen] = useState(false)
+	const [raw, setRaw] = useState(false)
 	const text = collapsedText(message.parts)
 
 	return (
@@ -434,8 +438,16 @@ function SystemMessageRow({ message }: { message: SpanMessage }) {
 				)}
 			</button>
 			{open && (
-				<div className="px-2.5 pb-2.5 pl-8">
-					<ClampedText text={text} />
+				<div className="flex items-start gap-1.5 px-2.5 pb-2.5 pl-8">
+					<div className="min-w-0 grow">
+						<ClampedText
+							text={text}
+							body={raw ? undefined : <MessageResponse className="text-sm">{text}</MessageResponse>}
+						/>
+					</div>
+					<ViewSwitch rendered="md" raw={raw} onRawChange={setRaw} />
+					{/* Copies the instructions as captured, not their rendering. */}
+					<CopyButton value={text} label="system message" className="-my-1 shrink-0" />
 				</div>
 			)}
 		</div>
@@ -443,6 +455,11 @@ function SystemMessageRow({ message }: { message: SpanMessage }) {
 }
 
 function MessageBlock({ message, span }: { message: SpanMessage; span: AiSessionSpan }) {
+	// One rendered ↔ raw choice per message: its text parts are one body the
+	// reader flips together, while the payload cards keep their own json switch.
+	const [raw, setRaw] = useState(false)
+	const hasText = message.parts.some((part) => part.kind === "text")
+
 	return (
 		<div className="flex min-w-0 flex-col gap-1.5">
 			<div className="flex items-center gap-2.5">
@@ -462,18 +479,26 @@ function MessageBlock({ message, span }: { message: SpanMessage; span: AiSession
 					</span>
 				)}
 				<span aria-hidden className="h-px min-w-4 flex-1 bg-border/60" />
+				{hasText && <ViewSwitch rendered="md" raw={raw} onRawChange={setRaw} />}
 			</div>
 			<div className="flex min-w-0 flex-col gap-2">
 				{message.parts.map((part, index) => (
-					<MessagePart key={index} part={part} />
+					<MessagePart key={index} part={part} raw={raw} />
 				))}
 			</div>
 		</div>
 	)
 }
 
-function MessagePart({ part }: { part: SpanMessagePart }) {
-	if (part.kind === "text") return <ClampedText text={part.text} />
+function MessagePart({ part, raw }: { part: SpanMessagePart; raw: boolean }) {
+	if (part.kind === "text") {
+		return (
+			<ClampedText
+				text={part.text}
+				body={raw ? undefined : <MessageResponse className="text-sm">{part.text}</MessageResponse>}
+			/>
+		)
+	}
 	if (part.kind === "reasoning") return <ReasoningPart part={part} />
 	if (part.kind === "tool_call") {
 		return <PayloadCard label="tool_call" name={part.name} meta={part.id} body={part.argumentsText} />
@@ -513,19 +538,67 @@ function ToolCallsSection({ toolCalls }: { toolCalls: readonly SpanToolCall[] })
 	return (
 		<div className="flex flex-col gap-3 pb-1">
 			{toolCalls.map((call, index) => (
-				<div key={index} className="flex flex-col gap-2">
-					<PayloadCard
-						label="tool_call"
-						name={call.name}
-						meta={call.id}
-						description={call.description}
-						body={call.argumentsText}
-					/>
-					{call.resultText !== undefined && (
-						<PayloadCard label="tool_result" body={call.resultText} />
-					)}
-				</div>
+				<ToolCallCard key={index} call={call} />
 			))}
+		</div>
+	)
+}
+
+/**
+ * One invocation as one card: the call and its result belong to the same event,
+ * and two stacked cards made the reader pair them by eye. A selector shows one
+ * half at a time — the other stays a click away, never a scroll.
+ */
+function ToolCallCard({ call }: { call: SpanToolCall }) {
+	const [side, setSide] = useState<"arguments" | "result">(
+		call.argumentsText === undefined && call.resultText !== undefined ? "result" : "arguments",
+	)
+	const body = side === "arguments" ? call.argumentsText : call.resultText
+
+	return (
+		<div className="min-w-0 overflow-hidden rounded-md border border-border/70">
+			<div className="flex items-center gap-2 bg-muted/40 px-2.5 py-1.5">
+				<span aria-hidden className="size-1.5 shrink-0 rounded-xs bg-chart-4" />
+				<span className="shrink-0 font-medium font-mono text-chart-4 text-xs">tool</span>
+				{call.name !== undefined && (
+					<span className="min-w-0 truncate font-mono text-foreground text-xs" title={call.name}>
+						{call.name}
+					</span>
+				)}
+				<span className="ml-auto flex shrink-0 items-center gap-2">
+					{call.id !== undefined && (
+						<span className="max-w-40 truncate font-mono text-[11px] text-muted-foreground/80" title={call.id}>
+							{call.id}
+						</span>
+					)}
+					<span
+						role="group"
+						aria-label="Tool payload"
+						className="flex shrink-0 items-center overflow-hidden rounded-sm border border-border"
+					>
+						<ViewSegment active={side === "arguments"} onSelect={() => setSide("arguments")}>
+							arguments
+						</ViewSegment>
+						<ViewSegment active={side === "result"} onSelect={() => setSide("result")}>
+							result
+						</ViewSegment>
+					</span>
+				</span>
+			</div>
+			{call.description !== undefined && (
+				<p className="border-border/60 border-t px-2.5 py-1.5 text-muted-foreground text-xs">
+					{call.description}
+				</p>
+			)}
+			{body === undefined ? (
+				<p className="border-border/60 border-t bg-background/50 px-2.5 py-2 text-muted-foreground text-xs italic">
+					{side === "arguments"
+						? "No arguments were captured for this call."
+						: "No result was captured — whether the call succeeded is unknown."}
+				</p>
+			) : (
+				<PayloadBody text={body} copyLabel={side} />
+			)}
 		</div>
 	)
 }
@@ -562,11 +635,29 @@ function PayloadCard({
 					{description}
 				</p>
 			)}
-			{body !== undefined && (
-				<div className="border-border/60 border-t bg-background/50 px-2.5 py-2">
-					<ClampedText text={body} mono />
-				</div>
+			{body !== undefined && <PayloadBody text={body} copyLabel={label} />}
+		</div>
+	)
+}
+
+/**
+ * A payload card's body: pretty-printed and highlighted where it parses as
+ * JSON, with the same json ↔ raw switch the transcript's cards carry — the
+ * captured bytes stay one click away, and the copy takes what is displayed.
+ */
+function PayloadBody({ text, copyLabel }: { text: string; copyLabel: string }) {
+	const { formatted, highlighted } = useJsonPayload(text)
+	const [raw, setRaw] = useState(false)
+
+	return (
+		<div className="flex items-start gap-1.5 border-border/60 border-t bg-background/50 px-2.5 py-2">
+			<div className="min-w-0 grow">
+				<ClampedText text={raw ? text : formatted} html={raw ? undefined : highlighted} mono />
+			</div>
+			{highlighted !== undefined && (
+				<ViewSwitch rendered="json" raw={raw} onRawChange={setRaw} className="self-start" />
 			)}
+			<CopyButton value={raw ? text : formatted} label={copyLabel} className="-my-1 shrink-0" />
 		</div>
 	)
 }

--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -15,6 +15,7 @@ import {
 	CheckIcon,
 	ChevronDownIcon,
 	ChevronRightIcon,
+	CircleWarningIcon,
 	CircleXmarkIcon,
 	CopyIcon,
 	ExternalLinkIcon,
@@ -41,6 +42,7 @@ import { classifyAiSpan, spanFailed, spanModel, spanTtftMs } from "@/lib/agent-s
 import { callMetaLine, formatCost } from "@/lib/agent-sessions/session-summary"
 import { ClampedText, firstLine } from "./clamped-text"
 import { useJsonPayload, ViewSegment, ViewSwitch } from "./payload-view"
+import { Pill } from "./pill"
 import { CATEGORY_ICON, CATEGORY_TEXT } from "./span-visuals"
 
 /**
@@ -129,7 +131,7 @@ export function SpanExpansion({
 
 			<MetaStrip span={span} />
 
-			{active === "details" && <DetailsSection span={span} />}
+			{active === "details" && <DetailsSection span={span} toolCalls={toolCalls} />}
 			{active === "messages" && <MessagesSection messages={messages} span={span} />}
 			{active === "tools" && <ToolCallsSection toolCalls={toolCalls} />}
 			{active === "logs" && <LogsSection span={span} />}
@@ -675,8 +677,19 @@ const toSpanId = Schema.decodeSync(SpanId)
  * through the shared attribute sections. The maps are fetched here — the
  * session endpoint drops them server-side, so this is the panel's own lazy
  * `spanDetail` read, made once the tab is open.
+ *
+ * A FAILED span leads with its failure, whatever form the span reported it in:
+ * the status message where there is one, otherwise the attributes the failure
+ * was read from — Details is where a reader looks first, and a failed call
+ * whose evidence is only on another tab reads as a call that did not fail.
  */
-function DetailsSection({ span }: { span: AiSessionSpan }) {
+function DetailsSection({
+	span,
+	toolCalls,
+}: {
+	span: AiSessionSpan
+	toolCalls: readonly SpanToolCall[]
+}) {
 	const detailResult = useAtomValue(
 		span.traceId !== "" && span.spanId !== ""
 			? getSpanDetailResultAtom({
@@ -690,18 +703,38 @@ function DetailsSection({ span }: { span: AiSessionSpan }) {
 	)
 	const detailAttrs = Result.isSuccess(detailResult) ? detailResult.value : undefined
 
+	const failed = spanFailed(span)
+	// A failed tool call's captured result is usually where the actual error
+	// text lives; surfacing it here saves the reader the trip to the Tool calls
+	// tab. Tool spans only — a model span's tool calls are its OUTPUT, and their
+	// results say nothing about why the model call itself failed. The own call
+	// is first in `spanToolCalls`' order.
+	const failedToolResult =
+		failed && classifyAiSpan(span) === "tool" ? toolCalls[0]?.resultText : undefined
+
 	return (
 		<div className="flex flex-col gap-3 pb-1">
-			{span.statusCode === "Error" && span.statusMessage !== "" && (
-				<ErrorSection
-					message={span.statusMessage}
-					badge={span.genAi.errorType}
-					prompt={{
-						serviceName: span.serviceName,
-						operation: span.spanName,
-						attributes: detailAttrs?.spanAttributes,
-					}}
-					className="mx-0 my-0"
+			{failed &&
+				(span.statusMessage !== "" ? (
+					<ErrorSection
+						message={span.statusMessage}
+						badge={span.genAi.errorType}
+						prompt={{
+							serviceName: span.serviceName,
+							operation: span.spanName,
+							attributes: detailAttrs?.spanAttributes,
+						}}
+						className="mx-0 my-0"
+					/>
+				) : (
+					<FailureBanner span={span} />
+				))}
+			{failedToolResult !== undefined && (
+				<PayloadCard
+					label="result"
+					name={toolCalls[0]?.name}
+					meta={span.statusCode === "Error" ? "span status Error" : undefined}
+					body={failedToolResult}
 				/>
 			)}
 			<IdentityRows span={span} />
@@ -722,6 +755,48 @@ function DetailsSection({ span }: { span: AiSessionSpan }) {
 					</>
 				))
 				.render()}
+		</div>
+	)
+}
+
+/**
+ * The failure of a span that recorded no status message. The pills name the
+ * attributes the failure was actually read from — the same evidence
+ * `spanFailed` reads — because with no message, saying WHERE the claim comes
+ * from is all the banner can honestly do.
+ */
+function FailureBanner({ span }: { span: AiSessionSpan }) {
+	const errorType = span.genAi.errorType
+	const responseStatus = span.genAi.responseStatus
+
+	return (
+		<div className="flex flex-col gap-1.5 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2.5">
+			<div className="flex flex-wrap items-center gap-2">
+				<CircleWarningIcon size={13} className="shrink-0 text-destructive" />
+				<span className="font-medium text-[13px] text-destructive">This call failed</span>
+				{span.statusCode === "Error" && (
+					<Pill tone="error" className="font-mono normal-case tracking-normal">
+						span status Error
+					</Pill>
+				)}
+				{errorType !== undefined && errorType !== "" && (
+					<Pill tone="error" className="font-mono normal-case tracking-normal">
+						error.type {errorType}
+					</Pill>
+				)}
+				{/* Only where it is the evidence: with a status or an error type above,
+				    restating the response status would just be noise beside them. */}
+				{span.statusCode !== "Error" &&
+					(errorType === undefined || errorType === "") &&
+					responseStatus !== undefined && (
+						<Pill tone="error" className="font-mono normal-case tracking-normal">
+							response.status {responseStatus}
+						</Pill>
+					)}
+			</div>
+			<p className="text-muted-foreground text-xs leading-relaxed">
+				The span reports the failure through the attributes above; it carries no status message.
+			</p>
 		</div>
 	)
 }

--- a/apps/web/src/lib/agent-sessions/session-transcript.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-transcript.test.ts
@@ -1664,6 +1664,31 @@ describe("buildTranscript — parallel turns", () => {
 		expect(marker.overlapEndMs).toBe(T0 + 20 * SECOND)
 	})
 
+	// The indentation is what makes the fork legible from the middle of a long
+	// chapter, where the marker has long scrolled away.
+	it("indents every cluster member one lane under the marker", () => {
+		const rows = transcript(twoTurns)
+		expect(findRow(rows, "parallel-turns").depth).toBe(0)
+		for (const header of findRows(rows, "turn")) expect(header.depth).toBe(1)
+		// The members' own rows shift with their headers.
+		for (const row of findRows(rows, "assistant")) expect(row.depth).toBe(1)
+	})
+
+	it("keeps sequential turns on the margin", () => {
+		const sequential = [
+			...conversationTurn({ id: "a", agentName: "a-lane", startMs: 0, durationMs: 5 * SECOND }),
+			...conversationTurn({
+				id: "b",
+				agentName: "b-lane",
+				startMs: 10 * SECOND,
+				durationMs: 5 * SECOND,
+			}),
+		]
+		const rows = transcript(sequential)
+		for (const header of findRows(rows, "turn")) expect(header.depth).toBe(0)
+		for (const row of findRows(rows, "assistant")) expect(row.depth).toBe(0)
+	})
+
 	it("gives each member turn header reciprocal jump data", () => {
 		const rows = transcript(twoTurns)
 		const headers = findRows(rows, "turn")

--- a/apps/web/src/lib/agent-sessions/session-transcript.ts
+++ b/apps/web/src/lib/agent-sessions/session-transcript.ts
@@ -302,7 +302,12 @@ export function buildTranscript(input: TranscriptInput): readonly TranscriptRow[
 		const marking = concurrent.get(entry.turn.id)
 		// The marker opens the cluster, so it is carried by its first member.
 		if (marking?.marker !== undefined) body.push(marking.marker)
-		body.push(marking?.header ?? entry.header)
+		// A cluster member's whole chapter shifts one lane right, the same move a
+		// lane makes inside a turn: the indentation is what says "these chapters
+		// hang off the fork above" without the reader having to parse the marker.
+		const indent = marking === undefined ? 0 : 1
+		const header = marking?.header ?? entry.header
+		body.push(indent === 0 ? header : { ...header, depth: header.depth + indent })
 		// Per-turn only where the session-level banner is not already up.
 		if (
 			!bannerUp &&
@@ -312,13 +317,19 @@ export function buildTranscript(input: TranscriptInput): readonly TranscriptRow[
 			body.push({
 				kind: "note",
 				key: `note:${entry.turn.id}`,
-				depth: 0,
+				depth: indent,
 				noteKind: "capture-off",
 				scope: "turn",
 				anyCaptured: false,
 			})
 		}
-		if (!input.collapsedTurns.has(entry.turn.id)) body.push(...entry.rows)
+		if (!input.collapsedTurns.has(entry.turn.id)) {
+			body.push(
+				...(indent === 0
+					? entry.rows
+					: entry.rows.map((row) => ({ ...row, depth: row.depth + indent }))),
+			)
+		}
 	}
 
 	// Nothing survived. The empty state says which of the two reasons it was, and


### PR DESCRIPTION
Third round of feedback on the agent session detail page.

## Horizontal overflow — the underlying fix

Round two added \`overflow-x-hidden\` to the page scroller, which stopped the sideways scrolling but silently clipped the rows that were too wide — the actual problem was rows whose minimum content width exceeds the viewport. Those rows are now built so they cannot:

- Both parallel markers were a single flex line of unshrinkable (\`shrink-0\`) sentence + chips — the widest offender. They are now a banner whose text and chips wrap.
- The lane-open header wraps, so a wide fan-out's "ran in parallel with …" chips drop to a second line.
- The capture-boundary note and compaction divider sentences shrink and wrap instead of forcing the row wider.
- The turn header's per-turn jump chips (unshrinkable buttons, one per overlapping sibling) are replaced by one bounded pill (below).

Verified by scanning all 24 viewport-heights of the lab fixture transcript at an 800 px viewport: \`scrollWidth − clientWidth = 0\` everywhere.

## Parallel turns are visibly parallel

- The cluster opens with a prominent bordered/tinted **fork banner** (icon, "Parallel — N turns ran at the same time", the overlap window, and one jump chip per member turn).
- Every member turn — header and body — **indents one lane** under the banner, the same visual move a lane makes inside a turn, so the fork stays legible even mid-chapter where the banner has scrolled away. The indent hairline runs the length of the cluster.
- Each member header carries a compact \`⑂ parallel\` pill that survives collapse (the old jump chips listed every sibling and pushed the page sideways).
- The lane-level fork marker uses the same banner, so one visual language covers both levels.

## Formatting in the other views

The span expansion (Traces inline detail and the Flow drawer) now renders like the transcript:

- Message text parts render as **markdown**, with the same \`md ↔ raw\` switch per message.
- Tool arguments/results and message payload parts are **pretty-printed and syntax-highlighted** where they parse as JSON, with a \`json ↔ raw\` switch and a copy control; non-JSON payloads stay verbatim.
- The switch + JSON formatting moved to a shared \`payload-view.tsx\` used by both the transcript and the expansion.

## Tool call + result grouped on Traces

The expansion's Tool calls tab showed a \`tool_call\` card and a separate \`tool_result\` card the reader had to pair by eye. It now renders **one card per invocation** with an \`arguments ↔ result\` selector — one half at a time, the other a click away. A missing result still says "not captured — whether the call succeeded is unknown" rather than implying success.

## Notes

- New builder tests for the cluster indentation, and a component test for the grouped tool card.
- Full \`apps/web\` vitest run: the only failures are the four pre-existing localStorage-environment failures in \`use-timezone-preference\` / \`use-recently-used-times\` (untouched here).
- Verified in the browser on \`/lab/agent-session\`: both fork banners, the indented cluster, the grouped tool card, and markdown/JSON rendering in the Traces expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790277954&installation_model_id=427786&pr_number=635&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F635&signature=c1157a84774ae7b86e2639fb82c29a508c4c5c7eda9397cd51d4d94baf0554aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Failed spans lead with their failure on Details (follow-up commit)

Details is where a reader looks first on a failure, but the tab only showed the error when the span had *both* `statusCode: Error` and a non-empty status message. Now:

- The error section renders for every `spanFailed()` span with a status message, whatever the status code.
- A failed span with **no status message** gets a failure banner naming the evidence the failure was read from (`span status Error` / `error.type …` / `response.status …`) instead of staying silent.
- A **failed tool call's captured result** — where the actual error text usually lives — renders on Details under the banner, so the reader doesn't have to find it on the Tool calls tab. Tool spans only: a model span's tool calls are its output and say nothing about why the model call failed.

Covered by a new component test (message-less `error.type`-only tool failure → banner + evidence pill + result on Details), and verified in the browser on the lab fixture's failed `run_tests` call.
