### PR TITLE
fix(web): drop the attention verdict's subline

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -124,17 +124,14 @@ function Verdict({
 						</p>
 					</>
 				) : verdict.status === "attention" ? (
-					<>
-						<p className="flex items-baseline gap-x-2 font-semibold text-lg">
-							<VerdictDot className="bg-severity-warn" />
-							<span>
-								Completed, with {findingCount} {findingCount === 1 ? "finding" : "findings"}
-							</span>
-						</p>
-						<p className="pl-[1.375rem] text-muted-foreground text-sm">
-							The final {turnWord} closed cleanly; what looked off is listed below.
-						</p>
-					</>
+					// No subline: the findings right below are the explanation, and a
+					// sentence pointing at them said nothing the layout doesn't.
+					<p className="flex items-baseline gap-x-2 font-semibold text-lg">
+						<VerdictDot className="bg-severity-warn" />
+						<span>
+							Completed, with {findingCount} {findingCount === 1 ? "finding" : "findings"}
+						</span>
+					</p>
 				) : (
 					<>
 						<p className="flex items-baseline gap-x-2 font-semibold text-lg">


### PR DESCRIPTION
Removes "The final turn closed cleanly; what looked off is listed below." from the Completed-with-findings verdict on the agent-session Overview — the findings directly below are the explanation, and a sentence pointing at them said nothing the layout doesn't. The Failed and Completed-cleanly sublines stay: each carries a claim of its own.

Follow-up to #637.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790320018&installation_model_id=427786&pr_number=640&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F640&signature=961093a0c96c78166c46e6809bdfa58fa7921af5474608a7d1ef39dacfddbce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->