### PR TITLE
fix(ui): a copy button sized to the word it shows

### DIFF
--- a/packages/ui/src/components/attributes/json-value.tsx
+++ b/packages/ui/src/components/attributes/json-value.tsx
@@ -44,17 +44,7 @@ export function CollapsibleJsonValue({ value, parsed }: CollapsibleJsonValueProp
 				{expanded && <span className="text-muted-foreground">JSON</span>}
 			</button>
 			{expanded && (
-				<div className="mt-1 rounded-md bg-muted/30 border overflow-hidden">
-					<div className="flex items-center justify-end px-2 py-1 border-b">
-						<CopyButton
-							value={value}
-							label="JSON"
-							idleLabel="Copy"
-							size="xs"
-							iconSize={10}
-							onClick={(e) => e.stopPropagation()}
-						/>
-					</div>
+				<div className="group/json relative mt-1 overflow-hidden rounded-md border bg-muted/30">
 					<div className="max-h-64 overflow-auto p-2">
 						<pre className="text-xs leading-relaxed">
 							{highlightJson ? (
@@ -64,6 +54,19 @@ export function CollapsibleJsonValue({ value, parsed }: CollapsibleJsonValueProp
 							)}
 						</pre>
 					</div>
+					{/* Anchored over the payload rather than given a bar of its own: a
+					    strip holding one button is most of the block's chrome and none
+					    of its content, and these blocks nest inside attribute rows that
+					    are already dense. It rides above the scroll, so a long line
+					    scrolling under it keeps a backdrop to stay legible against. */}
+					<CopyButton
+						value={value}
+						label="JSON"
+						tooltip
+						iconSize={10}
+						className="absolute top-1 right-1 border-border/60 bg-background/80 opacity-0 backdrop-blur-sm transition-opacity focus-visible:opacity-100 group-hover/json:opacity-100 pointer-coarse:opacity-100"
+						onClick={(e) => e.stopPropagation()}
+					/>
 				</div>
 			)}
 		</div>

--- a/packages/ui/src/components/ui/copy-button.tsx
+++ b/packages/ui/src/components/ui/copy-button.tsx
@@ -81,6 +81,9 @@ const LABEL_ACTIVE: Record<CopyStatus, string> = {
 
 export interface CopyTooltipLabels {
 	copiedLabel?: string
+	/** Failure wording, used verbatim inline and in the tooltip. Left unset,
+	 *  the inline label is a compact "Failed" and the tooltip the full
+	 *  sentence, so the button is not sized to a state it is almost never in. */
 	errorLabel?: string
 }
 
@@ -240,7 +243,7 @@ export function CopyButton({
 	label,
 	idleLabel,
 	copiedLabel = "Copied",
-	errorLabel = "Failed to copy",
+	errorLabel,
 	tooltip,
 	iconSize = 14,
 	idleIcon,
@@ -258,6 +261,17 @@ export function CopyButton({
 	const { copy, status } = useCopy({ label, onCopy, onError, successMessage, timeout, toast })
 	const withLabel = idleLabel !== undefined
 	const resolvedSize = size ?? (withLabel ? "sm" : "icon-xs")
+
+	/**
+	 * The three inline labels are stacked, so the button reserves the widest of
+	 * them for good — and a full "Failed to copy" beside a resting "Copy" is a
+	 * button three times wider than the word it shows, all of it dead space in
+	 * the state it sits in essentially always. Inline the failure reads fine as
+	 * one word; the tooltip, the toast and the live region keep the sentence. A
+	 * callsite that passes its own `errorLabel` gets it verbatim in both.
+	 */
+	const inlineErrorLabel = errorLabel ?? "Failed"
+	const errorText = errorLabel ?? "Failed to copy"
 
 	const button = (
 		<Button
@@ -279,12 +293,12 @@ export function CopyButton({
 					labels={[
 						["idle", idleLabel],
 						["copied", copiedLabel],
-						["error", errorLabel],
+						["error", inlineErrorLabel],
 					]}
 				/>
 			)}
 			<span role="status" aria-live="polite" className="sr-only">
-				{status === "copied" ? copiedLabel : status === "error" ? errorLabel : ""}
+				{status === "copied" ? copiedLabel : status === "error" ? errorText : ""}
 			</span>
 		</Button>
 	)
@@ -294,7 +308,7 @@ export function CopyButton({
 	return (
 		<Tooltip>
 			<TooltipTrigger render={button} />
-			<TooltipPopup>{copyTooltipText(status, label, { copiedLabel, errorLabel })}</TooltipPopup>
+			<TooltipPopup>{copyTooltipText(status, label, { copiedLabel, errorLabel: errorText })}</TooltipPopup>
 		</Tooltip>
 	)
 }


### PR DESCRIPTION
The gen-AI JSON field carried both of these; neither is specific to it.

### The button was sized to a state it is almost never in

The three inline labels are stacked in one grid cell so the width never jumps mid-animation — which meant every labelled `CopyButton` reserved the width of `"Failed to copy"` for good. A resting `Copy` sat in a button roughly three times the width of the word it shows.

Inline, the failure now reads as one word (`Failed`); the tooltip, the toast and the live region keep the full sentence. A callsite that passes its own `errorLabel` gets it verbatim in both places. Every labelled copy button tightens up — the log raw panel, the expanded log row, the install modal, the 2FA backup codes, metric graduation.

### The expanded JSON block had a bar for one button

`CollapsibleJsonValue` put the copy control in a bordered header strip of its own — most of the block's chrome and none of its content, inside attribute rows that are already dense. It is now anchored over the payload, revealed on hover or focus (always shown on coarse pointers), with a translucent backdrop so a long line scrolling under it stays legible.

### Verification

Driven in the browser at `/lab/widgets` with a temporary `AttributesSection` specimen (attributes need a span fetch the lab has no fixture for; the specimen was reverted): labelled buttons hug their text, the expanded JSON renders as one clean block, hover reveals the copy glyph, and clicking it writes to the clipboard. `packages/ui` typecheck clean, 638 tests pass.

| before | after |
| --- | --- |
| `[⧉    Copy      ]` under a header rule | `⧉` in the block's top-right corner |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790463357&installation_model_id=427786&pr_number=662&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F662&signature=064e866d888a65564909d73919ed9a03e2fdda3c82cf1c5fe4b1b5e1ef5139f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->