### PR TITLE
fix(query-engine): let the engine own SQL terminal clauses

### DIFF
--- a/apps/api/src/services/warehouse/WarehouseQueryService.test.ts
+++ b/apps/api/src/services/warehouse/WarehouseQueryService.test.ts
@@ -843,6 +843,22 @@ describe("createTinybirdSdkSqlClient.sql FORMAT normalization", () => {
 		const sent = await captureSql("SELECT 1;")
 		assert.strictEqual(sent, "SELECT 1\nFORMAT JSON")
 	})
+
+	it("keeps the SETTINGS clause when appending FORMAT JSON", async () => {
+		const sent = await captureSql("SELECT 1\nSETTINGS max_threads=2")
+		assert.strictEqual(sent, "SELECT 1\nSETTINGS max_threads=2\nFORMAT JSON")
+	})
+
+	it("ignores a FORMAT that is only a column reference", async () => {
+		const sent = await captureSql("SELECT format FROM t")
+		assert.strictEqual(sent, "SELECT format FROM t\nFORMAT JSON")
+	})
+
+	it("ignores a FORMAT nested in a subquery", async () => {
+		const sent = await captureSql("SELECT * FROM (SELECT 1 FORMAT JSON) AS x")
+		assert.strictEqual(countFormats(sent), 2)
+		assert.match(sent, /FORMAT JSON$/)
+	})
 })
 
 describe("ingest routes writes to the managed pipeline, not a per-org read override", () => {

--- a/apps/api/src/services/warehouse/WarehouseQueryService.ts
+++ b/apps/api/src/services/warehouse/WarehouseQueryService.ts
@@ -1,5 +1,6 @@
 import { createClient as createClickHouseClient } from "@clickhouse/client-web"
 import { Tinybird } from "@tinybirdco/sdk"
+import { splitTerminalClauses } from "@maple-dev/clickhouse-builder/sql"
 import { Context, Effect, Layer, Option, Redacted } from "effect"
 import { WarehouseConfigError, type WarehouseQueryRequest } from "@maple/domain/http"
 import {
@@ -180,11 +181,14 @@ const createTinybirdSdkSqlClient = (
 				// queries already end with `FORMAT JSON` (profile SETTINGS are inserted
 				// before it by appendSettings) — appending a second FORMAT clause is a
 				// ClickHouse syntax error, so only add one when the query doesn't carry
-				// its own. The trailing-SETTINGS alternative covers SQL from callers that
-				// still emit the legacy `FORMAT JSON SETTINGS …` order.
-				const trimmed = sql.trimEnd().replace(/;$/, "")
-				const hasFormat = /\bFORMAT\s+\w+(\s+SETTINGS\s[^\n]*)?$/i.test(trimmed)
-				const jsonSql = hasFormat ? trimmed : `${trimmed}\nFORMAT JSON`
+				// its own.
+				const terminal = splitTerminalClauses(sql)
+				const jsonSql =
+					terminal.format !== undefined
+						? sql.trimEnd().replace(/;\s*$/, "")
+						: [terminal.body, terminal.settings, "FORMAT JSON"]
+								.filter((part) => part !== undefined)
+								.join("\n")
 				const limits = options?.responseLimits
 				// The SDK normally buffers through response.json(). Raw execution gets
 				// a fetch adapter that aborts before constructing an oversized Response.

--- a/lib/clickhouse-builder/src/ch/compile.ts
+++ b/lib/clickhouse-builder/src/ch/compile.ts
@@ -13,6 +13,7 @@ import type { CHUnionQuery } from "./union"
 import { createColumnAccessor, createJoinedColumnAccessor } from "./query"
 import { aliased } from "./expr"
 import { raw, ident, escapeClickHouseString, compile as compileSqlFragment } from "../sql/sql-fragment"
+import { splitTerminalClauses } from "../sql/terminal-clauses"
 import { compileQuery, type SqlQuery } from "../sql/sql-query"
 import { Effect, Option, Schema } from "effect"
 
@@ -301,7 +302,7 @@ export function compileCH<
 		// owns formatting. Strips a trailing `\nFORMAT <fmt>` defensively.
 		const innerCompiled = compileUnion(state.fromUnion, params)
 		fromSourceScope = innerCompiled.tenantScope
-		const innerSql = innerCompiled.sql.replace(/\nFORMAT \w+$/, "")
+		const innerSql = splitTerminalClauses(innerCompiled.sql).body
 		fromFragment = raw(`(\n${innerSql}\n) AS ${state.fromQueryAlias}`)
 	} else if (state.tableAlias) {
 		fromFragment = raw(`${state.tableName} AS ${state.tableAlias}`)

--- a/lib/clickhouse-builder/src/sql/index.ts
+++ b/lib/clickhouse-builder/src/sql/index.ts
@@ -12,3 +12,5 @@ export {
 } from "./sql-fragment"
 
 export { type SqlQuery, compileQuery } from "./sql-query"
+
+export { type TerminalClauses, maskLiteralsAndComments, splitTerminalClauses } from "./terminal-clauses"

--- a/lib/clickhouse-builder/src/sql/terminal-clauses.test.ts
+++ b/lib/clickhouse-builder/src/sql/terminal-clauses.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import { maskLiteralsAndComments, splitTerminalClauses } from "./terminal-clauses"
+
+describe("maskLiteralsAndComments", () => {
+	it("preserves offsets so matches index the original", () => {
+		const sql = "SELECT 'a FORMAT JSON' AS x -- FORMAT CSV\nFROM t"
+		const masked = maskLiteralsAndComments(sql)
+		expect(masked.length).toBe(sql.length)
+		expect(masked).not.toMatch(/FORMAT/)
+		expect(masked.indexOf("FROM t")).toBe(sql.indexOf("FROM t"))
+	})
+
+	it("keeps newlines inside block comments", () => {
+		const masked = maskLiteralsAndComments("SELECT 1 /* a\nb */ FROM t")
+		expect(masked).toBe("SELECT 1     \n     FROM t")
+	})
+
+	it("handles doubled and backslash-escaped quotes", () => {
+		const sql = "SELECT 'it''s', 'a\\'b' FROM t"
+		const masked = maskLiteralsAndComments(sql)
+		expect(masked.length).toBe(sql.length)
+		expect(masked.trimEnd().endsWith("FROM t")).toBe(true)
+	})
+})
+
+describe("splitTerminalClauses", () => {
+	it("returns the whole statement when there is no terminal clause", () => {
+		expect(splitTerminalClauses("SELECT 1")).toEqual({
+			body: "SELECT 1",
+			settings: undefined,
+			format: undefined,
+		})
+	})
+
+	it("splits a trailing FORMAT", () => {
+		expect(splitTerminalClauses("SELECT 1\nFORMAT JSON")).toEqual({
+			body: "SELECT 1",
+			settings: undefined,
+			format: "FORMAT JSON",
+		})
+	})
+
+	it("drops a trailing semicolon", () => {
+		expect(splitTerminalClauses("SELECT 1 FORMAT JSONEachRow;")).toEqual({
+			body: "SELECT 1",
+			settings: undefined,
+			format: "FORMAT JSONEachRow",
+		})
+	})
+
+	it("splits both clauses in grammar order", () => {
+		expect(splitTerminalClauses("SELECT 1 SETTINGS max_threads=2 FORMAT JSON")).toEqual({
+			body: "SELECT 1",
+			settings: "SETTINGS max_threads=2",
+			format: "FORMAT JSON",
+		})
+	})
+
+	it("splits both clauses in legacy order", () => {
+		expect(splitTerminalClauses("SELECT 1 FORMAT JSON SETTINGS max_threads=2")).toEqual({
+			body: "SELECT 1",
+			settings: "SETTINGS max_threads=2",
+			format: "FORMAT JSON",
+		})
+	})
+
+	it("ignores FORMAT inside a string literal", () => {
+		const sql = "SELECT concat(a, ' FORMAT JSON') FROM t"
+		expect(splitTerminalClauses(sql).body).toBe(sql)
+		expect(splitTerminalClauses(sql).format).toBeUndefined()
+	})
+
+	it("ignores FORMAT inside a trailing comment", () => {
+		expect(splitTerminalClauses("SELECT 1 FROM t -- FORMAT JSON").format).toBeUndefined()
+	})
+
+	it("ignores FORMAT inside a subquery", () => {
+		expect(splitTerminalClauses("SELECT * FROM (SELECT 1 FORMAT JSON) AS x").format).toBeUndefined()
+	})
+
+	it("ignores a column named format", () => {
+		expect(splitTerminalClauses("SELECT format FROM t").format).toBeUndefined()
+		expect(splitTerminalClauses("SELECT format, count() FROM t").format).toBeUndefined()
+	})
+
+	it("ignores a column named settings", () => {
+		expect(splitTerminalClauses("SELECT settings FROM t").settings).toBeUndefined()
+	})
+
+	it("does not match a keyword prefix", () => {
+		const sql = "SELECT formatDateTime(now(), '%F') AS format_col FROM t"
+		expect(splitTerminalClauses(sql).format).toBeUndefined()
+	})
+
+	it("splits a multi-line SETTINGS clause", () => {
+		expect(splitTerminalClauses("SELECT 1\nSETTINGS max_execution_time=10,\n  max_threads=2")).toEqual({
+			body: "SELECT 1",
+			settings: "SETTINGS max_execution_time=10,\n  max_threads=2",
+			format: undefined,
+		})
+	})
+
+	it("keeps the last FORMAT when an earlier one is only an identifier", () => {
+		expect(splitTerminalClauses("SELECT format FROM t FORMAT JSON")).toEqual({
+			body: "SELECT format FROM t",
+			settings: undefined,
+			format: "FORMAT JSON",
+		})
+	})
+})

--- a/lib/clickhouse-builder/src/sql/terminal-clauses.ts
+++ b/lib/clickhouse-builder/src/sql/terminal-clauses.ts
@@ -1,0 +1,153 @@
+// Terminal clauses of a ClickHouse statement: `SETTINGS` and `FORMAT`.
+//
+// Both are statement *terminators* — legal only at the very end of a top-level
+// statement, never inside a subquery. Anything that rewrites a statement (adding
+// a settings clause, nesting a query inside `SELECT * FROM (…)`, picking a wire
+// format) has to know where the body ends and the terminal clauses begin, and a
+// trailing-anchored regex gets that wrong the moment two clauses are present or
+// the keyword also appears as an identifier.
+
+/**
+ * Blank out comments and string/identifier literals, preserving every offset so
+ * matches against the masked text index the original.
+ *
+ * Newlines survive so line-oriented checks still work.
+ */
+export function maskLiteralsAndComments(sql: string): string {
+	let out = ""
+	let i = 0
+	const blank = (count: number) => {
+		out += " ".repeat(count)
+	}
+	while (i < sql.length) {
+		const ch = sql[i]
+		const next = sql[i + 1]
+
+		if (ch === "-" && next === "-") {
+			const nl = sql.indexOf("\n", i)
+			const end = nl === -1 ? sql.length : nl
+			blank(end - i)
+			i = end
+			continue
+		}
+		if (ch === "/" && next === "*") {
+			const close = sql.indexOf("*/", i + 2)
+			const end = close === -1 ? sql.length : close + 2
+			for (let j = i; j < end; j++) out += sql[j] === "\n" ? "\n" : " "
+			i = end
+			continue
+		}
+		if (ch === "'" || ch === "`" || ch === '"') {
+			const quote = ch
+			blank(1)
+			i++
+			while (i < sql.length) {
+				const c = sql[i]
+				if (c === "\\") {
+					blank(Math.min(2, sql.length - i))
+					i += 2
+					continue
+				}
+				blank(1)
+				i++
+				if (c === quote) break
+			}
+			continue
+		}
+
+		out += ch
+		i++
+	}
+	return out
+}
+
+export interface TerminalClauses {
+	/** Everything up to the first terminal clause, with any trailing `;` removed. */
+	readonly body: string
+	/** The `SETTINGS …` clause verbatim, or undefined. */
+	readonly settings: string | undefined
+	/** The `FORMAT …` clause verbatim, or undefined. */
+	readonly format: string | undefined
+}
+
+type Candidate = { readonly start: number; readonly kind: "settings" | "format" }
+
+const TERMINAL_KEYWORD_RE = /\b(SETTINGS|FORMAT)\b/gi
+
+/** Paren nesting depth at each offset of the masked text. */
+const depthsOf = (masked: string): Int32Array => {
+	const depths = new Int32Array(masked.length)
+	let depth = 0
+	for (let i = 0; i < masked.length; i++) {
+		const ch = masked[i]
+		if (ch === ")") depth = Math.max(0, depth - 1)
+		depths[i] = depth
+		if (ch === "(") depth++
+	}
+	return depths
+}
+
+/**
+ * A candidate only counts as a terminal clause if the whole tail from its start
+ * parses as a chain of terminal clauses — which is what separates the `FORMAT`
+ * in `SELECT 1 FORMAT JSON` from the column in `SELECT format FROM t`.
+ */
+const clauseIsWellFormed = (kind: Candidate["kind"], segment: string): boolean =>
+	kind === "format" ? /^FORMAT\s+\w+\s*$/i.test(segment) : /^SETTINGS\s+\w+\s*=/i.test(segment)
+
+/**
+ * Split a single ClickHouse statement into its body and terminal clauses.
+ *
+ * Tolerates either clause order — the grammar puts `SETTINGS` before `FORMAT`,
+ * but `FORMAT … SETTINGS …` is still accepted by older servers and appears in
+ * hand-written SQL. A trailing semicolon is dropped.
+ */
+export function splitTerminalClauses(sql: string): TerminalClauses {
+	const trimmed = sql.replace(/;\s*$/, "")
+	const masked = maskLiteralsAndComments(trimmed)
+	const depths = depthsOf(masked)
+
+	const candidates: Array<Candidate> = []
+	TERMINAL_KEYWORD_RE.lastIndex = 0
+	let match: RegExpExecArray | null = TERMINAL_KEYWORD_RE.exec(masked)
+	while (match !== null) {
+		if (depths[match.index] === 0) {
+			candidates.push({
+				start: match.index,
+				kind: match[1].toLowerCase() === "format" ? "format" : "settings",
+			})
+		}
+		match = TERMINAL_KEYWORD_RE.exec(masked)
+	}
+
+	// Walk boundaries right-to-left, keeping the earliest one whose whole tail is
+	// a well-formed chain with at most one clause of each kind.
+	let boundary = -1
+	const seen = new Set<Candidate["kind"]>()
+	for (let i = candidates.length - 1; i >= 0; i--) {
+		const candidate = candidates[i]
+		const end = i + 1 < candidates.length ? candidates[i + 1].start : trimmed.length
+		if (seen.has(candidate.kind)) break
+		if (!clauseIsWellFormed(candidate.kind, masked.slice(candidate.start, end))) break
+		seen.add(candidate.kind)
+		boundary = candidate.start
+	}
+
+	if (boundary === -1) return { body: trimmed, settings: undefined, format: undefined }
+
+	const tail = candidates.filter((candidate) => candidate.start >= boundary)
+	const clauseText = (index: number) => {
+		const start = tail[index].start
+		const end = index + 1 < tail.length ? tail[index + 1].start : trimmed.length
+		return trimmed.slice(start, end).trim()
+	}
+
+	let settings: string | undefined
+	let format: string | undefined
+	for (let i = 0; i < tail.length; i++) {
+		if (tail[i].kind === "settings") settings = clauseText(i)
+		else format = clauseText(i)
+	}
+
+	return { body: trimmed.slice(0, boundary).trimEnd(), settings, format }
+}

--- a/packages/query-engine/src/execution/fingerprint.ts
+++ b/packages/query-engine/src/execution/fingerprint.ts
@@ -1,3 +1,5 @@
+import { splitTerminalClauses } from "@maple-dev/clickhouse-builder/sql"
+
 /**
  * Cap traced SQL at 16 KB. OTel's default attribute size limit is 32 KB, and
  * 16 KB covers the overwhelming majority of compiled DSL queries while leaving
@@ -71,12 +73,13 @@ export const summarizeSql = (sql: string): SqlSummary => {
 }
 
 /**
- * The official ClickHouse client rejects a trailing `FORMAT JSONEachRow`/`FORMAT
- * JSON` (it sets the format itself) and a trailing `;`. Strip both before
- * handing the SQL to the CH driver. Tinybird's `/v0/sql` keeps the SQL as-is.
+ * The official ClickHouse client sets the wire format itself, so it rejects a
+ * statement that carries its own `FORMAT` clause (any format, not just the
+ * `FORMAT JSON` the DSL emits) and a trailing `;`. Strip both before handing the
+ * SQL to the CH driver, keeping any `SETTINGS` clause. Tinybird's `/v0/sql`
+ * keeps the SQL as-is.
  */
-export const normalizeSqlForClickHouseClient = (sql: string): string =>
-	sql
-		.replace(/;\s*$/, "")
-		.replace(/\s+FORMAT\s+(?:JSONEachRow|JSON)\s*$/i, "")
-		.replace(/;\s*$/, "")
+export const normalizeSqlForClickHouseClient = (sql: string): string => {
+	const terminal = splitTerminalClauses(sql)
+	return terminal.settings === undefined ? terminal.body : `${terminal.body}\n${terminal.settings}`
+}

--- a/packages/query-engine/src/profiles/query-profile.test.ts
+++ b/packages/query-engine/src/profiles/query-profile.test.ts
@@ -19,7 +19,7 @@ describe("appendSettings", () => {
 
 	it("appends a single setting", () => {
 		expect(appendSettings("SELECT 1", { maxExecutionTime: 10 })).toBe(
-			"SELECT 1 SETTINGS max_execution_time=10",
+			"SELECT 1\nSETTINGS max_execution_time=10",
 		)
 	})
 
@@ -30,12 +30,12 @@ describe("appendSettings", () => {
 				maxMemoryUsage: 1_000_000,
 				maxThreads: 4,
 			}),
-		).toBe("SELECT 1 SETTINGS max_execution_time=10, max_memory_usage=1000000, max_threads=4")
+		).toBe("SELECT 1\nSETTINGS max_execution_time=10, max_memory_usage=1000000, max_threads=4")
 	})
 
 	it("strips trailing semicolon before appending", () => {
 		expect(appendSettings("SELECT 1;", { maxExecutionTime: 5 })).toBe(
-			"SELECT 1 SETTINGS max_execution_time=5",
+			"SELECT 1\nSETTINGS max_execution_time=5",
 		)
 	})
 
@@ -46,16 +46,18 @@ describe("appendSettings", () => {
 				maxMemoryUsage: NaN,
 				maxThreads: 2,
 			}),
-		).toBe("SELECT 1 SETTINGS max_threads=2")
+		).toBe("SELECT 1\nSETTINGS max_threads=2")
 	})
 
 	it("appends max_block_size", () => {
-		expect(appendSettings("SELECT 1", { maxBlockSize: 512 })).toBe("SELECT 1 SETTINGS max_block_size=512")
+		expect(appendSettings("SELECT 1", { maxBlockSize: 512 })).toBe(
+			"SELECT 1\nSETTINGS max_block_size=512",
+		)
 	})
 
 	it("appends the verified full-text feature setting", () => {
 		expect(appendSettings("SELECT 1", { enableFullTextIndex: 1 })).toBe(
-			"SELECT 1 SETTINGS enable_full_text_index=1",
+			"SELECT 1\nSETTINGS enable_full_text_index=1",
 		)
 	})
 
@@ -64,13 +66,13 @@ describe("appendSettings", () => {
 	// a trailing FORMAT clause.
 	it("inserts SETTINGS before a trailing FORMAT clause", () => {
 		expect(appendSettings("SELECT 1 FORMAT JSON", { maxExecutionTime: 15 })).toBe(
-			"SELECT 1 SETTINGS max_execution_time=15 FORMAT JSON",
+			"SELECT 1\nSETTINGS max_execution_time=15\nFORMAT JSON",
 		)
 	})
 
 	it("inserts SETTINGS before FORMAT with a trailing semicolon and newlines", () => {
 		expect(appendSettings("SELECT 1\nFORMAT JSONEachRow;", { maxThreads: 2 })).toBe(
-			"SELECT 1 SETTINGS max_threads=2\nFORMAT JSONEachRow",
+			"SELECT 1\nSETTINGS max_threads=2\nFORMAT JSONEachRow",
 		)
 	})
 
@@ -78,9 +80,33 @@ describe("appendSettings", () => {
 		expect(appendSettings("SELECT 1 FORMAT JSON", {})).toBe("SELECT 1 FORMAT JSON")
 	})
 
+	it("separates the clause with a newline so a trailing comment cannot swallow it", () => {
+		expect(appendSettings("SELECT 1 -- keep me", { maxThreads: 2 })).toBe(
+			"SELECT 1 -- keep me\nSETTINGS max_threads=2",
+		)
+	})
+
+	it("leaves a statement that already carries its own SETTINGS untouched", () => {
+		expect(appendSettings("SELECT 1 SETTINGS max_threads=8", { maxThreads: 2 })).toBe(
+			"SELECT 1 SETTINGS max_threads=8",
+		)
+	})
+
+	it("inserts SETTINGS before a non-JSON FORMAT clause", () => {
+		expect(appendSettings("SELECT 1 FORMAT CSV", { maxThreads: 2 })).toBe(
+			"SELECT 1\nSETTINGS max_threads=2\nFORMAT CSV",
+		)
+	})
+
+	it("ignores a FORMAT inside a subquery", () => {
+		expect(appendSettings("SELECT * FROM (SELECT 1 FORMAT JSON) AS x", { maxThreads: 2 })).toBe(
+			"SELECT * FROM (SELECT 1 FORMAT JSON) AS x\nSETTINGS max_threads=2",
+		)
+	})
+
 	it("only treats a FORMAT at the end of the query as the format clause", () => {
 		expect(appendSettings("SELECT formatDateTime(now(), '%F') AS format_col", { maxThreads: 2 })).toBe(
-			"SELECT formatDateTime(now(), '%F') AS format_col SETTINGS max_threads=2",
+			"SELECT formatDateTime(now(), '%F') AS format_col\nSETTINGS max_threads=2",
 		)
 	})
 })

--- a/packages/query-engine/src/profiles/query-profile.ts
+++ b/packages/query-engine/src/profiles/query-profile.ts
@@ -1,3 +1,5 @@
+import { splitTerminalClauses } from "@maple-dev/clickhouse-builder/sql"
+
 /**
  * ClickHouse query settings forwarded via inline `SETTINGS` clause.
  *
@@ -135,19 +137,16 @@ export const stripTinybirdRestrictedSettings = (
 }
 
 /**
- * Matches a trailing `FORMAT <name>` clause (the DSL compiler terminates every
- * query with `FORMAT JSON`). `SETTINGS` must precede `FORMAT` — Tinybird's
- * ClickHouse rejects `FORMAT JSON SETTINGS …` with a syntax error.
- */
-const trailingFormatRe = /\s+FORMAT\s+\w+\s*$/i
-
-/**
  * Add a ClickHouse `SETTINGS` clause to a SQL string, inserting it before a
- * trailing `FORMAT <name>` clause when present. Returns the input unchanged
- * when no settings are provided.
+ * trailing `FORMAT <name>` clause when present (the DSL compiler terminates
+ * every query with `FORMAT JSON`, and Tinybird's ClickHouse rejects the
+ * `FORMAT JSON SETTINGS …` order with a syntax error). Returns the input
+ * unchanged when no settings are provided.
  *
- * Caller must guarantee the SQL doesn't already contain a SETTINGS
- * clause — none of maple's DSL queries do today.
+ * A statement that already carries its own `SETTINGS` is returned untouched —
+ * appending a second clause is a syntax error, and silently merging would hide
+ * whichever budget lost. Raw SQL rejects an author-supplied `SETTINGS` upstream
+ * in `prepareRawSql`; no DSL query emits one.
  */
 export const appendSettings = (sql: string, settings: WarehouseQuerySettings | undefined): string => {
 	if (!settings) return sql
@@ -159,14 +158,14 @@ export const appendSettings = (sql: string, settings: WarehouseQuerySettings | u
 		}
 	}
 	if (parts.length === 0) return sql
+	const terminal = splitTerminalClauses(sql)
+	if (terminal.settings !== undefined) return sql
 	const clause = `SETTINGS ${parts.join(", ")}`
-	const trimmed = sql.replace(/;\s*$/, "")
-	const formatMatch = trimmed.match(trailingFormatRe)
-	if (formatMatch) {
-		const body = trimmed.slice(0, formatMatch.index)
-		return `${body} ${clause}${formatMatch[0]}`
-	}
-	return `${trimmed} ${clause}`
+	// Newline-separated: a body ending in a `--` comment would swallow a
+	// space-joined clause and run the query with no budget at all.
+	return terminal.format === undefined
+		? `${terminal.body}\n${clause}`
+		: `${terminal.body}\n${clause}\n${terminal.format}`
 }
 
 /**

--- a/packages/query-engine/src/runtime/raw-sql.test.ts
+++ b/packages/query-engine/src/runtime/raw-sql.test.ts
@@ -185,6 +185,64 @@ const executeRows = (rows: ReadonlyArray<Record<string, unknown>>) =>
 		},
 	)
 
+// Regression: the row cap nests the query, so a terminal clause left in place
+// lands mid-statement and ClickHouse fails with "Syntax error at 'FORMAT'".
+it.effect("strips a trailing FORMAT clause instead of nesting it", () =>
+	Effect.gen(function* () {
+		for (const suffix of ["FORMAT JSONEachRow", "FORMAT JSON", "format CSV", "FORMAT JSONEachRow;"]) {
+			const prepared = yield* prepareOk(`SELECT count() FROM Logs WHERE $__orgFilter\n${suffix}`)
+			assert.notMatch(prepared.sql, /FORMAT/i, suffix)
+			assert.match(prepared.sql, /LIMIT 1001$/)
+		}
+	}),
+)
+
+it.effect("keeps a FORMAT that is only a column reference", () =>
+	Effect.gen(function* () {
+		const prepared = yield* prepareOk("SELECT format FROM Logs WHERE $__orgFilter")
+		assert.include(prepared.sql, "SELECT format FROM Logs")
+	}),
+)
+
+it.effect("rejects an author-supplied SETTINGS clause", () =>
+	Effect.gen(function* () {
+		const error = yield* prepareFail(
+			"SELECT count() FROM Logs WHERE $__orgFilter SETTINGS max_execution_time=3000",
+		)
+		assert.strictEqual(error.code, "DisallowedStatement")
+		assert.include(error.message, "SETTINGS is managed by Maple")
+	}),
+)
+
+it.effect("rejects INTO OUTFILE", () =>
+	Effect.gen(function* () {
+		const error = yield* prepareFail("SELECT count() FROM Logs WHERE $__orgFilter INTO OUTFILE '/tmp/x'")
+		assert.strictEqual(error.code, "DisallowedStatement")
+		assert.include(error.message, "INTO OUTFILE")
+	}),
+)
+
+it.effect("accepts a single trailing terminator", () =>
+	Effect.gen(function* () {
+		const prepared = yield* prepareOk("SELECT count() FROM Logs WHERE $__orgFilter;")
+		assert.notInclude(prepared.sql, ";")
+	}),
+)
+
+// `escapeClickHouseString` escapes quotes and backslashes, not `$` — with a
+// string replacement `$'` would splice the rest of the statement into the
+// literal, quotes and all.
+it.effect("does not expand replacement patterns in interpolated values", () =>
+	Effect.gen(function* () {
+		const prepared = yield* prepareRawSql({
+			...baseInput,
+			orgId: "org_$'_$&",
+			sql: "SELECT count() FROM Logs WHERE $__orgFilter AND Body = 'tail'",
+		})
+		assert.include(prepared.sql, "OrgId = 'org_$\\'_$&'")
+	}),
+)
+
 describe("makeExecuteRawSql", () => {
 	it.effect("accepts exactly 1,000 rows and returns metadata", () =>
 		Effect.gen(function* () {

--- a/packages/query-engine/src/runtime/raw-sql.ts
+++ b/packages/query-engine/src/runtime/raw-sql.ts
@@ -7,7 +7,11 @@ import {
 	RawSqlValidationError,
 } from "@maple/domain/http"
 import type { QueryProfileName } from "../profiles"
-import { escapeClickHouseString } from "@maple-dev/clickhouse-builder/sql"
+import {
+	escapeClickHouseString,
+	maskLiteralsAndComments,
+	splitTerminalClauses,
+} from "@maple-dev/clickhouse-builder/sql"
 
 // User-authored ClickHouse SQL: validation, macro expansion, and execution.
 //
@@ -38,6 +42,12 @@ const DENY_LIST = [
 ] as const
 
 const DENY_LIST_RE = new RegExp(`\\b(${DENY_LIST.join("|")})\\b`, "i")
+
+/**
+ * `INTO OUTFILE` is a SELECT terminal clause, so it slips past the deny list's
+ * statement-keyword check while asking the server to write a file.
+ */
+const INTO_OUTFILE_RE = /\bINTO\s+OUTFILE\b/i
 
 /** One extra row is the overflow sentinel for the public 1,000-row cap. */
 export const RAW_SQL_FETCH_ROW_LIMIT = MAX_RAW_SQL_RESULT_ROWS + 1
@@ -78,53 +88,6 @@ export interface RawSqlWarehouse<TTenant, E> {
 	) => Effect.Effect<ReadonlyArray<Record<string, unknown>>, E>
 }
 
-/**
- * Strip ClickHouse-style comments and string literals so keyword and semicolon
- * checks do not false-positive on their contents.
- */
-function maskLiteralsAndComments(sql: string): string {
-	let out = ""
-	let i = 0
-	while (i < sql.length) {
-		const ch = sql[i]
-		const next = sql[i + 1]
-
-		if (ch === "-" && next === "-") {
-			const nl = sql.indexOf("\n", i)
-			i = nl === -1 ? sql.length : nl
-			continue
-		}
-		if (ch === "/" && next === "*") {
-			const end = sql.indexOf("*/", i + 2)
-			i = end === -1 ? sql.length : end + 2
-			continue
-		}
-		if (ch === "'" || ch === "`" || ch === '"') {
-			const quote = ch
-			out += " "
-			i++
-			while (i < sql.length) {
-				const c = sql[i]
-				if (c === "\\") {
-					i += 2
-					continue
-				}
-				if (c === quote) {
-					i++
-					break
-				}
-				out += " "
-				i++
-			}
-			continue
-		}
-
-		out += ch
-		i++
-	}
-	return out
-}
-
 const fail = (code: RawSqlValidationError["code"], message: string) =>
 	Effect.fail(new RawSqlValidationError({ code, message }))
 
@@ -158,10 +121,15 @@ export const prepareRawSql = Effect.fn("RawSql.prepare")(function* (input: Prepa
 	const endLiteral = `toDateTime('${escapeClickHouseString(input.endTime)}')`
 	const granularity = Math.max(1, Math.round(input.granularitySeconds))
 
-	sql = sql.replaceAll("$__orgFilter", `OrgId = ${orgLiteral}`)
-	sql = sql.replaceAll("$__startTime", startLiteral)
-	sql = sql.replaceAll("$__endTime", endLiteral)
-	sql = sql.replaceAll("$__interval_s", String(granularity))
+	// Function-form replacements throughout: a `$&`, `` $` `` or `$'` in an
+	// interpolated value is a substitution pattern to `String.replace`, and
+	// `escapeClickHouseString` escapes quotes and backslashes but not `$`. With a
+	// string replacement, `$'` would splice the rest of the statement into the
+	// literal — quotes and all.
+	sql = sql.replaceAll("$__orgFilter", () => `OrgId = ${orgLiteral}`)
+	sql = sql.replaceAll("$__startTime", () => startLiteral)
+	sql = sql.replaceAll("$__endTime", () => endLiteral)
+	sql = sql.replaceAll("$__interval_s", () => String(granularity))
 
 	const timeFilterMatches = [...sql.matchAll(/\$__timeFilter\(([^)]*)\)/g)]
 	for (const match of timeFilterMatches) {
@@ -172,7 +140,7 @@ export const prepareRawSql = Effect.fn("RawSql.prepare")(function* (input: Prepa
 				`$__timeFilter argument '${column}' must be a column identifier (letters, digits, underscores, dots).`,
 			)
 		}
-		sql = sql.replace(match[0], `${column} >= ${startLiteral} AND ${column} <= ${endLiteral}`)
+		sql = sql.replace(match[0], () => `${column} >= ${startLiteral} AND ${column} <= ${endLiteral}`)
 	}
 
 	// Bucketing macro. An alert query that selects `$__timeGroup(Timestamp) AS bucket`
@@ -188,7 +156,7 @@ export const prepareRawSql = Effect.fn("RawSql.prepare")(function* (input: Prepa
 				`$__timeGroup argument '${column}' must be a column identifier (letters, digits, underscores, dots).`,
 			)
 		}
-		sql = sql.replace(match[0], `toStartOfInterval(${column}, INTERVAL ${granularity} SECOND)`)
+		sql = sql.replace(match[0], () => `toStartOfInterval(${column}, INTERVAL ${granularity} SECOND)`)
 	}
 
 	if (sql.includes("$__")) {
@@ -199,7 +167,14 @@ export const prepareRawSql = Effect.fn("RawSql.prepare")(function* (input: Prepa
 		)
 	}
 
-	const masked = maskLiteralsAndComments(sql)
+	// A single trailing terminator is one statement, not several — rejecting it as
+	// "multiple statements" is a false error on the most common way to end a query.
+	let masked = maskLiteralsAndComments(sql)
+	const terminatorMatch = masked.match(/;\s*$/)
+	if (terminatorMatch?.index !== undefined) {
+		sql = sql.slice(0, terminatorMatch.index)
+		masked = masked.slice(0, terminatorMatch.index)
+	}
 	if (masked.includes(";")) {
 		return yield* fail(
 			"MultipleStatements",
@@ -214,6 +189,12 @@ export const prepareRawSql = Effect.fn("RawSql.prepare")(function* (input: Prepa
 			`Statement keyword '${denyMatch[1].toUpperCase()}' is not allowed in raw SQL.`,
 		)
 	}
+	if (INTO_OUTFILE_RE.test(masked)) {
+		return yield* fail(
+			"DisallowedStatement",
+			"INTO OUTFILE is not allowed in raw SQL — results are returned over the API.",
+		)
+	}
 	if (!/^\s*(?:SELECT|WITH)\b/i.test(masked)) {
 		return yield* fail(
 			"DisallowedStatement",
@@ -221,8 +202,29 @@ export const prepareRawSql = Effect.fn("RawSql.prepare")(function* (input: Prepa
 		)
 	}
 
+	// The row cap nests the query, and `SETTINGS` / `FORMAT` are statement
+	// terminators — legal only at the very end of a top-level statement. Left in
+	// place they land mid-statement and ClickHouse fails with a syntax error at
+	// the clause keyword.
+	const terminal = splitTerminalClauses(sql)
+	if (terminal.settings !== undefined) {
+		return yield* fail(
+			"DisallowedStatement",
+			"SETTINGS is managed by Maple — raw queries run under a fixed time and memory budget. Remove the SETTINGS clause.",
+		)
+	}
+	// A trailing FORMAT is dropped rather than rejected: the wire format belongs
+	// to the driver (the ClickHouse client asks for JSONEachRow, the Tinybird SDK
+	// for JSON), so the author's choice was never going to be honoured. Erroring
+	// on the most idiomatic way to end a ClickHouse query buys nothing.
+
+	// The wrapper is what caps rows server-side — `max_result_rows` is Tinybird-
+	// restricted, so there is no settings-level equivalent. The cost is that
+	// modifiers attached to the inner result (`WITH TOTALS`, `LIMIT BY`,
+	// `WITH FILL`) are discarded by the outer SELECT.
+
 	return {
-		sql: `SELECT * FROM (\n${sql.trim()}\n) AS maple_raw_sql_limited\nLIMIT ${RAW_SQL_FETCH_ROW_LIMIT}`,
+		sql: `SELECT * FROM (\n${terminal.body.trim()}\n) AS maple_raw_sql_limited\nLIMIT ${RAW_SQL_FETCH_ROW_LIMIT}`,
 		granularitySeconds: granularity,
 	} satisfies PreparedRawSql
 })


### PR DESCRIPTION
Raw SQL ending in `FORMAT JSONEachRow` failed with `Syntax error at 'FORMAT'` (issue `f5d78af5`, recurring). The row cap nests the author's SQL in `SELECT * FROM (…) AS maple_raw_sql_limited LIMIT 1001`, and `FORMAT` is a *statement terminator* — legal only at the very end of a top-level statement. Once nested it lands mid-statement, and every downstream trailing-anchored regex stops seeing it. Both backends fail identically, so this is not a Tinybird quirk.

It recurs because the author is usually an LLM going through MCP `run_sql`, and `FORMAT JSONEachRow` is the idiomatic way to end a ClickHouse query.

## The shared fix

Four sites each guessed at terminal clauses with their own regex:

| Site | Regex |
|---|---|
| `raw-sql.ts` | none — wrapped the SQL blind |
| `query-profile.ts` | `/\s+FORMAT\s+\w+\s*$/i` |
| `fingerprint.ts` | `/\s+FORMAT\s+(?:JSONEachRow\|JSON)\s*$/i` |
| `WarehouseQueryService.ts` | `/\bFORMAT\s+\w+(\s+SETTINGS\s[^\n]*)?$/i` |
| `compile.ts` | `/\nFORMAT \w+$/` |

New `lib/clickhouse-builder/src/sql/terminal-clauses.ts` replaces all five. It masks strings and comments (offset-preserving), then accepts a keyword as a terminal clause only when the *whole tail* from that point parses as a clause chain — which is what separates `SELECT 1 FORMAT JSON` from `SELECT format FROM t`. Handles both clause orders and a trailing `;`. The literal/comment masker moved here from `raw-sql.ts`, so the deny-list checks and the splitter share one implementation.

A trailing `FORMAT` is **dropped, not rejected**: the driver dictates the wire format (the ClickHouse client asks for JSONEachRow, the SDK for JSON), so the author's choice was never going to be honoured. Erroring on it buys nothing.

## Other bugs fixed while in here

- **An author `SETTINGS` clause defeated the cost profile.** It was nested along with everything else, and ClickHouse propagates subquery settings to the query context — so a raw query could set its own `max_execution_time` / `max_memory_usage` and walk past the `rawInteractive` budget. Now rejected.
- **`INTO OUTFILE` walked past the deny list.** It's a SELECT terminal clause, not a statement keyword. Now rejected.
- **Macro expansion expanded `$&` / `` $` `` / `$'`.** Interpolated values went in as `String.replace` string replacements, and the escaper covers quotes and backslashes but not `$` — so a `$'` would splice the rest of the statement into the literal, quotes and all. Function-form replacements throughout. Not reachable over HTTP today (`TinybirdDateTime` is pattern-checked, orgId comes from auth), but `prepareRawSql` is a library called from MCP, dashboards, and alert evaluation.
- **`appendSettings` space-joined the clause**, so a body ending in a `--` comment swallowed it and ran the query with no budget at all. Newline-separated now.
- **The CH-client normalizer stripped only JSON/JSONEachRow**, leaving `FORMAT CSV` and friends to collide with the format the driver requests.
- **A single trailing `;` reported "Multiple SQL statements are not allowed"** — a false error on the most common way to end a query. Detected via the masked text, so a `;` inside a literal still counts.

## Reviewer notes

- **`SETTINGS` rejection is the breaking half.** Any saved raw-SQL widget or alert carrying a `SETTINGS` clause now fails validation on edit and on evaluation. Worth checking stored dashboard documents and `alert_rules.rawQuerySql` for `SETTINGS` before this ships — I couldn't query prod from the session. Stripping it silently was the alternative, but then the resource hole closes quietly and nobody learns their tuning was ignored.
- **Local-dev note only:** `@maple-dev/clickhouse-builder/sql` resolves to `dist`, so running `bun run --cwd packages/query-engine test` directly against a stale build fails with `maskLiteralsAndComments is not a function`. CI is unaffected — turbo's `test`/`typecheck` both `dependsOn: ["^build"]`, and clickhouse-builder is one of the dist-pointing packages that edge exists for.
- The `LIMIT 1001` wrapper stays. `max_result_rows` is Tinybird-restricted so there's no settings-level equivalent; the cost (inner `WITH TOTALS` / `LIMIT BY` / `WITH FILL` discarded by the outer SELECT) is now documented at the wrapper.

## Tests

16 splitter cases (FORMAT in a literal / comment / subquery / as a column / as a keyword prefix, multi-line SETTINGS, both clause orders), 6 new `prepareRawSql`, 4 new `appendSettings`, 3 new Tinybird SDK.

- `lib/clickhouse-builder` — 163 pass
- `packages/query-engine` — 1281 pass
- `apps/api` warehouse / alerts / query-engine — 522 pass
- typecheck clean across all three; oxlint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790337921&installation_model_id=427786&pr_number=645&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F645&signature=347e8b81615636fbeecd0572e89b7ced7b258ad90262554895afd4d9b4ea552e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
