### PR TITLE
fix: name the real columns on a bad raw-SQL column, and the R2 cause on a failed replay PUT

### DIFF
--- a/apps/api/src/mcp/tools/__tests__/run-sql-unknown-column.test.ts
+++ b/apps/api/src/mcp/tools/__tests__/run-sql-unknown-column.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { withColumnListOnUnknownColumn } from "../run-sql"
+import { McpQueryError } from "../types"
+
+const err = (message: string) => new McpQueryError({ message, pipeName: "run_sql" })
+
+// The exact production SQL: three invented columns on one rollup table.
+const ROLLUP_SQL =
+	"SELECT AttributeKey, sum(Count) AS c FROM attribute_keys_hourly WHERE $__orgFilter " +
+	"AND $__timeFilter(Timestamp) AND ServiceName = 'enrichment-api' GROUP BY AttributeKey"
+
+describe("withColumnListOnUnknownColumn", () => {
+	it("appends the referenced table's real columns to an unknown-identifier error", () => {
+		const enriched = withColumnListOnUnknownColumn(ROLLUP_SQL)(
+			err("Unknown expression or function identifier 'Count' in scope SELECT AttributeKey, sum(Count)"),
+		)
+		expect(enriched.message).toContain("Unknown expression or function identifier 'Count'")
+		expect(enriched.message).toContain("`attribute_keys_hourly`")
+		expect(enriched.message).toContain("UsageCount")
+		expect(enriched.message).toContain("Hour")
+		// The absent dimension the agent kept guessing at must not be listed.
+		expect(enriched.message).not.toContain("ServiceName")
+	})
+
+	it("matches the older Missing columns / no column wordings", () => {
+		expect(
+			withColumnListOnUnknownColumn(ROLLUP_SQL)(err("Missing columns: 'Timestamp'")).message,
+		).toContain("UsageCount")
+		expect(
+			withColumnListOnUnknownColumn(ROLLUP_SQL)(err("There's no column 'Timestamp' in table")).message,
+		).toContain("UsageCount")
+	})
+
+	// Errors that already carry an actionable message must not get a schema dump.
+	it("leaves unrelated warehouse errors untouched", () => {
+		const original = err("Memory limit (for query) exceeded")
+		expect(withColumnListOnUnknownColumn(ROLLUP_SQL)(original)).toBe(original)
+	})
+
+	// Nothing useful to append when the query names no catalog table — that case
+	// is `withTableListOnUnknownTable`'s.
+	it("leaves the error untouched when no known table is referenced", () => {
+		const original = err("Unknown identifier 'Count'")
+		expect(withColumnListOnUnknownColumn("SELECT Count FROM otel_traces")(original)).toBe(original)
+	})
+
+	it("describes every referenced table in a join, capped at three", () => {
+		const sql =
+			"SELECT * FROM traces t JOIN logs l USING TraceId JOIN error_events e USING TraceId " +
+			"JOIN service_usage u USING OrgId"
+		const message = withColumnListOnUnknownColumn(sql)(err("Unknown identifier 'x'")).message
+		expect(message).toContain("`traces`")
+		expect(message).toContain("`logs`")
+		expect(message).toContain("`error_events`")
+		expect(message).not.toContain("`service_usage`")
+	})
+
+	it("preserves pipeName and cause", () => {
+		const enriched = withColumnListOnUnknownColumn(ROLLUP_SQL)(
+			new McpQueryError({
+				message: "Unknown identifier 'Count'",
+				pipeName: "run_sql",
+				cause: new Error("boom"),
+			}),
+		)
+		expect(enriched.pipeName).toBe("run_sql")
+		expect(enriched.cause).toBeInstanceOf(Error)
+	})
+
+	// `cause` is an optionalKey on McpQueryError — rebuilding without one must not
+	// materialise it as an explicit `undefined`.
+	it("omits cause entirely when the original had none", () => {
+		const enriched = withColumnListOnUnknownColumn(ROLLUP_SQL)(err("Unknown identifier 'Count'"))
+		expect("cause" in enriched && enriched.cause !== undefined).toBe(false)
+	})
+})

--- a/apps/api/src/mcp/tools/run-sql.ts
+++ b/apps/api/src/mcp/tools/run-sql.ts
@@ -14,7 +14,7 @@ import { createDualContent } from "@/mcp/lib/structured-output"
 import { formatTable, truncate } from "@/mcp/lib/format"
 import { toMcpQueryError } from "@/mcp/lib/map-warehouse-error"
 import { McpQueryError } from "./types"
-import { listWarehouseTables } from "@/services/warehouse/warehouse-catalog"
+import { describeWarehouseTable, listWarehouseTables } from "@/services/warehouse/warehouse-catalog"
 
 // Rows returned to the model are capped so a wide/long result doesn't blow the
 // context. The full count is always reported via meta.rowCount.
@@ -37,6 +37,56 @@ export const withTableListOnUnknownTable = (error: McpQueryError): McpQueryError
 		cause: error.cause,
 	})
 }
+
+/**
+ * Matches how each backend words a column that isn't on the referenced table.
+ * ClickHouse's analyzer says "Unknown expression or function identifier '<x>' in
+ * scope <query>"; the older paths say "Unknown identifier" / "Missing columns" /
+ * "There's no column".
+ */
+const UNKNOWN_COLUMN = /unknown (?:expression or function )?identifier|missing columns|there'?s no column/i
+
+/** Cap on how many tables one enrichment describes. */
+const MAX_DESCRIBED_TABLES = 3
+
+/** Catalog tables the submitted SQL actually names, in first-mention order. */
+const referencedTables = (sql: string): ReadonlyArray<string> =>
+	listWarehouseTables()
+		.map((t) => ({ name: t.name, at: sql.search(new RegExp(`\\b${t.name}\\b`)) }))
+		.filter((t) => t.at >= 0)
+		.sort((a, b) => a.at - b.at)
+		.map((t) => t.name)
+
+/**
+ * The column counterpart of `withTableListOnUnknownTable`, and it exists for the
+ * same reason: the warehouse names the column the agent invented but never the
+ * ones that exist, so a wrong guess on a rollup table (`Count`/`Timestamp`/
+ * `ServiceName` against `attribute_keys_hourly`, whose columns are `Hour` and
+ * `UsageCount` and which has no per-service dimension at all) fails every retry.
+ * Put the real columns in the error rather than pointing at a tool agents skip.
+ */
+export const withColumnListOnUnknownColumn =
+	(sql: string) =>
+	(error: McpQueryError): McpQueryError => {
+		if (!UNKNOWN_COLUMN.test(error.message)) return error
+
+		// Only the tables the query names; a schema dump of all 38 would bury the
+		// message it is attached to.
+		const described = referencedTables(sql)
+			.slice(0, MAX_DESCRIBED_TABLES)
+			.map((name) => describeWarehouseTable(name))
+			.filter((info) => info !== null)
+		if (described.length === 0) return error
+
+		const listing = described.map(
+			(info) => `\`${info.name}\`: ${info.columns.map((c) => c.name).join(", ")}`,
+		)
+		return new McpQueryError({
+			message: `${error.message}\n\nColumns available —\n${listing.join("\n")}`,
+			pipeName: error.pipeName,
+			cause: error.cause,
+		})
+	}
 
 const runSqlSchema = Schema.Struct({
 	sql: requiredStringParam(
@@ -111,6 +161,8 @@ export function registerRunSqlTool(server: McpToolRegistrar) {
 				// points at describe_warehouse_tables instead, which agents skip — 60
 				// calls against 1,008 run_sql calls. Put the answer in the error.
 				Effect.mapError(withTableListOnUnknownTable),
+				// Same gap one level down: the table exists but the column was invented.
+				Effect.mapError(withColumnListOnUnknownColumn(params.sql)),
 			)
 
 			if (!outcome.ok) return outcome.result

--- a/apps/api/src/services/warehouse/warehouse-catalog.ts
+++ b/apps/api/src/services/warehouse/warehouse-catalog.ts
@@ -50,6 +50,18 @@ const TABLE_NOTES: Record<string, ReadonlyArray<string>> = {
 	metrics_histogram: [
 		"Pre-aggregated histograms (bucket counts + sum + count). Reconstruct percentiles with `quantilesExact`/`quantileBFloat16` if needed.",
 	],
+	attribute_keys_hourly: [
+		"The time column is `Hour` (a top-of-hour DateTime), NOT `Timestamp`. Use `$__timeFilter(Hour)` and snap range bounds with `toStartOfHour`.",
+		"The count column is `UsageCount` (SimpleAggregateFunction(sum, UInt64)) — aggregate with `sum(UsageCount)`. There is no `Count` column.",
+		"There is NO `ServiceName` column: this rollup is per (org, scope, hour, key) only, so attribute keys cannot be split by service here. Query `traces` / `logs` directly for a per-service breakdown.",
+		"`AttributeScope` values are lowercase: 'span', 'resource', 'log', 'metric'. Filter with `AttributeScope = 'span'` (NOT 'Span').",
+		"Sorting key: `(OrgId, AttributeScope, Hour, AttributeKey)` — filtering on `AttributeScope` first is what makes this table fast.",
+	],
+	attribute_values_hourly: [
+		"Same shape as `attribute_keys_hourly` one level deeper, adding `AttributeValue`. Time column is `Hour`, count column is `UsageCount`, and there is no `ServiceName`.",
+		"`AttributeScope` values are lowercase: 'span', 'resource', 'log', 'metric'.",
+		"Sorting key: `(OrgId, AttributeScope, AttributeKey, Hour, AttributeValue)` — pin `AttributeKey` to look up one key's values cheaply.",
+	],
 	service_usage: [
 		"Hourly per-service rollup of STORED rows, 365-day TTL — far longer than the 30-day `logs`/`traces` retention, so it is the right table for long-range volume trends.",
 		"`Hour` is a top-of-hour DateTime. Snap both range bounds to their hour floor (`toStartOfHour`) or sub-hour windows return no rows at all; this necessarily over-reports at the window edges.",

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -3552,7 +3552,11 @@ async fn handle_replay_blob_inner(
                         "replay chunk blob upload failed"
                     );
                     metrics::replay_blob_put_failed(&org_id);
+                    // The store error is the only thing that says *why* the PUT
+                    // failed. Without it the span carries a bare 503 and the
+                    // failure is undiagnosable from the dashboard.
                     ApiError::service_unavailable("failed to store replay chunk")
+                        .with_detail(e.to_string())
                 })?;
             Span::current().record(
                 "maple.replay.blob_put_ms",


### PR DESCRIPTION
Two production failures found in telemetry. Both are errors that say what went wrong but not enough to act on.

## Raw SQL against the hourly rollups (`maple-api`, 3 issues, 12 events)

Agents keep inventing columns on `attribute_keys_hourly` — `Count`, `Timestamp`, and `ServiceName`. The real columns are `OrgId, Hour, AttributeKey, AttributeScope, UsageCount`, and there is **no** per-service dimension at all, so those queries were unanswerable rather than misspelled. The warehouse names the column that doesn't exist but never the ones that do, so every retry failed identically:

```
Unknown expression or function identifier 'Count' in scope
SELECT AttributeKey, sum(Count) AS c FROM attribute_keys_hourly …
```

**`withColumnListOnUnknownColumn`** is the column counterpart of the existing `withTableListOnUnknownTable`, and exists for the reason that one already documents: agents skip `describe_warehouse_tables` (60 calls against 1,008 `run_sql` calls), so the answer belongs in the error. It scans the submitted SQL for catalog table names and appends their real columns, capped at three tables so a join doesn't dump the whole catalog. Errors that already carry an actionable message (timeouts, memory limits) are left untouched.

```
Unknown expression or function identifier 'Count' in scope …

Columns available —
`attribute_keys_hourly`: OrgId, Hour, AttributeKey, AttributeScope, UsageCount
```

**Curated notes** for `attribute_keys_hourly` and `attribute_values_hourly` cover the same three wrong guesses for the path where `describe_warehouse_tables` *is* called, plus the lowercase `AttributeScope` values (`span`/`resource`/`log`/`metric`) and the sort key.

## Replay blob PUT failures (`ingest`, 104 events, still firing)

`POST /v1/sessionReplays/blob` dropped the R2 error entirely — the span carried a bare 503 and the cause reached no telemetry, so the failures were undiagnosable from the dashboard. `ApiError` already has `with_detail` for exactly this ("Internal cause, kept off the wire. Recorded as the span's reject reason"); the call site just never used it. The handler routes through `record_rejection_reason` and the status is 5xx, so the cause now lands on both `maple.ingest.reject_reason` and `otel.status_description`, and stays off the HTTP response body.

This makes the failures diagnosable; it does not fix whatever is causing them (~13 in one 07:00 burst, then a trickle). That's the follow-up.

## Testing

- New `run-sql-unknown-column.test.ts`, 8 cases including the verbatim production SQL; 13/13 pass across both run-sql test files.
- `tsc --noEmit` clean for `apps/api`.
- `cargo check` clean, `cargo test replay` 6/6, `cargo clippy` shows no new warnings (remaining ones are pre-existing in `session_analytics.rs`).

## Notes for the reviewer

- The pre-existing unused `optionalStringParam` import in `run-sql.ts` is left alone — it's on `main` already and out of scope here.
- A third issue found in the same triage — the raw-SQL wrapper not rejecting a trailing `FORMAT` clause, which makes `SELECT * FROM (…) AS maple_raw_sql_limited` invalid — is being handled separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790337429&installation_model_id=427786&pr_number=644&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F644&signature=01054ec3114b32bb1e63743cd965e1b5f791cf01b5c46b9da40800cb2d4d386f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->