### PR TITLE
fix(landing): "Start free trial" opens sign-up, not sign-in

### DIFF
--- a/apps/landing/src/components/BottomCTA.astro
+++ b/apps/landing/src/components/BottomCTA.astro
@@ -1,5 +1,6 @@
 ---
 import * as m from "../paraglide/messages.js";
+import { APP_SIGN_UP_URL } from "../lib/app-urls";
 ---
 
 <section class="relative py-16 md:py-24 lg:py-32 overflow-hidden">
@@ -21,7 +22,7 @@ import * as m from "../paraglide/messages.js";
         </p>
 
         <div class="flex flex-wrap items-center justify-center gap-3">
-            <a href="https://app.maple.dev" data-track="cta_click" data-track-location="bottom" class="inline-flex h-9 items-center justify-center rounded-lg bg-primary px-3 text-xs font-medium text-primary-foreground transition-all hover:bg-primary/80">
+            <a href={APP_SIGN_UP_URL} data-track="cta_click" data-track-location="bottom" class="inline-flex h-9 items-center justify-center rounded-lg bg-primary px-3 text-xs font-medium text-primary-foreground transition-all hover:bg-primary/80">
                 {m.cta_get_started()}
             </a>
             <a href="https://github.com/MapleTechLabs/maple" target="_blank" rel="noopener noreferrer" class="inline-flex h-9 items-center justify-center rounded-lg border border-input bg-input/30 px-3 text-xs font-medium text-fg transition-all hover:bg-input/50">

--- a/apps/landing/src/components/HeroCta.tsx
+++ b/apps/landing/src/components/HeroCta.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import * as m from "../paraglide/messages.js"
+import { APP_SIGN_UP_URL, APP_URL } from "../lib/app-urls"
 import { SIGNED_IN_EVENT } from "./auth-signal"
 
 /**
@@ -17,7 +18,7 @@ export function HeroCta({ className }: { className?: string }) {
 	}, [])
 	return (
 		<a
-			href="https://app.maple.dev"
+			href={signedIn ? APP_URL : APP_SIGN_UP_URL}
 			data-hero-cta
 			data-track="cta_click"
 			data-track-location="hero"

--- a/apps/landing/src/components/NavBar.tsx
+++ b/apps/landing/src/components/NavBar.tsx
@@ -15,6 +15,7 @@ import { cn } from "@maple/ui/lib/utils"
 import * as m from "../paraglide/messages.js"
 import { broadcastSignedIn } from "./auth-signal"
 import { ClerkProvider } from "./ClerkProvider"
+import { APP_SIGN_IN_URL, APP_SIGN_UP_URL, APP_URL } from "../lib/app-urls"
 import { formatStars } from "../lib/github-stars"
 import { features } from "../lib/features"
 import { featurePath, useCasePath } from "../lib/page-registry"
@@ -27,7 +28,31 @@ const PUBLISHABLE_KEY = import.meta.env.PUBLIC_CLERK_PUBLISHABLE_KEY
 
 type MenuLink = { href: string; label: () => string; desc: () => string }
 
-function AuthAwareCTA() {
+type CTAProps = {
+	className?: string
+	trackLocation: string
+	"aria-hidden"?: boolean
+	tabIndex?: number
+}
+
+/**
+ * The href flips with the label: signed out, "Get started" has to name
+ * `/sign-up`, because the app root sends a session-less visitor to `/sign-in`.
+ */
+function CTAAnchor({ signedIn, trackLocation, ...rest }: CTAProps & { signedIn: boolean }) {
+	return (
+		<a
+			href={signedIn ? APP_URL : APP_SIGN_UP_URL}
+			data-track="cta_click"
+			data-track-location={trackLocation}
+			{...rest}
+		>
+			{signedIn ? m.nav_dashboard() : m.nav_get_started()}
+		</a>
+	)
+}
+
+function AuthAwareCTA(props: CTAProps) {
 	const { isSignedIn, isLoaded, userId } = useAuth()
 	const signedIn = isLoaded && isSignedIn === true
 	useEffect(() => {
@@ -37,15 +62,15 @@ function AuthAwareCTA() {
 		// later app sessions through the cross-subdomain visitor cookie.
 		identifyLanding(signedIn ? userId : null)
 	}, [signedIn, userId])
-	return signedIn ? m.nav_dashboard() : m.nav_get_started()
+	return <CTAAnchor signedIn={signedIn} {...props} />
 }
 
-function CTAButton() {
+function CTAButton(props: CTAProps) {
 	// Only use Clerk auth hook when the provider is actually available
 	if (!PUBLISHABLE_KEY) {
-		return m.nav_get_started()
+		return <CTAAnchor signedIn={false} {...props} />
 	}
-	return <AuthAwareCTA />
+	return <AuthAwareCTA {...props} />
 }
 
 function Eyebrow({ children }: { children: React.ReactNode }) {
@@ -258,7 +283,7 @@ function NavBarInner({ locale = "en", stars }: { locale?: string; stars?: number
 				<GithubStarButton stars={stars} className="hidden sm:inline-flex" />
 
 				<a
-					href="https://app.maple.dev"
+					href={APP_SIGN_IN_URL}
 					data-track="cta_click"
 					data-track-location="nav_login"
 					className="hidden text-[13px] font-medium text-fg-muted transition-colors hover:text-fg md:inline-flex"
@@ -266,10 +291,8 @@ function NavBarInner({ locale = "en", stars }: { locale?: string; stars?: number
 					{m.nav_login()}
 				</a>
 
-				<a
-					href="https://app.maple.dev"
-					data-track="cta_click"
-					data-track-location="nav"
+				<CTAButton
+					trackLocation="nav"
 					className={cn(
 						buttonVariants({ size: "sm" }),
 						"overflow-hidden transition-all duration-300",
@@ -279,9 +302,7 @@ function NavBarInner({ locale = "en", stars }: { locale?: string; stars?: number
 					)}
 					aria-hidden={ctaCollapsed}
 					tabIndex={ctaCollapsed ? -1 : undefined}
-				>
-					<CTAButton />
-				</a>
+				/>
 
 				{/* The centred nav list only fits from lg, so the sheet has to
 				    cover everything below it — not just below sm. */}
@@ -376,14 +397,10 @@ function NavBarInner({ locale = "en", stars }: { locale?: string; stars?: number
 								</span>
 								{stars != null && <span className="tabular-nums">{formatStars(stars)}</span>}
 							</a>
-							<a
-								href="https://app.maple.dev"
-								data-track="cta_click"
-								data-track-location="nav_mobile"
+							<CTAButton
+								trackLocation="nav_mobile"
 								className={buttonVariants({ size: "sm" })}
-							>
-								<CTAButton />
-							</a>
+							/>
 						</div>
 					</nav>
 				</SheetContent>

--- a/apps/landing/src/components/PricingCalculator.tsx
+++ b/apps/landing/src/components/PricingCalculator.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useRef } from "react"
 import { trackLanding } from "../lib/telemetry"
+import { APP_SIGN_UP_URL } from "../lib/app-urls"
 
 export type Competitor = "datadog" | "grafana" | "new-relic" | "dash0"
 
@@ -469,7 +470,7 @@ export function PricingCalculator({ competitor }: { competitor: Competitor }) {
 							</p>
 						</div>
 						<a
-							href="https://app.maple.dev"
+							href={APP_SIGN_UP_URL}
 							className="shrink-0 bg-[oklch(0.75_0.12_70)] text-[oklch(0.15_0.02_60)] px-6 py-2.5 text-sm font-medium hover:opacity-90 transition-opacity"
 						>
 							Start free trial

--- a/apps/landing/src/components/PricingTable.astro
+++ b/apps/landing/src/components/PricingTable.astro
@@ -19,6 +19,7 @@
  * "call us" card given equal weight costs self-serve conversion.
  */
 import * as m from "../paraglide/messages.js";
+import { APP_SIGN_UP_URL } from "../lib/app-urls";
 import {
     getOffer,
     money,
@@ -144,7 +145,7 @@ const containerClass = variant === "home" ? "shell" : "mx-auto max-w-5xl px-6"
                     </div>
 
                     <a
-                        href="https://app.maple.dev"
+                        href={APP_SIGN_UP_URL}
                         data-track="pricing_plan_selected"
                         data-track-plan={offer.name}
                         class="mt-8 flex h-11 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"

--- a/apps/landing/src/components/home/FinalCta.astro
+++ b/apps/landing/src/components/home/FinalCta.astro
@@ -10,6 +10,7 @@
  * place the left axis should break.
  */
 import * as m from "../../paraglide/messages.js";
+import { APP_SIGN_UP_URL } from "../../lib/app-urls";
 ---
 
 <section class="relative overflow-hidden drenched-amber">
@@ -24,7 +25,7 @@ import * as m from "../../paraglide/messages.js";
 		</p>
 		<div class="mt-10 flex flex-wrap items-center justify-center gap-3">
 			<a
-				href="https://app.maple.dev"
+				href={APP_SIGN_UP_URL}
 				class="inline-flex h-11 items-center justify-center rounded-lg bg-foreground px-5 text-sm font-medium text-background transition-colors hover:bg-foreground/90"
 			>
 				{m.cta_bookend_primary()}

--- a/apps/landing/src/components/page/PageCta.astro
+++ b/apps/landing/src/components/page/PageCta.astro
@@ -11,6 +11,7 @@
  * `max-w-6xl`; it stays in the tree for the pages still using it.
  */
 import * as m from "../../paraglide/messages.js";
+import { APP_SIGN_UP_URL } from "../../lib/app-urls";
 
 interface Props {
 	title: string;
@@ -30,7 +31,7 @@ const { title, lede } = Astro.props;
 		<p class="mx-auto mt-5 max-w-[52ch] text-base leading-relaxed opacity-85">{lede}</p>
 		<div class="mt-10 flex flex-wrap items-center justify-center gap-3">
 			<a
-				href="https://app.maple.dev"
+				href={APP_SIGN_UP_URL}
 				class="inline-flex h-11 items-center justify-center rounded-lg bg-foreground px-5 text-sm font-medium text-background transition-colors hover:bg-foreground/90"
 			>
 				{m.cta_bookend_primary()}

--- a/apps/landing/src/lib/app-urls.ts
+++ b/apps/landing/src/lib/app-urls.ts
@@ -1,0 +1,10 @@
+/**
+ * Links into the dashboard app.
+ *
+ * The app root bounces a signed-out visitor to `/sign-in`, so every acquisition
+ * CTA has to name `/sign-up` itself — "Start free trial" pointing at the bare
+ * origin lands a visitor with no account on a login form.
+ */
+export const APP_URL = "https://app.maple.dev"
+export const APP_SIGN_UP_URL = `${APP_URL}/sign-up`
+export const APP_SIGN_IN_URL = `${APP_URL}/sign-in`


### PR DESCRIPTION
Clicking **Start free trial** landed you on the sign-in page.

## Cause

Every acquisition CTA linked to the bare app origin, `https://app.maple.dev`. The dashboard root gates on a session — `__root.tsx`’s `beforeLoad` redirects any visitor without one to `/sign-in`:

```ts
if (!context.auth?.isAuthenticated) {
  throw redirect({ to: "/sign-in", search: { redirect_url: redirectUrl } })
}
```

So the one visitor the CTA exists for — someone with no account — got a login form. `/sign-up` already existed and is already public (`EXACT_PUBLIC_PATHS`); nothing linked to it.

## Change

New `src/lib/app-urls.ts` holds `APP_URL` / `APP_SIGN_UP_URL` / `APP_SIGN_IN_URL`, and the trial CTAs name `/sign-up`:

- `HeroCta.tsx`, `NavBar.tsx` (desktop + mobile)
- `BottomCTA.astro`, `home/FinalCta.astro`, `page/PageCta.astro`
- `PricingTable.astro` (offer card), `PricingCalculator.tsx` (savings callout)

Nav **Log in** names `/sign-in` explicitly instead of relying on the same redirect.

Left on the root: the docs header “App” link and the docs-index “open the app” rail. Those are dashboard links, not acquisition — a signed-in reader should land in the app.

The nav CTA’s href has to flip with its label (signed in it reads “Dashboard” and belongs at the root), so the `<a>` moved inside a `CTAAnchor` component that owns both.

## Verification

`bun run build` + `bun run test` (22/22) in a clean worktree off `main`. Built HTML:

| page | `/sign-up` | `/sign-in` | root |
| --- | --- | --- | --- |
| `index.html` | 4 | 1 | 0 |
| `pricing/index.html` | 5 | 1 | 0 |
| `docs/index.html` | 0 | 0 | 2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790463334&installation_model_id=427786&pr_number=661&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F661&signature=b8edec4f3e38caae41bbdfd471669159bc6c341e3a4187260c5d7242a9d89bbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->