### PR TITLE
feat(query-engine): pass a parsed statement to the driver, not SQL text

### DIFF
--- a/apps/api/src/mcp/__evals__/fake-warehouse.ts
+++ b/apps/api/src/mcp/__evals__/fake-warehouse.ts
@@ -25,7 +25,8 @@ const defaultTraceFixtures = (): FixtureRule[] => [
  */
 export const installFakeWarehouse = (rules: FixtureRule[] = defaultTraceFixtures()): void => {
 	__testables.setClientFactory(() => ({
-		sql: async (sql: string) => {
+		sql: async (statement) => {
+			const sql = statement.text
 			const rule = rules.find((r) => r.match(sql))
 			if (!rule) {
 				throw new Error(`[eval fake warehouse] no fixture matched SQL:\n${sql.slice(0, 600)}`)

--- a/apps/api/src/services/warehouse/WarehouseQueryService.test.ts
+++ b/apps/api/src/services/warehouse/WarehouseQueryService.test.ts
@@ -17,6 +17,7 @@ import {
 	WarehouseUpstreamError,
 } from "@maple/domain/http"
 import { unsafeCompiledQuery } from "@maple/query-engine/ch"
+import { parseStatement, type ClickHouseStatement } from "@maple-dev/clickhouse-builder/sql"
 import { EdgeCacheService, MemoryCacheBackendLive } from "@maple/cache"
 import { makeWarehouseExecutor, type ResolvedWarehouseConfig } from "@maple/query-engine/execution"
 import { __testables, WarehouseQueryService } from "./WarehouseQueryService"
@@ -776,18 +777,19 @@ describe("createTinybirdSdkSqlClient.insert wire framing (the production insert 
 	})
 })
 
-describe("createTinybirdSdkSqlClient.sql FORMAT normalization", () => {
-	// DSL-compiled queries already end with `FORMAT JSON` (optionally followed by
-	// profile SETTINGS). Appending a second FORMAT clause is a ClickHouse syntax
-	// error ("Syntax error at (FORMAT) ... Expected: SETTINGS, end of query") that
-	// broke every alerting query against managed Tinybird — pin the normalization.
+describe("createTinybirdSdkSqlClient.sql wire format", () => {
+	// The FORMAT decision moved to the executor, which settles the statement's
+	// terminal clauses from the backend's dialect before any driver sees it. This
+	// driver's whole job is to render what it was handed — the double-FORMAT
+	// syntax error that broke every alerting query against managed Tinybird can no
+	// longer originate here, because nothing here inspects SQL text.
 	const tbConfig = {
 		kind: "tinybird" as const,
 		host: "https://api.tinybird.co",
 		token: "tok_123",
 	}
 
-	const captureSql = async (sql: string): Promise<string> => {
+	const captureSql = async (statement: ClickHouseStatement): Promise<string> => {
 		const sent: string[] = []
 		const requestFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 			const url = new URL(String(input))
@@ -803,61 +805,30 @@ describe("createTinybirdSdkSqlClient.sql FORMAT normalization", () => {
 		}) as typeof fetch
 
 		const client = __testables.createTinybirdSdkSqlClient(tbConfig, requestFetch)
-		await client.sql(sql, undefined)
+		await client.sql(statement, undefined)
 
 		assert.strictEqual(sent.length, 1)
 		return sent[0]!
 	}
 
-	const countFormats = (sql: string) => (sql.match(/FORMAT JSON/g) ?? []).length
-
-	it("does not double-append when the query already ends with FORMAT JSON", async () => {
-		const sent = await captureSql("SELECT 1\nFORMAT JSON")
-		assert.strictEqual(countFormats(sent), 1)
-		assert.match(sent, /FORMAT JSON$/)
-	})
-
-	it("does not double-append when profile SETTINGS precede FORMAT JSON", async () => {
-		// Canonical order emitted by appendSettings — Tinybird rejects the inverse.
-		const sent = await captureSql(
-			"SELECT 1 SETTINGS max_execution_time=15, max_memory_usage=1500000000\nFORMAT JSON",
-		)
-		assert.strictEqual(countFormats(sent), 1)
-		assert.match(sent, /SETTINGS max_execution_time=15, max_memory_usage=1500000000\nFORMAT JSON$/)
-	})
-
-	it("does not double-append when FORMAT JSON is followed by profile SETTINGS", async () => {
-		const sent = await captureSql(
-			"SELECT 1\nFORMAT JSON SETTINGS max_execution_time=15, max_memory_usage=1500000000",
-		)
-		assert.strictEqual(countFormats(sent), 1)
-		assert.match(sent, /FORMAT JSON SETTINGS max_execution_time=15, max_memory_usage=1500000000$/)
-	})
-
-	it("appends FORMAT JSON to raw SQL without a FORMAT clause", async () => {
-		const sent = await captureSql("SELECT 1")
+	it("sends the statement as the executor rendered it", async () => {
+		const sent = await captureSql(parseStatement("SELECT 1\nFORMAT JSON"))
 		assert.strictEqual(sent, "SELECT 1\nFORMAT JSON")
 	})
 
-	it("strips a trailing semicolon before appending", async () => {
-		const sent = await captureSql("SELECT 1;")
-		assert.strictEqual(sent, "SELECT 1\nFORMAT JSON")
+	it("keeps SETTINGS ahead of FORMAT", async () => {
+		const sent = await captureSql(parseStatement("SELECT 1 SETTINGS max_execution_time=15\nFORMAT JSON"))
+		assert.strictEqual(sent, "SELECT 1\nSETTINGS max_execution_time=15\nFORMAT JSON")
 	})
 
-	it("keeps the SETTINGS clause when appending FORMAT JSON", async () => {
-		const sent = await captureSql("SELECT 1\nSETTINGS max_threads=2")
-		assert.strictEqual(sent, "SELECT 1\nSETTINGS max_threads=2\nFORMAT JSON")
+	it("does not add a format the executor left off", async () => {
+		const sent = await captureSql(parseStatement("SELECT 1"))
+		assert.strictEqual(sent, "SELECT 1")
 	})
 
-	it("ignores a FORMAT that is only a column reference", async () => {
-		const sent = await captureSql("SELECT format FROM t")
-		assert.strictEqual(sent, "SELECT format FROM t\nFORMAT JSON")
-	})
-
-	it("ignores a FORMAT nested in a subquery", async () => {
-		const sent = await captureSql("SELECT * FROM (SELECT 1 FORMAT JSON) AS x")
-		assert.strictEqual(countFormats(sent), 2)
-		assert.match(sent, /FORMAT JSON$/)
+	it("leaves a nested FORMAT alone", async () => {
+		const sent = await captureSql(parseStatement("SELECT * FROM (SELECT 1 FORMAT JSON) AS x"))
+		assert.strictEqual(sent, "SELECT * FROM (SELECT 1 FORMAT JSON) AS x")
 	})
 })
 

--- a/apps/api/src/services/warehouse/WarehouseQueryService.ts
+++ b/apps/api/src/services/warehouse/WarehouseQueryService.ts
@@ -1,6 +1,5 @@
 import { createClient as createClickHouseClient } from "@clickhouse/client-web"
 import { Tinybird } from "@tinybirdco/sdk"
-import { splitTerminalClauses } from "@maple-dev/clickhouse-builder/sql"
 import { Context, Effect, Layer, Option, Redacted } from "effect"
 import { WarehouseConfigError, type WarehouseQueryRequest } from "@maple/domain/http"
 import {
@@ -54,9 +53,12 @@ const createClickHouseSqlClient = (config: ClickHouseProtocolBackendConfig): War
 		? ({ output_format_json_quote_64bit_integers: 0 } as const)
 		: undefined
 	return {
-		sql: async (sql: string, options) => {
+		// `wireFormat: "out-of-band"` for every ClickHouse-protocol backend, so the
+		// executor has already stripped any FORMAT clause and the format travels as
+		// a request field instead.
+		sql: async (statement, options) => {
 			const resultSet = await client.query({
-				query: sql,
+				query: statement.text,
 				format: "JSONEachRow",
 				...(clickhouseSettings ? { clickhouse_settings: clickhouseSettings } : undefined),
 			})
@@ -173,22 +175,15 @@ const createTinybirdSdkSqlClient = (
 	const client = makeClient()
 	const boundedClients = new Map<number, typeof client>()
 	return {
-		sql: async (sql: string, options) => {
+		sql: async (statement, options) => {
 			try {
 				// Tinybird Cloud currently defaults /v0/sql to JSON, while Tinybird Local
-				// defaults to tab-separated output. The SDK always calls response.json(), so
-				// make the expected wire format explicit for both environments. DSL-compiled
-				// queries already end with `FORMAT JSON` (profile SETTINGS are inserted
-				// before it by appendSettings) — appending a second FORMAT clause is a
-				// ClickHouse syntax error, so only add one when the query doesn't carry
-				// its own.
-				const terminal = splitTerminalClauses(sql)
-				const jsonSql =
-					terminal.format !== undefined
-						? sql.trimEnd().replace(/;\s*$/, "")
-						: [terminal.body, terminal.settings, "FORMAT JSON"]
-								.filter((part) => part !== undefined)
-								.join("\n")
+				// defaults to tab-separated output, and the SDK always calls
+				// response.json() — so the format has to be explicit for both. This
+				// backend's dialect is `wireFormat: "in-statement"`, so the executor has
+				// already put a FORMAT clause on the statement; rendering it is all this
+				// driver has to do.
+				const jsonSql = statement.text
 				const limits = options?.responseLimits
 				// The SDK normally buffers through response.json(). Raw execution gets
 				// a fetch adapter that aborts before constructing an oversized Response.

--- a/apps/cli/src/core/executor.ts
+++ b/apps/cli/src/core/executor.ts
@@ -18,7 +18,8 @@ const LOCAL_TENANT = { orgId: LOCAL_ORG_ID, userId: LOCAL_USER_ID, authMode: "lo
 // stderr. The `finally` logs even on failure so a failing query still shows
 // its SQL.
 const localChdbClient = (baseUrl: string): WarehouseSqlClient => ({
-	sql: async (sql) => {
+	sql: async (statement) => {
+		const sql = statement.text
 		const started = performance.now()
 		try {
 			return { data: await executeLocalQuery<Record<string, unknown>>(sql, baseUrl) }

--- a/lib/clickhouse-builder/src/sql/index.ts
+++ b/lib/clickhouse-builder/src/sql/index.ts
@@ -14,3 +14,13 @@ export {
 export { type SqlQuery, compileQuery } from "./sql-query"
 
 export { type TerminalClauses, maskLiteralsAndComments, splitTerminalClauses } from "./terminal-clauses"
+
+export {
+	type ClickHouseStatementFields,
+	ClickHouseStatement,
+	ClickHouseStatementFromString,
+	parseStatement,
+	renderStatement,
+	withFormat,
+	withSettings,
+} from "./statement"

--- a/lib/clickhouse-builder/src/sql/statement.test.ts
+++ b/lib/clickhouse-builder/src/sql/statement.test.ts
@@ -1,0 +1,86 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "vitest"
+import {
+	ClickHouseStatement,
+	ClickHouseStatementFromString,
+	parseStatement,
+	renderStatement,
+	withFormat,
+	withSettings,
+} from "./statement"
+
+describe("parseStatement / renderStatement", () => {
+	it("round-trips a statement with both clauses", () => {
+		const sql = "SELECT 1\nSETTINGS max_threads=2\nFORMAT JSON"
+		expect(renderStatement(parseStatement(sql))).toBe(sql)
+	})
+
+	it("normalizes the legacy clause order on the way back out", () => {
+		expect(renderStatement(parseStatement("SELECT 1 FORMAT JSON SETTINGS max_threads=2"))).toBe(
+			"SELECT 1\nSETTINGS max_threads=2\nFORMAT JSON",
+		)
+	})
+
+	it("exposes the rendered text on the instance", () => {
+		expect(parseStatement("SELECT 1 FORMAT JSON").text).toBe("SELECT 1\nFORMAT JSON")
+	})
+
+	it("keeps the body free of terminal clauses so it is safe to nest", () => {
+		expect(parseStatement("SELECT 1 SETTINGS max_threads=2 FORMAT JSON").body).toBe("SELECT 1")
+	})
+
+	it("renders a bare body unchanged", () => {
+		expect(renderStatement(parseStatement("SELECT 1"))).toBe("SELECT 1")
+	})
+})
+
+describe("withSettings / withFormat", () => {
+	const base = parseStatement("SELECT 1")
+
+	it("adds clauses in grammar order", () => {
+		const statement = withFormat(withSettings(base, "SETTINGS max_threads=2"), "FORMAT JSON")
+		expect(statement.text).toBe("SELECT 1\nSETTINGS max_threads=2\nFORMAT JSON")
+	})
+
+	it("drops a clause with undefined", () => {
+		const statement = parseStatement("SELECT 1 SETTINGS max_threads=2 FORMAT JSON")
+		expect(withFormat(statement, undefined).text).toBe("SELECT 1\nSETTINGS max_threads=2")
+		expect(withSettings(statement, undefined).text).toBe("SELECT 1\nFORMAT JSON")
+	})
+
+	it("replaces rather than appends", () => {
+		const statement = parseStatement("SELECT 1 SETTINGS max_threads=2")
+		expect(withSettings(statement, "SETTINGS max_threads=8").text).toBe(
+			"SELECT 1\nSETTINGS max_threads=8",
+		)
+	})
+
+	it("cannot swallow a clause behind a trailing comment", () => {
+		const statement = withSettings(parseStatement("SELECT 1 -- note"), "SETTINGS max_threads=2")
+		expect(statement.text).toBe("SELECT 1 -- note\nSETTINGS max_threads=2")
+	})
+})
+
+describe("ClickHouseStatementFromString", () => {
+	const decode = Schema.decodeUnknownSync(ClickHouseStatementFromString)
+	const encode = Schema.encodeSync(ClickHouseStatementFromString)
+
+	it("decodes text into the parsed shape", () => {
+		const statement = decode("SELECT 1 SETTINGS max_threads=2 FORMAT JSON")
+		expect(statement).toBeInstanceOf(ClickHouseStatement)
+		expect(statement.body).toBe("SELECT 1")
+		expect(statement.settings).toBe("SETTINGS max_threads=2")
+		expect(statement.format).toBe("FORMAT JSON")
+	})
+
+	it("encodes back to SQL text", () => {
+		expect(encode(decode("SELECT 1\nFORMAT JSON"))).toBe("SELECT 1\nFORMAT JSON")
+	})
+
+	it("decodes a statement with no terminal clause", () => {
+		const statement = decode("SELECT format FROM t")
+		expect(statement.body).toBe("SELECT format FROM t")
+		expect(statement.settings).toBeUndefined()
+		expect(statement.format).toBeUndefined()
+	})
+})

--- a/lib/clickhouse-builder/src/sql/statement.ts
+++ b/lib/clickhouse-builder/src/sql/statement.ts
@@ -1,0 +1,75 @@
+import { Schema, SchemaGetter } from "effect"
+import { splitTerminalClauses } from "./terminal-clauses"
+
+// A ClickHouse statement as a value rather than a string.
+//
+// `SETTINGS` and `FORMAT` are statement terminators, so every stage that wants
+// to add, replace, or nest one has to know where the body ends. Passing the
+// parsed shape means that boundary is found once, at the edge, instead of being
+// re-derived by each stage from text — which is how a driver ends up disagreeing
+// with the executor about which clauses the statement already carries.
+
+/**
+ * The parsed form of a single ClickHouse statement.
+ *
+ * `body` never includes a terminal clause or a trailing `;`, so it is the only
+ * part that is safe to nest inside another query — and the only part stable
+ * enough to fingerprint, since the terminal clauses vary with the backend and
+ * the cost profile rather than with the query.
+ */
+// `Schema.optional`, not `optionalKey`: an absent terminal clause is a real
+// `undefined` in the parsed shape, and the codec encodes to SQL text rather than
+// to JSON, so key presence never reaches a wire format.
+export class ClickHouseStatement extends Schema.Class<ClickHouseStatement>("ClickHouseStatement")({
+	body: Schema.String,
+	settings: Schema.optional(Schema.String),
+	format: Schema.optional(Schema.String),
+}) {
+	/** The statement as SQL, terminal clauses in the order ClickHouse expects. */
+	get text(): string {
+		return renderStatement(this)
+	}
+}
+
+export interface ClickHouseStatementFields {
+	readonly body: string
+	readonly settings?: string | undefined
+	readonly format?: string | undefined
+}
+
+/**
+ * Render a statement back to SQL. `SETTINGS` precedes `FORMAT` — Tinybird's
+ * ClickHouse rejects the inverse order with a syntax error — and clauses are
+ * newline-separated so a body ending in a `--` comment cannot swallow them.
+ */
+export const renderStatement = (statement: ClickHouseStatementFields): string =>
+	[statement.body, statement.settings, statement.format]
+		.filter((part): part is string => part !== undefined && part !== "")
+		.join("\n")
+
+/** Parse SQL text into a statement. Total — any string has a body. */
+export const parseStatement = (sql: string): ClickHouseStatement =>
+	new ClickHouseStatement(splitTerminalClauses(sql))
+
+/**
+ * `SETTINGS`/`FORMAT` as a codec, for the boundaries that carry a statement as
+ * text (persisted documents, wire payloads) but want the parsed shape in hand.
+ * Decoding cannot fail; the round trip normalizes clause order and separators.
+ */
+export const ClickHouseStatementFromString = Schema.String.pipe(
+	Schema.decodeTo(ClickHouseStatement, {
+		decode: SchemaGetter.transform(splitTerminalClauses),
+		encode: SchemaGetter.transform(renderStatement),
+	}),
+)
+
+/** Replace the settings clause (or drop it with `undefined`). */
+export const withSettings = (
+	statement: ClickHouseStatement,
+	settings: string | undefined,
+): ClickHouseStatement =>
+	new ClickHouseStatement({ body: statement.body, settings, format: statement.format })
+
+/** Replace the format clause (or drop it with `undefined`). */
+export const withFormat = (statement: ClickHouseStatement, format: string | undefined): ClickHouseStatement =>
+	new ClickHouseStatement({ body: statement.body, settings: statement.settings, format })

--- a/packages/query-engine/src/execution/backend.ts
+++ b/packages/query-engine/src/execution/backend.ts
@@ -90,10 +90,17 @@ export interface WarehouseBackendDialect {
 	 */
 	readonly stripTinybirdRestrictedSettings: boolean
 	/**
-	 * The official ClickHouse client rejects a trailing `FORMAT …`/`;` (it sets
-	 * the format itself); Tinybird's `/v0/sql` requires them.
+	 * Where the wire format is declared. The official ClickHouse client sets it
+	 * per request and rejects a statement that carries its own `FORMAT` clause;
+	 * Tinybird's `/v0/sql` has no such channel and reads it from the statement.
+	 * The executor applies this so no driver has to re-derive it from SQL text.
 	 */
-	readonly normalizeSqlForClient: boolean
+	readonly wireFormat: "in-statement" | "out-of-band"
+	/**
+	 * The format a driver reading `wireFormat: "in-statement"` expects, applied
+	 * by the executor when the statement does not already name one.
+	 */
+	readonly statementFormat: string | undefined
 	/**
 	 * OTel database-system identity. chDB implements the ClickHouse interface,
 	 * so its system remains `clickhouse` even though the logical peer is `chdb`.
@@ -130,7 +137,8 @@ export const BackendDialect: Record<WarehouseBackendKind, WarehouseBackendDialec
 		driver: "tinybird-sdk",
 		dbClient: "tinybird-sdk",
 		stripTinybirdRestrictedSettings: true,
-		normalizeSqlForClient: false,
+		wireFormat: "in-statement",
+		statementFormat: "FORMAT JSON",
 		dbSystemName: "tinybird",
 		peerService: "tinybird",
 		// The SDK's /v0/sql JSON already returns 64-bit ints as numbers.
@@ -141,7 +149,8 @@ export const BackendDialect: Record<WarehouseBackendKind, WarehouseBackendDialec
 		driver: "clickhouse-web",
 		dbClient: "clickhouse",
 		stripTinybirdRestrictedSettings: true,
-		normalizeSqlForClient: true,
+		wireFormat: "out-of-band",
+		statementFormat: undefined,
 		dbSystemName: "clickhouse",
 		peerService: "clickhouse",
 		unquote64BitIntegers: true,
@@ -151,7 +160,8 @@ export const BackendDialect: Record<WarehouseBackendKind, WarehouseBackendDialec
 		driver: "clickhouse-web",
 		dbClient: "clickhouse",
 		stripTinybirdRestrictedSettings: false,
-		normalizeSqlForClient: true,
+		wireFormat: "out-of-band",
+		statementFormat: undefined,
 		dbSystemName: "clickhouse",
 		peerService: "clickhouse",
 		unquote64BitIntegers: true,
@@ -161,7 +171,8 @@ export const BackendDialect: Record<WarehouseBackendKind, WarehouseBackendDialec
 		driver: "clickhouse-web",
 		dbClient: "clickhouse",
 		stripTinybirdRestrictedSettings: false,
-		normalizeSqlForClient: true,
+		wireFormat: "out-of-band",
+		statementFormat: undefined,
 		dbSystemName: "clickhouse",
 		peerService: "chdb",
 		unquote64BitIntegers: true,

--- a/packages/query-engine/src/execution/executor.test.ts
+++ b/packages/query-engine/src/execution/executor.test.ts
@@ -10,6 +10,7 @@ import { WarehouseResponseLimitError } from "./response-limits"
 import type {
 	ExecutionTenant,
 	ResolvedWarehouseConfig,
+	SqlQueryOptions,
 	WarehouseExecutorDeps,
 	WarehouseSqlClient,
 } from "./ports"
@@ -277,8 +278,8 @@ const makeRecordingDeps = (
 	sqls: Array<string>,
 ): WarehouseExecutorDeps => ({
 	createClient: () => ({
-		sql: async (sql: string) => {
-			sqls.push(sql)
+		sql: async (statement) => {
+			sqls.push(statement.text)
 			return { data: [] }
 		},
 		insert: async () => {},
@@ -351,6 +352,106 @@ describe("makeWarehouseExecutor compiled-query defaults", () => {
 	)
 })
 
+describe("makeWarehouseExecutor wire format", () => {
+	// The dialect decides where the wire format is declared, and the executor
+	// applies it — so a driver never has to re-derive from SQL text which terminal
+	// clauses the statement already carries.
+	const runOn = (config: ResolvedWarehouseConfig) =>
+		Effect.gen(function* () {
+			const sqls: Array<string> = []
+			const executor = makeWarehouseExecutor(
+				makeRecordingDeps({ config, clientCacheKey: "read:managed" }, sqls),
+			)
+			yield* executor.compiledQuery(tenant, compiled, { context: "test", profile: "list" })
+			assert.lengthOf(sqls, 1)
+			return sqls[0]!
+		})
+
+	it.effect("declares FORMAT in the statement for the Tinybird SDK backend", () =>
+		Effect.gen(function* () {
+			const sql = yield* runOn(tinybirdConfig)
+			assert.match(sql, /\nFORMAT JSON$/)
+			// SETTINGS must precede FORMAT — Tinybird rejects the inverse order.
+			assert.isTrue(sql.indexOf("SETTINGS") < sql.indexOf("FORMAT JSON"))
+		}),
+	)
+
+	for (const [label, config] of [
+		["the Tinybird CH-gateway", tinybirdGatewayConfig],
+		["BYO ClickHouse", clickhouseConfig],
+		["chDB", chdbConfig],
+	] as const) {
+		it.effect(`leaves FORMAT off the statement for ${label}`, () =>
+			Effect.gen(function* () {
+				const sql = yield* runOn(config)
+				assert.notMatch(sql, /\bFORMAT\s+\w+\s*$/)
+			}),
+		)
+	}
+})
+
+describe("makeWarehouseExecutor query fingerprint", () => {
+	// The fingerprint is the QueryKey of the db-query-shape rollup. Hashing the
+	// rendered statement forked one query into a shape per backend and per
+	// profile-shape, so it covers the body alone.
+	const fingerprintOn = (config: ResolvedWarehouseConfig, options: SqlQueryOptions) =>
+		Effect.gen(function* () {
+			const { spans, tracer } = makeRecordingTracer()
+			const executor = makeWarehouseExecutor(
+				makeRecordingDeps({ config, clientCacheKey: "read:managed" }, []),
+			)
+			yield* executor.compiledQuery(tenant, compiled, options).pipe(Effect.withTracer(tracer))
+			const span = spans.find((candidate) => candidate.name === "WarehouseQueryService.executeSql")
+			assert.isDefined(span)
+			return span.attributes.get("db.query.fingerprint") as string
+		})
+
+	it.effect("is identical across backends for the same query", () =>
+		Effect.gen(function* () {
+			const options = { context: "test", profile: "list" } as const
+			const tinybird = yield* fingerprintOn(tinybirdConfig, options)
+			const gateway = yield* fingerprintOn(tinybirdGatewayConfig, options)
+			const byo = yield* fingerprintOn(clickhouseConfig, options)
+			assert.match(tinybird, /^[0-9a-f]{8}$/)
+			assert.strictEqual(gateway, tinybird)
+			assert.strictEqual(byo, tinybird)
+		}),
+	)
+
+	it.effect("is identical across cost profiles for the same query", () =>
+		Effect.gen(function* () {
+			const list = yield* fingerprintOn(clickhouseConfig, { context: "test", profile: "list" })
+			const unbounded = yield* fingerprintOn(clickhouseConfig, {
+				context: "test",
+				profile: "unbounded",
+			})
+			assert.strictEqual(unbounded, list)
+		}),
+	)
+
+	it.effect("still separates different queries", () =>
+		Effect.gen(function* () {
+			const { spans, tracer } = makeRecordingTracer()
+			const executor = makeWarehouseExecutor(makeDeps([]))
+			// Different tables, not different literals: the fingerprint normalizes
+			// numbers and strings so the same shape groups across params.
+			for (const sql of [
+				"SELECT count() FROM traces WHERE OrgId = 'org_test'",
+				"SELECT count() FROM logs WHERE OrgId = 'org_test'",
+			]) {
+				yield* executor
+					.compiledQuery(tenant, scoped(sql), { context: "test", profile: "list" })
+					.pipe(Effect.withTracer(tracer))
+			}
+			const fingerprints = spans
+				.filter((candidate) => candidate.name === "WarehouseQueryService.executeSql")
+				.map((span) => span.attributes.get("db.query.fingerprint"))
+			assert.lengthOf(fingerprints, 2)
+			assert.notStrictEqual(fingerprints[0], fingerprints[1])
+		}),
+	)
+})
+
 describe("makeWarehouseExecutor restricted-settings strip", () => {
 	it.effect("strips max_block_size for the managed Tinybird CH-gateway", () =>
 		Effect.gen(function* () {
@@ -417,7 +518,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 			let metadataQueries = 0
 			const executor = makeWarehouseExecutor({
 				createClient: () => ({
-					sql: async (sql) => {
+					sql: async (statement) => {
+						const sql = statement.text
 						sqls.push(sql)
 						if (sql.includes("SELECT version()")) {
 							metadataQueries += 1
@@ -483,7 +585,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 			})
 			const executor = makeWarehouseExecutor({
 				createClient: () => ({
-					sql: async (sql) => {
+					sql: async (statement) => {
+						const sql = statement.text
 						if (sql.includes("SELECT version()")) {
 							versionQueries += 1
 							signalVersionQueryStarted?.()
@@ -554,7 +657,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 			const executed: string[] = []
 			const executor = makeWarehouseExecutor({
 				createClient: () => ({
-					sql: async (sql) => {
+					sql: async (statement) => {
+						const sql = statement.text
 						if (sql.includes("system.") || sql.includes("SELECT version()")) {
 							throw new Error("ACCESS_DENIED")
 						}
@@ -594,7 +698,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 			const sqls: string[] = []
 			const executor = makeWarehouseExecutor({
 				createClient: () => ({
-					sql: async (sql) => {
+					sql: async (statement) => {
+						const sql = statement.text
 						sqls.push(sql)
 						// A probe here would be a bug: Tinybird answers `403` for
 						// `system.columns` / `system.data_skipping_indices`, so any
@@ -639,7 +744,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 			const executed: string[] = []
 			const executor = makeWarehouseExecutor({
 				createClient: () => ({
-					sql: (sql) => {
+					sql: (statement) => {
+						const sql = statement.text
 						if (sql.includes("SELECT version()") || sql.includes("system.")) {
 							return new Promise<{ data: never[] }>(() => {})
 						}
@@ -690,7 +796,8 @@ describe("makeWarehouseExecutor capability-aware compilation", () => {
 			const sqls: string[] = []
 			const executor = makeWarehouseExecutor({
 				createClient: () => ({
-					sql: async (sql) => {
+					sql: async (statement) => {
+						const sql = statement.text
 						sqls.push(sql)
 						if (sql.includes("SELECT version()")) return { data: [{ version: "26.2.1" }] }
 						if (sql.includes("system.data_skipping_indices")) {
@@ -864,7 +971,7 @@ describe("makeWarehouseExecutor raw response limits", () => {
 			const executor = makeWarehouseExecutor({
 				...makeDeps([]),
 				createClient: () => ({
-					sql: async (_sql: string, options?: unknown) => {
+					sql: async (_statement, options?: unknown) => {
 						seen = options
 						return { data: [] }
 					},

--- a/packages/query-engine/src/execution/executor.ts
+++ b/packages/query-engine/src/execution/executor.ts
@@ -12,9 +12,10 @@ import {
 } from "@maple/domain/http"
 import type { WarehouseQueryName } from "@maple/domain/warehouse-queries"
 import { compilePipeQuery, type CompiledQuery, type TenantScope } from "../ch"
+import { parseStatement, withFormat, withSettings } from "@maple-dev/clickhouse-builder/sql"
 import type { WarehouseExecutorApi } from "../observability"
 import {
-	appendSettings,
+	settingsClause,
 	type QueryProfileName,
 	resolveSettings,
 	stripTinybirdRestrictedSettings,
@@ -26,13 +27,7 @@ import {
 	type WarehouseReadExecutionError,
 } from "./errors"
 import { WarehouseResponseLimitError, type WarehouseResponseLimits } from "./response-limits"
-import {
-	SQL_LOG_MAX,
-	SQL_TRACE_MAX,
-	fingerprintSql,
-	normalizeSqlForClickHouseClient,
-	truncateSql,
-} from "./fingerprint"
+import { SQL_LOG_MAX, SQL_TRACE_MAX, fingerprintSql, truncateSql } from "./fingerprint"
 import { BackendDialect, warehouseTargetAttributes } from "./backend"
 import { managedWarehouseCapabilities } from "./managed-capabilities"
 import { findIngestPinnedTable } from "./datasource-routing"
@@ -182,7 +177,7 @@ export const makeWarehouseExecutor = (deps: WarehouseExecutorDeps): WarehouseQue
 			})
 		const queryRows = (target: WarehouseCapabilityMetadataTarget, sql: string) =>
 			Effect.tryPromise({
-				try: () => client.sql(sql),
+				try: () => client.sql(parseStatement(sql)),
 				catch: (cause) => probeError(target, cause),
 			}).pipe(Effect.map((result) => result.data))
 		const logProbeFailure = (error: WarehouseCapabilityProbeError) =>
@@ -441,14 +436,23 @@ WHERE name = 'enable_full_text_index'`,
 		const settings = dialect.stripTinybirdRestrictedSettings
 			? stripTinybirdRestrictedSettings(resolveSettings(options))
 			: resolveSettings(options)
-		const sqlForClient = dialect.normalizeSqlForClient ? normalizeSqlForClickHouseClient(sql) : sql
-		const finalSql = appendSettings(sqlForClient, settings)
+		// Parsed once here and passed to the driver as a statement, so no driver
+		// re-derives from SQL text which terminal clauses it already carries.
+		const parsed = parseStatement(sql)
+		const statement = withFormat(
+			withSettings(parsed, parsed.settings ?? settingsClause(settings)),
+			dialect.wireFormat === "in-statement" ? (parsed.format ?? dialect.statementFormat) : undefined,
+		)
+		const finalSql = statement.text
 		const sqlLength = finalSql.length
 		const sqlTruncated = sqlLength > SQL_TRACE_MAX
 		yield* Effect.annotateCurrentSpan("db.query.text", truncateSql(finalSql, SQL_TRACE_MAX))
 		yield* Effect.annotateCurrentSpan("db.query.length", sqlLength)
 		yield* Effect.annotateCurrentSpan("db.query.truncated", sqlTruncated)
-		yield* Effect.annotateCurrentSpan("db.query.fingerprint", fingerprintSql(finalSql))
+		// Fingerprint the body, not the rendered statement: SETTINGS and FORMAT
+		// vary with the backend and the cost profile, and hashing them forks one
+		// query into several shapes in the query-shape rollup, which keys on this.
+		yield* Effect.annotateCurrentSpan("db.query.fingerprint", fingerprintSql(statement.body))
 		if (settings) yield* Effect.annotateCurrentSpan("ch.settings", JSON.stringify(settings))
 
 		const client = getCachedOrCreateClient(
@@ -469,7 +473,7 @@ WHERE name = 'enable_full_text_index'`,
 		const queryAttempt = Effect.tryPromise({
 			try: () =>
 				client.sql(
-					finalSql,
+					statement,
 					effectiveResponseLimits === undefined
 						? undefined
 						: { responseLimits: effectiveResponseLimits },

--- a/packages/query-engine/src/execution/fingerprint.ts
+++ b/packages/query-engine/src/execution/fingerprint.ts
@@ -73,11 +73,13 @@ export const summarizeSql = (sql: string): SqlSummary => {
 }
 
 /**
- * The official ClickHouse client sets the wire format itself, so it rejects a
- * statement that carries its own `FORMAT` clause (any format, not just the
- * `FORMAT JSON` the DSL emits) and a trailing `;`. Strip both before handing the
- * SQL to the CH driver, keeping any `SETTINGS` clause. Tinybird's `/v0/sql`
- * keeps the SQL as-is.
+ * Drop a statement's `FORMAT` clause (any format, not just the `FORMAT JSON`
+ * the DSL emits) and trailing `;`, keeping any `SETTINGS`.
+ *
+ * The executor no longer needs this — it settles terminal clauses from the
+ * backend dialect before the driver sees the statement. This is for callers
+ * that hold compiled SQL as text and hand it straight to a ClickHouse client,
+ * which sets the wire format itself and rejects a statement carrying its own.
  */
 export const normalizeSqlForClickHouseClient = (sql: string): string => {
 	const terminal = splitTerminalClauses(sql)

--- a/packages/query-engine/src/execution/ports.ts
+++ b/packages/query-engine/src/execution/ports.ts
@@ -1,4 +1,5 @@
 import type { Effect, Option } from "effect"
+import type { ClickHouseStatement } from "@maple-dev/clickhouse-builder/sql"
 import type { OrgId, UserId } from "@maple/domain"
 import type {
 	RawSqlValidationError,
@@ -37,10 +38,19 @@ export type CompiledQueryError<Routing extends "ingest" | undefined> = Routing e
 	? ManagedWarehouseError
 	: WarehouseCompiledQueryError
 
-/** Minimal client interface — raw SQL execution plus row inserts. */
+/**
+ * Minimal client interface — statement execution plus row inserts.
+ *
+ * The executor hands over a parsed `ClickHouseStatement` with its terminal
+ * clauses already settled for this backend's dialect: `SETTINGS` applied, and
+ * `format` present exactly when the dialect declares the wire format in the
+ * statement. A driver renders it (`statement.text`) and sends it — deciding
+ * for itself which clauses to add or strip is what let the executor and the
+ * drivers disagree.
+ */
 export interface WarehouseSqlClient {
 	readonly sql: (
-		sql: string,
+		statement: ClickHouseStatement,
 		options?: {
 			readonly responseLimits?: WarehouseResponseLimits
 		},

--- a/packages/query-engine/src/profiles/query-profile.ts
+++ b/packages/query-engine/src/profiles/query-profile.ts
@@ -1,4 +1,4 @@
-import { splitTerminalClauses } from "@maple-dev/clickhouse-builder/sql"
+import { parseStatement, renderStatement, withSettings } from "@maple-dev/clickhouse-builder/sql"
 
 /**
  * ClickHouse query settings forwarded via inline `SETTINGS` clause.
@@ -137,19 +137,11 @@ export const stripTinybirdRestrictedSettings = (
 }
 
 /**
- * Add a ClickHouse `SETTINGS` clause to a SQL string, inserting it before a
- * trailing `FORMAT <name>` clause when present (the DSL compiler terminates
- * every query with `FORMAT JSON`, and Tinybird's ClickHouse rejects the
- * `FORMAT JSON SETTINGS …` order with a syntax error). Returns the input
- * unchanged when no settings are provided.
- *
- * A statement that already carries its own `SETTINGS` is returned untouched —
- * appending a second clause is a syntax error, and silently merging would hide
- * whichever budget lost. Raw SQL rejects an author-supplied `SETTINGS` upstream
- * in `prepareRawSql`; no DSL query emits one.
+ * The `SETTINGS …` clause for these settings, or undefined when there is
+ * nothing to set. Non-finite and undefined values are dropped.
  */
-export const appendSettings = (sql: string, settings: WarehouseQuerySettings | undefined): string => {
-	if (!settings) return sql
+export const settingsClause = (settings: WarehouseQuerySettings | undefined): string | undefined => {
+	if (!settings) return undefined
 	const parts: string[] = []
 	for (const key of Object.keys(settings) as Array<keyof WarehouseQuerySettings>) {
 		const value = settings[key]
@@ -157,15 +149,28 @@ export const appendSettings = (sql: string, settings: WarehouseQuerySettings | u
 			parts.push(`${settingToCh[key]}=${value}`)
 		}
 	}
-	if (parts.length === 0) return sql
-	const terminal = splitTerminalClauses(sql)
-	if (terminal.settings !== undefined) return sql
-	const clause = `SETTINGS ${parts.join(", ")}`
-	// Newline-separated: a body ending in a `--` comment would swallow a
-	// space-joined clause and run the query with no budget at all.
-	return terminal.format === undefined
-		? `${terminal.body}\n${clause}`
-		: `${terminal.body}\n${clause}\n${terminal.format}`
+	return parts.length === 0 ? undefined : `SETTINGS ${parts.join(", ")}`
+}
+
+/**
+ * Add a ClickHouse `SETTINGS` clause to SQL text, before a trailing `FORMAT`
+ * clause when there is one (Tinybird's ClickHouse rejects the inverse order).
+ * Returns the input unchanged when there is nothing to set.
+ *
+ * A statement that already carries its own `SETTINGS` is returned untouched —
+ * appending a second clause is a syntax error, and silently merging would hide
+ * whichever budget lost. Raw SQL rejects an author-supplied `SETTINGS` upstream
+ * in `prepareRawSql`; no DSL query emits one.
+ *
+ * The executor works on the parsed statement instead of round-tripping text;
+ * this is for call sites that hold SQL as a string.
+ */
+export const appendSettings = (sql: string, settings: WarehouseQuerySettings | undefined): string => {
+	const clause = settingsClause(settings)
+	if (clause === undefined) return sql
+	const statement = parseStatement(sql)
+	if (statement.settings !== undefined) return sql
+	return renderStatement(withSettings(statement, clause))
 }
 
 /**


### PR DESCRIPTION
Stacked on #645 — review that one first; this diff is against its branch.

## Why

The executor produced a SQL string and every driver re-derived from it what the executor already knew:

- the Tinybird SDK appended its own `FORMAT JSON` after inspecting the text,
- the ClickHouse client passed `format` out-of-band and *depended* on the executor having stripped one,
- chdb depended on the same.

That split is what let the executor and the drivers disagree about which terminal clauses a statement already carried — the class of bug #645 fixed one instance of.

## What

`ClickHouseStatement` is that agreement as a value: `body` plus optional `settings` and `format`, with a `Schema.decodeTo` codec to and from SQL text for boundaries that carry a statement as a string. The executor parses **once**, settles both clauses from the backend's dialect, and hands the statement to the driver. A driver renders it (`statement.text`) and sends it — nothing downstream inspects SQL text any more.

`BackendDialect.normalizeSqlForClient: boolean` becomes `wireFormat: "in-statement" | "out-of-band"` plus `statementFormat`, which says the thing directly instead of naming a transformation.

`WarehouseSqlClient.sql` now takes a `ClickHouseStatement`. Four implementations updated (ClickHouse web, Tinybird SDK, chdb in `apps/cli`, the MCP eval fake).

## The bug this fixes

`db.query.fingerprint` was hashed over the **rendered** statement. It is the `QueryKey` of `service_map_db_query_shapes_hourly` ([local-schema-v11.sql:1418](apps/cli/src/server/schema/local-schema-v11.sql:1418)), so the same query produced different shapes depending on where it ran:

```
body only          : edebe45d
managed tinybird   : 663362d8   ← + FORMAT JSON
byo clickhouse     : f393d5e5   ← + max_block_size (Tinybird strips it)
```

`unbounded` forked again by emitting no `SETTINGS` at all. An org moving to its own cluster silently re-keyed every query shape it had. The fingerprint now covers `statement.body` — the part that varies with the query rather than with where it runs. Numeric and string literals still normalize, so params still group.

**Migration note:** existing shapes in the rollup re-key once when this ships, then stay stable. That's a one-time fork replacing a permanent per-backend one.

## Not in this PR

The plan had a third stage — a branded `RawSql` schema replacing the five bare `Schema.String` declarations of the same field ([RawSqlExecuteRequest.sql](packages/domain/src/http/query-engine.ts:1758), [alerts.rawQuerySql](packages/domain/src/http/alerts.ts:490) ×2, [V2RawSqlDataSource.sql](packages/domain/src/http/v2/dashboards.ts:222), `PlannedRawSqlParams.sql`) and deleting [validateRawSqlMacro](apps/api/src/mcp/lib/raw-sql-widget.ts:66), which checks `$__orgFilter` and nothing else. Today an MCP agent can save a dashboard widget whose SQL is deny-listed or carries `SETTINGS`, and it only fails at render.

Held deliberately: it rejects SQL that is currently accepted, so it needs the same prod audit as the `SETTINGS` rejection already in flight in #645.

## Reviewer notes

- **A codec is not a perf win here.** I benchmarked the splitter over the real SQL catalog (40 queries, median 765 bytes): 17.8µs per parse. Going from ~3 parses to 1 saves ~35µs against queries that take 100ms–10s. The reason to do this is that the parse boundary stops being re-derived, not speed.
- `normalizeSqlForClickHouseClient` stays exported — the executor no longer uses it, but three ClickHouse e2e suites hand compiled SQL straight to a client. Its doc now says so.
- Running `bun run --cwd packages/query-engine test` directly needs `lib/clickhouse-builder` built first (it resolves to `dist`). CI is unaffected — turbo's `test`/`typecheck` both `dependsOn: ["^build"]`. I claimed otherwise in #645 and was wrong.

## Tests

12 new statement/codec cases in the builder; new executor coverage for the per-dialect wire format (4 backends) and for fingerprint stability across backends and profiles, including a case pinning that different queries still separate. The Tinybird driver's FORMAT-normalization suite moved up to the executor, where the decision now lives; what's left asserts the driver renders verbatim.

- `lib/clickhouse-builder` — 175 pass
- `packages/query-engine` — 1288 pass
- `apps/api` warehouse / query-engine / alerts / dashboards / mcp — 1010 pass
- `apps/cli` — 517 pass
- typecheck clean across all four; oxlint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790339612&installation_model_id=427786&pr_number=646&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F646&signature=6b694308259ad4d1a0798f8f094dd6ceaae1a60d0ee46c749883b010936c1a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
