### PR TITLE
feat(web): unified span-inspection popover across agent session views

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
@@ -7,7 +7,7 @@ import { highlightCode } from "@/lib/sugar-high"
 
 /**
  * The rendered ↔ raw affordances every captured body shares, wherever it is
- * opened — a transcript block, the Traces expansion, the Flow drawer. Markdown
+ * opened — a transcript block, the span popover. Markdown
  * layout and pretty-printed JSON are readings of the capture, and a reading can
  * hide things — whitespace, key order, a literal `**` — so every rendered body
  * keeps a way back to the captured bytes.

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -5,7 +5,7 @@
 // navigates: span clicks raise `onSelectSpan` for the page to handle, and the
 // trace links render through a mocked `Link` so no router needs mounting.
 //
-// The span popover portals to `document.body`, so it is read through
+// The span inspection overlay portals to `document.body`, so it is read through
 // `spanPopover()` below rather than the render's own container.
 
 import { useState, type ReactNode } from "react"
@@ -273,11 +273,16 @@ const { turns: delegationTurns, summary: delegationSummary } = sessionOf([
 const EMPTY = new Set<string>()
 const noop = () => {}
 
-/** The one span-inspection panel, wherever it was opened from. */
+/** The one span-inspection overlay, wherever it was opened from. */
 function spanPopover(): HTMLElement {
 	const popup = document.querySelector<HTMLElement>('[data-slot="span-popover"]')
 	if (popup === null) throw new Error("no span popover is open")
 	return popup
+}
+
+/** The dimmed page behind the overlay — the scrim that gives it its depth. */
+function spanScrim(): HTMLElement | null {
+	return document.querySelector<HTMLElement>('[data-slot="dialog-backdrop"]')
 }
 
 function spanPopoverCount(): number {
@@ -368,10 +373,12 @@ describe("SessionOverview", () => {
 	function Overview(props: {
 		turns?: readonly SessionTurn[]
 		summary?: SessionSummary
+		/** What a pasted `?span=` link lands with. */
+		initialSpanId?: string
 		onSelectSpan?: (spanId: string | undefined) => void
 		onOpenTraceView?: () => void
 	}) {
-		const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>(undefined)
+		const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>(props.initialSpanId)
 		return (
 			<SessionOverview
 				turns={props.turns ?? turns}
@@ -425,8 +432,8 @@ describe("SessionOverview", () => {
 	})
 
 	// The finding's evidence used to live one view away: clicking it swapped the
-	// page out from under the reader. It opens here instead, and the way across
-	// is inside the panel for the reader who wants the whole waterfall.
+	// page out from under the reader. It opens over this page instead, and the
+	// way across is inside the panel for the reader who wants the whole waterfall.
 	it("inspects a finding's span in place, and still offers the way across", () => {
 		const onOpenTraceView = vi.fn()
 		render(<Overview onOpenTraceView={onOpenTraceView} />)
@@ -434,10 +441,32 @@ describe("SessionOverview", () => {
 		fireEvent.click(screen.getByText("error · run_tests"))
 		const popover = within(spanPopover())
 		expect(popover.getByText("exit 1")).toBeTruthy()
+		// A scrim behind it, so the page reads as underneath rather than beside.
+		expect(spanScrim()).not.toBeNull()
 		expect(onOpenTraceView).not.toHaveBeenCalled()
 
 		fireEvent.click(popover.getByRole("button", { name: "Open in Traces view" }))
 		expect(onOpenTraceView).toHaveBeenCalled()
+	})
+
+	// The panel is no longer anchored to the element that named the span, so a
+	// selection this view never made — a pasted `?span=` link, or the reader
+	// arriving from another view — opens it here too.
+	it("opens a pasted span link without a click, and Escape clears it", () => {
+		const onSelectSpan = vi.fn()
+		render(
+			<Overview
+				turns={failedTurns}
+				summary={failedSummary}
+				initialSpanId="f-llm"
+				onSelectSpan={onSelectSpan}
+			/>,
+		)
+
+		expect(within(spanPopover()).getAllByText(/claude-opus-5/).length).toBeGreaterThan(0)
+
+		fireEvent.keyDown(spanPopover(), { key: "Escape" })
+		expect(onSelectSpan).toHaveBeenCalledWith(undefined)
 	})
 
 	it("says a clean session completed cleanly, and what that claim covers", () => {
@@ -565,7 +594,7 @@ describe("SessionWaterfall", () => {
 		expect(link.getAttribute("href")).toBe("/traces/trace-1")
 	})
 
-	it("opens the selected span's panel against its row", () => {
+	it("opens the selected span over the list, leaving its row marked underneath", () => {
 		render(<Waterfall selectedSpanId="llm-1" />)
 
 		const row = screen.getAllByText(/^chat$/)[0]!.closest("button")!
@@ -851,7 +880,7 @@ describe("SessionFlow", () => {
 		expect(onSelectSpan).toHaveBeenCalledWith("tool-2")
 	})
 
-	it("opens the selected span's panel against its node", () => {
+	it("opens the selected span's panel, naming the node's turn", () => {
 		render(<Flow selectedSpanId="tool-2" />)
 
 		// The panel names the span and where it lives, and offers the way across.
@@ -864,7 +893,7 @@ describe("SessionFlow", () => {
 	it("opens the panel even for a span the flow drew no node for", () => {
 		// The app's own HTTP span earns no node, but selection addresses spans the
 		// same way in both views, so a span opened in Trace still opens here — the
-		// canvas is the anchor when there is no node to point at.
+		// panel is an overlay over the canvas, not a pointer at some node on it.
 		render(<Flow selectedSpanId="http-1" agentSpansOnly={false} />)
 
 		expect(within(spanPopover()).getByText("GET /repo/file")).toBeTruthy()
@@ -1035,9 +1064,9 @@ describe("SessionViews", () => {
 		expect(screen.getByRole("button", { name: /Turn 1/ }).getAttribute("aria-expanded")).toBe("false")
 	})
 
-	// One panel for the whole page. Clicking the page outside it closes it — that
-	// is what a popover does — so the way to cross views with a span still open
-	// is the panel's own door, and it keeps both the span and the reader's tab.
+	// One panel for the whole page, and the page behind it is scrimmed, so the
+	// way to cross views with a span still open is the panel's own door — which
+	// keeps both the span and the reader's tab.
 	it("carries the open span and its tab through the panel's door into Traces", () => {
 		render(<Views view="flow" />)
 

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -4,6 +4,9 @@
 // two layout globals below are stubbed for that reason alone. Nothing here
 // navigates: span clicks raise `onSelectSpan` for the page to handle, and the
 // trace links render through a mocked `Link` so no router needs mounting.
+//
+// The span popover portals to `document.body`, so it is read through
+// `spanPopover()` below rather than the render's own container.
 
 import { useState, type ReactNode } from "react"
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react"
@@ -270,6 +273,17 @@ const { turns: delegationTurns, summary: delegationSummary } = sessionOf([
 const EMPTY = new Set<string>()
 const noop = () => {}
 
+/** The one span-inspection panel, wherever it was opened from. */
+function spanPopover(): HTMLElement {
+	const popup = document.querySelector<HTMLElement>('[data-slot="span-popover"]')
+	if (popup === null) throw new Error("no span popover is open")
+	return popup
+}
+
+function spanPopoverCount(): number {
+	return document.querySelectorAll('[data-slot="span-popover"]').length
+}
+
 /** The waterfall's expansion state lives in SessionViews, so the tests supply it. */
 function Waterfall(props: {
 	turns?: readonly SessionTurn[]
@@ -350,16 +364,26 @@ describe("SessionOverview", () => {
 		}),
 	])
 
+	/** `?span=` is a search param on the real page; here it is local state. */
 	function Overview(props: {
 		turns?: readonly SessionTurn[]
 		summary?: SessionSummary
-		onOpenSpan?: (spanId: string) => void
+		onSelectSpan?: (spanId: string | undefined) => void
+		onOpenTraceView?: () => void
 	}) {
+		const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>(undefined)
 		return (
 			<SessionOverview
 				turns={props.turns ?? turns}
 				summary={props.summary ?? summary}
-				onOpenSpan={props.onOpenSpan ?? noop}
+				selectedSpanId={selectedSpanId}
+				onSelectSpan={(spanId) => {
+					setSelectedSpanId(spanId)
+					props.onSelectSpan?.(spanId)
+				}}
+				spanTab={undefined}
+				onSpanTabChange={noop}
+				onOpenTraceView={props.onOpenTraceView ?? noop}
 			/>
 		)
 	}
@@ -373,28 +397,47 @@ describe("SessionOverview", () => {
 	})
 
 	// The five-second answer: the verdict names what killed the final turn and
-	// links the span that is its evidence — the one link the v2 page lost.
+	// opens the span that is its evidence — the one link the v2 page lost.
 	it("says a failed session failed, names the cause, and opens the failing span", () => {
-		const onOpenSpan = vi.fn()
-		render(<Overview turns={failedTurns} summary={failedSummary} onOpenSpan={onOpenSpan} />)
+		const onSelectSpan = vi.fn()
+		render(<Overview turns={failedTurns} summary={failedSummary} onSelectSpan={onSelectSpan} />)
 
 		expect(screen.getByText("Failed")).toBeTruthy()
 		expect(screen.getAllByText("context_length_exceeded").length).toBeGreaterThan(0)
 
 		fireEvent.click(screen.getByRole("button", { name: /Open failing span/ }))
 		// The deepest span carrying the failure, not the wrapper that copied it.
-		expect(onOpenSpan).toHaveBeenCalledWith("f-llm")
+		expect(onSelectSpan).toHaveBeenCalledWith("f-llm")
+		// In place, against the button that named it — the Overview is still on
+		// screen behind the panel.
+		expect(within(spanPopover()).getByText("f-llm")).toBeTruthy()
 	})
 
 	// A mid-session failure the session recovered from is not a failed session —
 	// but it is exactly what the findings list exists to surface.
-	it("completes-with-findings when something failed mid-session, and links it", () => {
-		const onOpenSpan = vi.fn()
-		render(<Overview onOpenSpan={onOpenSpan} />)
+	it("completes-with-findings when something failed mid-session, and opens it", () => {
+		const onSelectSpan = vi.fn()
+		render(<Overview onSelectSpan={onSelectSpan} />)
 
 		expect(screen.getByText(/Completed, with 1 finding/)).toBeTruthy()
 		fireEvent.click(screen.getByText("error · run_tests"))
-		expect(onOpenSpan).toHaveBeenCalledWith("tool-3")
+		expect(onSelectSpan).toHaveBeenCalledWith("tool-3")
+	})
+
+	// The finding's evidence used to live one view away: clicking it swapped the
+	// page out from under the reader. It opens here instead, and the way across
+	// is inside the panel for the reader who wants the whole waterfall.
+	it("inspects a finding's span in place, and still offers the way across", () => {
+		const onOpenTraceView = vi.fn()
+		render(<Overview onOpenTraceView={onOpenTraceView} />)
+
+		fireEvent.click(screen.getByText("error · run_tests"))
+		const popover = within(spanPopover())
+		expect(popover.getByText("exit 1")).toBeTruthy()
+		expect(onOpenTraceView).not.toHaveBeenCalled()
+
+		fireEvent.click(popover.getByRole("button", { name: "Open in Traces view" }))
+		expect(onOpenTraceView).toHaveBeenCalled()
 	})
 
 	it("says a clean session completed cleanly, and what that claim covers", () => {
@@ -406,14 +449,14 @@ describe("SessionOverview", () => {
 	})
 
 	// The shape strip replaces the turn digest: one cell per turn, colored by
-	// what the findings attribute to it, each a door into the Traces view.
+	// what the findings attribute to it, each opening the turn's anchor span.
 	it("draws one cell per turn and opens the turn's anchor from a click", () => {
-		const onOpenSpan = vi.fn()
-		render(<Overview onOpenSpan={onOpenSpan} />)
+		const onSelectSpan = vi.fn()
+		render(<Overview onSelectSpan={onSelectSpan} />)
 
 		const cellTwo = screen.getByRole("button", { name: "2" })
 		fireEvent.click(cellTwo)
-		expect(onOpenSpan).toHaveBeenCalledWith("agent-2")
+		expect(onSelectSpan).toHaveBeenCalledWith("agent-2")
 	})
 
 	it("says no cost was reported rather than pricing tokens itself", () => {
@@ -501,15 +544,15 @@ describe("SessionWaterfall", () => {
 		expect(screen.queryByText(/^idle \d/)).toBeNull()
 	})
 
-	it("selects a span for inline expansion from a click, and collapses on the second", () => {
+	it("opens a span's panel from a click, and closes it on the second", () => {
 		const onSelectSpan = vi.fn()
 		const view = render(<Waterfall onSelectSpan={onSelectSpan} />)
 
 		fireEvent.click(screen.getByText("grep_repo"))
 		expect(onSelectSpan).toHaveBeenCalledWith("tool-2")
 
-		// Clicking the already-expanded row collapses it. The expansion repeats
-		// the tool's name in its payload card, so the row is the first match.
+		// Clicking the open row closes it. The panel repeats the tool's name in
+		// its payload card, so the row is the first match.
 		view.rerender(<Waterfall selectedSpanId="tool-2" onSelectSpan={onSelectSpan} />)
 		fireEvent.click(screen.getAllByText("grep_repo")[0]!)
 		expect(onSelectSpan).toHaveBeenLastCalledWith(undefined)
@@ -522,25 +565,24 @@ describe("SessionWaterfall", () => {
 		expect(link.getAttribute("href")).toBe("/traces/trace-1")
 	})
 
-	it("expands the selected span inline, directly under its row", () => {
-		const view = render(<Waterfall selectedSpanId="llm-1" />)
+	it("opens the selected span's panel against its row", () => {
+		render(<Waterfall selectedSpanId="llm-1" />)
 
 		const row = screen.getAllByText(/^chat$/)[0]!.closest("button")!
 		expect(row.getAttribute("aria-current")).toBe("true")
 
-		// The expansion carries the captured messages at full width — the user's
+		// The panel carries the captured messages at full width — the user's
 		// prompt appears complete here, beyond the truncated turn label above it.
-		const detail = view.container.querySelector('[data-slot="span-inline-detail"]')!
-		expect(detail).toBeTruthy()
-		expect(within(detail as HTMLElement).getByText("fix the webhook retry backoff")).toBeTruthy()
-		expect(within(detail as HTMLElement).getByRole("button", { name: /Messages/ })).toBeTruthy()
-		expect(within(detail as HTMLElement).getByText("Open in Traces")).toBeTruthy()
+		const detail = within(spanPopover())
+		expect(detail.getByText("fix the webhook retry backoff")).toBeTruthy()
+		expect(detail.getByRole("button", { name: /Messages/ })).toBeTruthy()
+		expect(detail.getByText("Open in Traces")).toBeTruthy()
 	})
 
-	it("leads the expansion's tabs with Details; Attributes and Timing are folded into it", () => {
-		const view = render(<Waterfall selectedSpanId="llm-1" />)
+	it("leads the panel's tabs with Details; Attributes and Timing are folded into it", () => {
+		render(<Waterfall selectedSpanId="llm-1" />)
 
-		const detail = within(view.container.querySelector('[data-slot="span-inline-detail"]') as HTMLElement)
+		const detail = within(spanPopover())
 		const labels = detail
 			.getAllByRole("button")
 			.filter((button) => button.hasAttribute("aria-pressed"))
@@ -570,9 +612,9 @@ describe("SessionWaterfall", () => {
 				},
 			}),
 		])
-		const view = render(<Waterfall turns={failTurns} summary={failSummary} selectedSpanId="ft-tool" />)
+		render(<Waterfall turns={failTurns} summary={failSummary} selectedSpanId="ft-tool" />)
 
-		const detail = view.container.querySelector('[data-slot="span-inline-detail"]') as HTMLElement
+		const detail = spanPopover()
 		// A failed span opens on Details by default.
 		expect(within(detail).getByRole("button", { name: "Details" }).getAttribute("aria-pressed")).toBe(
 			"true",
@@ -584,9 +626,9 @@ describe("SessionWaterfall", () => {
 	})
 
 	it("opens an errored span on Details, where the error and the ids are", () => {
-		const view = render(<Waterfall selectedSpanId="tool-3" />)
+		render(<Waterfall selectedSpanId="tool-3" />)
 
-		const detail = within(view.container.querySelector('[data-slot="span-inline-detail"]') as HTMLElement)
+		const detail = within(spanPopover())
 		expect(detail.getByRole("button", { name: "Details" }).getAttribute("aria-pressed")).toBe("true")
 		// The error banner and the identity rows render ahead of the lazily
 		// loaded attribute maps (held at Initial by the atom mock above).
@@ -594,15 +636,17 @@ describe("SessionWaterfall", () => {
 		expect(detail.getByText("Trace ID")).toBeTruthy()
 	})
 
-	it("expands one span at a time — the selection, not a set", () => {
+	it("opens one span at a time — the selection, not a set", () => {
 		const view = render(<Waterfall selectedSpanId="tool-1" />)
-		expect(view.container.querySelectorAll('[data-slot="span-inline-detail"]')).toHaveLength(1)
+		expect(spanPopoverCount()).toBe(1)
 
 		view.rerender(<Waterfall selectedSpanId="tool-2" />)
-		expect(view.container.querySelectorAll('[data-slot="span-inline-detail"]')).toHaveLength(1)
+		expect(spanPopoverCount()).toBe(1)
+		// The one panel followed the selection rather than joining the first.
+		expect(within(spanPopover()).getAllByText("grep_repo").length).toBeGreaterThan(0)
 	})
 
-	// A call and its result are one event: the expansion shows them as one card
+	// A call and its result are one event: the panel shows them as one card
 	// whose selector flips between the halves, instead of two stacked cards the
 	// reader has to pair by eye.
 	it("groups a tool call and its result into one card behind a selector", () => {
@@ -621,12 +665,10 @@ describe("SessionWaterfall", () => {
 				},
 			}),
 		])
-		const view = render(
-			<Waterfall turns={toolTurns} summary={toolSummary} selectedSpanId="tc-tool" spanTab="tools" />,
-		)
+		render(<Waterfall turns={toolTurns} summary={toolSummary} selectedSpanId="tc-tool" spanTab="tools" />)
 
 		// Arguments first, pretty-printed; the result is a click away, not a scroll.
-		const detail = view.container.querySelector('[data-slot="span-inline-detail"]') as HTMLElement
+		const detail = spanPopover()
 		expect(detail.textContent).toContain('"sql"')
 		expect(detail.textContent).not.toContain('"rows"')
 
@@ -635,18 +677,21 @@ describe("SessionWaterfall", () => {
 		expect(detail.textContent).not.toContain('"sql"')
 	})
 
-	it("moves the span cursor with the arrows, expands on Enter, collapses on Esc", () => {
+	// The panel is a dialog, so the page-level keys stand down while it is open:
+	// the arrows walk the list up to the point one opens, and the panel's own
+	// close (its button, or Escape inside it) is what puts the reader back.
+	it("moves the span cursor with the arrows, opens on Enter, closes from the panel", () => {
 		const onSelectSpan = vi.fn()
 		const view = render(<Waterfall onSelectSpan={onSelectSpan} />)
 
 		// First ↓ lands on the first span row — turn 1's root agent span; Enter
-		// expands it.
+		// opens it.
 		fireEvent.keyDown(document.body, { key: "ArrowDown" })
 		fireEvent.keyDown(document.body, { key: "Enter" })
 		expect(onSelectSpan).toHaveBeenCalledWith("agent-1")
 
 		view.rerender(<Waterfall selectedSpanId="agent-1" onSelectSpan={onSelectSpan} />)
-		fireEvent.keyDown(document.body, { key: "Escape" })
+		fireEvent.click(within(spanPopover()).getByRole("button", { name: "Close span detail" }))
 		expect(onSelectSpan).toHaveBeenLastCalledWith(undefined)
 	})
 
@@ -798,7 +843,7 @@ describe("SessionFlow", () => {
 		expect(screen.getByText("grep_repo")).toBeTruthy()
 	})
 
-	it("selects a span for the docked drawer from a node click", () => {
+	it("opens a span's panel from a node click", () => {
 		const onSelectSpan = vi.fn()
 		render(<Flow onSelectSpan={onSelectSpan} />)
 
@@ -806,25 +851,23 @@ describe("SessionFlow", () => {
 		expect(onSelectSpan).toHaveBeenCalledWith("tool-2")
 	})
 
-	it("docks a full-width drawer under the canvas for the selected span", () => {
-		const view = render(<Flow selectedSpanId="tool-2" />)
+	it("opens the selected span's panel against its node", () => {
+		render(<Flow selectedSpanId="tool-2" />)
 
-		const drawer = view.container.querySelector('[data-slot="span-drawer"]')!
-		expect(drawer).toBeTruthy()
-		// The drawer names the span and where it lives, and offers the way across.
-		expect(within(drawer as HTMLElement).getAllByText(/grep_repo/).length).toBeGreaterThan(0)
-		expect(within(drawer as HTMLElement).getByText(/Turn 1/)).toBeTruthy()
-		expect(within(drawer as HTMLElement).getByText("Open in Traces view")).toBeTruthy()
+		// The panel names the span and where it lives, and offers the way across.
+		const panel = within(spanPopover())
+		expect(panel.getAllByText(/grep_repo/).length).toBeGreaterThan(0)
+		expect(panel.getByText(/Turn 1/)).toBeTruthy()
+		expect(panel.getByText("Open in Traces view")).toBeTruthy()
 	})
 
-	it("opens the drawer even for a span the flow drew no node for", () => {
+	it("opens the panel even for a span the flow drew no node for", () => {
 		// The app's own HTTP span earns no node, but selection addresses spans the
-		// same way in both views, so a span expanded in Trace still opens here.
-		const view = render(<Flow selectedSpanId="http-1" agentSpansOnly={false} />)
+		// same way in both views, so a span opened in Trace still opens here — the
+		// canvas is the anchor when there is no node to point at.
+		render(<Flow selectedSpanId="http-1" agentSpansOnly={false} />)
 
-		const drawer = view.container.querySelector('[data-slot="span-drawer"]')!
-		expect(drawer).toBeTruthy()
-		expect(within(drawer as HTMLElement).getByText("GET /repo/file")).toBeTruthy()
+		expect(within(spanPopover()).getByText("GET /repo/file")).toBeTruthy()
 	})
 
 	it("merges a run of identical calls into one counted node", () => {
@@ -992,38 +1035,38 @@ describe("SessionViews", () => {
 		expect(screen.getByRole("button", { name: /Turn 1/ }).getAttribute("aria-expanded")).toBe("false")
 	})
 
-	// The spec's shared rules: 1/2/3 switch views, and the selection survives a
-	// Trace ↔ Flow switch because both views address spans the same way.
-	it("switches views on 2/3 and carries the expanded span across", () => {
-		const view = render(<Views />)
+	// One panel for the whole page. Clicking the page outside it closes it — that
+	// is what a popover does — so the way to cross views with a span still open
+	// is the panel's own door, and it keeps both the span and the reader's tab.
+	it("carries the open span and its tab through the panel's door into Traces", () => {
+		render(<Views view="flow" />)
 
 		fireEvent.click(screen.getByText("grep_repo"))
-		expect(view.container.querySelector('[data-slot="span-inline-detail"]')).toBeTruthy()
+		fireEvent.click(within(spanPopover()).getByRole("button", { name: "Details" }))
 
-		fireEvent.keyDown(document.body, { key: "3" })
-		expect(view.container.querySelector('[data-slot="span-drawer"]')).toBeTruthy()
+		fireEvent.click(within(spanPopover()).getByRole("button", { name: "Open in Traces view" }))
 
-		fireEvent.keyDown(document.body, { key: "2" })
-		expect(view.container.querySelector('[data-slot="span-inline-detail"]')).toBeTruthy()
+		// The waterfall's own column header: the Traces view is what is on screen.
+		expect(screen.getByText("Model / target")).toBeTruthy()
+		expect(spanPopoverCount()).toBe(1)
+		expect(
+			within(spanPopover()).getByRole("button", { name: "Details" }).getAttribute("aria-pressed"),
+		).toBe("true")
 	})
 
 	// The tab choice lives beside the other cross-view state in SessionViews:
-	// moving the expansion to another span must not reset the reader's tab.
-	it("keeps the chosen detail tab open when the expansion moves to another span", () => {
-		const view = render(<Views />)
+	// moving the panel to another span must not reset the reader's tab.
+	it("keeps the chosen detail tab open when the panel moves to another span", () => {
+		render(<Views />)
 
 		// The tool span opens on its own payload (Tool calls); choose Details.
 		fireEvent.click(screen.getByText("grep_repo"))
-		fireEvent.click(screen.getByRole("button", { name: "Details" }))
+		fireEvent.click(within(spanPopover()).getByRole("button", { name: "Details" }))
 
-		// Move the expansion to a different span — the choice holds.
+		// Move the panel to a different span — the choice holds.
 		fireEvent.click(screen.getAllByText("read_file")[0]!)
-		const detail = within(view.container.querySelector('[data-slot="span-inline-detail"]') as HTMLElement)
-		expect(detail.getByRole("button", { name: "Details" }).getAttribute("aria-pressed")).toBe("true")
-
-		// And it holds across the view switch into the Flow drawer too.
-		fireEvent.keyDown(document.body, { key: "3" })
-		const drawer = within(view.container.querySelector('[data-slot="span-drawer"]') as HTMLElement)
-		expect(drawer.getByRole("button", { name: "Details" }).getAttribute("aria-pressed")).toBe("true")
+		expect(
+			within(spanPopover()).getByRole("button", { name: "Details" }).getAttribute("aria-pressed"),
+		).toBe("true")
 	})
 })

--- a/apps/web/src/components/agent-sessions/session-detail/session-flow.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-flow.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useRef } from "react"
+import { memo, useMemo, useRef, useState, type Ref } from "react"
 import {
 	Handle,
 	Position,
@@ -32,7 +32,8 @@ import {
 	type AiSpanCategory,
 } from "@/lib/agent-sessions/session-turns"
 import { filterSpans, isDelegation, shortTarget } from "@/lib/agent-sessions/span-filters"
-import { SpanDrawer, type SpanDetailTab } from "./span-expansion"
+import type { SpanDetailTab } from "./span-expansion"
+import { SpanPopover } from "./span-popover"
 import { CATEGORY_ICON, CATEGORY_TEXT } from "./span-visuals"
 
 // One lane per turn, positioned by hand and handed to `@xyflow/react` — the
@@ -53,8 +54,8 @@ const WRAP_GAP = 24
 const MIN_ZOOM = 0.5
 const MAX_ZOOM = 1.5
 /** How far past the graph the canvas can be panned. Roughly half a viewport:
- *  enough to pull any node clear of the floor's legend and drawer, while a
- *  fling can never strand the reader on empty canvas with no node in sight. */
+ *  enough to pull any node clear of the floor's legend, while a fling can never
+ *  strand the reader on empty canvas with no node in sight. */
 const PAN_MARGIN = 400
 
 /** Where the hidden ports sit on every card, mirrored by `Ports` below. */
@@ -95,16 +96,16 @@ interface SessionFlowProps {
 	agentSpansOnly: boolean
 	zoom: number
 	onZoomChange: (zoom: number) => void
-	/** The one span open in the docked drawer (`?span=`). */
+	/** The one span open in the popover (`?span=`). */
 	selectedSpanId: string | undefined
-	/** Raised with a span id to open the drawer, `undefined` to close it. */
+	/** Raised with a span id to open it, `undefined` to close. */
 	onSelectSpan: (spanId: string | undefined) => void
-	/** The drawer's tab, shared with the Traces view's inline expansion. */
+	/** The popover's tab, shared with the other views. */
 	spanTab: SpanDetailTab | undefined
 	onSpanTabChange: (tab: SpanDetailTab) => void
-	/** The session's captured tool results by call id, for the drawer. */
+	/** The session's captured tool results by call id, for the popover. */
 	toolResults?: ReadonlyMap<string, string>
-	/** The drawer's "Open in Traces view": same span, sibling view. */
+	/** The popover's "Open in Traces view": same span, sibling view. */
 	onOpenTraceView: () => void
 }
 
@@ -129,7 +130,12 @@ export function SessionFlow({
 	const paneRef = useRef<HTMLDivElement>(null)
 	const instanceRef = useRef<ReactFlowInstance<Node, Edge> | null>(null)
 
-	// Selection addresses spans the same way in both views, so a span expanded
+	// The node the popover points at. Nothing here virtualizes, so it only ever
+	// goes null when the filter drops the node — the canvas itself is the
+	// fallback, which is what a span the flow drew no node for anchors to.
+	const [anchor, setAnchor] = useState<HTMLElement | null>(null)
+
+	// Selection addresses spans the same way in both views, so a span opened
 	// in the Trace view opens here even when the flow drew no node for it (a
 	// wrapper, or a span the filter hides).
 	const selectedSpan = useMemo(() => {
@@ -235,6 +241,7 @@ export function SessionFlow({
 							node,
 							selected: selectedSpanId === node.span.spanId,
 							focused: focusedId === node.span.spanId,
+							anchorRef: selectedSpanId === node.span.spanId ? setAnchor : null,
 							onSelect: (spanId: string) => {
 								setFocusedId(spanId)
 								onSelectSpan(selectedSpanId === spanId ? undefined : spanId)
@@ -252,7 +259,7 @@ export function SessionFlow({
 					}),
 				),
 			]),
-		[lanes, selectedSpanId, focusedId, setFocusedId, onSelectSpan],
+		[lanes, selectedSpanId, focusedId, setFocusedId, onSelectSpan, setAnchor],
 	)
 
 	// One neutral stroke for every connector: the line says "this ran inside
@@ -293,8 +300,8 @@ export function SessionFlow({
 		<ReactFlowProvider>
 			{/* The canvas takes whatever height the viewport leaves it (the page
 			    column fills the scroller), and xyflow owns panning inside it; the
-			    floor block below stays a sibling so the drawer can dock under the
-			    canvas rather than float over it. */}
+			    floor block below stays a sibling so the legend and zoom sit on the
+			    canvas rather than inside its transformed pane. */}
 			<div className="relative flex grow flex-col">
 				{lanes.length === 0 ? (
 					<p className="px-2.5 py-8 text-center text-muted-foreground text-sm">
@@ -337,11 +344,10 @@ export function SessionFlow({
 				)}
 
 				{/* The view's floor, pinned to the viewport's bottom edge: the legend
-				    and zoom on top, and under them the docked drawer when a span is
-				    open. Sticky rather than absolute so a page grown past the
-				    viewport (a tall drawer) still keeps them on screen. Guarded,
-				    because there is nothing to key, zoom or open when the filter
-				    emptied the canvas. */}
+				    and the zoom controls. Sticky rather than absolute so a page grown
+				    past the viewport still keeps them on screen. Guarded, because
+				    there is nothing to key or zoom when the filter emptied the
+				    canvas. */}
 				{lanes.length > 0 && (
 					<div className="sticky bottom-0 z-10 mt-auto flex flex-col">
 						<div className="pointer-events-none flex items-end justify-between gap-4 p-3">
@@ -365,19 +371,23 @@ export function SessionFlow({
 							</div>
 							<FlowControls zoom={zoom} />
 						</div>
-
-						{selectedSpan !== undefined && (
-							<SpanDrawer
-								span={selectedSpan.span}
-								turnOrdinal={turnOrdinal(selectedSpan.turn)}
-								tab={spanTab}
-								onTabChange={onSpanTabChange}
-								toolResults={toolResults}
-								onClose={() => onSelectSpan(undefined)}
-								onOpenTraceView={onOpenTraceView}
-							/>
-						)}
 					</div>
+				)}
+
+				{/* Against the node when the flow drew one, and against the canvas
+				    when it did not — a wrapper span, or one the filter hides, still
+				    has to open somewhere. */}
+				{lanes.length > 0 && (
+					<SpanPopover
+						span={selectedSpan?.span}
+						anchor={anchor ?? paneRef}
+						turnOrdinal={selectedSpan === undefined ? undefined : turnOrdinal(selectedSpan.turn)}
+						tab={spanTab}
+						onTabChange={onSpanTabChange}
+						toolResults={toolResults}
+						onClose={() => onSelectSpan(undefined)}
+						onOpenTraceView={onOpenTraceView}
+					/>
 				)}
 			</div>
 		</ReactFlowProvider>
@@ -454,13 +464,15 @@ function Ports() {
 interface StepData extends Record<string, unknown> {
 	readonly node: FlowNode
 	readonly selected: boolean
-	/** Under the keyboard's span cursor — distinct from `selected`, the open drawer. */
+	/** Under the keyboard's span cursor — distinct from `selected`, the open popover. */
 	readonly focused: boolean
+	/** Set on the selected node only: it is what the span popover points at. */
+	readonly anchorRef: Ref<HTMLButtonElement>
 	readonly onSelect: (spanId: string) => void
 }
 
 const StepNode = memo(function StepNode({ data }: NodeProps & { data: StepData }) {
-	const { node, selected, focused, onSelect } = data
+	const { node, selected, focused, anchorRef, onSelect } = data
 	// The glyph carries the kind of work; a failure takes it over outright — the
 	// outcome outranks the kind, exactly as the waterfall's dots read.
 	const Icon = node.errored ? CircleXmarkIcon : CATEGORY_ICON[node.category]
@@ -469,10 +481,12 @@ const StepNode = memo(function StepNode({ data }: NodeProps & { data: StepData }
 		<>
 			<Ports />
 			<button
+				ref={anchorRef}
 				type="button"
 				onClick={() => onSelect(node.span.spanId)}
 				data-span-id={node.span.spanId}
 				aria-current={selected || undefined}
+				aria-haspopup="dialog"
 				className={cn(
 					"flex size-full cursor-pointer flex-col justify-center gap-1 rounded-md border bg-card px-2.5 py-2 text-left hover:border-ring",
 					"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",

--- a/apps/web/src/components/agent-sessions/session-detail/session-flow.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-flow.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useRef, useState, type Ref } from "react"
+import { memo, useMemo, useRef } from "react"
 import {
 	Handle,
 	Position,
@@ -130,11 +130,6 @@ export function SessionFlow({
 	const paneRef = useRef<HTMLDivElement>(null)
 	const instanceRef = useRef<ReactFlowInstance<Node, Edge> | null>(null)
 
-	// The node the popover points at. Nothing here virtualizes, so it only ever
-	// goes null when the filter drops the node — the canvas itself is the
-	// fallback, which is what a span the flow drew no node for anchors to.
-	const [anchor, setAnchor] = useState<HTMLElement | null>(null)
-
 	// Selection addresses spans the same way in both views, so a span opened
 	// in the Trace view opens here even when the flow drew no node for it (a
 	// wrapper, or a span the filter hides).
@@ -241,7 +236,6 @@ export function SessionFlow({
 							node,
 							selected: selectedSpanId === node.span.spanId,
 							focused: focusedId === node.span.spanId,
-							anchorRef: selectedSpanId === node.span.spanId ? setAnchor : null,
 							onSelect: (spanId: string) => {
 								setFocusedId(spanId)
 								onSelectSpan(selectedSpanId === spanId ? undefined : spanId)
@@ -259,7 +253,7 @@ export function SessionFlow({
 					}),
 				),
 			]),
-		[lanes, selectedSpanId, focusedId, setFocusedId, onSelectSpan, setAnchor],
+		[lanes, selectedSpanId, focusedId, setFocusedId, onSelectSpan],
 	)
 
 	// One neutral stroke for every connector: the line says "this ran inside
@@ -374,21 +368,17 @@ export function SessionFlow({
 					</div>
 				)}
 
-				{/* Against the node when the flow drew one, and against the canvas
-				    when it did not — a wrapper span, or one the filter hides, still
-				    has to open somewhere. */}
-				{lanes.length > 0 && (
-					<SpanPopover
-						span={selectedSpan?.span}
-						anchor={anchor ?? paneRef}
-						turnOrdinal={selectedSpan === undefined ? undefined : turnOrdinal(selectedSpan.turn)}
-						tab={spanTab}
-						onTabChange={onSpanTabChange}
-						toolResults={toolResults}
-						onClose={() => onSelectSpan(undefined)}
-						onOpenTraceView={onOpenTraceView}
-					/>
-				)}
+				{/* Whether or not the flow drew a node for it: a wrapper span, or one
+				    the filter hides, still opens where it was addressed. */}
+				<SpanPopover
+					span={selectedSpan?.span}
+					turnOrdinal={selectedSpan === undefined ? undefined : turnOrdinal(selectedSpan.turn)}
+					tab={spanTab}
+					onTabChange={onSpanTabChange}
+					toolResults={toolResults}
+					onClose={() => onSelectSpan(undefined)}
+					onOpenTraceView={onOpenTraceView}
+				/>
 			</div>
 		</ReactFlowProvider>
 	)
@@ -464,15 +454,13 @@ function Ports() {
 interface StepData extends Record<string, unknown> {
 	readonly node: FlowNode
 	readonly selected: boolean
-	/** Under the keyboard's span cursor — distinct from `selected`, the open popover. */
+	/** Under the keyboard's span cursor — distinct from `selected`, the open panel. */
 	readonly focused: boolean
-	/** Set on the selected node only: it is what the span popover points at. */
-	readonly anchorRef: Ref<HTMLButtonElement>
 	readonly onSelect: (spanId: string) => void
 }
 
 const StepNode = memo(function StepNode({ data }: NodeProps & { data: StepData }) {
-	const { node, selected, focused, anchorRef, onSelect } = data
+	const { node, selected, focused, onSelect } = data
 	// The glyph carries the kind of work; a failure takes it over outright — the
 	// outcome outranks the kind, exactly as the waterfall's dots read.
 	const Icon = node.errored ? CircleXmarkIcon : CATEGORY_ICON[node.category]
@@ -481,7 +469,6 @@ const StepNode = memo(function StepNode({ data }: NodeProps & { data: StepData }
 		<>
 			<Ports />
 			<button
-				ref={anchorRef}
 				type="button"
 				onClick={() => onSelect(node.span.spanId)}
 				data-span-id={node.span.spanId}

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -45,9 +45,10 @@ const SEVERITY_DOT = {
  *
  * The page leads with a verdict and a findings list rather than another way to
  * browse the turns — Traces, Flow and Transcript already do that three ways.
- * Every finding opens the span that is its evidence in place, against the row
- * that named it: reading a finding used to cost the reader this page. The facts
- * — time bar, cost, tokens, tools — stay, each figure appearing exactly once.
+ * Every finding opens the span that is its evidence in the inspection overlay,
+ * over this page rather than instead of it: reading a finding used to cost the
+ * reader the page. The facts — time bar, cost, tokens, tools — stay, each
+ * figure appearing exactly once.
  */
 export function SessionOverview({
 	turns,
@@ -79,17 +80,7 @@ export function SessionOverview({
 		[turns],
 	)
 
-	// A finding carries a span id; the row that named it is what the popover
-	// points at. Kept together so a selection made elsewhere — a pasted `?span=`,
-	// or the reader coming back from another view — cannot anchor the panel to
-	// the row of a different span.
-	const [anchor, setAnchor] = useState<{ spanId: string; element: HTMLElement } | undefined>(undefined)
-	const anchored = anchor !== undefined && anchor.spanId === selectedSpanId
-
-	const openSpan = (spanId: string, element: HTMLElement) => {
-		setAnchor({ spanId, element })
-		onSelectSpan(selectedSpanId === spanId ? undefined : spanId)
-	}
+	const openSpan = (spanId: string) => onSelectSpan(selectedSpanId === spanId ? undefined : spanId)
 
 	return (
 		<div className="@container flex grow flex-col pt-5 pb-10">
@@ -114,8 +105,7 @@ export function SessionOverview({
 			</div>
 
 			<SpanPopover
-				span={anchored && selectedSpanId !== undefined ? spansById.get(selectedSpanId) : undefined}
-				anchor={anchored ? anchor.element : null}
+				span={selectedSpanId === undefined ? undefined : spansById.get(selectedSpanId)}
 				tab={spanTab}
 				onTabChange={onSpanTabChange}
 				toolResults={toolResults}
@@ -130,8 +120,9 @@ export function SessionOverview({
 /* Verdict                                                                    */
 /* -------------------------------------------------------------------------- */
 
-/** Open a span's payload against the element that named it. */
-type OpenSpan = (spanId: string, anchor: HTMLElement) => void
+/** Open a span's payload in the inspection overlay; opening the one already
+ *  open closes it. */
+type OpenSpan = (spanId: string) => void
 
 function Verdict({
 	verdict,
@@ -195,7 +186,7 @@ function Verdict({
 					variant="outline"
 					size="sm"
 					aria-haspopup="dialog"
-					onClick={(event) => onOpenSpan(verdict.spanId!, event.currentTarget)}
+					onClick={() => onOpenSpan(verdict.spanId!)}
 				>
 					Open failing span
 					<ArrowRightIcon size={14} />
@@ -250,7 +241,7 @@ function FindingRow({ finding, onOpenSpan }: { finding: SessionFinding; onOpenSp
 		<button
 			type="button"
 			aria-haspopup="dialog"
-			onClick={(event) => onOpenSpan(finding.spanId, event.currentTarget)}
+			onClick={() => onOpenSpan(finding.spanId)}
 			className={cn(
 				"group flex w-full items-start gap-3 border-border border-t px-3 py-3.5 text-left hover:bg-accent/40",
 				finding.severity === "failure" &&
@@ -336,7 +327,7 @@ function TurnHealthStrip({
 						key={turn.id}
 						type="button"
 						aria-haspopup="dialog"
-						onClick={(event) => onOpenSpan(turn.anchor.spanId, event.currentTarget)}
+						onClick={() => onOpenSpan(turn.anchor.spanId)}
 						title={`${turnOrdinal(turn)}${turn.label === undefined ? "" : ` — ${turn.label}`}`}
 						className={cn(
 							"flex size-8 items-center justify-center rounded-sm border font-mono text-[11px] tabular-nums",

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -21,7 +21,10 @@ import {
 	type SessionToolUsage,
 } from "@/lib/agent-sessions/session-summary"
 import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
+import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
 import { shortTarget } from "@/lib/agent-sessions/span-filters"
+import type { SpanDetailTab } from "./span-expansion"
+import { SpanPopover } from "./span-popover"
 import { OCCUPANCY_DOT_FILL, OCCUPANCY_FILL, OCCUPANCY_LABEL } from "./span-visuals"
 
 const TOKEN_BUCKETS = [
@@ -42,21 +45,51 @@ const SEVERITY_DOT = {
  *
  * The page leads with a verdict and a findings list rather than another way to
  * browse the turns — Traces, Flow and Transcript already do that three ways.
- * Every finding links the span that is its evidence, so the Overview is the
- * door into the debug views instead of a fourth sibling of them. The facts —
- * time bar, cost, tokens, tools — stay, each figure appearing exactly once.
+ * Every finding opens the span that is its evidence in place, against the row
+ * that named it: reading a finding used to cost the reader this page. The facts
+ * — time bar, cost, tokens, tools — stay, each figure appearing exactly once.
  */
 export function SessionOverview({
 	turns,
 	summary,
-	onOpenSpan,
+	selectedSpanId,
+	onSelectSpan,
+	spanTab,
+	onSpanTabChange,
+	toolResults,
+	onOpenTraceView,
 }: {
 	turns: readonly SessionTurn[]
 	summary: SessionSummary
-	/** Raised with a span id to open it in the Traces view. */
-	onOpenSpan: (spanId: string) => void
+	/** The one span open in the popover (`?span=`). */
+	selectedSpanId: string | undefined
+	/** Raised with a span id to open it, `undefined` to close. */
+	onSelectSpan: (spanId: string | undefined) => void
+	/** The popover's tab, shared with the other views. */
+	spanTab: SpanDetailTab | undefined
+	onSpanTabChange: (tab: SpanDetailTab) => void
+	/** The session's captured tool results by call id, for the popover. */
+	toolResults?: SessionToolResults
+	/** The popover's "Open in Traces view": same span, sibling view. */
+	onOpenTraceView: () => void
 }) {
 	const report = useMemo(() => buildSessionFindings(turns, summary), [turns, summary])
+	const spansById = useMemo(
+		() => new Map(turns.flatMap((turn) => turn.spans).map((span) => [span.spanId, span])),
+		[turns],
+	)
+
+	// A finding carries a span id; the row that named it is what the popover
+	// points at. Kept together so a selection made elsewhere — a pasted `?span=`,
+	// or the reader coming back from another view — cannot anchor the panel to
+	// the row of a different span.
+	const [anchor, setAnchor] = useState<{ spanId: string; element: HTMLElement } | undefined>(undefined)
+	const anchored = anchor !== undefined && anchor.spanId === selectedSpanId
+
+	const openSpan = (spanId: string, element: HTMLElement) => {
+		setAnchor({ spanId, element })
+		onSelectSpan(selectedSpanId === spanId ? undefined : spanId)
+	}
 
 	return (
 		<div className="@container flex grow flex-col pt-5 pb-10">
@@ -66,19 +99,29 @@ export function SessionOverview({
 						verdict={report.verdict}
 						findingCount={report.findings.length}
 						turns={turns}
-						onOpenSpan={onOpenSpan}
+						onOpenSpan={openSpan}
 					/>
-					<Findings findings={report.findings} onOpenSpan={onOpenSpan} />
+					<Findings findings={report.findings} onOpenSpan={openSpan} />
 					<TurnHealthStrip
 						turns={turns}
 						health={report.turnHealth}
 						summary={summary}
-						onOpenSpan={onOpenSpan}
+						onOpenSpan={openSpan}
 					/>
 					<TimeComposition summary={summary} turns={turns} />
 				</div>
 				<Rail summary={summary} />
 			</div>
+
+			<SpanPopover
+				span={anchored && selectedSpanId !== undefined ? spansById.get(selectedSpanId) : undefined}
+				anchor={anchored ? anchor.element : null}
+				tab={spanTab}
+				onTabChange={onSpanTabChange}
+				toolResults={toolResults}
+				onClose={() => onSelectSpan(undefined)}
+				onOpenTraceView={onOpenTraceView}
+			/>
 		</div>
 	)
 }
@@ -86,6 +129,9 @@ export function SessionOverview({
 /* -------------------------------------------------------------------------- */
 /* Verdict                                                                    */
 /* -------------------------------------------------------------------------- */
+
+/** Open a span's payload against the element that named it. */
+type OpenSpan = (spanId: string, anchor: HTMLElement) => void
 
 function Verdict({
 	verdict,
@@ -96,7 +142,7 @@ function Verdict({
 	verdict: SessionVerdict
 	findingCount: number
 	turns: readonly SessionTurn[]
-	onOpenSpan: (spanId: string) => void
+	onOpenSpan: OpenSpan
 }) {
 	const turnWord = turns[0]?.anchorKind === "trace" ? "segment" : "turn"
 	const turnsText = `${turns.length} ${turnWord}${turns.length === 1 ? "" : "s"}`
@@ -145,7 +191,12 @@ function Verdict({
 				)}
 			</div>
 			{verdict.spanId !== undefined && (
-				<Button variant="outline" size="sm" onClick={() => onOpenSpan(verdict.spanId!)}>
+				<Button
+					variant="outline"
+					size="sm"
+					aria-haspopup="dialog"
+					onClick={(event) => onOpenSpan(verdict.spanId!, event.currentTarget)}
+				>
 					Open failing span
 					<ArrowRightIcon size={14} />
 				</Button>
@@ -162,13 +213,7 @@ function VerdictDot({ className }: { className: string }) {
 /* Findings                                                                   */
 /* -------------------------------------------------------------------------- */
 
-function Findings({
-	findings,
-	onOpenSpan,
-}: {
-	findings: readonly SessionFinding[]
-	onOpenSpan: (spanId: string) => void
-}) {
+function Findings({ findings, onOpenSpan }: { findings: readonly SessionFinding[]; onOpenSpan: OpenSpan }) {
 	return (
 		<section>
 			<div className="flex items-baseline justify-between gap-2 pb-3.5">
@@ -200,17 +245,12 @@ function Findings({
 	)
 }
 
-function FindingRow({
-	finding,
-	onOpenSpan,
-}: {
-	finding: SessionFinding
-	onOpenSpan: (spanId: string) => void
-}) {
+function FindingRow({ finding, onOpenSpan }: { finding: SessionFinding; onOpenSpan: OpenSpan }) {
 	return (
 		<button
 			type="button"
-			onClick={() => onOpenSpan(finding.spanId)}
+			aria-haspopup="dialog"
+			onClick={(event) => onOpenSpan(finding.spanId, event.currentTarget)}
 			className={cn(
 				"group flex w-full items-start gap-3 border-border border-t px-3 py-3.5 text-left hover:bg-accent/40",
 				finding.severity === "failure" &&
@@ -239,7 +279,7 @@ function FindingRow({
 				)}
 			</span>
 			<span className="mt-0.5 flex shrink-0 items-center gap-1 text-muted-foreground text-xs opacity-0 transition-opacity group-hover:opacity-100">
-				trace
+				inspect
 				<ArrowRightIcon size={12} />
 			</span>
 		</button>
@@ -265,7 +305,7 @@ function TurnHealthStrip({
 	turns: readonly SessionTurn[]
 	health: readonly TurnHealth[]
 	summary: SessionSummary
-	onOpenSpan: (spanId: string) => void
+	onOpenSpan: OpenSpan
 }) {
 	// "with errors", not "failed": a red cell marks a turn something went wrong
 	// INSIDE — the turn itself may have closed cleanly, and calling it failed
@@ -295,7 +335,8 @@ function TurnHealthStrip({
 					<button
 						key={turn.id}
 						type="button"
-						onClick={() => onOpenSpan(turn.anchor.spanId)}
+						aria-haspopup="dialog"
+						onClick={(event) => onOpenSpan(turn.anchor.spanId, event.currentTarget)}
 						title={`${turnOrdinal(turn)}${turn.label === undefined ? "" : ` — ${turn.label}`}`}
 						className={cn(
 							"flex size-8 items-center justify-center rounded-sm border font-mono text-[11px] tabular-nums",

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -210,8 +210,8 @@ export function SessionViews({
 			    scroller gave up (`pb-0`, so the Flow floor can pin flush — see the
 			    route); the Flow view stays unpadded for the same reason. Only the
 			    active view sees the span selection: an outgoing panel stays
-			    mounted until its exit transition completes, and two views must
-			    never hold the inspection popover open at once. */}
+			    mounted until its exit transition completes, and two views holding
+			    the inspection overlay open would stack two scrims. */}
 			<TabsContent value="overview" className="flex flex-[1_1_auto] flex-col pb-4">
 				<SessionOverview
 					turns={turns}

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -62,9 +62,9 @@ export function SessionViews({
 	summary: SessionSummary
 	/** The response dropped the END of the session — the transcript says so. */
 	truncated: boolean
-	/** The span expanded inline / open in the flow drawer (`?span=`). */
+	/** The span open in the inspection popover, in whichever view (`?span=`). */
 	selectedSpanId: string | undefined
-	/** Raised with a span id to expand it, `undefined` to collapse. */
+	/** Raised with a span id to open it, `undefined` to close. */
 	onSelectSpan: (spanId: string | undefined) => void
 }) {
 	const [query, setQuery] = useState("")
@@ -82,9 +82,9 @@ export function SessionViews({
 	// keyed by row, and holds the rows flipped AWAY from their default.
 	const [openRows, setOpenRows] = useState<ReadonlySet<string>>(() => new Set())
 	const [zoom, setZoom] = useState(1)
-	// One tab choice for every span expansion, in both debug views: switching
-	// spans — or Trace ↔ Flow — keeps the reader on the tab they chose.
-	// `undefined` means no choice yet, and the expansion picks by content.
+	// One tab choice for every span the popover opens, in every view: switching
+	// spans — or views — keeps the reader on the tab they chose. `undefined`
+	// means no choice yet, and the panel picks by content.
 	const [spanTab, setSpanTab] = useState<SpanDetailTab | undefined>(undefined)
 
 	// 1/2/3/4 switch views from anywhere on the page — the switcher stays
@@ -213,12 +213,12 @@ export function SessionViews({
 				<SessionOverview
 					turns={turns}
 					summary={summary}
-					// A finding's evidence lives in the Traces view: select the span and
-					// go — the waterfall scrolls to and expands the selection on mount.
-					onOpenSpan={(spanId) => {
-						onSelectSpan(spanId)
-						onViewChange("trace")
-					}}
+					selectedSpanId={selectedSpanId}
+					onSelectSpan={onSelectSpan}
+					spanTab={spanTab}
+					onSpanTabChange={setSpanTab}
+					toolResults={toolResults}
+					onOpenTraceView={() => onViewChange("trace")}
 				/>
 			</TabsContent>
 			<TabsContent value="trace" className="flex flex-[1_1_auto] flex-col pb-4">

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -208,12 +208,15 @@ export function SessionViews({
 
 			{/* Overview, Trace and Transcript carry the bottom padding the page
 			    scroller gave up (`pb-0`, so the Flow floor can pin flush — see the
-			    route); the Flow view stays unpadded for the same reason. */}
+			    route); the Flow view stays unpadded for the same reason. Only the
+			    active view sees the span selection: an outgoing panel stays
+			    mounted until its exit transition completes, and two views must
+			    never hold the inspection popover open at once. */}
 			<TabsContent value="overview" className="flex flex-[1_1_auto] flex-col pb-4">
 				<SessionOverview
 					turns={turns}
 					summary={summary}
-					selectedSpanId={selectedSpanId}
+					selectedSpanId={view === "overview" ? selectedSpanId : undefined}
 					onSelectSpan={onSelectSpan}
 					spanTab={spanTab}
 					onSpanTabChange={setSpanTab}
@@ -230,7 +233,7 @@ export function SessionViews({
 					collapseIdle={collapseIdle}
 					collapsedTurns={collapsedTurns}
 					onToggleTurn={(turnId) => setCollapsedTurns((previous) => toggled(previous, turnId))}
-					selectedSpanId={selectedSpanId}
+					selectedSpanId={view === "trace" ? selectedSpanId : undefined}
 					onSelectSpan={onSelectSpan}
 					spanTab={spanTab}
 					onSpanTabChange={setSpanTab}
@@ -245,7 +248,7 @@ export function SessionViews({
 					agentSpansOnly={agentSpansOnly}
 					zoom={zoom}
 					onZoomChange={setZoom}
-					selectedSpanId={selectedSpanId}
+					selectedSpanId={view === "flow" ? selectedSpanId : undefined}
 					onSelectSpan={onSelectSpan}
 					spanTab={spanTab}
 					onSpanTabChange={setSpanTab}

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo, useRef, useState, type Ref } from "react"
 import { Link } from "@tanstack/react-router"
 import { useVirtualizer } from "@tanstack/react-virtual"
 
@@ -30,18 +30,15 @@ import {
 } from "@/lib/agent-sessions/session-turns"
 import { filterSpans, isDelegation, shortTarget } from "@/lib/agent-sessions/span-filters"
 import { Pill } from "./pill"
-import { SpanInlineDetail, type SpanDetailTab } from "./span-expansion"
+import type { SpanDetailTab } from "./span-expansion"
+import { SpanPopover } from "./span-popover"
 import { CATEGORY_FILL, CATEGORY_ICON, CATEGORY_TEXT } from "./span-visuals"
 
-// Row heights are fixed and known, so the virtualizer never has to measure —
-// except the one inline detail row, whose height is its payload's and is
-// measured (`measureElement`) instead.
+// Every row height is fixed and known, so the virtualizer never measures.
 const TURN_ROW_HEIGHT = 30
 /** Two above the old 26: the category glyphs need a touch more air than the
  *  dots they replaced. */
 const ROW_HEIGHT = 28
-/** Starting guess for the detail row; the measurement replaces it on mount. */
-const DETAIL_ROW_ESTIMATE = 480
 /** Past this the indent eats the span name; deep agent trees are common. */
 const MAX_INDENT_DEPTH = 6
 const INDENT_PX = 14
@@ -69,7 +66,6 @@ type WaterfallRow =
 			readonly visibleCount: number
 	  }
 	| { readonly kind: "span"; readonly key: string; readonly span: AiSessionSpan; readonly depth: number }
-	| { readonly kind: "detail"; readonly key: string; readonly span: AiSessionSpan }
 	| { readonly kind: "gap"; readonly key: string; readonly gap: IdleGap }
 
 interface SessionWaterfallProps {
@@ -83,14 +79,14 @@ interface SessionWaterfallProps {
 	/** Expansion state lives in SessionViews so a Trace → Flow → Trace round-trip keeps it. */
 	collapsedTurns: ReadonlySet<string>
 	onToggleTurn: (turnId: string) => void
-	/** The one span expanded inline (`?span=`). */
+	/** The one span open in the popover (`?span=`). */
 	selectedSpanId: string | undefined
-	/** Raised with a span id to expand it, `undefined` to collapse. */
+	/** Raised with a span id to open it, `undefined` to close. */
 	onSelectSpan: (spanId: string | undefined) => void
-	/** The expansion's tab, shared with the Flow view's drawer. */
+	/** The popover's tab, shared with the other views. */
 	spanTab: SpanDetailTab | undefined
 	onSpanTabChange: (tab: SpanDetailTab) => void
-	/** The session's captured tool results by call id, for the expansion. */
+	/** The session's captured tool results by call id, for the popover. */
 	toolResults?: ReadonlyMap<string, string>
 }
 
@@ -116,6 +112,12 @@ export function SessionWaterfall({
 		[turns],
 	)
 
+	// The popover points at the selected row itself, attached by the row's own
+	// ref: a row scrolled out of the virtualizer's window unmounts, which closes
+	// the popover instead of leaving it pointing at a detached box, and scrolling
+	// back re-attaches it — the selection never left the URL.
+	const [anchor, setAnchor] = useState<HTMLElement | null>(null)
+
 	const collapsedGaps = collapseIdle ? summary.idleGaps : NO_GAPS
 	const axis = useMemo(
 		() => buildSessionAxis({ startMs: summary.startMs, endMs: summary.endMs, collapsedGaps }),
@@ -124,27 +126,22 @@ export function SessionWaterfall({
 	const ticks = axis.ticks
 
 	const rows = useMemo(
-		() =>
-			buildRows({ turns, gaps: collapsedGaps, collapsedTurns, query, agentSpansOnly, selectedSpanId }),
-		[turns, collapsedGaps, collapsedTurns, query, agentSpansOnly, selectedSpanId],
+		() => buildRows({ turns, gaps: collapsedGaps, collapsedTurns, query, agentSpansOnly }),
+		[turns, collapsedGaps, collapsedTurns, query, agentSpansOnly],
 	)
 
 	const virtualizer = useVirtualizer({
 		count: rows.length,
 		getScrollElement,
-		estimateSize: (index) => {
-			const row = rows[index]!
-			if (row.kind === "turn") return TURN_ROW_HEIGHT
-			if (row.kind === "detail") return DETAIL_ROW_ESTIMATE
-			return ROW_HEIGHT
-		},
+		estimateSize: (index) => (rows[index]!.kind === "turn" ? TURN_ROW_HEIGHT : ROW_HEIGHT),
 		getItemKey: (index) => rows[index]!.key,
 		overscan: 16,
 		scrollMargin,
 	})
 
 	// The keyboard's span cursor: ↑/↓ walk the span rows the filter left
-	// visible, Enter expands the one under the cursor, Esc collapses.
+	// visible, Enter opens the one under the cursor. Escape is the popover's
+	// once one is open; this one covers the rest.
 	const spanRowIndexById = useMemo(() => {
 		const byId = new Map<string, number>()
 		rows.forEach((row, index) => {
@@ -169,8 +166,9 @@ export function SessionWaterfall({
 	})
 
 	// A pasted `?span=` link lands on the exact span it names: the cursor starts
-	// there and the row is scrolled into view. Once, on mount — after that the
-	// URL follows the reader rather than leading them.
+	// there and the row is scrolled into view, which is also what puts the
+	// popover's anchor on screen. Once, on mount — after that the URL follows the
+	// reader rather than leading them.
 	const didInitialScroll = useRef(false)
 	useEffect(() => {
 		if (didInitialScroll.current || selectedSpanId === undefined) return
@@ -238,25 +236,18 @@ export function SessionWaterfall({
 					<div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
 						{virtualizer.getVirtualItems().map((item) => {
 							const row = rows[item.index]!
+							const selected = row.kind === "span" && selectedSpanId === row.span.spanId
 							return (
 								<div
 									key={item.key}
-									// Only the detail row is measured: its height is its
-									// payload's, and the fixed rows stay estimate-only.
-									ref={row.kind === "detail" ? virtualizer.measureElement : undefined}
 									data-index={item.index}
 									className="absolute inset-x-0 top-0"
 									// `start` is in the page scroller's coordinates; the margin
-									// brings it back to this list's own. The detail row takes its
-									// height from its payload instead of the estimate.
-									style={
-										row.kind === "detail"
-											? { transform: `translateY(${item.start - scrollMargin}px)` }
-											: {
-													height: item.size,
-													transform: `translateY(${item.start - scrollMargin}px)`,
-												}
-									}
+									// brings it back to this list's own.
+									style={{
+										height: item.size,
+										transform: `translateY(${item.start - scrollMargin}px)`,
+									}}
 								>
 									{row.kind === "turn" && (
 										<TurnHeader
@@ -269,27 +260,16 @@ export function SessionWaterfall({
 									)}
 									{row.kind === "span" && (
 										<SpanRow
+											ref={selected ? setAnchor : null}
 											row={row}
 											axis={axis}
 											spansById={spansById}
-											selected={selectedSpanId === row.span.spanId}
+											selected={selected}
 											focused={focusedId === row.span.spanId}
 											onClick={() => {
 												setFocusedId(row.span.spanId)
-												onSelectSpan(
-													selectedSpanId === row.span.spanId
-														? undefined
-														: row.span.spanId,
-												)
+												onSelectSpan(selected ? undefined : row.span.spanId)
 											}}
-										/>
-									)}
-									{row.kind === "detail" && (
-										<SpanInlineDetail
-											span={row.span}
-											tab={spanTab}
-											onTabChange={onSpanTabChange}
-											toolResults={toolResults}
 										/>
 									)}
 									{row.kind === "gap" && <GapRow gap={row.gap} />}
@@ -299,6 +279,15 @@ export function SessionWaterfall({
 					</div>
 				)}
 			</div>
+
+			<SpanPopover
+				span={selectedSpanId === undefined ? undefined : spansById.get(selectedSpanId)}
+				anchor={anchor}
+				tab={spanTab}
+				onTabChange={onSpanTabChange}
+				toolResults={toolResults}
+				onClose={() => onSelectSpan(undefined)}
+			/>
 		</div>
 	)
 }
@@ -321,7 +310,6 @@ function buildRows(input: {
 	collapsedTurns: ReadonlySet<string>
 	query: string
 	agentSpansOnly: boolean
-	selectedSpanId: string | undefined
 }): readonly WaterfallRow[] {
 	const surviving = input.turns.flatMap((turn) => {
 		const spans = filterSpans(turn.spans, input.query, input.agentSpansOnly)
@@ -355,11 +343,6 @@ function buildRows(input: {
 			// turn's own rows split cleanly at the first span that starts after it.
 			flushGaps(spanStartMs(span))
 			rows.push({ kind: "span", key: `${turn.id}:${span.spanId}`, span, depth })
-			// The selected span's payload expands inline, directly under its row —
-			// one at a time, which is why this is the selection and not a set.
-			if (span.spanId === input.selectedSpanId) {
-				rows.push({ kind: "detail", key: `detail:${span.spanId}`, span })
-			}
 		}
 		flushGaps(turn.endMs)
 	}
@@ -518,6 +501,7 @@ function TraceLink({ traceId, timestamp }: { traceId: string; timestamp: string 
 }
 
 function SpanRow({
+	ref,
 	row,
 	axis,
 	spansById,
@@ -525,11 +509,13 @@ function SpanRow({
 	focused,
 	onClick,
 }: {
+	/** Set on the selected row only: it is what the span popover points at. */
+	ref: Ref<HTMLButtonElement>
 	row: Extract<WaterfallRow, { kind: "span" }>
 	axis: SessionAxis
 	spansById: ReadonlyMap<string, AiSessionSpan>
 	selected: boolean
-	/** Under the keyboard's span cursor — distinct from `selected`, which means expanded. */
+	/** Under the keyboard's span cursor — distinct from `selected`, which means open. */
 	focused: boolean
 	onClick: () => void
 }) {
@@ -546,9 +532,11 @@ function SpanRow({
 
 	return (
 		<button
+			ref={ref}
 			type="button"
 			onClick={onClick}
 			aria-current={selected || undefined}
+			aria-haspopup="dialog"
 			aria-expanded={selected}
 			className={cn(
 				"flex h-full w-full cursor-pointer items-center px-2.5 text-left text-xs hover:bg-accent/40",

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type Ref } from "react"
+import { useEffect, useMemo, useRef } from "react"
 import { Link } from "@tanstack/react-router"
 import { useVirtualizer } from "@tanstack/react-virtual"
 
@@ -112,12 +112,6 @@ export function SessionWaterfall({
 		[turns],
 	)
 
-	// The popover points at the selected row itself, attached by the row's own
-	// ref: a row scrolled out of the virtualizer's window unmounts, which closes
-	// the popover instead of leaving it pointing at a detached box, and scrolling
-	// back re-attaches it — the selection never left the URL.
-	const [anchor, setAnchor] = useState<HTMLElement | null>(null)
-
 	const collapsedGaps = collapseIdle ? summary.idleGaps : NO_GAPS
 	const axis = useMemo(
 		() => buildSessionAxis({ startMs: summary.startMs, endMs: summary.endMs, collapsedGaps }),
@@ -166,9 +160,9 @@ export function SessionWaterfall({
 	})
 
 	// A pasted `?span=` link lands on the exact span it names: the cursor starts
-	// there and the row is scrolled into view, which is also what puts the
-	// popover's anchor on screen. Once, on mount — after that the URL follows the
-	// reader rather than leading them.
+	// there and the row is scrolled into view, so the row is waiting underneath
+	// when the reader closes the overlay. Once, on mount — after that the URL
+	// follows the reader rather than leading them.
 	const didInitialScroll = useRef(false)
 	useEffect(() => {
 		if (didInitialScroll.current || selectedSpanId === undefined) return
@@ -260,7 +254,6 @@ export function SessionWaterfall({
 									)}
 									{row.kind === "span" && (
 										<SpanRow
-											ref={selected ? setAnchor : null}
 											row={row}
 											axis={axis}
 											spansById={spansById}
@@ -282,7 +275,6 @@ export function SessionWaterfall({
 
 			<SpanPopover
 				span={selectedSpanId === undefined ? undefined : spansById.get(selectedSpanId)}
-				anchor={anchor}
 				tab={spanTab}
 				onTabChange={onSpanTabChange}
 				toolResults={toolResults}
@@ -501,7 +493,6 @@ function TraceLink({ traceId, timestamp }: { traceId: string; timestamp: string 
 }
 
 function SpanRow({
-	ref,
 	row,
 	axis,
 	spansById,
@@ -509,8 +500,6 @@ function SpanRow({
 	focused,
 	onClick,
 }: {
-	/** Set on the selected row only: it is what the span popover points at. */
-	ref: Ref<HTMLButtonElement>
 	row: Extract<WaterfallRow, { kind: "span" }>
 	axis: SessionAxis
 	spansById: ReadonlyMap<string, AiSessionSpan>
@@ -532,7 +521,6 @@ function SpanRow({
 
 	return (
 		<button
-			ref={ref}
 			type="button"
 			onClick={onClick}
 			aria-current={selected || undefined}

--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -44,11 +44,15 @@ import { Pill } from "./pill"
 
 /**
  * The payload of one span. The chrome around it is the caller's — today that is
- * `SpanPopover`, which every view opens against whatever the reader clicked —
- * and it reaches this body through `header`.
+ * `SpanPopover`, the overlay every view opens a span into — and it reaches this
+ * body through `header`.
  */
 
 export type SpanDetailTab = "details" | "messages" | "tools" | "logs"
+
+/** The overlay is a reading surface, not a peek, so a payload gets twice the
+ *  transcript's twelve lines before it asks to be expanded. */
+const PANEL_CLAMP = "line-clamp-[24]"
 
 export function SpanExpansion({
 	span,
@@ -110,9 +114,12 @@ export function SpanExpansion({
 	)
 
 	return (
-		<div className="flex min-w-0 flex-col text-left">
+		// The header and the tab strip are the panel's fixed chrome; only the
+		// payload under them scrolls, so switching tabs never costs the reader the
+		// span's name or the way out.
+		<div className="flex min-h-0 min-w-0 grow flex-col text-left">
 			{header}
-			<div className="flex flex-wrap items-center gap-2 border-border border-b pb-1.5">
+			<div className="flex shrink-0 flex-wrap items-center gap-2 border-border border-b px-5 pb-2">
 				{tabs}
 				<div className="ml-auto flex items-center gap-2">
 					<CopySpanJsonButton span={span} />
@@ -120,12 +127,14 @@ export function SpanExpansion({
 				</div>
 			</div>
 
-			<MetaStrip span={span} />
+			<div className="min-h-0 grow overflow-y-auto overscroll-contain px-5 pb-6">
+				<MetaStrip span={span} />
 
-			{active === "details" && <DetailsSection span={span} toolCalls={toolCalls} />}
-			{active === "messages" && <MessagesSection messages={messages} span={span} />}
-			{active === "tools" && <ToolCallsSection toolCalls={toolCalls} />}
-			{active === "logs" && <LogsSection span={span} />}
+				{active === "details" && <DetailsSection span={span} toolCalls={toolCalls} />}
+				{active === "messages" && <MessagesSection messages={messages} span={span} />}
+				{active === "tools" && <ToolCallsSection toolCalls={toolCalls} />}
+				{active === "logs" && <LogsSection span={span} />}
+			</div>
 		</div>
 	)
 }
@@ -330,6 +339,7 @@ function SystemMessageRow({ message }: { message: SpanMessage }) {
 					<div className="min-w-0 grow">
 						<ClampedText
 							text={text}
+							clampClass={PANEL_CLAMP}
 							body={raw ? undefined : <MessageResponse className="text-sm">{text}</MessageResponse>}
 						/>
 					</div>
@@ -383,6 +393,7 @@ function MessagePart({ part, raw }: { part: SpanMessagePart; raw: boolean }) {
 		return (
 			<ClampedText
 				text={part.text}
+				clampClass={PANEL_CLAMP}
 				body={raw ? undefined : <MessageResponse className="text-sm">{part.text}</MessageResponse>}
 			/>
 		)
@@ -409,7 +420,7 @@ function ReasoningPart({ part }: { part: Extract<SpanMessagePart, { kind: "reaso
 						: "No reasoning text was captured."}
 				</p>
 			) : (
-				<ClampedText text={part.text} />
+				<ClampedText text={part.text} clampClass={PANEL_CLAMP} />
 			)}
 		</div>
 	)
@@ -540,7 +551,12 @@ function PayloadBody({ text, copyLabel }: { text: string; copyLabel: string }) {
 	return (
 		<div className="flex items-start gap-1.5 border-border/60 border-t bg-background/50 px-2.5 py-2">
 			<div className="min-w-0 grow">
-				<ClampedText text={raw ? text : formatted} html={raw ? undefined : highlighted} mono />
+				<ClampedText
+					text={raw ? text : formatted}
+					html={raw ? undefined : highlighted}
+					clampClass={PANEL_CLAMP}
+					mono
+				/>
 			</div>
 			{highlighted !== undefined && (
 				<ViewSwitch rendered="json" raw={raw} onRawChange={setRaw} className="self-start" />

--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -16,10 +16,8 @@ import {
 	ChevronDownIcon,
 	ChevronRightIcon,
 	CircleWarningIcon,
-	CircleXmarkIcon,
 	CopyIcon,
 	ExternalLinkIcon,
-	XmarkIcon,
 } from "@/components/icons"
 import { MessageResponse } from "@/components/ai-elements/message-response"
 import { AttributesSection, CopyableValue, ResourceAttributesSection } from "@/components/attributes"
@@ -38,18 +36,16 @@ import {
 	type SpanMessagePart,
 	type SpanToolCall,
 } from "@/lib/agent-sessions/span-detail"
-import { classifyAiSpan, spanFailed, spanModel, spanTtftMs } from "@/lib/agent-sessions/session-turns"
+import { classifyAiSpan, spanFailed, spanTtftMs } from "@/lib/agent-sessions/session-turns"
 import { callMetaLine, formatCost } from "@/lib/agent-sessions/session-summary"
 import { ClampedText, firstLine } from "./clamped-text"
 import { useJsonPayload, ViewSegment, ViewSwitch } from "./payload-view"
 import { Pill } from "./pill"
-import { CATEGORY_ICON, CATEGORY_TEXT } from "./span-visuals"
 
 /**
- * The payload of one span, expanded in place — under its waterfall row, or in
- * the Flow view's docked drawer. One component for both because the spec's
- * whole point is that a span reads the same wherever it was opened; only the
- * header differs, and the caller supplies that through `header`.
+ * The payload of one span. The chrome around it is the caller's — today that is
+ * `SpanPopover`, which every view opens against whatever the reader clicked —
+ * and it reaches this body through `header`.
  */
 
 export type SpanDetailTab = "details" | "messages" | "tools" | "logs"
@@ -57,16 +53,13 @@ export type SpanDetailTab = "details" | "messages" | "tools" | "logs"
 export function SpanExpansion({
 	span,
 	header,
-	tabsInHeader = false,
 	tab,
 	onTabChange,
 	toolResults,
 }: {
 	span: AiSessionSpan
-	/** Rendered above the tabs; receives the tab strip when `tabsInHeader`. */
-	header?: (tabs: ReactNode) => ReactNode
-	/** Drawer layout: the tab strip rides inside the header row. */
-	tabsInHeader?: boolean
+	/** Rendered above the tab strip. */
+	header?: ReactNode
 	/** The reader's tab choice, held by SessionViews so it survives switching
 	 *  spans and views; `undefined` means none made yet — pick by content. */
 	tab: SpanDetailTab | undefined
@@ -118,16 +111,14 @@ export function SpanExpansion({
 
 	return (
 		<div className="flex min-w-0 flex-col text-left">
-			{header !== undefined && header(tabsInHeader ? tabs : null)}
-			{!tabsInHeader && (
-				<div className="flex flex-wrap items-center gap-2 border-border border-b pb-1.5">
-					{tabs}
-					<div className="ml-auto flex items-center gap-2">
-						<CopySpanJsonButton span={span} />
-						<OpenInTracesLink span={span} />
-					</div>
+			{header}
+			<div className="flex flex-wrap items-center gap-2 border-border border-b pb-1.5">
+				{tabs}
+				<div className="ml-auto flex items-center gap-2">
+					<CopySpanJsonButton span={span} />
+					<OpenInTracesLink span={span} />
 				</div>
-			)}
+			</div>
 
 			<MetaStrip span={span} />
 
@@ -135,111 +126,6 @@ export function SpanExpansion({
 			{active === "messages" && <MessagesSection messages={messages} span={span} />}
 			{active === "tools" && <ToolCallsSection toolCalls={toolCalls} />}
 			{active === "logs" && <LogsSection span={span} />}
-		</div>
-	)
-}
-
-/** The inline form the Traces view mounts under the selected row. */
-export function SpanInlineDetail({
-	span,
-	tab,
-	onTabChange,
-	toolResults,
-}: {
-	span: AiSessionSpan
-	tab: SpanDetailTab | undefined
-	onTabChange: (tab: SpanDetailTab) => void
-	toolResults?: SessionToolResults
-}) {
-	return (
-		<div
-			data-slot="span-inline-detail"
-			className="border-primary border-l-2 border-border border-b bg-card/40 py-2 pr-3 pl-6"
-		>
-			<SpanExpansion
-				key={span.spanId}
-				span={span}
-				tab={tab}
-				onTabChange={onTabChange}
-				toolResults={toolResults}
-			/>
-		</div>
-	)
-}
-
-/** The docked drawer the Flow view opens along the bottom of the canvas. */
-export function SpanDrawer({
-	span,
-	turnOrdinal,
-	tab,
-	onTabChange,
-	toolResults,
-	onClose,
-	onOpenTraceView,
-}: {
-	span: AiSessionSpan
-	/** "Turn 3" / "Segment 2" — where the span lives, for the drawer's title row. */
-	turnOrdinal: string | undefined
-	tab: SpanDetailTab | undefined
-	onTabChange: (tab: SpanDetailTab) => void
-	toolResults?: SessionToolResults
-	onClose: () => void
-	/** Switch to the Traces view with this span still selected. */
-	onOpenTraceView: () => void
-}) {
-	const category = classifyAiSpan(span)
-	const errored = spanFailed(span)
-	// The canvas the drawer docks under draws its nodes with these glyphs, so the
-	// drawer names its span in the same vocabulary.
-	const Glyph = errored ? CircleXmarkIcon : CATEGORY_ICON[category]
-	const subtitle = [turnOrdinal, spanModel(span), formatDuration(span.durationMs)]
-		.filter((part): part is string => part !== undefined)
-		.join(" · ")
-
-	return (
-		<div
-			data-slot="span-drawer"
-			className="max-h-[45vh] overflow-y-auto border-border border-t bg-background px-4 pb-4"
-		>
-			<SpanExpansion
-				key={span.spanId}
-				span={span}
-				tab={tab}
-				onTabChange={onTabChange}
-				toolResults={toolResults}
-				tabsInHeader
-				header={(tabs) => (
-					<div className="sticky top-0 z-10 flex flex-wrap items-center gap-x-3 gap-y-1 bg-background py-2">
-						<Glyph
-							aria-hidden
-							size={13}
-							className={cn("shrink-0", errored ? "text-destructive" : CATEGORY_TEXT[category])}
-						/>
-						<span className="font-medium font-mono text-sm">{span.spanName}</span>
-						{subtitle !== "" && <span className="text-muted-foreground text-xs">{subtitle}</span>}
-						{tabs}
-						<div className="ml-auto flex items-center gap-2">
-							<CopySpanJsonButton span={span} />
-							<Button
-								variant="outline"
-								size="sm"
-								className="h-6.5 text-xs"
-								onClick={onOpenTraceView}
-							>
-								Open in Traces view
-							</Button>
-							<Button
-								variant="ghost"
-								size="icon-sm"
-								aria-label="Close span detail"
-								onClick={onClose}
-							>
-								<XmarkIcon size={14} />
-							</Button>
-						</div>
-					</div>
-				)}
-			/>
 		</div>
 	)
 }

--- a/apps/web/src/components/agent-sessions/session-detail/span-popover.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-popover.tsx
@@ -1,0 +1,148 @@
+import type { ComponentProps } from "react"
+
+import type { AiSessionSpan } from "@maple/domain/http"
+import { Button } from "@maple/ui/components/ui/button"
+import { Popover, PopoverContent } from "@maple/ui/components/ui/popover"
+import { formatDuration } from "@maple/ui/lib/format"
+import { cn } from "@maple/ui/lib/utils"
+
+import { CircleXmarkIcon, XmarkIcon } from "@/components/icons"
+import { classifyAiSpan, spanFailed, spanModel } from "@/lib/agent-sessions/session-turns"
+import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
+import { SpanExpansion, type SpanDetailTab } from "./span-expansion"
+import { CATEGORY_ICON, CATEGORY_TEXT } from "./span-visuals"
+
+/** What the popover points at — a row, a node, a cell. A ref is accepted so a
+ *  view can name a fallback container it has not rendered yet. */
+export type SpanAnchor = ComponentProps<typeof PopoverContent>["anchor"]
+
+/**
+ * One span, inspected in place.
+ *
+ * Every view opens the same panel against whatever the reader clicked: the
+ * Overview's findings, the flow's nodes, the waterfall's rows. It replaced
+ * three different chromes — a tab switch, a docked drawer and an inline row —
+ * that each answered the same question in a different place, and each cost the
+ * reader the view they were reading it from.
+ *
+ * The popover is open exactly when a span is selected AND its anchor is on
+ * screen. In the virtualized waterfall the anchor row unmounts when it scrolls
+ * far enough away, which closes the panel rather than leaving it pointing at a
+ * detached box; the selection stays in the URL, so scrolling back reopens it.
+ */
+export function SpanPopover({
+	span,
+	anchor,
+	turnOrdinal,
+	tab,
+	onTabChange,
+	toolResults,
+	onClose,
+	onOpenTraceView,
+}: {
+	/** The selected span, or `undefined` when nothing is open. */
+	span: AiSessionSpan | undefined
+	anchor: SpanAnchor
+	/** "Turn 3" / "Segment 2" — where the span lives, for the title row. */
+	turnOrdinal?: string | undefined
+	/** The reader's tab choice, held by SessionViews so it survives switching
+	 *  spans and views; `undefined` means none made yet — pick by content. */
+	tab: SpanDetailTab | undefined
+	onTabChange: (tab: SpanDetailTab) => void
+	/** The session's captured tool results by call id (`sessionToolResults`). */
+	toolResults?: SessionToolResults
+	/** Clears the selection: Escape, the close button, a press outside. */
+	onClose: () => void
+	/** Offered only where the reader is not already in the Traces view. */
+	onOpenTraceView?: (() => void) | undefined
+}) {
+	const open = span !== undefined && anchor !== null && anchor !== undefined
+
+	return (
+		<Popover
+			open={open}
+			onOpenChange={(next) => {
+				if (!next) onClose()
+			}}
+		>
+			{span !== undefined && (
+				<PopoverContent
+					anchor={anchor}
+					side="bottom"
+					align="start"
+					className="max-h-[min(32rem,var(--available-height))] w-[min(40rem,calc(100vw-2rem))]"
+				>
+					{/* The panel's own handle, for the page's tests and for anything
+					    that needs to find it inside the portal. */}
+					<div data-slot="span-popover" className="min-w-0">
+						<SpanExpansion
+							key={span.spanId}
+							span={span}
+							tab={tab}
+							onTabChange={onTabChange}
+							toolResults={toolResults}
+							header={
+								<TitleRow
+									span={span}
+									turnOrdinal={turnOrdinal}
+									onClose={onClose}
+									onOpenTraceView={onOpenTraceView}
+								/>
+							}
+						/>
+					</div>
+				</PopoverContent>
+			)}
+		</Popover>
+	)
+}
+
+/** Names the span in the same vocabulary the row or node that opened it used,
+ *  and stays put while the payload under it scrolls. */
+function TitleRow({
+	span,
+	turnOrdinal,
+	onClose,
+	onOpenTraceView,
+}: {
+	span: AiSessionSpan
+	turnOrdinal: string | undefined
+	onClose: () => void
+	onOpenTraceView: (() => void) | undefined
+}) {
+	const category = classifyAiSpan(span)
+	const errored = spanFailed(span)
+	const Glyph = errored ? CircleXmarkIcon : CATEGORY_ICON[category]
+	const subtitle = [turnOrdinal, spanModel(span), formatDuration(span.durationMs)]
+		.filter((part): part is string => part !== undefined)
+		.join(" · ")
+
+	return (
+		// Negative margins against the viewport's own padding: the row pins flush
+		// to the popup's edges when the payload scrolls under it.
+		<div
+			className={cn(
+				"-mx-4 -mt-4 sticky top-0 z-10 flex flex-wrap items-center gap-x-3 gap-y-1",
+				"bg-popover px-4 pt-4 pb-2",
+			)}
+		>
+			<Glyph
+				aria-hidden
+				size={13}
+				className={cn("shrink-0", errored ? "text-destructive" : CATEGORY_TEXT[category])}
+			/>
+			<span className="min-w-0 truncate font-medium font-mono text-sm">{span.spanName}</span>
+			{subtitle !== "" && <span className="text-muted-foreground text-xs">{subtitle}</span>}
+			<div className="ml-auto flex items-center gap-2">
+				{onOpenTraceView !== undefined && (
+					<Button variant="outline" size="sm" className="h-6.5 text-xs" onClick={onOpenTraceView}>
+						Open in Traces view
+					</Button>
+				)}
+				<Button variant="ghost" size="icon-sm" aria-label="Close span detail" onClick={onClose}>
+					<XmarkIcon size={14} />
+				</Button>
+			</div>
+		</div>
+	)
+}

--- a/apps/web/src/components/agent-sessions/session-detail/span-popover.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-popover.tsx
@@ -1,8 +1,6 @@
-import type { ComponentProps } from "react"
-
 import type { AiSessionSpan } from "@maple/domain/http"
 import { Button } from "@maple/ui/components/ui/button"
-import { Popover, PopoverContent } from "@maple/ui/components/ui/popover"
+import { Dialog, DialogPopup } from "@maple/ui/components/ui/dialog"
 import { formatDuration } from "@maple/ui/lib/format"
 import { cn } from "@maple/ui/lib/utils"
 
@@ -12,27 +10,25 @@ import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
 import { SpanExpansion, type SpanDetailTab } from "./span-expansion"
 import { CATEGORY_ICON, CATEGORY_TEXT } from "./span-visuals"
 
-/** What the popover points at — a row, a node, a cell. A ref is accepted so a
- *  view can name a fallback container it has not rendered yet. */
-export type SpanAnchor = ComponentProps<typeof PopoverContent>["anchor"]
-
 /**
- * One span, inspected in place.
+ * One span, inspected over the whole page.
  *
- * Every view opens the same panel against whatever the reader clicked: the
- * Overview's findings, the flow's nodes, the waterfall's rows. It replaced
- * three different chromes — a tab switch, a docked drawer and an inline row —
- * that each answered the same question in a different place, and each cost the
- * reader the view they were reading it from.
+ * Every view opens the same panel: the Overview's findings, the flow's nodes,
+ * the waterfall's rows. It replaced three different chromes — a tab switch, a
+ * docked drawer and an inline row — that each answered the same question in a
+ * different place, and each cost the reader the view they were reading it from.
  *
- * The popover is open exactly when a span is selected AND its anchor is on
- * screen. In the virtualized waterfall the anchor row unmounts when it scrolls
- * far enough away, which closes the panel rather than leaving it pointing at a
- * detached box; the selection stays in the URL, so scrolling back reopens it.
+ * It is an overlay rather than a popover anchored to what was clicked: a
+ * captured prompt is thousands of tokens, and a panel sized to point at a
+ * 28px waterfall row made every payload a scroll through a letterbox. The
+ * backdrop dims the view underneath instead of hiding it — the reader is still
+ * in the session, one Escape from the row they came from.
+ *
+ * Open exactly when the active view has a span selected (`?span=`), which is
+ * also what makes a pasted link open the panel in whichever view it lands in.
  */
 export function SpanPopover({
 	span,
-	anchor,
 	turnOrdinal,
 	tab,
 	onTabChange,
@@ -42,7 +38,6 @@ export function SpanPopover({
 }: {
 	/** The selected span, or `undefined` when nothing is open. */
 	span: AiSessionSpan | undefined
-	anchor: SpanAnchor
 	/** "Turn 3" / "Segment 2" — where the span lives, for the title row. */
 	turnOrdinal?: string | undefined
 	/** The reader's tab choice, held by SessionViews so it survives switching
@@ -51,36 +46,33 @@ export function SpanPopover({
 	onTabChange: (tab: SpanDetailTab) => void
 	/** The session's captured tool results by call id (`sessionToolResults`). */
 	toolResults?: SessionToolResults
-	/** Clears the selection: Escape, the close button, a press outside. */
+	/** Clears the selection: Escape, the close button, a press on the backdrop. */
 	onClose: () => void
 	/** Offered only where the reader is not already in the Traces view. */
 	onOpenTraceView?: (() => void) | undefined
 }) {
-	const open = span !== undefined && anchor !== null && anchor !== undefined
-
 	return (
-		<Popover
-			open={open}
+		<Dialog
+			open={span !== undefined}
 			onOpenChange={(next) => {
 				if (!next) onClose()
 			}}
 		>
 			{span !== undefined && (
-				<PopoverContent
-					anchor={anchor}
-					side="bottom"
-					align="start"
-					className="w-[min(40rem,calc(100vw-2rem))]"
+				<DialogPopup
+					// The chrome is this panel's own — a title row that names the span
+					// and carries the way out — so the dialog's corner button would be a
+					// second close in the same corner.
+					showCloseButton={false}
+					bottomStickOnMobile={false}
+					className={cn(
+						"h-[86vh] w-[86vw] max-w-none",
+						"max-sm:h-[calc(100dvh-2rem)] max-sm:w-[calc(100vw-2rem)]",
+					)}
 				>
-					{/* The panel's own handle, for the page's tests and for anything
-					    that needs to find it inside the portal. It is also the scroll
-					    viewport: the height cap must live on the element that scrolls —
-					    capping the popup instead leaves the ui viewport sized to
-					    `--available-height`, spilling past the popup's border. */}
-					<div
-						data-slot="span-popover"
-						className="-m-4 max-h-[min(32rem,calc(var(--available-height)-2rem))] min-w-0 overflow-y-auto overscroll-contain p-4"
-					>
+					{/* The panel's own handle, for the page's tests and for anything that
+					    needs to find it inside the portal. */}
+					<div data-slot="span-popover" className="flex min-h-0 min-w-0 grow flex-col">
 						<SpanExpansion
 							key={span.spanId}
 							span={span}
@@ -97,9 +89,9 @@ export function SpanPopover({
 							}
 						/>
 					</div>
-				</PopoverContent>
+				</DialogPopup>
 			)}
-		</Popover>
+		</Dialog>
 	)
 }
 
@@ -124,19 +116,10 @@ function TitleRow({
 		.join(" · ")
 
 	return (
-		// Pins to the scroller's padding-box top, covering content that would
-		// otherwise show through the top padding. A negative top margin would
-		// shrink this row's margin box inside the flex column and paint it over
-		// the tab strip below — only the horizontal margins are safe to bleed.
-		<div
-			className={cn(
-				"-mx-4 sticky top-0 z-10 flex flex-wrap items-center gap-x-3 gap-y-1",
-				"bg-popover px-4 pb-2",
-			)}
-		>
+		<div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 px-5 pt-4 pb-3">
 			<Glyph
 				aria-hidden
-				size={13}
+				size={14}
 				className={cn("shrink-0", errored ? "text-destructive" : CATEGORY_TEXT[category])}
 			/>
 			<span className="min-w-0 truncate font-medium font-mono text-sm">{span.spanName}</span>

--- a/apps/web/src/components/agent-sessions/session-detail/span-popover.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-popover.tsx
@@ -70,11 +70,17 @@ export function SpanPopover({
 					anchor={anchor}
 					side="bottom"
 					align="start"
-					className="max-h-[min(32rem,var(--available-height))] w-[min(40rem,calc(100vw-2rem))]"
+					className="w-[min(40rem,calc(100vw-2rem))]"
 				>
 					{/* The panel's own handle, for the page's tests and for anything
-					    that needs to find it inside the portal. */}
-					<div data-slot="span-popover" className="min-w-0">
+					    that needs to find it inside the portal. It is also the scroll
+					    viewport: the height cap must live on the element that scrolls —
+					    capping the popup instead leaves the ui viewport sized to
+					    `--available-height`, spilling past the popup's border. */}
+					<div
+						data-slot="span-popover"
+						className="-m-4 max-h-[min(32rem,calc(var(--available-height)-2rem))] min-w-0 overflow-y-auto overscroll-contain p-4"
+					>
 						<SpanExpansion
 							key={span.spanId}
 							span={span}
@@ -118,12 +124,14 @@ function TitleRow({
 		.join(" · ")
 
 	return (
-		// Negative margins against the viewport's own padding: the row pins flush
-		// to the popup's edges when the payload scrolls under it.
+		// Pins to the scroller's padding-box top, covering content that would
+		// otherwise show through the top padding. A negative top margin would
+		// shrink this row's margin box inside the flex column and paint it over
+		// the tab strip below — only the horizontal margins are safe to bleed.
 		<div
 			className={cn(
-				"-mx-4 -mt-4 sticky top-0 z-10 flex flex-wrap items-center gap-x-3 gap-y-1",
-				"bg-popover px-4 pt-4 pb-2",
+				"-mx-4 sticky top-0 z-10 flex flex-wrap items-center gap-x-3 gap-y-1",
+				"bg-popover px-4 pb-2",
 			)}
 		>
 			<Glyph

--- a/apps/web/src/routes/agent-sessions/$sessionId.tsx
+++ b/apps/web/src/routes/agent-sessions/$sessionId.tsx
@@ -46,9 +46,9 @@ const agentSessionSearchSchema = Schema.Struct({
 	// segment on purpose: Back from the detail page returns to the list the
 	// reader came from, not to the view they looked at before this one.
 	view: Schema.optional(Schema.String),
-	// The span expanded inline (Trace) or open in the docked drawer (Flow). In
-	// the URL rather than component state so a pasted link reopens the exact
-	// span someone was looking at, in either debug view.
+	// The span open in the inspection popover, in whichever view it was opened
+	// from. In the URL rather than component state so a pasted link reopens the
+	// exact span someone was looking at.
 	span: Schema.optional(Schema.String.check(Schema.isMinLength(1), Schema.isTrimmed())),
 })
 
@@ -214,8 +214,8 @@ function SessionDetailBody({
 		(spanId: string | undefined) => {
 			navigate({
 				search: (prev: Record<string, unknown>) => ({ ...prev, span: spanId }),
-				// Expanding a span is a step the reader may want Back to undo;
-				// moving the expansion, or collapsing it, is not.
+				// Opening a span is a step the reader may want Back to undo;
+				// moving the panel to another span, or closing it, is not.
 				replace: search.span !== undefined,
 			})
 		},
@@ -261,9 +261,9 @@ function SessionDetailBody({
 				{/* `py-0` (the content blocks carry the padding instead) so the views'
 				    sticky elements pin flush to the scroller's edges — sticky offsets
 				    resolve against the padding edge. The top edge is the control bar;
-				    the bottom is the Flow view's floor, whose docked span drawer
-				    otherwise floats a padding's height short of the viewport with the
-				    canvas scrolling visibly beneath it. `pr-6` keeps the overlay
+				    the bottom is the Flow view's floor, whose legend and zoom otherwise
+				    float a padding's height short of the viewport with the canvas
+				    scrolling visibly beneath them. `pr-6` keeps the overlay
 				    scrollbar off the right-aligned duration/cost columns, and
 				    `overflow-x-hidden` means a span that escapes its truncation can
 				    never make the whole page scroll sideways. */}
@@ -297,8 +297,8 @@ function SessionDetailBody({
 					</div>
 				</DashboardLayout.Scroll>
 			</DashboardLayout.Content>
-			{/* No side panel at any width: span detail expands inline under its
-			    waterfall row, or in the Flow view's docked drawer. */}
+			{/* No side panel at any width: span detail opens as a popover against
+			    the row, node or finding the reader clicked. */}
 		</SessionShell>
 	)
 }


### PR DESCRIPTION
Span inspection on the agent session detail page was fragmented: Overview clicks switched you to the Traces tab, Flow opened a docked drawer, and the waterfall expanded an inline row. This replaces all three with one `SpanPopover` chrome around the shared `SpanExpansion` body, opened in place from whatever the reader clicked:

- **Overview**: findings, the verdict, and turn-health cells open the popover anchored to the clicked element — no tab switch. "Open in Traces view" lives inside the panel and carries the span and the chosen detail tab across.
- **Flow**: node click anchors the popover to the node (canvas fallback for spans without a node). The docked drawer is gone.
- **Traces (waterfall)**: span row click anchors the popover to the row. The synthetic `detail` row kind and its virtualizer measurement plumbing are removed, simplifying the waterfall.
- `?span=` stays the source of truth. In the virtualized waterfall, the anchor unmounting (scrolled far away) closes the panel rather than leaving it detached; scrolling back re-anchors it. Only the active view holds the popover open — an outgoing tab panel stays mounted through its exit transition, so inactive views are denied the selection to prevent a double popover.
- The detail-tab choice is held in `SessionViews`, so it survives switching spans and views.
- Net −140 lines in `span-expansion.tsx` from deleting the two old chromes.

Behavior notes: an outside press closes the panel and clears the selection (so switching tabs by clicking a tab drops it — cross-view carry is the panel's own door); view hotkeys 1–4 are suppressed while the panel is open via the existing dialog guard.

Verified: scoped `apps/web` typecheck green; agent-session suites pass (311 tests, including the rewritten `session-detail` popover tests); full `apps/web` vitest run shows only 4 pre-existing hook-test failures that reproduce identically on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790432216&installation_model_id=427786&pr_number=656&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F656&signature=0c87c47c8797a80474dac474954e23e345131c1b9a2a21e7b35c9b0ad403e763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->