### PR TITLE
feat(api): flag re-executed investigation lanes; correct the TTFT comment

### DIFF
--- a/apps/api/src/chat/loop/genai.ts
+++ b/apps/api/src/chat/loop/genai.ts
@@ -449,7 +449,7 @@ export const annotateModelCallEnd = (events: ReadonlyArray<LLMEvent>): Effect.Ef
  * The span's wall clock covers the whole stream lifetime — including the SSE
  * frames and durable writes that *consume* the model's output — so it
  * systematically overstates the model. These two attributes are the honest
- * numbers: request start → first provider frame (`time_to_first_chunk`,
+ * numbers: request start → first token-bearing event (`time_to_first_chunk`,
  * seconds, the key the session view's occupancy bar reads), and request start
  * → terminal event (model duration, milliseconds).
  */
@@ -460,9 +460,14 @@ export interface ModelCallTiming {
 
 /**
  * Annotate the current model-call span as events arrive: TTFT on the first
- * provider frame (`step-start` is emitted while processing that frame, never
- * before the network, so the first event of any type is the first byte), the
- * model's own duration on the terminal event.
+ * event, the model's own duration on the terminal event.
+ *
+ * The first event is the first *token-bearing* frame, not the first byte: the
+ * openai-chat protocol emits no `step-start`, and role-only chunks, keep-alive
+ * comments and hidden reasoning produce no events at all. So on a reasoning
+ * model TTFT spans the whole silent reasoning phase — deliberately, since that
+ * is when the first token actually reached this side of the wire. On
+ * tool-call-only steps this puts TTFT near the span's full duration.
  */
 export const annotateModelCallTiming = (timing: ModelCallTiming, event: LLMEvent): Effect.Effect<void> =>
 	Effect.suspend(() => {

--- a/apps/api/src/workflows/InvestigationFanoutWorkflow.run.test.ts
+++ b/apps/api/src/workflows/InvestigationFanoutWorkflow.run.test.ts
@@ -235,6 +235,37 @@ describe("runInvestigationFanout", () => {
 	})
 
 	/**
+	 * The engine can re-run a lane step whose result was lost to a retry boundary,
+	 * minutes later and with no failure recorded anywhere. The second execution
+	 * must know it is one, so its span does not read as new work after a silent
+	 * gap in the session view.
+	 */
+	it("flags a re-executed lane step as a rerun", async () => {
+		const seen: Array<{ id: string; rerun: boolean }> = []
+		const doubleStep: WorkflowStepLike = {
+			do: (async (name: string, configOrCb: unknown, cb?: () => Promise<unknown>) => {
+				const callback = cb ?? (configOrCb as () => Promise<unknown>)
+				const first = await callback()
+				return name.startsWith("hypothesis-") ? callback() : first
+			}) as WorkflowStepLike["do"],
+		}
+		await runInvestigationFanout(
+			env,
+			{ payload: harness.payload },
+			doubleStep,
+			baseDeps({
+				invokeHypothesis: async ({ hypothesis, rerun }) => {
+					seen.push({ id: hypothesis.id, rerun })
+					return hypothesisOutput(hypothesis.id)
+				},
+			}),
+		)
+		for (const id of HYPOTHESIS_IDS) {
+			expect(seen.filter((entry) => entry.id === id).map((entry) => entry.rerun)).toEqual([false, true])
+		}
+	})
+
+	/**
 	 * The reservation is made before the planner runs, so it is deliberately high.
 	 * Left unreconciled, an org's daily pass budget drains at the ceiling rather
 	 * than at what its investigations actually cost.

--- a/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
+++ b/apps/api/src/workflows/InvestigationFanoutWorkflow.run.ts
@@ -308,6 +308,9 @@ export interface InvokeHypothesisInput {
 	readonly deadlineAtMs: number
 	/** True on the collapsed path: answer with a full diagnosis, not a candidate. */
 	readonly solo: boolean
+	/** True when this lane's row shows a prior execution — the step re-ran after
+	 *  its result was lost to a retry boundary. */
+	readonly rerun: boolean
 	readonly runtime: SharedRuntime
 }
 
@@ -363,6 +366,7 @@ const invokeHypothesis = async (input: InvokeHypothesisInput): Promise<InvokeHyp
 		}),
 		tenant: tenantFor(input.orgId),
 		deadlineAtMs: input.deadlineAtMs,
+		rerun: input.rerun,
 	}
 
 	if (input.solo) {
@@ -850,6 +854,23 @@ async function runWithDb(
 				step
 					.do(`hypothesis-${ordinal}`, HYPOTHESIS_STEP, async (): Promise<HypothesisStepResult> => {
 						const startedAt = clock()
+						// A lane row past "queued" means this callback already ran and its step
+						// result was lost to a retry boundary (an engine reschedule can land
+						// minutes later, with no failure recorded anywhere). Stamped on the
+						// lane's span so a session view can tell a re-run from new work.
+						const prior = await dbStep((db) =>
+							db
+								.select({ status: investigationLensRuns.status })
+								.from(investigationLensRuns)
+								.where(
+									and(
+										eq(investigationLensRuns.investigationId, idTyped),
+										eq(investigationLensRuns.attempt, attempt),
+										eq(investigationLensRuns.lensId, hypothesis.id),
+									),
+								),
+						)
+						const rerun = prior[0] !== undefined && prior[0].status !== "queued"
 						await dbStep((db) =>
 							db
 								.update(investigationLensRuns)
@@ -879,6 +900,7 @@ async function runWithDb(
 								snapshot,
 								deadlineAtMs: hypothesisDeadlineAtMs,
 								solo: planned.collapsed,
+								rerun,
 								runtime,
 							})
 							const finishedAt = clock()

--- a/apps/api/src/workflows/hypothesis-agent.ts
+++ b/apps/api/src/workflows/hypothesis-agent.ts
@@ -31,6 +31,8 @@ export interface HypothesisAgentInput {
 	readonly tenant: TenantContext
 	/** Wall-clock budget; the turn spends one last step submitting past it. */
 	readonly deadlineAtMs: number
+	/** The workflow step re-ran after its result was lost to a retry boundary. */
+	readonly rerun: boolean
 }
 
 export interface HypothesisAgentOutput {
@@ -54,6 +56,7 @@ export const runHypothesisAgent = Effect.fn("investigation.hypothesis")(function
 	yield* Effect.annotateCurrentSpan({
 		"maple.investigation.id": input.investigationId,
 		"maple.hypothesis.id": input.hypothesis.id,
+		...(input.rerun ? { "maple.hypothesis.rerun": true } : undefined),
 	})
 
 	const pass = yield* runAgentPass({
@@ -125,6 +128,7 @@ export const runSoloHypothesisAgent = Effect.fn("investigation.solo")(function* 
 		"maple.investigation.id": input.investigationId,
 		"maple.hypothesis.id": input.hypothesis.id,
 		"maple.investigation.collapsed": true,
+		...(input.rerun ? { "maple.hypothesis.rerun": true } : undefined),
 	})
 
 	const pass = yield* runAgentPass({


### PR DESCRIPTION
## What

Investigating a TTFT/idle anomaly on an incident-investigation session surfaced two things worth landing:

**1. Re-executed hypothesis lanes are now stamped `maple.hypothesis.rerun`.**
A lane step whose result is lost to a retry boundary is re-run by the workflow engine on its own schedule — observed in production as a 4m23s silent hole followed by two lanes re-running with identical hypothesis ids, every span `Ok`, no failure recorded anywhere. The step now reads the lane row before claiming it (status past `queued` means a prior execution already ran) and passes `rerun` through to the lane agent, which stamps it on the `investigation.hypothesis` root span. Session views can then label the second wave as a re-run instead of anonymous idle-then-new-work.

Costs one `SELECT` per lane per attempt.

**2. The `annotateModelCallTiming` comment claimed first-byte semantics TTFT never had.**
The openai-chat protocol emits no `step-start` (only open-responses does), and role-only chunks, keep-alive comments and hidden reasoning produce no `LLMEvent`s — so `gen_ai.response.time_to_first_chunk` measures to the first *token-bearing* frame. On reasoning models that includes the whole silent reasoning phase, which is why tool-call-only steps show TTFT near the span's full duration. The behavior is intended (first token to arrive client-side); the comment now says what is actually measured.

## Verification

- New test re-runs each `hypothesis-*` step callback (modeling the engine re-execution) and asserts the second execution sees `rerun: true` while the first sees `false`.
- `InvestigationFanoutWorkflow.run.test.ts`: 16/16 pass.
- `turbo typecheck --filter=@maple/api`: clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790314091&installation_model_id=427786&pr_number=639&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F639&signature=b04f8bd2344c138680d74ee36e392d6f80e7cb1f697ffbe5a79fceb9441883e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->