### PR TITLE
fix(scraper): build clickhouse-builder in the Railway image

### DIFF
--- a/apps/scraper/Dockerfile
+++ b/apps/scraper/Dockerfile
@@ -5,7 +5,12 @@ FROM oven/bun:1.4.0 AS runner
 WORKDIR /app
 
 COPY . .
-RUN bun install --frozen-lockfile && bun run --cwd packages/effect-sdk build
+# @maple-dev/clickhouse-builder resolves through its dist/ exports, and
+# @maple/domain imports its ./sql subpath — build it or the container
+# crashloops at startup on a clean checkout.
+RUN bun install --frozen-lockfile \
+	&& bun run --cwd lib/clickhouse-builder build \
+	&& bun run --cwd packages/effect-sdk build
 
 EXPOSE 3475
 

--- a/apps/scraper/railway.json
+++ b/apps/scraper/railway.json
@@ -3,7 +3,12 @@
 	"build": {
 		"builder": "DOCKERFILE",
 		"dockerfilePath": "apps/scraper/Dockerfile",
-		"watchPatterns": ["apps/scraper/**", "packages/domain/**", "packages/effect-sdk/**"]
+		"watchPatterns": [
+			"apps/scraper/**",
+			"packages/domain/**",
+			"packages/effect-sdk/**",
+			"lib/clickhouse-builder/**"
+		]
 	},
 	"deploy": {
 		"healthcheckPath": "/health",


### PR DESCRIPTION
## Problem

Every Railway deploy of `prometheus-scraper` since 2026-08-26 16:24 CEST has failed. The build succeeds, but each replica crashloops at startup:

```
error: Cannot find module '@maple-dev/clickhouse-builder/sql' from '/app/packages/domain/src/raw-sql.ts'
```

so `/health` never answers and the 5-minute healthcheck window kills the deploy. The previously deployed replica kept serving, which is why the outage was invisible in telemetry.

## Cause

#650-era `packages/domain/src/raw-sql.ts` imports `@maple-dev/clickhouse-builder/sql`, and that package's exports all resolve through `dist/` (built by tsdown). The scraper image only built `packages/effect-sdk` after `bun install`, so on a clean checkout `dist/sql.mjs` doesn't exist and bun can't resolve the subpath at runtime. Local builds masked it: `COPY . .` picks up a developer's locally built `lib/clickhouse-builder/dist`.

## Fix

- Build `lib/clickhouse-builder` in the scraper Dockerfile before `packages/effect-sdk`.
- Add `lib/clickhouse-builder/**` to the Railway `watchPatterns` so changes there trigger a redeploy.

## Verification

Rebuilt the image from a clean checkout (fresh worktree, no `dist/`) and ran the container: startup now passes module resolution, the health endpoint listens on 3475, and the scraper main loop starts (remaining log lines are the expected missing-ingest-key warnings for a local run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790452219&installation_model_id=427786&pr_number=659&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F659&signature=ba1b9117af15837e5e12d12f73080fbd31c226bf16c14d54b91dba202c94f8ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->