### PR TITLE
feat(web): org-global namespace switcher in the org menu

### DIFF
--- a/apps/web/src/api/warehouse/custom-charts.ts
+++ b/apps/web/src/api/warehouse/custom-charts.ts
@@ -906,6 +906,7 @@ const GetOverviewTimeSeriesInputSchema = Schema.Struct({
 	startTime: Schema.optional(dateTimeString),
 	endTime: Schema.optional(dateTimeString),
 	environments: Schema.optional(Schema.mutable(Schema.Array(DeploymentEnvironment))),
+	namespaces: Schema.optional(Schema.mutable(Schema.Array(ServiceNamespace))),
 })
 
 type GetOverviewTimeSeriesInput = (typeof GetOverviewTimeSeriesInputSchema)["Encoded"]
@@ -928,6 +929,7 @@ const getOverviewTimeSeriesEffect = Effect.fn("QueryEngine.getOverviewTimeSeries
 		bucketSeconds,
 		rootSpansOnly: true,
 		environments: input.environments,
+		namespaces: input.namespaces,
 	}
 
 	// Throughput renders from the sampling-aware `estimatedSpanCount`; exact
@@ -1117,6 +1119,9 @@ const ThroughputRefinementShared = {
 	startTime: Schema.optional(dateTimeString),
 	endTime: Schema.optional(dateTimeString),
 	environments: Schema.optional(Schema.mutable(Schema.Array(DeploymentEnvironment))),
+	// The SpanMetrics calls MV can't be namespace-filtered, so a namespace scope
+	// skips the exact refinement the same way an environment scope does.
+	namespaces: Schema.optional(Schema.mutable(Schema.Array(ServiceNamespace))),
 	// The caller's sampling verdict, derived from the already-loaded primary
 	// chart. When false (or absent) the exact query is skipped — the estimate is
 	// already correct. Including it in the input makes it part of the atom key, so
@@ -1150,7 +1155,8 @@ const getServiceDetailThroughputRefinementEffect = Effect.fn(
 	)
 
 	const envScoped = (input.environments?.length ?? 0) > 0
-	if (!input.samplingActive || envScoped) {
+	const nsScoped = (input.namespaces?.length ?? 0) > 0
+	if (!input.samplingActive || envScoped || nsScoped) {
 		return { data: [] as ThroughputRefinementPoint[] }
 	}
 
@@ -1183,7 +1189,8 @@ const getOverviewThroughputRefinementEffect = Effect.fn("QueryEngine.getOverview
 		)
 
 		const envScoped = (input.environments?.length ?? 0) > 0
-		if (!input.samplingActive || envScoped) {
+		const nsScoped = (input.namespaces?.length ?? 0) > 0
+		if (!input.samplingActive || envScoped || nsScoped) {
 			return { data: [] as ThroughputRefinementPoint[] }
 		}
 

--- a/apps/web/src/api/warehouse/errors.ts
+++ b/apps/web/src/api/warehouse/errors.ts
@@ -14,8 +14,10 @@ import {
 	ErrorsSparkRequest,
 	FingerprintHash,
 	ServiceName,
+	ServiceNamespace,
 } from "@maple/domain/http"
 import { MapleInternalAtomClient } from "@/lib/services/common/internal-atom-client"
+import { scopeServicesToNamespaces } from "@/api/warehouse/namespace-scope"
 import {
 	WarehouseDateTimeString,
 	decodeInput,
@@ -27,6 +29,9 @@ import {
 const OptionalServiceArray = Schema.optional(Schema.mutable(Schema.Array(ServiceName)))
 const OptionalDeploymentEnvArray = Schema.optional(Schema.mutable(Schema.Array(DeploymentEnvironment)))
 const OptionalFingerprintHashArray = Schema.optional(Schema.mutable(Schema.Array(FingerprintHash)))
+// The error-events tables carry no ServiceNamespace column, so a namespaces
+// filter is lowered to service membership via `scopeServicesToNamespaces`.
+const OptionalNamespaceArray = Schema.optional(Schema.mutable(Schema.Array(ServiceNamespace)))
 /** "Error Type" / "Version" sidebar facets — plain strings, not branded. */
 const OptionalStringArray = Schema.optional(Schema.mutable(Schema.Array(Schema.String)))
 
@@ -45,6 +50,7 @@ const GetErrorsByTypeInputSchema = Schema.Struct({
 	endTime: Schema.optional(WarehouseDateTimeString),
 	services: OptionalServiceArray,
 	deploymentEnvs: OptionalDeploymentEnvArray,
+	namespaces: OptionalNamespaceArray,
 	fingerprintHashes: OptionalFingerprintHashArray,
 	errorLabels: OptionalStringArray,
 	serviceVersions: OptionalStringArray,
@@ -70,16 +76,26 @@ const getErrorsByTypeEffect = Effect.fn("QueryEngine.getErrorsByType")(function*
 }) {
 	const input = yield* decodeInput(GetErrorsByTypeInputSchema, data ?? {}, "getErrorsByType")
 	const fallback = defaultErrorsTimeRange(yield* Clock.currentTimeMillis)
+	const startTime = input.startTime ?? fallback.startTime
+	const endTime = input.endTime ?? fallback.endTime
+
+	const scope = yield* scopeServicesToNamespaces({
+		namespaces: input.namespaces,
+		services: input.services,
+		startTime,
+		endTime,
+	})
+	if (scope.empty) return { data: coerceErrorsByTypeRows([]) }
 
 	const result = yield* runWarehouseQuery("errorsByType", () =>
 		Effect.gen(function* () {
 			const client = yield* MapleInternalAtomClient
 			return yield* client.queryEngine.errorsByType({
 				payload: new ErrorsByTypeRequest({
-					startTime: input.startTime ?? fallback.startTime,
-					endTime: input.endTime ?? fallback.endTime,
+					startTime,
+					endTime,
 					rootOnly: input.rootOnly,
-					services: input.services,
+					services: scope.services,
 					deploymentEnvs: input.deploymentEnvs,
 					fingerprintHashes: input.fingerprintHashes,
 					errorLabels: input.errorLabels,
@@ -108,6 +124,7 @@ const GetErrorsFacetsInputSchema = Schema.Struct({
 	endTime: Schema.optional(WarehouseDateTimeString),
 	services: OptionalServiceArray,
 	deploymentEnvs: OptionalDeploymentEnvArray,
+	namespaces: OptionalNamespaceArray,
 	fingerprintHashes: OptionalFingerprintHashArray,
 	errorLabels: OptionalStringArray,
 	serviceVersions: OptionalStringArray,
@@ -139,18 +156,30 @@ const getErrorsFacetsEffect = Effect.fn("QueryEngine.getErrorsFacets")(function*
 }) {
 	const input = yield* decodeInput(GetErrorsFacetsInputSchema, data ?? {}, "getErrorsFacets")
 	const fallback = defaultErrorsTimeRange(yield* Clock.currentTimeMillis)
+	const startTime = input.startTime ?? fallback.startTime
+	const endTime = input.endTime ?? fallback.endTime
+
+	const scope = yield* scopeServicesToNamespaces({
+		namespaces: input.namespaces,
+		services: input.services,
+		startTime,
+		endTime,
+	})
+	if (scope.empty) {
+		return { data: { services: [], deploymentEnvs: [], errorTypes: [], serviceVersions: [] } }
+	}
 
 	const response = yield* executeQueryEngine(
 		"queryEngine.getErrorsFacets",
 		new QueryEngineExecuteRequest({
-			startTime: input.startTime ?? fallback.startTime,
-			endTime: input.endTime ?? fallback.endTime,
+			startTime,
+			endTime,
 			query: {
 				kind: "facets" as const,
 				source: "errors" as const,
 				filters: {
 					rootOnly: input.rootOnly,
-					services: input.services,
+					services: scope.services,
 					deploymentEnvs: input.deploymentEnvs,
 					fingerprintHashes: input.fingerprintHashes,
 					errorLabels: input.errorLabels,
@@ -165,12 +194,18 @@ const getErrorsFacetsEffect = Effect.fn("QueryEngine.getErrorsFacets")(function*
 	)
 
 	const facetsData = extractFacets(response)
+	// The services facet branch deliberately ignores the services filter (see
+	// `except` in `errorsFacetsQuery`), which would resurface out-of-namespace
+	// service names while namespace-scoped — drop them here.
+	const inScope = (row: { facetType: string; name: string }) =>
+		scope.memberServices === null || row.facetType !== "service" || scope.memberServices.has(row.name)
 	const services: FacetItem[] = []
 	const deploymentEnvs: FacetItem[] = []
 	const errorTypes: FacetItem[] = []
 	const serviceVersions: FacetItem[] = []
 
 	for (const row of facetsData) {
+		if (!inScope(row)) continue
 		const item = { name: row.name, count: Number(row.count) }
 		// These strings must match the `facetType` literals in `errorsFacetsQuery`.
 		// They did not: the query emits "environment"/"error_type" and this read
@@ -202,6 +237,7 @@ const GetErrorsSummaryInputSchema = Schema.Struct({
 	endTime: Schema.optional(WarehouseDateTimeString),
 	services: OptionalServiceArray,
 	deploymentEnvs: OptionalDeploymentEnvArray,
+	namespaces: OptionalNamespaceArray,
 	fingerprintHashes: OptionalFingerprintHashArray,
 	errorLabels: OptionalStringArray,
 	serviceVersions: OptionalStringArray,
@@ -222,16 +258,26 @@ const getErrorsSummaryEffect = Effect.fn("QueryEngine.getErrorsSummary")(functio
 }) {
 	const input = yield* decodeInput(GetErrorsSummaryInputSchema, data ?? {}, "getErrorsSummary")
 	const fallback = defaultErrorsTimeRange(yield* Clock.currentTimeMillis)
+	const startTime = input.startTime ?? fallback.startTime
+	const endTime = input.endTime ?? fallback.endTime
+
+	const scope = yield* scopeServicesToNamespaces({
+		namespaces: input.namespaces,
+		services: input.services,
+		startTime,
+		endTime,
+	})
+	if (scope.empty) return { data: coerceErrorsSummary(null) }
 
 	const result = yield* runWarehouseQuery("errorsSummary", () =>
 		Effect.gen(function* () {
 			const client = yield* MapleInternalAtomClient
 			return yield* client.queryEngine.errorsSummary({
 				payload: new ErrorsSummaryRequest({
-					startTime: input.startTime ?? fallback.startTime,
-					endTime: input.endTime ?? fallback.endTime,
+					startTime,
+					endTime,
 					rootOnly: input.rootOnly,
-					services: input.services,
+					services: scope.services,
 					deploymentEnvs: input.deploymentEnvs,
 					fingerprintHashes: input.fingerprintHashes,
 					errorLabels: input.errorLabels,
@@ -322,6 +368,7 @@ const GetErrorsSparkInputSchema = Schema.Struct({
 	endTime: Schema.optional(WarehouseDateTimeString),
 	services: OptionalServiceArray,
 	deploymentEnvs: OptionalDeploymentEnvArray,
+	namespaces: OptionalNamespaceArray,
 	errorLabels: OptionalStringArray,
 	serviceVersions: OptionalStringArray,
 	excludedServices: OptionalServiceArray,
@@ -349,15 +396,26 @@ const getErrorsSparkEffect = Effect.fn("QueryEngine.getErrorsSpark")(function* (
 	// here because the list renders before its issues have loaded.
 	if (input.fingerprintHashes.length === 0) return { data: [] as ErrorsSparkSeries[] }
 
+	const startTime = input.startTime ?? fallback.startTime
+	const endTime = input.endTime ?? fallback.endTime
+
+	const scope = yield* scopeServicesToNamespaces({
+		namespaces: input.namespaces,
+		services: input.services,
+		startTime,
+		endTime,
+	})
+	if (scope.empty) return { data: [] as ErrorsSparkSeries[] }
+
 	const result = yield* runWarehouseQuery("errorsSpark", () =>
 		Effect.gen(function* () {
 			const client = yield* MapleInternalAtomClient
 			return yield* client.queryEngine.errorsSpark({
 				payload: new ErrorsSparkRequest({
-					startTime: input.startTime ?? fallback.startTime,
-					endTime: input.endTime ?? fallback.endTime,
+					startTime,
+					endTime,
 					fingerprintHashes: input.fingerprintHashes,
-					services: input.services,
+					services: scope.services,
 					deploymentEnvs: input.deploymentEnvs,
 					errorLabels: input.errorLabels,
 					serviceVersions: input.serviceVersions,

--- a/apps/web/src/api/warehouse/logs.ts
+++ b/apps/web/src/api/warehouse/logs.ts
@@ -241,6 +241,9 @@ const GetLogsFacetsInputSchema = Schema.Struct({
 	deploymentEnv: Schema.optional(DeploymentEnvironment),
 	deploymentEnvMatchMode: Schema.optional(Schema.Literal("contains")),
 	namespace: Schema.optional(ServiceNamespace),
+	// Multi-value spelling, wins over the scalar (matches `listLogs`). Carries
+	// the org-global namespace pin.
+	namespaces: Schema.optional(Schema.Array(ServiceNamespace)),
 	namespaceMatchMode: Schema.optional(Schema.Literal("contains")),
 	startTime: Schema.optional(WarehouseDateTimeString),
 	endTime: Schema.optional(WarehouseDateTimeString),
@@ -273,7 +276,11 @@ const getLogsFacetsEffect = Effect.fn("QueryEngine.getLogsFacets")(function* ({
 					severity: input.severity,
 					environments: input.deploymentEnv ? [input.deploymentEnv] : undefined,
 					deploymentEnvMatchMode: input.deploymentEnvMatchMode,
-					namespaces: input.namespace ? [input.namespace] : undefined,
+					namespaces: input.namespaces?.length
+						? input.namespaces
+						: input.namespace
+							? [input.namespace]
+							: undefined,
 					namespaceMatchMode: input.namespaceMatchMode,
 				},
 			},

--- a/apps/web/src/api/warehouse/namespace-scope.ts
+++ b/apps/web/src/api/warehouse/namespace-scope.ts
@@ -1,0 +1,56 @@
+import { Effect, Schema } from "effect"
+import { coerceServiceOverviewRows, windowDurationSeconds } from "@maple/query-engine"
+import { ServiceName, ServiceNamespace, ServiceOverviewRequest } from "@maple/domain/http"
+import { MapleInternalAtomClient } from "@/lib/services/common/internal-atom-client"
+import { decodeInput, runWarehouseQuery } from "@/api/warehouse/effect-utils"
+
+export interface NamespaceServiceScope {
+	/** Services filter to apply, already intersected with the caller's own. */
+	services: ReadonlyArray<ServiceName> | undefined
+	/** No service in the namespace(s) — the caller should answer empty without querying. */
+	empty: boolean
+	/** Membership set for post-filtering rows/facets, or null when unscoped. */
+	memberServices: ReadonlySet<string> | null
+}
+
+/**
+ * Lower a `namespaces` filter onto tables that carry no `ServiceNamespace`
+ * column (error_events, traces_aggregates_hourly): resolve which services
+ * emitted under those namespaces in the window (service_overview rollup,
+ * server-cached) and scope by service membership instead. Approximate on
+ * purpose — a service emitting under several namespaces stays visible.
+ */
+export const scopeServicesToNamespaces = Effect.fn("QueryEngine.scopeServicesToNamespaces")(function* (opts: {
+	namespaces: ReadonlyArray<ServiceNamespace> | undefined
+	services: ReadonlyArray<ServiceName> | undefined
+	startTime: string
+	endTime: string
+}) {
+	if (!opts.namespaces?.length) {
+		return { services: opts.services, empty: false, memberServices: null } satisfies NamespaceServiceScope
+	}
+
+	const result = yield* runWarehouseQuery("namespaceServices", () =>
+		Effect.gen(function* () {
+			const client = yield* MapleInternalAtomClient
+			return yield* client.queryEngine.serviceOverview({
+				payload: new ServiceOverviewRequest({
+					startTime: opts.startTime,
+					endTime: opts.endTime,
+					namespaces: opts.namespaces,
+				}),
+			})
+		}),
+	)
+
+	const rows = coerceServiceOverviewRows(result.data, windowDurationSeconds(opts.startTime, opts.endTime))
+	const names = new Set(rows.map((row) => row.serviceName))
+
+	if (opts.services?.length) {
+		const services = opts.services.filter((service) => names.has(service))
+		return { services, empty: services.length === 0, memberServices: names } satisfies NamespaceServiceScope
+	}
+
+	const services = yield* decodeInput(Schema.Array(ServiceName), [...names], "scopeServicesToNamespaces")
+	return { services, empty: services.length === 0, memberServices: names } satisfies NamespaceServiceScope
+})

--- a/apps/web/src/api/warehouse/services.ts
+++ b/apps/web/src/api/warehouse/services.ts
@@ -17,6 +17,7 @@ import {
 	ServiceOverviewRequest,
 } from "@maple/domain/http"
 import { MapleInternalAtomClient } from "@/lib/services/common/internal-atom-client"
+import { scopeServicesToNamespaces } from "@/api/warehouse/namespace-scope"
 import {
 	buildBucketTimeline,
 	computeBucketSeconds,
@@ -117,6 +118,9 @@ const GetServiceHealthSnapshotInput = Schema.Struct({
 	startTime: Schema.optional(dateTimeString),
 	endTime: Schema.optional(dateTimeString),
 	environments: Schema.optional(Schema.mutable(Schema.Array(DeploymentEnvironment))),
+	// traces_aggregates_hourly has no ServiceNamespace column — lowered to
+	// service membership (see `scopeServicesToNamespaces`) after the query.
+	namespaces: Schema.optional(Schema.mutable(Schema.Array(ServiceNamespace))),
 })
 
 export type GetServiceHealthSnapshotInput = (typeof GetServiceHealthSnapshotInput)["Encoded"]
@@ -139,6 +143,14 @@ const getServiceHealthSnapshotEffect = Effect.fn("QueryEngine.getServiceHealthSn
 		1,
 	)
 
+	const scope = yield* scopeServicesToNamespaces({
+		namespaces: input.namespaces,
+		services: undefined,
+		startTime,
+		endTime,
+	})
+	if (scope.empty) return { data: [] as ServiceHealthSnapshot[] }
+
 	const response = yield* runWarehouseQuery("serviceHealthSnapshot", () =>
 		Effect.gen(function* () {
 			const client = yield* MapleInternalAtomClient
@@ -153,17 +165,19 @@ const getServiceHealthSnapshotEffect = Effect.fn("QueryEngine.getServiceHealthSn
 	)
 
 	return {
-		data: response.data.map(
-			(row): ServiceHealthSnapshot => ({
-				serviceName: String(row.serviceName),
-				environment: row.environment || "unknown",
-				requestCount: row.requestCount,
-				errorCount: row.errorCount,
-				errorRate: row.requestCount > 0 ? row.errorCount / row.requestCount : 0,
-				p95LatencyMs: row.p95LatencyMs,
-				throughput: row.requestCount / durationSeconds,
-			}),
-		),
+		data: response.data
+			.filter((row) => scope.memberServices === null || scope.memberServices.has(String(row.serviceName)))
+			.map(
+				(row): ServiceHealthSnapshot => ({
+					serviceName: String(row.serviceName),
+					environment: row.environment || "unknown",
+					requestCount: row.requestCount,
+					errorCount: row.errorCount,
+					errorRate: row.requestCount > 0 ? row.errorCount / row.requestCount : 0,
+					p95LatencyMs: row.p95LatencyMs,
+					throughput: row.requestCount / durationSeconds,
+				}),
+			),
 	}
 })
 

--- a/apps/web/src/components/dashboard/namespace-scope-menu.tsx
+++ b/apps/web/src/components/dashboard/namespace-scope-menu.tsx
@@ -1,0 +1,150 @@
+import { useMemo, useState } from "react"
+import { useRouter } from "@tanstack/react-router"
+import { formatWarehouseDateTime } from "@maple/query-engine"
+import { CheckIcon, LayersIcon } from "@/components/icons"
+import {
+	DropdownMenuGroup,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+} from "@maple/ui/components/ui/dropdown-menu"
+import { Input } from "@maple/ui/components/ui/input"
+import { Result, useAtomValue } from "@/lib/effect-atom"
+import { getServicesFacetsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
+import { setGlobalNamespace } from "@/lib/services/common/global-namespace"
+import { snapRangeForCache } from "@/lib/time-utils"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
+
+/** Search only earns its row once the list is long enough to need it. */
+const SEARCH_THRESHOLD = 8
+
+/**
+ * The searchable namespace list itself — the submenu's content for the Clerk
+ * switcher, rendered directly as the menu body for the self-hosted one.
+ * Mounted only when its menu (or submenu) opens, so the facets probe is lazy.
+ */
+function NamespaceScopeList({ emptyNotice = false }: { emptyNotice?: boolean }) {
+	const router = useRouter()
+	const pinned = useGlobalNamespace()
+	const [query, setQuery] = useState("")
+
+	// Same snapped 24h probe the overview and service map run, so all three
+	// share one cache entry. Deliberately NOT namespace-pinned — this list is
+	// how the pin is escaped.
+	const facetsRange = useMemo(() => {
+		const end = Date.now()
+		return snapRangeForCache({
+			startTime: formatWarehouseDateTime(end - 24 * 60 * 60 * 1000),
+			endTime: formatWarehouseDateTime(end),
+		})
+	}, [])
+	const facetsResult = useAtomValue(getServicesFacetsResultAtom({ data: facetsRange }))
+
+	const loading = !Result.isSuccess(facetsResult) && !Result.isFailure(facetsResult)
+	const observed = Result.isSuccess(facetsResult)
+		? facetsResult.value.data.namespaces.filter((item) => item.name !== "")
+		: []
+	const pinnedIsObserved = pinned === null || observed.some((item) => item.name === pinned)
+
+	const trimmed = query.trim().toLowerCase()
+	const matches =
+		trimmed === "" ? observed : observed.filter((item) => item.name.toLowerCase().includes(trimmed))
+
+	const select = (namespace: string | null) => {
+		setGlobalNamespace(namespace)
+		// Loaders re-run and the keyed Outlet in __root remounts the page tree,
+		// so every query input is rebuilt under the new scope.
+		void router.invalidate()
+	}
+
+	if (loading && observed.length === 0) {
+		return <div className="px-2 py-1.5 text-xs text-muted-foreground">Loading namespaces…</div>
+	}
+	if (observed.length === 0 && pinned === null) {
+		return emptyNotice ? (
+			<div className="px-2 py-1.5 text-xs text-muted-foreground">No namespaces detected</div>
+		) : null
+	}
+
+	return (
+		<>
+			{observed.length >= SEARCH_THRESHOLD && (
+				<div className="p-1 pb-1.5">
+					<Input
+						autoFocus
+						placeholder="Search namespaces…"
+						size="sm"
+						value={query}
+						onChange={(e) => setQuery(e.target.value)}
+						// The menu's typeahead would otherwise swallow keystrokes and
+						// jump highlight to matching items while typing here.
+						onKeyDown={(e) => e.stopPropagation()}
+					/>
+				</div>
+			)}
+			<div className="max-h-72 overflow-y-auto">
+				{trimmed === "" && (
+					<DropdownMenuItem onClick={() => select(null)}>
+						<span className="truncate">All namespaces</span>
+						{pinned === null && <CheckIcon size={16} className="ml-auto" />}
+					</DropdownMenuItem>
+				)}
+				{matches.map((item) => (
+					<DropdownMenuItem key={item.name} onClick={() => select(item.name)}>
+						<span className="truncate">{item.name}</span>
+						{pinned === item.name && <CheckIcon size={16} className="ml-auto" />}
+					</DropdownMenuItem>
+				))}
+				{matches.length === 0 && trimmed !== "" && (
+					<div className="px-2 py-1.5 text-xs text-muted-foreground">No namespaces match</div>
+				)}
+				{!pinnedIsObserved && pinned !== null && (trimmed === "" || pinned.toLowerCase().includes(trimmed)) && (
+					<DropdownMenuItem onClick={() => select(pinned)}>
+						<span className="truncate">{pinned}</span>
+						<span className="ml-2 text-xs text-muted-foreground">no recent data</span>
+						<CheckIcon size={16} className="ml-auto" />
+					</DropdownMenuItem>
+				)}
+			</div>
+		</>
+	)
+}
+
+/**
+ * "Namespace ▸" submenu row for the Clerk org switcher. The current scope
+ * reads directly on the trigger so the pin is visible without opening it.
+ */
+export function NamespaceScopeSubmenu() {
+	const pinned = useGlobalNamespace()
+
+	return (
+		<>
+			<DropdownMenuSeparator />
+			<DropdownMenuSub>
+				<DropdownMenuSubTrigger>
+					<LayersIcon size={14} />
+					Namespace
+					<span className="ml-auto max-w-32 truncate pl-4 text-xs text-muted-foreground">
+						{pinned ?? "All"}
+					</span>
+				</DropdownMenuSubTrigger>
+				<DropdownMenuSubContent className="min-w-52">
+					<NamespaceScopeList />
+				</DropdownMenuSubContent>
+			</DropdownMenuSub>
+		</>
+	)
+}
+
+/** Flat variant for the self-hosted switcher, where the menu holds nothing else. */
+export function NamespaceScopeMenuGroup({ emptyNotice = false }: { emptyNotice?: boolean }) {
+	return (
+		<DropdownMenuGroup>
+			<DropdownMenuLabel>Namespace</DropdownMenuLabel>
+			<NamespaceScopeList emptyNotice={emptyNotice} />
+		</DropdownMenuGroup>
+	)
+}

--- a/apps/web/src/components/dashboard/org-switcher-menu.tsx
+++ b/apps/web/src/components/dashboard/org-switcher-menu.tsx
@@ -19,6 +19,7 @@ import {
 } from "@maple/ui/components/ui/dialog"
 import { Input } from "@maple/ui/components/ui/input"
 import { Button } from "@maple/ui/components/ui/button"
+import { NamespaceScopeSubmenu } from "./namespace-scope-menu"
 
 export function OrgAvatar({
 	name,
@@ -54,10 +55,14 @@ export function ClerkOrgSwitcherMenu({
 	trigger,
 	contentSide = "bottom",
 	contentAlign = "start",
+	namespaceScope = false,
 }: {
 	trigger: ReactElement
 	contentSide?: "top" | "right" | "bottom" | "left"
 	contentAlign?: "start" | "center" | "end"
+	/** Show the org-global namespace switch. Off by default — this menu is also
+	 * reused by auth flows (CLI login, MCP authorize, onboarding). */
+	namespaceScope?: boolean
 }) {
 	const { organization } = useOrganization()
 	const { userMemberships, setActive, createOrganization } = useOrganizationList({
@@ -127,6 +132,7 @@ export function ClerkOrgSwitcherMenu({
 							Create Organization
 						</DropdownMenuItem>
 					</DropdownMenuGroup>
+					{namespaceScope && <NamespaceScopeSubmenu />}
 				</DropdownMenuContent>
 			</DropdownMenu>
 

--- a/apps/web/src/components/dashboard/org-switcher.tsx
+++ b/apps/web/src/components/dashboard/org-switcher.tsx
@@ -1,11 +1,19 @@
 import { useOrganization } from "@clerk/clerk-react"
 import { ChevronExpandYIcon, ServerIcon } from "@/components/icons"
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuTrigger,
+} from "@maple/ui/components/ui/dropdown-menu"
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@maple/ui/components/ui/sidebar"
 import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import { ClerkOrgSwitcherMenu, OrgAvatar } from "./org-switcher-menu"
+import { NamespaceScopeMenuGroup } from "./namespace-scope-menu"
 
 function ClerkOrgSwitcher() {
 	const { organization } = useOrganization()
+	const pinnedNamespace = useGlobalNamespace()
 	const orgName = organization?.name ?? "Select Organization"
 	const orgImageUrl = organization?.imageUrl
 
@@ -13,6 +21,7 @@ function ClerkOrgSwitcher() {
 		<ClerkOrgSwitcherMenu
 			contentSide="right"
 			contentAlign="start"
+			namespaceScope
 			trigger={
 				<SidebarMenuButton
 					size="lg"
@@ -21,7 +30,11 @@ function ClerkOrgSwitcher() {
 					<OrgAvatar name={orgName} imageUrl={orgImageUrl} />
 					<div className="grid flex-1 text-left text-sm leading-tight">
 						<span className="truncate font-medium">{orgName}</span>
-						<span className="truncate text-xs text-muted-foreground">Organization</span>
+						{pinnedNamespace !== null ? (
+							<span className="truncate text-xs font-medium text-primary">{pinnedNamespace}</span>
+						) : (
+							<span className="truncate text-xs text-muted-foreground">Organization</span>
+						)}
 					</div>
 					<ChevronExpandYIcon size={16} className="ml-auto" />
 				</SidebarMenuButton>
@@ -31,15 +44,33 @@ function ClerkOrgSwitcher() {
 }
 
 function SelfHostedOrgSwitcher() {
+	const pinnedNamespace = useGlobalNamespace()
+
 	return (
-		<SidebarMenuButton size="lg" className="cursor-default hover:bg-transparent active:bg-transparent">
-			<div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-				<ServerIcon size={16} />
-			</div>
-			<div className="grid flex-1 text-left text-sm leading-tight">
-				<span className="truncate font-medium">Self Hosted</span>
-			</div>
-		</SidebarMenuButton>
+		<DropdownMenu>
+			<DropdownMenuTrigger
+				render={
+					<SidebarMenuButton
+						size="lg"
+						className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+					>
+						<div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+							<ServerIcon size={16} />
+						</div>
+						<div className="grid flex-1 text-left text-sm leading-tight">
+							<span className="truncate font-medium">Self Hosted</span>
+							{pinnedNamespace !== null && (
+								<span className="truncate text-xs font-medium text-primary">{pinnedNamespace}</span>
+							)}
+						</div>
+						<ChevronExpandYIcon size={16} className="ml-auto" />
+					</SidebarMenuButton>
+				}
+			/>
+			<DropdownMenuContent side="right" align="start" sideOffset={4} className="min-w-56">
+				<NamespaceScopeMenuGroup emptyNotice />
+			</DropdownMenuContent>
+		</DropdownMenu>
 	)
 }
 

--- a/apps/web/src/components/filters/pinned-namespace-notice.tsx
+++ b/apps/web/src/components/filters/pinned-namespace-notice.tsx
@@ -1,21 +1,30 @@
 import { useRouter } from "@tanstack/react-router"
+import { LayersIcon } from "@/components/icons"
+import { FILTER_SECTION_LABEL } from "@maple/ui/components/filters/filter-styles"
+import { cn } from "@maple/ui/lib/utils"
 import { setGlobalNamespace } from "@/lib/services/common/global-namespace"
 
 /**
  * Replaces a sidebar's Namespace filter section while the org-global namespace
  * pin is active — the page-level filter is ignored (not rewritten) until the
- * pin is cleared here or in the org menu.
+ * pin is cleared here or in the org menu. Styled as a regular section so it
+ * reads as part of the sidebar, not a callout.
  */
 export function PinnedNamespaceNotice({ namespace }: { namespace: string }) {
 	const router = useRouter()
 
 	return (
-		<div className="rounded-md border bg-muted/40 px-3 py-2">
-			<div className="flex items-center justify-between gap-2">
-				<span className="text-xs font-medium text-muted-foreground">Namespace</span>
+		<div>
+			<div
+				className={cn(
+					"flex w-full items-center justify-between gap-2 py-2 text-muted-foreground",
+					FILTER_SECTION_LABEL,
+				)}
+			>
+				<span className="truncate">Namespace</span>
 				<button
 					type="button"
-					className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+					className="font-medium normal-case tracking-normal text-muted-foreground transition-colors hover:text-foreground"
 					onClick={() => {
 						setGlobalNamespace(null)
 						void router.invalidate()
@@ -24,8 +33,16 @@ export function PinnedNamespaceNotice({ namespace }: { namespace: string }) {
 					Clear
 				</button>
 			</div>
-			<div className="mt-0.5 truncate text-sm font-medium">{namespace}</div>
-			<p className="mt-1 text-xs text-muted-foreground">Pinned for the whole app in the org menu.</p>
+			<div className="flex items-center gap-2 py-1 text-sm">
+				<LayersIcon size={14} className="shrink-0 text-muted-foreground" />
+				<span className="truncate">{namespace}</span>
+				<span
+					title="Pinned for the whole app in the org menu"
+					className="ml-auto rounded-sm bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
+				>
+					Pinned
+				</span>
+			</div>
 		</div>
 	)
 }

--- a/apps/web/src/components/filters/pinned-namespace-notice.tsx
+++ b/apps/web/src/components/filters/pinned-namespace-notice.tsx
@@ -1,0 +1,31 @@
+import { useRouter } from "@tanstack/react-router"
+import { setGlobalNamespace } from "@/lib/services/common/global-namespace"
+
+/**
+ * Replaces a sidebar's Namespace filter section while the org-global namespace
+ * pin is active — the page-level filter is ignored (not rewritten) until the
+ * pin is cleared here or in the org menu.
+ */
+export function PinnedNamespaceNotice({ namespace }: { namespace: string }) {
+	const router = useRouter()
+
+	return (
+		<div className="rounded-md border bg-muted/40 px-3 py-2">
+			<div className="flex items-center justify-between gap-2">
+				<span className="text-xs font-medium text-muted-foreground">Namespace</span>
+				<button
+					type="button"
+					className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+					onClick={() => {
+						setGlobalNamespace(null)
+						void router.invalidate()
+					}}
+				>
+					Clear
+				</button>
+			</div>
+			<div className="mt-0.5 truncate text-sm font-medium">{namespace}</div>
+			<p className="mt-1 text-xs text-muted-foreground">Pinned for the whole app in the org menu.</p>
+		</div>
+	)
+}

--- a/apps/web/src/components/logs/logs-filter-sidebar.tsx
+++ b/apps/web/src/components/logs/logs-filter-sidebar.tsx
@@ -23,6 +23,8 @@ import {
 	FilterSidebarLoading,
 } from "@/components/filters/filter-sidebar"
 import { SEVERITY_COLORS } from "@maple/ui/lib/severity"
+import { PinnedNamespaceNotice } from "@/components/filters/pinned-namespace-notice"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 
 const routeApi = getRouteApi("/logs/")
 
@@ -33,6 +35,7 @@ function LoadingState() {
 export function LogsFilterSidebar() {
 	const navigate = routeApi.useNavigate()
 	const search = routeApi.useSearch()
+	const pinnedNamespace = useGlobalNamespace()
 	const { startTime: effectiveStartTime, endTime: effectiveEndTime } = useEffectiveTimeRange(
 		search.startTime,
 		search.endTime,
@@ -162,14 +165,18 @@ export function LogsFilterSidebar() {
 							onExcludedChange={(val) => updateFilter("excludedDeploymentEnvs", val)}
 						/>
 
-						<SearchableFilterSection
-							title="Namespace"
-							options={facets.namespaces ?? []}
-							selected={search.namespaces ?? []}
-							onChange={(val) => updateFilter("namespaces", val)}
-							excluded={search.excludedNamespaces ?? []}
-							onExcludedChange={(val) => updateFilter("excludedNamespaces", val)}
-						/>
+						{pinnedNamespace !== null ? (
+							<PinnedNamespaceNotice namespace={pinnedNamespace} />
+						) : (
+							<SearchableFilterSection
+								title="Namespace"
+								options={facets.namespaces ?? []}
+								selected={search.namespaces ?? []}
+								onChange={(val) => updateFilter("namespaces", val)}
+								excluded={search.excludedNamespaces ?? []}
+								onExcludedChange={(val) => updateFilter("excludedNamespaces", val)}
+							/>
+						)}
 
 						<SearchableFilterSection
 							title="Service"

--- a/apps/web/src/components/logs/logs-volume-chart.tsx
+++ b/apps/web/src/components/logs/logs-volume-chart.tsx
@@ -20,6 +20,7 @@ import {
 import { useTheme } from "@maple/ui/hooks/use-theme"
 import { ChartLoading } from "@maple/ui/components/charts"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import { getCustomChartTimeSeriesResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { computeBucketSeconds } from "@/api/warehouse/timeseries-utils"
 import { formatBucketLabel, formatNumber, inferBucketSeconds, inferRangeMs } from "@maple/ui/lib/format"
@@ -230,6 +231,9 @@ interface LogsVolumeChartProps {
 }
 
 export function LogsVolumeChart({ filters, onTimeRangeSelect }: LogsVolumeChartProps) {
+	// Injected here (not via the atom option) — the custom-chart family is
+	// shared with dashboard widgets, which stay unscoped for now.
+	const pinnedNamespace = useGlobalNamespace()
 	const { startTime: effectiveStartTime, endTime: effectiveEndTime } = useEffectiveTimeRange(
 		filters?.startTime,
 		filters?.endTime,
@@ -254,7 +258,12 @@ export function LogsVolumeChart({ filters, onTimeRangeSelect }: LogsVolumeChartP
 					serviceNames: filters?.services ? [...filters.services] : undefined,
 					severities: filters?.severities ? [...filters.severities] : undefined,
 					environments: filters?.deploymentEnvs ? [...filters.deploymentEnvs] : undefined,
-					namespaces: filters?.namespaces ? [...filters.namespaces] : undefined,
+					namespaces:
+						pinnedNamespace !== null
+							? [pinnedNamespace]
+							: filters?.namespaces
+								? [...filters.namespaces]
+								: undefined,
 					excludedServiceNames: filters?.excludedServices
 						? [...filters.excludedServices]
 						: undefined,
@@ -264,9 +273,10 @@ export function LogsVolumeChart({ filters, onTimeRangeSelect }: LogsVolumeChartP
 					excludedEnvironments: filters?.excludedDeploymentEnvs
 						? [...filters.excludedDeploymentEnvs]
 						: undefined,
-					excludedNamespaces: filters?.excludedNamespaces
-						? [...filters.excludedNamespaces]
-						: undefined,
+					excludedNamespaces:
+						pinnedNamespace === null && filters?.excludedNamespaces
+							? [...filters.excludedNamespaces]
+							: undefined,
 				},
 			},
 		}),

--- a/apps/web/src/components/service-map/service-map-view.tsx
+++ b/apps/web/src/components/service-map/service-map-view.tsx
@@ -24,6 +24,7 @@ import {
 import "@xyflow/react/dist/style.css"
 
 import { Result, useAtom, useAtomValue } from "@/lib/effect-atom"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import { retainedQuery } from "@/lib/services/common/atom-client"
 import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { serviceMapLayoutAtomFamily, upsertSnapshot } from "@/atoms/service-map-layout-atoms"
@@ -2559,8 +2560,40 @@ export function ServiceMapView({
 	// Node DATA that streams in after the canvas mounts and refines nodes in place
 	// (colors, icons, pod badges, detail-panel overlays) without moving them —
 	// topology-determining results (edges, db edges, overviews) are gated below.
-	const overviews = Result.isSuccess(bundleResult) ? bundleResult.value.overview : []
-	const dbEdges = Result.isSuccess(bundleResult) ? bundleResult.value.dbEdges : []
+	const allOverviews = Result.isSuccess(bundleResult) ? bundleResult.value.overview : []
+
+	// Client-side scoping for the org-global namespace pin: the bundle still
+	// fetches every namespace (a server-side service.namespace filter is a
+	// follow-up), so drop out-of-namespace services and everything that only
+	// they touch. serviceNamespace is blanked because a map where every node
+	// shares one namespace has nothing left to group.
+	const pinnedNamespace = useGlobalNamespace()
+	const memberServices = useMemo(() => {
+		if (pinnedNamespace === null) return null
+		return new Set(
+			allOverviews
+				.filter((o) => o.serviceNamespace === pinnedNamespace)
+				.map((o) => o.serviceName),
+		)
+	}, [pinnedNamespace, allOverviews])
+	const overviews = useMemo(
+		() =>
+			memberServices === null
+				? allOverviews
+				: allOverviews
+						.filter((o) => memberServices.has(o.serviceName))
+						.map((o) => ({ ...o, serviceNamespace: "" })),
+		[allOverviews, memberServices],
+	)
+
+	const allDbEdges = Result.isSuccess(bundleResult) ? bundleResult.value.dbEdges : []
+	const dbEdges = useMemo(
+		() =>
+			memberServices === null
+				? allDbEdges
+				: allDbEdges.filter((edge) => memberServices.has(edge.sourceService)),
+		[allDbEdges, memberServices],
+	)
 	const cloudflareServices = Result.isSuccess(cloudflareResult) ? cloudflareResult.value.services : []
 	const planetscaleStats = Result.isSuccess(planetscaleStatsResult)
 		? planetscaleStatsResult.value.databases
@@ -2636,7 +2669,14 @@ export function ServiceMapView({
 		return map
 	}, [bundleResult])
 
-	const workloads = Result.isSuccess(bundleResult) ? bundleResult.value.workloads : []
+	const allWorkloads = Result.isSuccess(bundleResult) ? bundleResult.value.workloads : []
+	const workloads = useMemo(
+		() =>
+			memberServices === null
+				? allWorkloads
+				: allWorkloads.filter((workload) => memberServices.has(workload.serviceName)),
+		[allWorkloads, memberServices],
+	)
 
 	return Result.builder(bundleResult)
 		.onInitial(() => <ServiceMapLoading />)
@@ -2653,7 +2693,15 @@ export function ServiceMapView({
 		})
 		.onSuccess((mapResponse) => (
 			<ServiceMapCanvas
-				edges={mapResponse.edges}
+				edges={
+					memberServices === null
+						? mapResponse.edges
+						: mapResponse.edges.filter(
+								(edge) =>
+									memberServices.has(edge.sourceService) &&
+									memberServices.has(edge.targetService),
+							)
+				}
 				dbEdges={dbEdges}
 				cloudflareServices={cloudflareServices}
 				faasNames={faasNames}

--- a/apps/web/src/components/services/services-filter-sidebar.tsx
+++ b/apps/web/src/components/services/services-filter-sidebar.tsx
@@ -6,6 +6,8 @@ import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { FilterSection, SearchableFilterSection } from "@/components/traces/filter-section"
 import { getServicesFacetsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { isServiceHealth, useServiceHealthSummary } from "@/components/services/use-service-health-summary"
+import { PinnedNamespaceNotice } from "@/components/filters/pinned-namespace-notice"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import {
 	FilterSidebarBody,
 	FilterSidebarError,
@@ -23,6 +25,7 @@ function LoadingState() {
 export function ServicesFilterSidebar() {
 	const navigate = routeApi.useNavigate()
 	const search = routeApi.useSearch()
+	const pinnedNamespace = useGlobalNamespace()
 	const { startTime: effectiveStartTime, endTime: effectiveEndTime } = useEffectiveTimeRange(
 		search.startTime,
 		search.endTime,
@@ -120,15 +123,19 @@ export function ServicesFilterSidebar() {
 							onExcludedChange={(val) => updateFilter("excludedEnvironments", val)}
 						/>
 
-						{facets.namespaces.length > 0 && (
-							<SearchableFilterSection
-								title="Namespace"
-								options={facets.namespaces}
-								selected={search.namespaces ?? []}
-								onChange={(val) => updateFilter("namespaces", val)}
-								excluded={search.excludedNamespaces ?? []}
-								onExcludedChange={(val) => updateFilter("excludedNamespaces", val)}
-							/>
+						{pinnedNamespace !== null ? (
+							<PinnedNamespaceNotice namespace={pinnedNamespace} />
+						) : (
+							facets.namespaces.length > 0 && (
+								<SearchableFilterSection
+									title="Namespace"
+									options={facets.namespaces}
+									selected={search.namespaces ?? []}
+									onChange={(val) => updateFilter("namespaces", val)}
+									excluded={search.excludedNamespaces ?? []}
+									onExcludedChange={(val) => updateFilter("excludedNamespaces", val)}
+								/>
+							)
 						)}
 
 						<FilterSection

--- a/apps/web/src/components/services/services-table.tsx
+++ b/apps/web/src/components/services/services-table.tsx
@@ -4,6 +4,7 @@ import { Result, useAtomValue } from "@/lib/effect-atom"
 import { Link, useNavigate } from "@tanstack/react-router"
 
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { useAlertIncidentsList } from "@/hooks/use-alerts-list"
 import {
@@ -136,9 +137,16 @@ function groupByNamespace(services: ServiceOverview[]): [string, [string, Servic
  * Unset `groupBy` in the URL means auto: group by namespace as soon as the
  * displayed rows carry any `service.namespace` (the semconv grouping
  * dimension), else fall back to the environment grouping every org has.
+ * While the org-global namespace pin is active every row shares one
+ * namespace, so auto falls back to environment grouping.
  */
-function resolveGroupBy(explicit: ServicesGroupBy | undefined, services: ServiceOverview[]): ServicesGroupBy {
+function resolveGroupBy(
+	explicit: ServicesGroupBy | undefined,
+	services: ServiceOverview[],
+	namespacePinned: boolean,
+): ServicesGroupBy {
 	if (explicit !== undefined) return explicit
+	if (namespacePinned) return "environment"
 	return services.some((service) => service.serviceNamespace !== "") ? "namespace" : "environment"
 }
 
@@ -605,6 +613,7 @@ function LoadingState() {
 
 export function ServicesTable({ filters }: ServicesTableProps) {
 	const navigate = useNavigate()
+	const pinnedNamespace = useGlobalNamespace()
 	const { startTime: effectiveStartTime, endTime: effectiveEndTime } = useEffectiveTimeRange(
 		filters?.startTime,
 		filters?.endTime,
@@ -687,7 +696,7 @@ export function ServicesTable({ filters }: ServicesTableProps) {
 				: overviewResponse.data
 
 			const hasNamespaces = services.some((service) => service.serviceNamespace !== "")
-			const groupBy = resolveGroupBy(filters?.groupBy, services)
+			const groupBy = resolveGroupBy(filters?.groupBy, services, pinnedNamespace !== null)
 			// One shape for both modes: namespace mode nests environment groups
 			// under each namespace; environment mode is a single anonymous outer
 			// group whose header is skipped.

--- a/apps/web/src/components/traces/traces-filter-sidebar.tsx
+++ b/apps/web/src/components/traces/traces-filter-sidebar.tsx
@@ -8,6 +8,8 @@ import {
 	serviceColorMap,
 } from "./filter-section"
 import { DurationRangeFilter } from "./duration-range-filter"
+import { PinnedNamespaceNotice } from "@/components/filters/pinned-namespace-notice"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import type { TracesFacetsResponse } from "@/api/warehouse/traces"
 import {
 	FilterSidebarBody,
@@ -39,6 +41,7 @@ function TracesFilterSidebarView({
 	onDurationRangeChange,
 	onClearFilters,
 }: TracesFilterSidebarViewProps) {
+	const pinnedNamespace = useGlobalNamespace()
 	const hasActiveFilters =
 		(filters.services?.length ?? 0) > 0 ||
 		(filters.spanNames?.length ?? 0) > 0 ||
@@ -102,14 +105,18 @@ function TracesFilterSidebarView({
 							onExcludedChange={(val) => onFilterChange("excludedDeploymentEnvs", val)}
 						/>
 
-						<SearchableFilterSection
-							title="Namespace"
-							options={facets.namespaces ?? []}
-							selected={filters.namespaces ?? []}
-							onChange={(val) => onFilterChange("namespaces", val)}
-							excluded={filters.excludedNamespaces ?? []}
-							onExcludedChange={(val) => onFilterChange("excludedNamespaces", val)}
-						/>
+						{pinnedNamespace !== null ? (
+							<PinnedNamespaceNotice namespace={pinnedNamespace} />
+						) : (
+							<SearchableFilterSection
+								title="Namespace"
+								options={facets.namespaces ?? []}
+								selected={filters.namespaces ?? []}
+								onChange={(val) => onFilterChange("namespaces", val)}
+								excluded={filters.excludedNamespaces ?? []}
+								onExcludedChange={(val) => onFilterChange("excludedNamespaces", val)}
+							/>
+						)}
 
 						<SearchableFilterSection
 							title="Service"

--- a/apps/web/src/hooks/use-global-namespace.ts
+++ b/apps/web/src/hooks/use-global-namespace.ts
@@ -1,0 +1,6 @@
+import { useSyncExternalStore } from "react"
+import { getGlobalNamespace, subscribeGlobalNamespace } from "@/lib/services/common/global-namespace"
+
+/** The active org's pinned service.namespace, or null for "All namespaces". */
+export const useGlobalNamespace = (): string | null =>
+	useSyncExternalStore(subscribeGlobalNamespace, getGlobalNamespace, () => null)

--- a/apps/web/src/hooks/use-infinite-logs.ts
+++ b/apps/web/src/hooks/use-infinite-logs.ts
@@ -3,6 +3,7 @@ import { Result } from "@/lib/effect-atom"
 
 import { listLogs, type Log, type LogsResponse } from "@/api/warehouse/logs"
 import { listLogsResultAtom, type QueryAtomFailure } from "@/lib/services/atoms/warehouse-query-atoms"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { useTableRefreshTimeRange } from "@/hooks/use-table-refresh-time-range"
 import { mapleRuntime } from "@/lib/registry"
@@ -24,7 +25,12 @@ export interface UseInfiniteLogsReturn {
 function buildQueryParams(
 	filters: LogsSearchParams | undefined,
 	range: { startTime: string; endTime: string },
+	globalNamespace: string | null,
 ) {
+	// The org-global pin overrides URL namespace filters (they stay in the URL
+	// untouched; unpinning restores them). Applied here so the atom page and the
+	// direct pagination fetches below stay byte-for-byte identical.
+	const pinned = globalNamespace !== null
 	return {
 		startTime: range.startTime,
 		endTime: range.endTime,
@@ -34,12 +40,12 @@ function buildQueryParams(
 		severities: filters?.severities,
 		deploymentEnvs: filters?.deploymentEnvs,
 		deploymentEnvMatchMode: filters?.deploymentEnvMatchMode,
-		namespaces: filters?.namespaces,
-		namespaceMatchMode: filters?.namespaceMatchMode,
+		namespaces: pinned ? [globalNamespace] : filters?.namespaces,
+		namespaceMatchMode: pinned ? undefined : filters?.namespaceMatchMode,
 		excludedServices: filters?.excludedServices,
 		excludedSeverities: filters?.excludedSeverities,
 		excludedDeploymentEnvs: filters?.excludedDeploymentEnvs,
-		excludedNamespaces: filters?.excludedNamespaces,
+		excludedNamespaces: pinned ? undefined : filters?.excludedNamespaces,
 		search: filters?.search,
 	}
 }
@@ -52,9 +58,11 @@ export function useInfiniteLogs(filters: LogsSearchParams | undefined): UseInfin
 		defaultRange: "12h",
 	})
 
+	const globalNamespace = useGlobalNamespace()
+
 	const queryParams = React.useMemo(
-		() => buildQueryParams(filters, { startTime, endTime }),
-		[filters, startTime, endTime],
+		() => buildQueryParams(filters, { startTime, endTime }, globalNamespace),
+		[filters, startTime, endTime, globalNamespace],
 	)
 
 	const filterKey = React.useMemo(() => JSON.stringify(queryParams), [queryParams])

--- a/apps/web/src/hooks/use-infinite-traces.ts
+++ b/apps/web/src/hooks/use-infinite-traces.ts
@@ -3,6 +3,7 @@ import { Result } from "@/lib/effect-atom"
 
 import { listTraces, type Trace, type TracesResponse } from "@/api/warehouse/traces"
 import { listTracesResultAtom, type QueryAtomFailure } from "@/lib/services/atoms/warehouse-query-atoms"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { useTableRefreshTimeRange } from "@/hooks/use-table-refresh-time-range"
 import type { TracesSearchParams } from "@/routes/traces"
@@ -27,7 +28,12 @@ export interface UseInfiniteTracesReturn {
 function buildQueryParams(
 	filters: TracesSearchParams | undefined,
 	refreshedRange: { startTime: string; endTime: string },
+	globalNamespace: string | null,
 ) {
+	// The org-global pin overrides URL namespace filters (they stay in the URL
+	// untouched; unpinning restores them). Applied here so the atom page and the
+	// direct pagination fetches below stay byte-for-byte identical.
+	const pinned = globalNamespace !== null
 	return {
 		services: filters?.services,
 		spanNames: filters?.spanNames,
@@ -37,7 +43,7 @@ function buildQueryParams(
 		httpMethods: filters?.httpMethods,
 		httpStatusCodes: filters?.httpStatusCodes,
 		deploymentEnvs: filters?.deploymentEnvs,
-		namespaces: filters?.namespaces,
+		namespaces: pinned ? [globalNamespace] : filters?.namespaces,
 		attributeFilters: filters?.attributeFilters,
 		resourceAttributeFilters: filters?.resourceAttributeFilters,
 		startTime: refreshedRange.startTime,
@@ -46,11 +52,11 @@ function buildQueryParams(
 		serviceMatchMode: filters?.serviceMatchMode,
 		spanNameMatchMode: filters?.spanNameMatchMode,
 		deploymentEnvMatchMode: filters?.deploymentEnvMatchMode,
-		namespaceMatchMode: filters?.namespaceMatchMode,
+		namespaceMatchMode: pinned ? undefined : filters?.namespaceMatchMode,
 		excludedServices: filters?.excludedServices,
 		excludedSpanNames: filters?.excludedSpanNames,
 		excludedDeploymentEnvs: filters?.excludedDeploymentEnvs,
-		excludedNamespaces: filters?.excludedNamespaces,
+		excludedNamespaces: pinned ? undefined : filters?.excludedNamespaces,
 		excludedHttpMethods: filters?.excludedHttpMethods,
 		excludedHttpStatusCodes: filters?.excludedHttpStatusCodes,
 		hideNoise: filters?.hideNoise,
@@ -68,9 +74,11 @@ export function useInfiniteTraces(filters: TracesSearchParams | undefined): UseI
 		defaultRange: "12h",
 	})
 
+	const globalNamespace = useGlobalNamespace()
+
 	const queryParams = React.useMemo(
-		() => buildQueryParams(filters, refreshedRange),
-		[filters, refreshedRange],
+		() => buildQueryParams(filters, refreshedRange, globalNamespace),
+		[filters, refreshedRange, globalNamespace],
 	)
 
 	const filterKey = React.useMemo(() => JSON.stringify(queryParams), [queryParams])

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.test.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest"
+import { setActiveOrgId } from "@/lib/services/common/auth-headers"
+import { setGlobalNamespace } from "@/lib/services/common/global-namespace"
+import { applyGlobalNamespace } from "./warehouse-query-atoms"
+
+// Unique org per test — the global-namespace store keeps a per-org in-memory
+// cache, so a reused org id would read a previous test's pin.
+let orgSeq = 0
+const freshOrg = () => `org_wqa_${orgSeq++}`
+
+describe("applyGlobalNamespace", () => {
+	beforeEach(() => {
+		localStorage.clear()
+		setActiveOrgId(freshOrg())
+	})
+
+	it("is a no-op while unpinned", () => {
+		const input = { data: { startTime: "2026-01-01 00:00:00", namespaces: ["from-url"] } }
+		expect(applyGlobalNamespace(input, "top")).toBe(input)
+	})
+
+	it("pins into top-level data and overrides URL-borne namespace filters", () => {
+		setGlobalNamespace("checkout")
+		const result = applyGlobalNamespace(
+			{
+				data: {
+					startTime: "2026-01-01 00:00:00",
+					namespaces: ["from-url"],
+					excludedNamespaces: ["other"],
+					namespaceMatchMode: "contains",
+					services: ["api"],
+				},
+			},
+			"top",
+		)
+		expect(result).toEqual({
+			data: {
+				startTime: "2026-01-01 00:00:00",
+				namespaces: ["checkout"],
+				excludedNamespaces: undefined,
+				namespaceMatchMode: undefined,
+				namespace: undefined,
+				services: ["api"],
+			},
+		})
+	})
+
+	it("pins into nested filters for the \"filters\" scope", () => {
+		setGlobalNamespace("checkout")
+		const result = applyGlobalNamespace(
+			{ data: { source: "logs", filters: { environments: ["prod"], excludedNamespaces: ["x"] } } },
+			"filters",
+		)
+		expect(result).toEqual({
+			data: {
+				source: "logs",
+				filters: { environments: ["prod"], namespaces: ["checkout"], excludedNamespaces: undefined },
+			},
+		})
+	})
+
+	it("creates the data/filters objects when absent", () => {
+		setGlobalNamespace("checkout")
+		expect(applyGlobalNamespace({}, "top")).toEqual({
+			data: {
+				namespaces: ["checkout"],
+				namespace: undefined,
+				namespaceMatchMode: undefined,
+				excludedNamespaces: undefined,
+			},
+		})
+		expect(applyGlobalNamespace({ data: {} }, "filters")).toEqual({
+			data: { filters: { namespaces: ["checkout"], excludedNamespaces: undefined } },
+		})
+	})
+})

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -3,6 +3,7 @@ import { Effect, Schema } from "effect"
 import { encodeOrgScopedKey, identityFromKey, orgScopedKeyPayload } from "@/lib/cache-key"
 import { nextRetentionNamespace, withRetention } from "@/lib/services/atoms/retained-atom"
 import { getActiveOrgId } from "@/lib/services/common/auth-headers"
+import { getGlobalNamespace } from "@/lib/services/common/global-namespace"
 import { MapleApiAtomClient } from "@/lib/services/common/atom-client"
 import type { BackendError, WarehouseApiError } from "@/api/warehouse/effect-utils"
 import {
@@ -136,6 +137,46 @@ interface QueryAtomOptions {
 	 * user's round trip away from the page tends to be.
 	 */
 	staleTime?: number
+	/**
+	 * Pin the org-global namespace (see `global-namespace.ts`) into this query's
+	 * input before key encoding, so the pin lands in both the request payload and
+	 * the cache key. `"top"` writes `data.namespaces`, `"filters"` writes
+	 * `data.filters.namespaces`. Only for families whose input schema accepts
+	 * `namespaces` — decode drops unknown keys, which would silently un-scope
+	 * the query while still fragmenting its cache.
+	 */
+	globalNamespace?: GlobalNamespaceScope
+}
+
+type GlobalNamespaceScope = "top" | "filters"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value)
+
+const pinIntoData = (data: Record<string, unknown>, scope: GlobalNamespaceScope, ns: string): Record<string, unknown> => {
+	if (scope === "filters") {
+		const prevFilters = isRecord(data.filters) ? data.filters : {}
+		return { ...data, filters: { ...prevFilters, namespaces: [ns], excludedNamespaces: undefined } }
+	}
+	// URL-borne namespace filters are ignored (overridden), never rewritten —
+	// unpinning restores them untouched. `encodeKey` strips `undefined` entries.
+	return {
+		...data,
+		namespaces: [ns],
+		namespace: undefined,
+		namespaceMatchMode: undefined,
+		excludedNamespaces: undefined,
+	}
+}
+
+/** Merge the pinned global namespace into a `{ data }` query input, if any.
+ * Exported for its unit tests — production callers go through the families. */
+export const applyGlobalNamespace = (input: unknown, scope: GlobalNamespaceScope): Record<string, unknown> => {
+	const base = isRecord(input) ? input : {}
+	const ns = getGlobalNamespace()
+	if (ns === null) return base
+	const data = isRecord(base.data) ? base.data : {}
+	return { ...base, data: pinIntoData(data, scope, ns) }
 }
 
 class QueryAtomError extends Schema.TaggedError<QueryAtomError>()("@maple/web/services/QueryAtomError", {
@@ -191,7 +232,13 @@ function makeQueryAtomFamily<Input, Output>(query: QueryEffect<Input, Output>, o
 		return withRetention(resultAtom, identity)
 	})
 
-	return (input: Input) => family(encodeOrgScopedKey(getActiveOrgId(), input))
+	// Pinning happens before key encoding so loader `warmAtoms` and component
+	// reads stay byte-for-byte identical, and the pin re-keys the cache entry.
+	const scope = options?.globalNamespace
+	return (input: Input) =>
+		family(
+			encodeOrgScopedKey(getActiveOrgId(), scope === undefined ? input : applyGlobalNamespace(input, scope)),
+		)
 }
 
 export const getServiceUsageResultAtom = makeQueryAtomFamily(getServiceUsage, {
@@ -211,31 +258,37 @@ export const getServicesFacetsResultAtom = makeQueryAtomFamily(getServicesFacets
 
 export const getServiceOverviewResultAtom = makeQueryAtomFamily(getServiceOverview, {
 	staleTime: 30_000,
+	globalNamespace: "top",
 })
 
 export const getServiceHealthSnapshotResultAtom = makeQueryAtomFamily(getServiceHealthSnapshot, {
 	staleTime: 30_000,
+	globalNamespace: "top",
 })
 
 export const getServiceHealthBaselineResultAtom = makeQueryAtomFamily(getServiceHealthBaseline, {
 	// The trailing-7d latency baseline moves slowly and the request payload is
 	// hour-snapped, so keep it warm far longer than the live overview.
 	staleTime: 30 * 60_000,
+	globalNamespace: "top",
 })
 
 export const getCustomChartServiceSparklinesResultAtom = makeQueryAtomFamily(
 	getCustomChartServiceSparklines,
 	{
 		staleTime: 30_000,
+		globalNamespace: "top",
 	},
 )
 
 export const listTracesResultAtom = makeQueryAtomFamily(listTraces, {
 	staleTime: 30_000,
+	globalNamespace: "top",
 })
 
 export const getTracesFacetsResultAtom = makeQueryAtomFamily(getTracesFacets, {
 	staleTime: 30_000,
+	globalNamespace: "top",
 })
 
 // Single-dimension facet list for dashboard variables — server compiles only
@@ -349,6 +402,7 @@ export const getSpanDetailResultAtom = makeQueryAtomFamily(getSpanDetail, {
 
 export const listLogsResultAtom = makeQueryAtomFamily(listLogs, {
 	staleTime: 30_000,
+	globalNamespace: "top",
 })
 
 export const getLogResultAtom = makeQueryAtomFamily(getLog, {
@@ -357,6 +411,7 @@ export const getLogResultAtom = makeQueryAtomFamily(getLog, {
 
 export const getLogsFacetsResultAtom = makeQueryAtomFamily(getLogsFacets, {
 	staleTime: 30_000,
+	globalNamespace: "top",
 })
 
 export const getLogsFacetValuesResultAtom = makeQueryAtomFamily(getLogsFacetValues, {
@@ -365,18 +420,22 @@ export const getLogsFacetValuesResultAtom = makeQueryAtomFamily(getLogsFacetValu
 
 export const getErrorsByTypeResultAtom = makeQueryAtomFamily(getErrorsByType, {
 	staleTime: 60_000,
+	globalNamespace: "top",
 })
 
 export const getErrorsSparkResultAtom = makeQueryAtomFamily(getErrorsSpark, {
 	staleTime: 60_000,
+	globalNamespace: "top",
 })
 
 export const getErrorsFacetsResultAtom = makeQueryAtomFamily(getErrorsFacets, {
 	staleTime: 60_000,
+	globalNamespace: "top",
 })
 
 export const getErrorsSummaryResultAtom = makeQueryAtomFamily(getErrorsSummary, {
 	staleTime: 60_000,
+	globalNamespace: "top",
 })
 
 export const listMetricsResultAtom = makeQueryAtomFamily(listMetrics, {
@@ -519,6 +578,7 @@ export const getServiceDetailOverviewResultAtom = makeQueryAtomFamily(getService
 
 export const getOverviewTimeSeriesResultAtom = makeQueryAtomFamily(getOverviewTimeSeries, {
 	staleTime: 30_000,
+	globalNamespace: "top",
 })
 
 // Non-blocking exact pre-sampling throughput overlays. Keyed (via the encoded
@@ -531,7 +591,7 @@ export const getServiceDetailThroughputRefinementResultAtom = makeQueryAtomFamil
 
 export const getOverviewThroughputRefinementResultAtom = makeQueryAtomFamily(
 	getOverviewThroughputRefinement,
-	{ staleTime: 30_000 },
+	{ staleTime: 30_000, globalNamespace: "top" },
 )
 
 export const getCustomChartTimeSeriesResultAtom = makeQueryAtomFamily(getCustomChartTimeSeries, {

--- a/apps/web/src/lib/services/common/global-namespace.test.ts
+++ b/apps/web/src/lib/services/common/global-namespace.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { setActiveOrgId } from "./auth-headers"
+import { getGlobalNamespace, setGlobalNamespace, subscribeGlobalNamespace } from "./global-namespace"
+
+// Each test uses its own org ids: the module keeps a per-org in-memory cache
+// (deliberately, for storage-denied sessions), so reusing an org id across
+// tests would read the previous test's value instead of localStorage.
+describe("global-namespace", () => {
+	beforeEach(() => {
+		localStorage.clear()
+		setActiveOrgId(null)
+	})
+
+	it("is null with no active org", () => {
+		expect(getGlobalNamespace()).toBeNull()
+	})
+
+	it("persists the pin per org in localStorage", () => {
+		setActiveOrgId("org_persist")
+		setGlobalNamespace("checkout")
+		expect(getGlobalNamespace()).toBe("checkout")
+		expect(localStorage.getItem("maple.global-namespace.org_persist")).toBe("checkout")
+	})
+
+	it("does not bleed across orgs", () => {
+		setActiveOrgId("org_bleed_a")
+		setGlobalNamespace("checkout")
+		setActiveOrgId("org_bleed_b")
+		expect(getGlobalNamespace()).toBeNull()
+		setGlobalNamespace("payments")
+		setActiveOrgId("org_bleed_a")
+		expect(getGlobalNamespace()).toBe("checkout")
+	})
+
+	it("clears the pin and its storage entry on null", () => {
+		setActiveOrgId("org_clear")
+		setGlobalNamespace("checkout")
+		setGlobalNamespace(null)
+		expect(getGlobalNamespace()).toBeNull()
+		expect(localStorage.getItem("maple.global-namespace.org_clear")).toBeNull()
+	})
+
+	it("notifies subscribers on change and stops after unsubscribe", () => {
+		setActiveOrgId("org_notify")
+		const notify = vi.fn()
+		const unsubscribe = subscribeGlobalNamespace(notify)
+		setGlobalNamespace("checkout")
+		expect(notify).toHaveBeenCalledTimes(1)
+		unsubscribe()
+		setGlobalNamespace(null)
+		expect(notify).toHaveBeenCalledTimes(1)
+	})
+
+	it("still honors the pin in-memory when storage writes are denied", () => {
+		setActiveOrgId("org_denied")
+		const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new Error("denied")
+		})
+		try {
+			setGlobalNamespace("checkout")
+			expect(getGlobalNamespace()).toBe("checkout")
+		} finally {
+			setItem.mockRestore()
+		}
+	})
+
+	it("treats an empty stored value as unpinned", () => {
+		setActiveOrgId("org_empty")
+		localStorage.setItem("maple.global-namespace.org_empty", "")
+		expect(getGlobalNamespace()).toBeNull()
+	})
+})

--- a/apps/web/src/lib/services/common/global-namespace.ts
+++ b/apps/web/src/lib/services/common/global-namespace.ts
@@ -1,0 +1,48 @@
+import { getActiveOrgId } from "./auth-headers"
+
+// The org-global service.namespace pin lives here rather than in an Atom.kvs
+// because query inputs are built synchronously outside atom contexts — in route
+// loaders (warmAtoms inputs must match component inputs byte for byte), in the
+// atom key encoder, and in the infinite hooks' direct page fetches.
+const STORAGE_PREFIX = "maple.global-namespace."
+
+let cached: { readonly orgId: string; readonly value: string | null } | null = null
+
+const subscribers = new Set<() => void>()
+
+const read = (orgId: string): string | null => {
+	try {
+		const raw = localStorage.getItem(`${STORAGE_PREFIX}${orgId}`)
+		return raw !== null && raw.length > 0 ? raw : null
+	} catch {
+		// SSR / storage denied — behave as "All namespaces".
+		return null
+	}
+}
+
+/** The active org's pinned service.namespace, or null for "All namespaces". */
+export const getGlobalNamespace = (): string | null => {
+	const orgId = getActiveOrgId()
+	if (orgId === null) return null
+	if (cached?.orgId !== orgId) cached = { orgId, value: read(orgId) }
+	return cached.value
+}
+
+export const setGlobalNamespace = (value: string | null) => {
+	const orgId = getActiveOrgId()
+	if (orgId === null) return
+	try {
+		if (value === null) localStorage.removeItem(`${STORAGE_PREFIX}${orgId}`)
+		else localStorage.setItem(`${STORAGE_PREFIX}${orgId}`, value)
+	} catch {
+		// Storage denied — the in-memory pin still applies for this session.
+	}
+	cached = { orgId, value }
+	for (const notify of subscribers) notify()
+}
+
+/** Subscribe to pin changes. Returns an unsubscribe fn (useSyncExternalStore-shaped). */
+export const subscribeGlobalNamespace = (notify: () => void): (() => void) => {
+	subscribers.add(notify)
+	return () => subscribers.delete(notify)
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -21,6 +21,7 @@ import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 import type { RouterAuthContext } from "@/router"
 import type { EffectRouterContext } from "@effect-router/core"
 import { captureChatReferrer } from "@/components/chat/auto-contexts"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import { GlobalChatSheet } from "@/components/chat/global-chat-sheet"
 import { GlobalShortcuts } from "@/components/command-palette/global-shortcuts"
 import { IdleRoutePrefetch } from "@/components/performance/idle-route-prefetch"
@@ -86,6 +87,10 @@ export const Route = createRootRouteWithContext<{ auth: RouterAuthContext } & Ef
 // the entire route tree on every commit.
 const AppFrame = memo(function AppFrame() {
 	const pathname = useRouterState({ select: (s) => s.location.pathname })
+	// Remount the page tree when the org-global namespace pin changes: every
+	// component rebuilds its query inputs under the new scope, so no memoized
+	// atom key can keep serving the previous scope's rows.
+	const globalNamespace = useGlobalNamespace()
 	useEffect(() => {
 		captureChatReferrer(pathname)
 	}, [pathname])
@@ -93,7 +98,7 @@ const AppFrame = memo(function AppFrame() {
 		<AttributesProvider highlightJson={highlightCode} renderValue={renderAttributeValue}>
 			<ToastProvider position="bottom-right">
 				<AnchoredToastProvider>
-					<Outlet />
+					<Outlet key={globalNamespace ?? "__all__"} />
 					{!isPublicPath(pathname) && <IdleRoutePrefetch />}
 					{!isPublicPath(pathname) && (
 						<>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -33,6 +33,7 @@ import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 
 import { formatWarehouseDateTime } from "@maple/query-engine"
 import { snapRangeForCache } from "@/lib/time-utils"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 const dashboardSearchSchema = Schema.Struct({
 	environment: Schema.optional(Schema.String),
 	...TimeRangeSearchFields,
@@ -163,6 +164,7 @@ function DashboardContent({
 }) {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
+	const pinnedNamespace = useGlobalNamespace()
 
 	const { startTime: effectiveStartTime, endTime: effectiveEndTime } = useEffectiveTimeRange(
 		search.startTime,
@@ -256,6 +258,9 @@ function DashboardContent({
 					filters: {
 						serviceName: undefined,
 						environments: environmentFilter,
+						// Injected per-site — the custom-chart family is shared with
+						// dashboard widgets, which stay unscoped for now.
+						namespaces: pinnedNamespace !== null ? [pinnedNamespace] : undefined,
 					},
 				},
 			})

--- a/apps/web/src/routes/logs/index.tsx
+++ b/apps/web/src/routes/logs/index.tsx
@@ -11,6 +11,7 @@ import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { ActiveFilterChips } from "@maple/ui/components/filters/active-filter-chips"
 import { logFilterChips } from "@/lib/logs/log-filter-chips"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 
 const logsSearchSchema = Schema.Struct({
 	services: OptionalStringArrayParam,
@@ -39,6 +40,7 @@ export const Route = createFileRoute("/logs/")({
 function LogsPage() {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
+	const pinnedNamespace = useGlobalNamespace()
 
 	const handleTimeChange = (
 		range: {
@@ -54,13 +56,21 @@ function LogsPage() {
 		})
 	}
 
-	const activeFilterChips = logFilterChips(search).map((chip) => ({
-		id: chip.param,
-		label: chip.label,
-		values: chip.values,
-		negated: chip.negated,
-		onRemove: () => navigate({ search: (prev) => ({ ...prev, [chip.param]: undefined }) }),
-	}))
+	const activeFilterChips = logFilterChips(search)
+		// URL namespace filters are ignored while the org-global pin is on —
+		// chips for them would suggest they still apply.
+		.filter(
+			(chip) =>
+				pinnedNamespace === null ||
+				(chip.param !== "namespaces" && chip.param !== "excludedNamespaces"),
+		)
+		.map((chip) => ({
+			id: chip.param,
+			label: chip.label,
+			values: chip.values,
+			negated: chip.negated,
+			onRemove: () => navigate({ search: (prev) => ({ ...prev, [chip.param]: undefined }) }),
+		}))
 
 	const clearFacetFilters = () => {
 		navigate({

--- a/apps/web/src/routes/services/index.tsx
+++ b/apps/web/src/routes/services/index.tsx
@@ -13,6 +13,7 @@ import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { ServicesTable } from "@/components/services/services-table"
 import { ActiveFilterChips } from "@maple/ui/components/filters/active-filter-chips"
 import { serviceFilterChips } from "@/lib/services-list/service-filter-chips"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import { ServicesFilterSidebar } from "@/components/services/services-filter-sidebar"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
@@ -93,6 +94,7 @@ export const Route = createFileRoute("/services/")({
 function ServicesPage() {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
+	const pinnedNamespace = useGlobalNamespace()
 	const { startTime: effectiveStartTime, endTime: effectiveEndTime } = useEffectiveTimeRange(
 		search.startTime,
 		search.endTime,
@@ -139,16 +141,25 @@ function ServicesPage() {
 						</DashboardLayout.Sticky>
 						<DashboardLayout.Scroll>
 							<ActiveFilterChips
-								chips={serviceFilterChips(search).map((chip) => ({
-									id: chip.param,
-									label: chip.label,
-									values: chip.values,
-									negated: chip.negated,
-									onRemove: () =>
-										navigate({
-											search: (prev) => ({ ...prev, [chip.param]: undefined }),
-										}),
-								}))}
+								chips={serviceFilterChips(search)
+									// URL namespace filters are ignored while the org-global
+									// pin is on — chips for them would suggest they still apply.
+									.filter(
+										(chip) =>
+											pinnedNamespace === null ||
+											(chip.param !== "namespaces" &&
+												chip.param !== "excludedNamespaces"),
+									)
+									.map((chip) => ({
+										id: chip.param,
+										label: chip.label,
+										values: chip.values,
+										negated: chip.negated,
+										onRemove: () =>
+											navigate({
+												search: (prev) => ({ ...prev, [chip.param]: undefined }),
+											}),
+									}))}
 							/>
 							<ServicesTable filters={search} />
 						</DashboardLayout.Scroll>

--- a/apps/web/src/routes/traces/index.tsx
+++ b/apps/web/src/routes/traces/index.tsx
@@ -20,6 +20,7 @@ import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-ran
 import { AutocompleteValuesProvider } from "@/hooks/use-autocomplete-values"
 import { ActiveFilterChips } from "@maple/ui/components/filters/active-filter-chips"
 import { traceFilterChips } from "@/lib/traces/trace-filter-chips"
+import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 
 const ContainsMatchMode = Schema.optional(Schema.Literals(["contains"]))
 
@@ -92,6 +93,7 @@ export const Route = createFileRoute("/traces/")({
 function TracesPage() {
 	const search = Route.useSearch()
 	const navigate = useNavigate({ from: Route.fullPath })
+	const pinnedNamespace = useGlobalNamespace()
 
 	const handleApplyWhereClause = React.useCallback(
 		(newClause: string) => {
@@ -104,14 +106,22 @@ function TracesPage() {
 
 	const activeFilterChips = React.useMemo(
 		() =>
-			traceFilterChips(search).map((chip) => ({
-				id: chip.param,
-				label: chip.label,
-				values: chip.values,
-				negated: chip.negated,
-				onRemove: () => navigate({ search: (prev) => ({ ...prev, [chip.param]: undefined }) }),
-			})),
-		[search, navigate],
+			traceFilterChips(search)
+				// URL namespace filters are ignored while the org-global pin is on —
+				// chips for them would suggest they still apply.
+				.filter(
+					(chip) =>
+						pinnedNamespace === null ||
+						(chip.param !== "namespaces" && chip.param !== "excludedNamespaces"),
+				)
+				.map((chip) => ({
+					id: chip.param,
+					label: chip.label,
+					values: chip.values,
+					negated: chip.negated,
+					onRemove: () => navigate({ search: (prev) => ({ ...prev, [chip.param]: undefined }) }),
+				})),
+		[search, navigate, pinnedNamespace],
 	)
 
 	const clearFacetFilters = React.useCallback(() => {


### PR DESCRIPTION
## What

Adds a global `service.namespace` scope to the web app, selectable from a new **Namespace** submenu in the org switcher (both auth variants). Picking a namespace pins it for the whole app: overview, services, traces, logs, errors, and the service map all narrow to that namespace, and the switcher's subtitle shows the active scope. "All namespaces" is the default; the pin is sticky per org (localStorage) and survives reloads.

While pinned:
- Page-level Namespace filter sections are replaced by a pinned notice with a Clear affordance, and namespace chips are hidden.
- URL `namespaces`/`excludedNamespaces` params are **ignored, never rewritten** — unpinning restores them exactly.
- The services table's auto grouping falls back to environment (single-namespace grouping is redundant).
- Orgs with no namespaces never see the section.

## How

- The pin lives in a module singleton (`global-namespace.ts`) persisted per org, mirroring the active-org-id pattern — it must be readable synchronously in route loaders, the atom key encoder, and the infinite hooks' direct page fetches, which an atom-based store can't provide.
- Injection happens at one choke point: `makeQueryAtomFamily` merges the pin into query inputs **before** org-scoped key encoding, so request payload, cache re-keying, and loader/component byte-parity all follow from one place. Families opt in via `globalNamespace: "top" | "filters"`.
- Scope changes remount the page tree via a keyed `<Outlet>` + `router.invalidate()` — no full reload.
- **`error_events` and `traces_aggregates_hourly` carry no `ServiceNamespace` column**, so errors and the health snapshot scope by *service membership*: `scopeServicesToNamespaces` resolves the namespace's services via the (server-cached) service-overview request and rewrites the `services` filter. This kept the change entirely web-side — no domain or query-engine edits. The errors facets' `except` mechanism would resurface out-of-namespace service names, so those are post-filtered.
- The service map filters nodes/edges client-side from the bundle's overview rows (a server-side filter is a follow-up); external/DB nodes survive only when an in-namespace edge touches them.

## Reviewer notes

- **Deliberately unscoped:** dashboards/query-builder widgets (the shared custom-chart family stays unpinned; the two log-volume call sites inject per-site instead), Postgres-side issue lists on non-volume sorts, metrics, infra (k8s namespaces are a different concept), detail views, and org-level usage tiles.
- **Known costs:** a namespace filter disables the traces-aggregates MV path (raw-table scans while pinned), and the SpanMetrics throughput refinement is skipped while pinned, same as env scope. Membership scoping is approximate: a service emitting under several namespaces stays visible on errors/snapshot.
- The empty-string "No namespace" sentinel is not offered globally in v1; per-page sidebars still serve it when unpinned.
- Verified end-to-end in the browser: pin/unpin across all six surfaces, payloads carrying the filter, URL-override + restore, reload persistence. `bun typecheck` clean; new unit tests for the store and injection plus the touched-area suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790463267&installation_model_id=427786&pr_number=660&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F660&signature=1e7963f85c463fc617628b2d29a1fa4325289ed7e121dd8acabb73de87a76144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->