### PR TITLE
ci: move every action off the deprecated node20 runtime

### DIFF
--- a/.github/workflows/aws-probe.yml
+++ b/.github/workflows/aws-probe.yml
@@ -70,7 +70,7 @@ jobs:
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - name: Setup mise (toolchain)
-              uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+              uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             # Needed only for `state: cloud` (the state store authenticates to
             # Cloudflare), but unconditional so the two runs differ in exactly one
@@ -87,7 +87,7 @@ jobs:
 
             - name: Configure AWS credentials (OIDC)
               id: aws
-              uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+              uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
               with:
                   role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
                   aws-region: us-east-1
@@ -107,13 +107,13 @@ jobs:
             # nothing heavy is emulated here, just one apt-get layer.
             - name: Register arm64 binfmt handlers (QEMU)
               if: inputs.level == 'image'
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+              uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
               with:
                   platforms: arm64
 
             - name: Download ingest binary
               if: inputs.level == 'image'
-              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: maple-ingest
                   path: apps/ingest/dist
@@ -156,7 +156,7 @@ jobs:
             # `if-no-files-found: ignore` swallowed the fact silently.
             - name: Upload probe state for recovery
               if: always()
-              uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: alchemy-probe-state
                   path: .alchemy/

--- a/.github/workflows/build-ingest-binary.yml
+++ b/.github/workflows/build-ingest-binary.yml
@@ -93,7 +93,7 @@ jobs:
                   fi
 
             - name: Upload binary
-              uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: ${{ inputs.artifact-name }}
                   path: apps/ingest/dist/maple-ingest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - uses: ./.github/actions/bun-install
               with:
@@ -410,7 +410,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             # The action always installs the root `maple` workspace, so naming
             # it as the only filter installs the CI tools (oxlint and the JS
@@ -475,7 +475,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - uses: ./.github/actions/bun-install
 
@@ -531,7 +531,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - uses: ./.github/actions/bun-install
 
@@ -592,7 +592,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - uses: ./.github/actions/bun-install
 
@@ -649,7 +649,7 @@ jobs:
             # whose evidence matters most.
             - name: Upload checkpoint failure evidence
               if: ${{ failure() || cancelled() }}
-              uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: native-checkpoint-failure-${{ github.run_id }}
                   # Both probes' roots: the migration probe used to fail without
@@ -728,7 +728,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - uses: ./.github/actions/bun-install
 
@@ -759,7 +759,7 @@ jobs:
             # otherwise collide on a single name, failing the upload.
             - name: Upload archive failure evidence
               if: ${{ failure() }}
-              uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: native-archive-failure-${{ matrix.probe }}-${{ github.run_id }}
                   path: ${{ runner.temp }}/${{ matrix.tmp }}
@@ -810,7 +810,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - uses: ./.github/actions/bun-install
               with:

--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -79,7 +79,7 @@ jobs:
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - name: Setup mise (toolchain)
-              uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+              uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - name: Load deployment secrets from Infisical
               uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -105,7 +105,7 @@ jobs:
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - name: Setup mise (toolchain)
-              uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+              uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - name: Load deployment secrets from Infisical
               uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
@@ -125,7 +125,7 @@ jobs:
             # AccessDenied until it is widened.
             - name: Configure AWS credentials (OIDC)
               id: aws
-              uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+              uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
               with:
                   role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
                   aws-region: us-east-1
@@ -145,13 +145,13 @@ jobs:
             # nothing heavy is emulated here, just one apt-get layer.
             - name: Register arm64 binfmt handlers (QEMU)
               if: ${{ env.TEARDOWN != 'true' }}
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+              uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
               with:
                   platforms: arm64
 
             - name: Download ingest binary
               if: ${{ env.TEARDOWN != 'true' }}
-              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: maple-ingest
                   path: apps/ingest/dist

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -45,7 +45,7 @@ jobs:
                   ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
             - name: Setup mise (toolchain)
-              uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+              uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - name: Load deployment secrets from Infisical
               uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
@@ -64,7 +64,7 @@ jobs:
             # anything stale carrying the same names out of Infisical.
             - name: Configure AWS credentials (OIDC)
               id: aws
-              uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+              uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
               with:
                   role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
                   aws-region: us-east-1
@@ -83,12 +83,12 @@ jobs:
             # The COPYed binary itself is compiled natively by the build job —
             # nothing heavy is emulated here, just one apt-get layer.
             - name: Register arm64 binfmt handlers (QEMU)
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+              uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
               with:
                   platforms: arm64
 
             - name: Download ingest binary
-              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: maple-ingest
                   path: apps/ingest/dist

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -40,7 +40,7 @@ jobs:
                   ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
             - name: Setup mise (toolchain)
-              uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+              uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - name: Load deployment secrets from Infisical
               uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
@@ -55,7 +55,7 @@ jobs:
             # AFTER Infisical — see the note in deploy-prd.yml.
             - name: Configure AWS credentials (OIDC)
               id: aws
-              uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+              uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
               with:
                   role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
                   aws-region: us-east-1
@@ -74,12 +74,12 @@ jobs:
             # The COPYed binary itself is compiled natively by the build job —
             # nothing heavy is emulated here, just one apt-get layer.
             - name: Register arm64 binfmt handlers (QEMU)
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+              uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
               with:
                   platforms: arm64
 
             - name: Download ingest binary
-              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: maple-ingest
                   path: apps/ingest/dist

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -44,7 +44,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - uses: ./.github/actions/bun-install
               with:

--- a/.github/workflows/ingest-load-tests.yml
+++ b/.github/workflows/ingest-load-tests.yml
@@ -45,7 +45,7 @@ jobs:
             # Installs the rust version pinned in the root mise.toml (was a floating
             # `stable`). Keep rust-cache below — mise caches the toolchain, not the
             # cargo registry / target dir.
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:

--- a/.github/workflows/ingest-rust-tests.yml
+++ b/.github/workflows/ingest-rust-tests.yml
@@ -56,7 +56,7 @@ jobs:
             # Installs the rust version pinned in the root mise.toml (was a floating
             # `stable`). Keep rust-cache below — mise caches the toolchain, not the
             # cargo registry / target dir.
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
               with:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -39,7 +39,7 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - name: Select Xcode
-              uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+              uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
               with:
                   xcode-version: latest-stable
 

--- a/.github/workflows/local-binary-release.yml
+++ b/.github/workflows/local-binary-release.yml
@@ -61,7 +61,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             - name: Install JS dependencies
               run: bun install --frozen-lockfile
@@ -137,7 +137,7 @@ jobs:
                   echo "name=$name" >> "$GITHUB_OUTPUT"
 
             - name: Upload build artifact
-              uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: ${{ steps.package.outputs.name }}
                   path: |

--- a/.github/workflows/otel-collector-maple-tests.yml
+++ b/.github/workflows/otel-collector-maple-tests.yml
@@ -25,7 +25,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+            - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
               with:
                   # Match `go 1.25.0` in packages/otel-collector-maple-exporter/go.mod.
                   go-version-file: packages/otel-collector-maple-exporter/go.mod

--- a/.github/workflows/publish-k8s-infra-chart.yml
+++ b/.github/workflows/publish-k8s-infra-chart.yml
@@ -18,7 +18,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+            - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
             - name: Package chart
               run: ./scripts/package-k8s-infra-chart.sh

--- a/.github/workflows/publish-maple-otel-chart.yml
+++ b/.github/workflows/publish-maple-otel-chart.yml
@@ -18,7 +18,7 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-            - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+            - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
             - name: Publish chart to GHCR
               env:

--- a/.github/workflows/publish-otel-collector-maple.yml
+++ b/.github/workflows/publish-otel-collector-maple.yml
@@ -60,12 +60,12 @@ jobs:
                   echo "tag=$tag" >> "$GITHUB_OUTPUT"
                   echo "Resolved: ghcr.io/${owner_lc}/maple/otel-collector-maple:${tag}"
 
-            - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+            - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
-            - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+            - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
             - name: Log in to GHCR
-              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+              uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}
@@ -75,7 +75,7 @@ jobs:
             # binary is statically linked, so the same Dockerfile produces a
             # working image on both amd64 and arm64.
             - name: Build + push (amd64, arm64)
-              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+              uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
               with:
                   context: .
                   file: deploy/k8s-infra/Dockerfile.otel-collector-maple

--- a/.github/workflows/tinybird-cd.yml
+++ b/.github/workflows/tinybird-cd.yml
@@ -46,7 +46,7 @@ jobs:
         environment: ${{ matrix.target.environment }}
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
             - name: Install dependencies
               # Run install before any secrets are scoped to the deploy step.
               run: bun install --frozen-lockfile

--- a/.github/workflows/token-cost.yml
+++ b/.github/workflows/token-cost.yml
@@ -30,7 +30,7 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+            - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
             # This script only needs the API dependency closure. Installing all
             # workspaces accounted for roughly half of this job's wall time.


### PR DESCRIPTION
## What

Bumps the eleven actions still running on the node20 runtime to their latest node24 majors, still SHA-pinned with the version in the trailing comment.

| action | was | now |
| --- | --- | --- |
| `jdx/mise-action` | v2.4.4 | v4.3.0 (18 call sites) |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `actions/download-artifact` | v4 | v8.0.1 |
| `actions/setup-go` | v5 | v7.0.0 |
| `aws-actions/configure-aws-credentials` | v5 | v6.2.3 |
| `azure/setup-helm` | v4 | v5.0.1 |
| `docker/setup-qemu-action` | v3 | v4.2.0 |
| `docker/setup-buildx-action` | v3 | v4.3.0 |
| `docker/login-action` | v3 | v4.6.0 |
| `docker/build-push-action` | v6 | v7.3.0 |
| `maxim-lobanov/setup-xcode` | v1.6.0 | v1.7.0 |

After this, every `uses:` in `.github/` is on a node24 runtime.

## Why

GitHub forces node24 as the Actions default in June 2026. Nothing in this repo ever asked for node 20 — there is no `setup-node` anywhere and `mise.toml` pins `node = "24.18.0"` — it was purely the runtime each third-party action declares in its own `action.yml`. Since these are SHA-pinned, nothing was bumping them for us, and most had drifted several majors behind.

`Infisical/secrets-action@v1.0.16` was already node24 and is left alone. `actions/checkout`, `actions/cache`, `Swatinem/rust-cache`, `dorny/paths-filter` and `planetscale/setup-pscale-action` were already on node24 pins.

## Breaking changes, checked against our call sites

- **download-artifact v5** changed the output path for downloads by `artifact-ids`. All four of ours (`aws-probe`, `deploy-prd`, `deploy-stg`, `deploy-pr-preview`) fetch `name: maple-ingest`, so they are unaffected.
- **download-artifact v8** now *errors* on a digest mismatch instead of warning (overridable via the new `digest-mismatch` input), and skips decompression for non-zip `Content-Type`. Our uploads are ordinary zipped artifacts. **This is the one live behaviour change in the PR.**
- **upload-artifact v7** adds `archive: false` for single-file direct uploads; the default is unchanged and all five call sites pass `name`/`path` as before.
- **setup-buildx v4 / build-push v7** removed deprecated inputs and the `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs. `publish-otel-collector-maple.yml` sets none of them.
- **setup-go v6** tightened toolchain selection. `packages/otel-collector-maple-exporter/go.mod` declares `go 1.25.0` with no `toolchain` directive, so resolution is unchanged; the inputs we pass (`go-version-file`, `cache`, `cache-dependency-path`) all still exist in v7.
- **mise-action v3** began exporting `mise.toml` `[env]` vars into the job env. Ours is only `_.file = ".env.local"`, which does not exist in CI — a no-op there, as the comment in `mise.toml` already assumes. All 18 call sites are bare `uses:` with no inputs.
- Every node24 major requires runner >= 2.327.1. We are entirely on GitHub-hosted runners (`ubuntu-latest`, `ubuntu-24.04-arm`, `ubuntu-22.04`, `macos-15`, `macos-14`), which satisfy that.

## Review notes

This is only verifiable by running it — a green CI run on this PR exercises `mise-action`, `upload-artifact`, `setup-go`, `paths-filter` and the artifact round-trip, but the deploy (`configure-aws-credentials`, Infisical OIDC), chart-publish (`setup-helm`) and image-publish (qemu/buildx/login/build-push) paths only run on their own triggers and are not covered by this PR's checks. Worth a look at the first `deploy-stg` and `publish-otel-collector-maple` runs after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790331998&installation_model_id=427786&pr_number=641&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F641&signature=e142d7fb5d9a1b991534893a673f9ade979ce726ddbc081bbd2cf9f54f62c1db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->