### PR TITLE
fix(web): failure banner names its own pills, not "above"

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -697,7 +697,8 @@ function FailureBanner({ span }: { span: AiSessionSpan }) {
 					)}
 			</div>
 			<p className="text-muted-foreground text-xs leading-relaxed">
-				The span reports the failure through the attributes above; it carries no status message.
+				The pills here are the attributes the failure was read from; the span carries no status
+				message.
 			</p>
 		</div>
 	)


### PR DESCRIPTION
The no-status-message failure banner said the span reports the failure "through the attributes above" — which reads as pointing at something earlier in the panel. The attributes it means are the pills on the line directly above the sentence, inside the same banner.

Reworded to name them: "The pills here are the attributes the failure was read from; the span carries no status message."

Text-only, no test asserts the string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790451662&installation_model_id=427786&pr_number=658&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F658&signature=8d0edaca86be2304dac8fae7157cc65e956bbd04a71ae9a31c10508f67eab1c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->