### PR TITLE
feat(web): render JSON genai message bodies as JSON, not markdown

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
@@ -29,6 +29,21 @@ export function useJsonPayload(text: string): { formatted: string; highlighted: 
 }
 
 /**
+ * A message body's rendering, chosen from the capture: markdown for prose, the
+ * payload cards' pretty-printed JSON where the text parses as a JSON document —
+ * a JSON message laid out as markdown collapses its structure into one
+ * paragraph. `rendered` names the choice and is what the ViewSwitch shows.
+ */
+export function useMessageBody(text: string): {
+	rendered: "md" | "json"
+	formatted: string
+	highlighted: string | undefined
+} {
+	const payload = useJsonPayload(text)
+	return { rendered: payload.highlighted === undefined ? "md" : "json", ...payload }
+}
+
+/**
  * The rendered ↔ raw selector: two labelled segments where the selected one is
  * the view the reader is IN — a lone pressed icon named either the current view
  * or the one a click would bring, depending on who read it.

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -40,7 +40,7 @@ import {
 import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
 import { formatClockInTimezone } from "@/lib/timezone-format"
 import { ClampedText, firstLine } from "./clamped-text"
-import { useJsonPayload, ViewSwitch } from "./payload-view"
+import { useJsonPayload, useMessageBody, ViewSwitch } from "./payload-view"
 import { Pill } from "./pill"
 
 /**
@@ -451,6 +451,7 @@ function UserBlock({
 	const rawKey = `${row.key}:raw`
 	const raw = disclosed(openRows, rawKey, false)
 	const textKey = `${row.key}:text`
+	const body = useMessageBody(row.text)
 
 	return (
 		<Row time={clockOf(row.startMs, timeZone)} depth={row.depth} rail="bg-foreground" className="pt-5">
@@ -475,7 +476,7 @@ function UserBlock({
 						</button>
 					)}
 					<ViewSwitch
-						rendered="md"
+						rendered={body.rendered}
 						raw={raw}
 						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
 					/>
@@ -483,9 +484,11 @@ function UserBlock({
 				{/* Clamped like every other long body: a pasted 400-line prompt is one
 				    block of a conversation, not the page. "Show full" opens it. */}
 				<ClampedText
-					text={row.text}
+					text={raw ? row.text : body.formatted}
+					html={raw ? undefined : body.highlighted}
+					mono={!raw && body.rendered === "json"}
 					body={
-						raw ? undefined : (
+						raw || body.rendered === "json" ? undefined : (
 							<MessageResponse className="text-foreground text-sm leading-relaxed">
 								{row.text}
 							</MessageResponse>
@@ -538,6 +541,7 @@ function SystemBlock({
 	const textKey = `${row.key}:text`
 	const rawKey = `${row.key}:raw`
 	const raw = disclosed(openRows, rawKey, false)
+	const body = useMessageBody(row.text)
 
 	return (
 		<Row depth={row.depth} rail="bg-muted-foreground/40" className="pt-3.5">
@@ -573,9 +577,11 @@ function SystemBlock({
 				<div className="flex items-start gap-1.5 pb-2 pl-6">
 					<div className="min-w-0 grow">
 						<ClampedText
-							text={row.text}
+							text={raw ? row.text : body.formatted}
+							html={raw ? undefined : body.highlighted}
+							mono={!raw && body.rendered === "json"}
 							body={
-								raw ? undefined : (
+								raw || body.rendered === "json" ? undefined : (
 									<MessageResponse className="text-sm">{row.text}</MessageResponse>
 								)
 							}
@@ -584,7 +590,7 @@ function SystemBlock({
 						/>
 					</div>
 					<ViewSwitch
-						rendered="md"
+						rendered={body.rendered}
 						raw={raw}
 						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
 					/>
@@ -611,6 +617,7 @@ function AssistantBlock({
 	// whole JSON error envelope, so it gets the same JSON treatment as a tool
 	// payload. Empty where the call succeeded, and the hook is cheap on "".
 	const error = useJsonPayload(row.failed ? row.span.statusMessage : "")
+	const body = useMessageBody(row.text ?? "")
 	const rawKey = `${row.key}:raw`
 	const raw = disclosed(openRows, rawKey, false)
 	const errorRawKey = `${row.key}:error-raw`
@@ -645,7 +652,7 @@ function AssistantBlock({
 				)}
 				{row.text !== undefined && (
 					<ViewSwitch
-						rendered="md"
+						rendered={body.rendered}
 						raw={raw}
 						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
 					/>
@@ -657,6 +664,11 @@ function AssistantBlock({
 					<p className="whitespace-pre-wrap break-words pt-2.5 text-foreground text-sm leading-relaxed">
 						{row.text}
 					</p>
+				) : body.highlighted !== undefined ? (
+					<div
+						className="min-w-0 whitespace-pre-wrap break-words pt-2.5 font-mono text-muted-foreground text-xs leading-relaxed"
+						dangerouslySetInnerHTML={{ __html: body.highlighted }}
+					/>
 				) : (
 					<MessageResponse className="pt-2.5 text-foreground text-sm leading-relaxed">
 						{row.text}
@@ -717,6 +729,7 @@ function PromptBlock({
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "prompt" }> }) {
 	const rawKey = `${row.key}:raw`
 	const raw = disclosed(openRows, rawKey, false)
+	const body = useMessageBody(row.text)
 
 	return (
 		<Row time={clockOf(row.startMs, timeZone)} depth={row.depth} rail="bg-chart-2" className="pt-3">
@@ -728,7 +741,7 @@ function PromptBlock({
 					<span className="grow" />
 					<span className={cn(META, "shrink-0")}>{row.span.serviceName}</span>
 					<ViewSwitch
-						rendered="md"
+						rendered={body.rendered}
 						raw={raw}
 						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
 					/>
@@ -737,6 +750,11 @@ function PromptBlock({
 					<p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
 						{row.text}
 					</p>
+				) : body.highlighted !== undefined ? (
+					<div
+						className="min-w-0 whitespace-pre-wrap break-words font-mono text-muted-foreground text-xs leading-relaxed"
+						dangerouslySetInnerHTML={{ __html: body.highlighted }}
+					/>
 				) : (
 					<MessageResponse className="text-foreground text-sm leading-relaxed">
 						{row.text}

--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -20,7 +20,12 @@ import {
 	ExternalLinkIcon,
 } from "@/components/icons"
 import { MessageResponse } from "@/components/ai-elements/message-response"
-import { AttributesSection, CopyableValue, ResourceAttributesSection } from "@/components/attributes"
+import {
+	AttributesSection,
+	CopyableValue,
+	ResourceAttributesSection,
+	tryParseJson,
+} from "@/components/attributes"
 import { SpanLogs } from "@/components/traces/span-detail-panel"
 import type { SpanDetailResult } from "@/api/warehouse/traces"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
@@ -39,7 +44,7 @@ import {
 import { classifyAiSpan, spanFailed, spanTtftMs } from "@/lib/agent-sessions/session-turns"
 import { callMetaLine, formatCost } from "@/lib/agent-sessions/session-summary"
 import { ClampedText, firstLine } from "./clamped-text"
-import { useJsonPayload, ViewSegment, ViewSwitch } from "./payload-view"
+import { useJsonPayload, useMessageBody, ViewSegment, ViewSwitch } from "./payload-view"
 import { Pill } from "./pill"
 
 /**
@@ -313,6 +318,7 @@ function SystemMessageRow({ message }: { message: SpanMessage }) {
 	const [open, setOpen] = useState(false)
 	const [raw, setRaw] = useState(false)
 	const text = collapsedText(message.parts)
+	const body = useMessageBody(text)
 
 	return (
 		<div className="rounded-md border border-border/60 bg-muted/30">
@@ -338,12 +344,18 @@ function SystemMessageRow({ message }: { message: SpanMessage }) {
 				<div className="flex items-start gap-1.5 px-2.5 pb-2.5 pl-8">
 					<div className="min-w-0 grow">
 						<ClampedText
-							text={text}
+							text={raw ? text : body.formatted}
+							html={raw ? undefined : body.highlighted}
+							mono={!raw && body.rendered === "json"}
 							clampClass={PANEL_CLAMP}
-							body={raw ? undefined : <MessageResponse className="text-sm">{text}</MessageResponse>}
+							body={
+								raw || body.rendered === "json" ? undefined : (
+									<MessageResponse className="text-sm">{text}</MessageResponse>
+								)
+							}
 						/>
 					</div>
-					<ViewSwitch rendered="md" raw={raw} onRawChange={setRaw} />
+					<ViewSwitch rendered={body.rendered} raw={raw} onRawChange={setRaw} />
 					{/* Copies the instructions as captured, not their rendering. */}
 					<CopyButton value={text} label="system message" className="-my-1 shrink-0" />
 				</div>
@@ -357,6 +369,15 @@ function MessageBlock({ message, span }: { message: SpanMessage; span: AiSession
 	// reader flips together, while the payload cards keep their own json switch.
 	const [raw, setRaw] = useState(false)
 	const hasText = message.parts.some((part) => part.kind === "text")
+	// The switch names what the rendering IS, and each text part chooses its own
+	// (JSON where it parses as a document) — "json" only when they all agree.
+	const rendered = useMemo(
+		() =>
+			message.parts.some((part) => part.kind === "text" && tryParseJson(part.text) === null)
+				? "md"
+				: "json",
+		[message.parts],
+	)
 
 	return (
 		<div className="flex min-w-0 flex-col gap-1.5">
@@ -377,7 +398,7 @@ function MessageBlock({ message, span }: { message: SpanMessage; span: AiSession
 					</span>
 				)}
 				<span aria-hidden className="h-px min-w-4 flex-1 bg-border/60" />
-				{hasText && <ViewSwitch rendered="md" raw={raw} onRawChange={setRaw} />}
+				{hasText && <ViewSwitch rendered={rendered} raw={raw} onRawChange={setRaw} />}
 			</div>
 			<div className="flex min-w-0 flex-col gap-2">
 				{message.parts.map((part, index) => (
@@ -389,20 +410,31 @@ function MessageBlock({ message, span }: { message: SpanMessage; span: AiSession
 }
 
 function MessagePart({ part, raw }: { part: SpanMessagePart; raw: boolean }) {
-	if (part.kind === "text") {
-		return (
-			<ClampedText
-				text={part.text}
-				clampClass={PANEL_CLAMP}
-				body={raw ? undefined : <MessageResponse className="text-sm">{part.text}</MessageResponse>}
-			/>
-		)
-	}
+	if (part.kind === "text") return <TextPart text={part.text} raw={raw} />
 	if (part.kind === "reasoning") return <ReasoningPart part={part} />
 	if (part.kind === "tool_call") {
 		return <PayloadCard label="tool_call" name={part.name} meta={part.id} body={part.argumentsText} />
 	}
 	return <PayloadCard label="tool_result" meta={part.id} body={part.resultText} />
+}
+
+/** A text part in the message's chosen view — markdown prose, or the payload
+ *  cards' pretty-printed JSON where the captured text is a JSON document. */
+function TextPart({ text, raw }: { text: string; raw: boolean }) {
+	const body = useMessageBody(text)
+	return (
+		<ClampedText
+			text={raw ? text : body.formatted}
+			html={raw ? undefined : body.highlighted}
+			mono={!raw && body.rendered === "json"}
+			clampClass={PANEL_CLAMP}
+			body={
+				raw || body.rendered === "json" ? undefined : (
+					<MessageResponse className="text-sm">{text}</MessageResponse>
+				)
+			}
+		/>
+	)
 }
 
 /** Reasoning is the model thinking, not the model answering, so it is set apart

--- a/apps/web/src/lab/agent-session-fixture.ts
+++ b/apps/web/src/lab/agent-session-fixture.ts
@@ -4,7 +4,7 @@
 // tidy: fourteen turns so the Overview's digest elides its middle, idle gaps of
 // wildly different lengths, two models, five tools, per-call usage and cost, a
 // sub-agent handoff, and a final turn that dies on a context-window error
-// reported at two levels — the roll-up the counting rules exist for. Six more
+// reported at two levels — the roll-up the counting rules exist for. Seven more
 // turns after those carry what the Transcript view needs and the fourteen do
 // not produce (see `buildTranscriptTurns`) — the last three a dispatched
 // fan-out that overlaps in time and so lands as concurrent CHAPTERS.
@@ -482,7 +482,53 @@ function buildTranscriptTurns(startMs: number): readonly AiSessionSpan[] {
 		...richTurn(startMs),
 		...captureOffTurn(startMs + 3 * MINUTE),
 		...mixedCaptureTurn(startMs + 5 * MINUTE),
+		...jsonBodiesTurn(startMs + 6 * MINUTE),
 		...parallelTurns(startMs + 7 * MINUTE),
+	]
+}
+
+/** A turn whose message bodies are JSON documents, not prose — an event-driven
+ *  agent fed a webhook payload, answering with a structured verdict. The
+ *  transcript renders these as JSON: `{"a":1}` set as markdown is one paragraph
+ *  with the structure collapsed. */
+function jsonBodiesTurn(t: number): readonly AiSessionSpan[] {
+	const event = JSON.stringify({
+		event: "invoice.payment_failed",
+		attempt: 3,
+		invoice: { id: "in_1PxK2m", amount_due: 4900, currency: "usd" },
+		customer: { id: "cus_9f2K", email: "billing@acme.dev" },
+	})
+	const verdict = JSON.stringify({
+		action: "retry",
+		delay_seconds: 3600,
+		reason: "card_declined is retryable and the customer has no dunning hold",
+	})
+	return [
+		agentSpan({
+			spanId: "json-agent",
+			traceId: "trace-json",
+			startMs: t,
+			durationMs: 4 * SECOND,
+			agentName: "dunning-agent",
+			serviceName: "billing",
+		}),
+		llmSpan({
+			spanId: "json-l1",
+			parentSpanId: "json-agent",
+			traceId: "trace-json",
+			startMs: t + SECOND,
+			durationMs: 1_900,
+			spanName: "chat claude-haiku-4-5",
+			model: "claude-haiku-4-5",
+			ttftSeconds: 0.21,
+			serviceName: "billing",
+			genAi: {
+				...usage(1_800, 96, 0.004),
+				inputMessages: userMessages(event),
+				outputMessages: assistantText(verdict),
+				responseFinishReasons: ["end_turn"],
+			},
+		}),
 	]
 }
 


### PR DESCRIPTION
## What

GenAI message bodies (user, system, assistant, prompt) whose captured text parses as a JSON document now render pretty-printed and syntax-highlighted, the same treatment tool payloads already get. Previously every message went through the markdown pipeline, which collapses a JSON document's structure into a single paragraph.

- New `useMessageBody` hook in `payload-view.tsx` picks the rendering per body: `json` where the text parses as an object/array (the payload cards' test — an emitter-truncated fragment fails the parse and stays as-is), `md` otherwise.
- The rendered ↔ raw switch labels itself with the rendering it gives (`json`/`md`); raw still shows the captured bytes and copy behavior is unchanged.
- Applied across the Transcript view's User/System/Assistant/Prompt blocks and the span expansion's system rows and message text parts. In the span expansion the message-level switch says `json` only when every text part agrees; each part still picks its own rendering.
- Lab fixture gains a JSON-bodied `dunning-agent` turn (webhook event in, structured verdict out) so `/lab/agent-session` exercises the state.

## Verification

- `@maple/web` typecheck green; `session-transcript` + `session-detail` tests pass (133).
- Verified in-browser on `/lab/agent-session?view=transcript`: JSON user/assistant bodies render highlighted with a `json | raw` switch, prose turns keep `md | raw`, raw shows compact captured bytes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790463538&installation_model_id=427786&pr_number=663&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F663&signature=71369cb2fa8d6d73c7585af4c473789a3cb12350b1d023ae343f1bc67e1e6d8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->