### PR TITLE
fix(query-engine): guard infra conditional aggregates against NaN

### DIFF
--- a/packages/query-engine/src/ch/queries/infra.test.ts
+++ b/packages/query-engine/src/ch/queries/infra.test.ts
@@ -4,6 +4,7 @@ import { compileUnionUnsafe } from "@maple-dev/clickhouse-builder"
 import {
 	listHostsQuery,
 	hostDetailSummaryQuery,
+	fleetUtilizationTimeseriesQuery,
 	listPodsQuery,
 	listPodsSummaryQuery,
 	podDetailSummaryQuery,
@@ -63,7 +64,7 @@ describe("listPodsQuery", () => {
 	it("defaults to worst-first: peak saturation, then peak CPU for unlimited pods", () => {
 		const { sql } = compileUnsafe(listPodsQuery({}), baseParams)
 		expect(sql).toContain(
-			"greatest(maxIf(Value, MetricName = 'k8s.pod.cpu_limit_utilization'), maxIf(Value, MetricName = 'k8s.pod.memory_limit_utilization')) AS saturation",
+			"greatest(ifNotFinite(maxIf(Value, MetricName = 'k8s.pod.cpu_limit_utilization'), 0), ifNotFinite(maxIf(Value, MetricName = 'k8s.pod.memory_limit_utilization'), 0)) AS saturation",
 		)
 		expect(sql).toContain("ORDER BY saturation DESC, cpuUsagePeak DESC, podName ASC")
 		expect(sql).not.toContain("ORDER BY lastSeen")
@@ -71,8 +72,10 @@ describe("listPodsQuery", () => {
 
 	it("selects peaks alongside averages so a row can show avg → peak", () => {
 		const { sql } = compileUnsafe(listPodsQuery({}), baseParams)
-		expect(sql).toContain("avgIf(Value, MetricName = 'k8s.pod.cpu.usage') AS cpuUsage")
-		expect(sql).toContain("maxIf(Value, MetricName = 'k8s.pod.cpu.usage') AS cpuUsagePeak")
+		expect(sql).toContain("ifNotFinite(avgIf(Value, MetricName = 'k8s.pod.cpu.usage'), 0) AS cpuUsage")
+		expect(sql).toContain(
+			"ifNotFinite(maxIf(Value, MetricName = 'k8s.pod.cpu.usage'), 0) AS cpuUsagePeak",
+		)
 	})
 
 	it("honours an explicit sort key and never drops the tiebreak", () => {
@@ -482,4 +485,36 @@ describe("pod facet exclusions", () => {
 		expect(sql).toContain("IN ('default', 'web')")
 		expect(sql).toContain("NOT IN ('kube-system')")
 	})
+})
+
+// A pod with no CPU limit set emits no `cpu_limit_utilization` samples at all,
+// so `avgIf`/`maxIf` over that family returns `nan` — which ClickHouse
+// serializes as JSON `null`, failing the numeric row schema and 502-ing the
+// whole page rather than the one row. Every conditional aggregate here has to
+// carry its `ifNotFinite` guard, so this sweeps them rather than spot-checking.
+describe("conditional aggregates are NaN-guarded", () => {
+	const queries: ReadonlyArray<[string, string]> = [
+		["listHostsQuery", compileUnsafe(listHostsQuery({}), baseParams).sql],
+		["hostDetailSummaryQuery", compileUnsafe(hostDetailSummaryQuery({ hostName: "h1" }), baseParams).sql],
+		["fleetUtilizationTimeseriesQuery", compileUnsafe(fleetUtilizationTimeseriesQuery(), baseParams).sql],
+		["listPodsQuery", compileUnsafe(listPodsQuery({}), baseParams).sql],
+		["listPodsSummaryQuery", compileUnsafe(listPodsSummaryQuery({}), baseParams).sql],
+		["podDetailSummaryQuery", compileUnsafe(podDetailSummaryQuery({ podName: "p1" }), baseParams).sql],
+		["listNodesQuery", compileUnsafe(listNodesQuery({}), baseParams).sql],
+		["nodeDetailSummaryQuery", compileUnsafe(nodeDetailSummaryQuery({ nodeName: "n1" }), baseParams).sql],
+		["listWorkloadsQuery", compileUnsafe(listWorkloadsQuery({ kind: "deployment" }), baseParams).sql],
+		[
+			"workloadDetailSummaryQuery",
+			compileUnsafe(workloadDetailSummaryQuery({ kind: "deployment", workloadName: "w1" }), baseParams)
+				.sql,
+		],
+	]
+
+	for (const [name, sql] of queries) {
+		it(`${name} wraps every avgIf/maxIf in ifNotFinite`, () => {
+			const unguarded = [...sql.matchAll(/(?:^|[^(])\b(avgIf|maxIf)\(/g)]
+			expect(unguarded, `unguarded conditional aggregate in ${name}`).toEqual([])
+			expect(sql).toMatch(/ifNotFinite\((?:avgIf|maxIf)\(/)
+		})
+	}
 })

--- a/packages/query-engine/src/ch/queries/infra.ts
+++ b/packages/query-engine/src/ch/queries/infra.ts
@@ -19,6 +19,17 @@ import { MetricsGauge, MetricsSum } from "../tables"
 import { deploymentEnvExpr } from "@maple/domain/tinybird/semconv-renames"
 import type { FacetOutput } from "./query-helpers"
 
+// A conditional aggregate over a metric family the entity never emitted returns
+// `nan`, which ClickHouse serializes as JSON `null` — and one null against a
+// numeric row schema fails the decode for the whole page, not just that row.
+// Absent samples mean "none of this resource in use", which is what the callers
+// already assume: `podScopeCondition("unbounded")` tests `saturation = 0`.
+const avgIfOrZero = (value: CH.Expr<number>, condition: CH.Condition): CH.Expr<number> =>
+	CH.ifNotFinite(CH.avgIf(value, condition), 0)
+
+const maxIfOrZero = (value: CH.Expr<number>, condition: CH.Condition): CH.Expr<number> =>
+	CH.ifNotFinite(CH.maxIf(value, condition), 0)
+
 const HOSTMETRIC_NAMES = [
 	"system.cpu.utilization",
 	"system.memory.utilization",
@@ -54,19 +65,19 @@ export function listHostsQuery(opts: ListHostsOpts = {}) {
 			hostArch: CH.any_($.ResourceAttributes.get("host.arch")),
 			cloudProvider: CH.any_($.ResourceAttributes.get("cloud.provider")),
 			lastSeen: CH.max_($.TimeUnix),
-			cpuPct: CH.avgIf(
+			cpuPct: avgIfOrZero(
 				$.Value,
 				$.MetricName.eq("system.cpu.utilization").and($.Attributes.get("state").neq("idle")),
 			),
-			memoryPct: CH.avgIf(
+			memoryPct: avgIfOrZero(
 				$.Value,
 				$.MetricName.eq("system.memory.utilization").and($.Attributes.get("state").eq("used")),
 			),
-			diskPct: CH.maxIf(
+			diskPct: maxIfOrZero(
 				$.Value,
 				$.MetricName.eq("system.filesystem.utilization").and($.Attributes.get("state").eq("used")),
 			),
-			load15: CH.avgIf($.Value, $.MetricName.eq("system.cpu.load_average.15m")),
+			load15: avgIfOrZero($.Value, $.MetricName.eq("system.cpu.load_average.15m")),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
@@ -115,19 +126,19 @@ export function hostDetailSummaryQuery(opts: HostDetailSummaryOpts) {
 			cloudRegion: CH.any_($.ResourceAttributes.get("cloud.region")),
 			firstSeen: CH.min_($.TimeUnix),
 			lastSeen: CH.max_($.TimeUnix),
-			cpuPct: CH.avgIf(
+			cpuPct: avgIfOrZero(
 				$.Value,
 				$.MetricName.eq("system.cpu.utilization").and($.Attributes.get("state").neq("idle")),
 			),
-			memoryPct: CH.avgIf(
+			memoryPct: avgIfOrZero(
 				$.Value,
 				$.MetricName.eq("system.memory.utilization").and($.Attributes.get("state").eq("used")),
 			),
-			diskPct: CH.maxIf(
+			diskPct: maxIfOrZero(
 				$.Value,
 				$.MetricName.eq("system.filesystem.utilization").and($.Attributes.get("state").eq("used")),
 			),
-			load15: CH.avgIf($.Value, $.MetricName.eq("system.cpu.load_average.15m")),
+			load15: avgIfOrZero($.Value, $.MetricName.eq("system.cpu.load_average.15m")),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
@@ -208,11 +219,11 @@ export function fleetUtilizationTimeseriesQuery() {
 	return from(MetricsGauge)
 		.select(($) => ({
 			bucket: CH.toStartOfInterval($.TimeUnix, param.int("bucketSeconds")),
-			avgCpu: CH.avgIf(
+			avgCpu: avgIfOrZero(
 				$.Value,
 				$.MetricName.eq("system.cpu.utilization").and($.Attributes.get("state").neq("idle")),
 			),
-			avgMemory: CH.avgIf(
+			avgMemory: avgIfOrZero(
 				$.Value,
 				$.MetricName.eq("system.memory.utilization").and($.Attributes.get("state").eq("used")),
 			),
@@ -464,18 +475,18 @@ export function listPodsQuery(opts: ListPodsOpts = {}) {
 			podUid: CH.any_($.ResourceAttributes.get("k8s.pod.uid")),
 			computeType: CH.any_($.ResourceAttributes.get("eks.amazonaws.com/compute-type")),
 			lastSeen: CH.max_($.TimeUnix),
-			cpuUsage: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
-			cpuLimitPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
-			memoryLimitPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
-			cpuRequestPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu_request_utilization")),
-			memoryRequestPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.memory_request_utilization")),
+			cpuUsage: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
+			cpuLimitPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
+			memoryLimitPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
+			cpuRequestPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu_request_utilization")),
+			memoryRequestPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.memory_request_utilization")),
 			// Peaks ride along on the same scan the averages already pay for.
-			cpuUsagePeak: CH.maxIf($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
-			cpuLimitPctPeak: CH.maxIf($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
-			memoryLimitPctPeak: CH.maxIf($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
+			cpuUsagePeak: maxIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
+			cpuLimitPctPeak: maxIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
+			memoryLimitPctPeak: maxIfOrZero($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
 			saturation: CH.greatest_(
-				CH.maxIf($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
-				CH.maxIf($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
+				maxIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
+				maxIfOrZero($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
 			),
 		}))
 		.where(($) => [...podBaseConditions($), ...podFilterConditions($, opts)])
@@ -572,10 +583,10 @@ export function listPodsSummaryQuery(opts: ListPodsOpts = {}) {
 		.select(($) => ({
 			podName: $.ResourceAttributes.get("k8s.pod.name"),
 			lastSeen: CH.max_($.TimeUnix),
-			cpuUsagePeak: CH.maxIf($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
+			cpuUsagePeak: maxIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
 			saturation: CH.greatest_(
-				CH.maxIf($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
-				CH.maxIf($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
+				maxIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
+				maxIfOrZero($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
 			),
 			limitSamples: CH.countIf(
 				$.MetricName.in_("k8s.pod.cpu_limit_utilization", "k8s.pod.memory_limit_utilization"),
@@ -637,11 +648,11 @@ export function podDetailSummaryQuery(opts: PodDetailSummaryOpts) {
 			podStartTime: CH.any_($.ResourceAttributes.get("k8s.pod.start_time")),
 			firstSeen: CH.min_($.TimeUnix),
 			lastSeen: CH.max_($.TimeUnix),
-			cpuUsage: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
-			cpuLimitPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
-			memoryLimitPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
-			cpuRequestPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu_request_utilization")),
-			memoryRequestPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.memory_request_utilization")),
+			cpuUsage: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
+			cpuLimitPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
+			memoryLimitPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
+			cpuRequestPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu_request_utilization")),
+			memoryRequestPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.memory_request_utilization")),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
@@ -755,8 +766,8 @@ export function listNodesQuery(opts: ListNodesOpts = {}) {
 			environment: CH.any_(deploymentEnvExpr($.ResourceAttributes)),
 			kubeletVersion: CH.any_($.ResourceAttributes.get("k8s.kubelet.version")),
 			lastSeen: CH.max_($.TimeUnix),
-			cpuUsage: CH.avgIf($.Value, $.MetricName.eq("k8s.node.cpu.usage")),
-			uptime: CH.maxIf($.Value, $.MetricName.eq("k8s.node.uptime")),
+			cpuUsage: avgIfOrZero($.Value, $.MetricName.eq("k8s.node.cpu.usage")),
+			uptime: maxIfOrZero($.Value, $.MetricName.eq("k8s.node.uptime")),
 		}))
 		.where(($) => [...nodeBaseConditions($), ...nodeFilterConditions($, opts)])
 		.groupBy("nodeName")
@@ -790,8 +801,8 @@ export function nodeDetailSummaryQuery(opts: NodeDetailSummaryOpts) {
 			containerRuntime: CH.any_($.ResourceAttributes.get("container.runtime")),
 			firstSeen: CH.min_($.TimeUnix),
 			lastSeen: CH.max_($.TimeUnix),
-			cpuUsage: CH.avgIf($.Value, $.MetricName.eq("k8s.node.cpu.usage")),
-			uptime: CH.maxIf($.Value, $.MetricName.eq("k8s.node.uptime")),
+			cpuUsage: avgIfOrZero($.Value, $.MetricName.eq("k8s.node.cpu.usage")),
+			uptime: maxIfOrZero($.Value, $.MetricName.eq("k8s.node.uptime")),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
@@ -892,9 +903,9 @@ export function listWorkloadsQuery(opts: ListWorkloadsOpts) {
 			environment: CH.any_(deploymentEnvExpr($.ResourceAttributes)),
 			podCount: CH.uniq($.ResourceAttributes.get("k8s.pod.uid")),
 			lastSeen: CH.max_($.TimeUnix),
-			avgCpuLimitPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
-			avgMemoryLimitPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
-			avgCpuUsage: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
+			avgCpuLimitPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
+			avgMemoryLimitPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
+			avgCpuUsage: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
@@ -938,9 +949,9 @@ export function workloadDetailSummaryQuery(opts: WorkloadDetailSummaryOpts) {
 			podCount: CH.uniq($.ResourceAttributes.get("k8s.pod.uid")),
 			firstSeen: CH.min_($.TimeUnix),
 			lastSeen: CH.max_($.TimeUnix),
-			avgCpuLimitPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
-			avgMemoryLimitPct: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
-			avgCpuUsage: CH.avgIf($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
+			avgCpuLimitPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu_limit_utilization")),
+			avgMemoryLimitPct: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.memory_limit_utilization")),
+			avgCpuUsage: avgIfOrZero($.Value, $.MetricName.eq("k8s.pod.cpu.usage")),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),


### PR DESCRIPTION
## What

Every `avgIf` / `maxIf` in `packages/query-engine/src/ch/queries/infra.ts` now goes through `avgIfOrZero` / `maxIfOrZero`, which wrap the aggregate in `ifNotFinite(..., 0)`.

```
ifNotFinite(avgIf(Value, MetricName = 'k8s.pod.cpu_limit_utilization'), 0) AS cpuLimitPct
```

## Why

A pod with no CPU limit set emits no `cpu_limit_utilization` samples at all, so the conditional aggregate returns `nan` — and ClickHouse serializes `nan` as JSON `null`. One null against the derived numeric row schema fails the decode for the **entire result set**, so the page 502s instead of the single row degrading.

Verified against production: `SELECT avgIf(Value, MetricName = 'never_matches')` returns `null` with `isNaN = 1`.

This was live — 104 `WarehouseResultDecodeError`s in six hours, surfacing to users as `HTTP 500/502` on `/internal/query-engine/list-pods` and `/internal/query-engine/list-workloads`.

## Scope

Widened past the two queries that were actually failing. Hosts, nodes, the pod/node/workload detail summaries and the fleet timeseries are the identical shape and were equally exposed — they just had not yet met a tenant with the right gap.

Two details worth a reviewer's eye:

- **`saturation` guards each `maxIf` inside the `greatest()`**, not the result. A pod with a CPU limit but no memory limit keeps its real CPU number rather than collapsing to the fallback.
- **The plain `avg` / `sum` timeseries queries are deliberately untouched.** Their `MetricName` filter sits in the `WHERE`, so a bucket with no matching rows does not exist rather than aggregating to `nan`.

## Second bug fixed by the same change

`podScopeCondition` defines the `unbounded` scope as `saturation = 0 AND cpuUsagePeak > 0`, with a comment asserting that unlimited pods report 0. They reported `nan`, so the equality was never true — that filter had been returning an empty list. It works now.

## Why the type system did not catch this

Nothing in the type chain is wrong. `avgIf` is declared `defineFn<[Expr<number>, Condition], number>(..., T.float64)`, and the column really is a non-nullable `Float64`; TS `number` includes `NaN`, so there is no type-level distinction available. The loss happens in JSON serialization, outside TypeScript's reach.

The real gap is that the builder **already models this hazard for division** — `ifNotFinite`'s own docs call it "the counterpart to division's nullable decoding (see `div`)". Conditional aggregates over an empty set have the identical failure mode and never got the same treatment.

**Suggested follow-up (not in this PR):** make `avgIf` / `maxIf` / `minIf` decode nullably in `lib/clickhouse-builder`, the way `div` does, so the compiler forces a decision at each call site. That touches a `lib/` package with other consumers, so it wants its own change.

## Tests

`packages/query-engine`: typecheck clean, 1317/1317 passing.

The new test compiles all ten affected queries and fails on any `avgIf`/`maxIf` not wrapped in `ifNotFinite`, rather than spot-checking strings — this is a defect a new call site reintroduces silently. Confirmed non-vacuous by reverting one call site and watching it fail on exactly that query.

## Note for whoever picks this up

While verifying, I found `lib/clickhouse-builder/dist` in `node_modules` was stale — built before the semicolon hex-escaping landed. Anything consuming the built package was not escaping semicolons at all, and regenerating the SQL catalog snapshot silently rewrote `'bot\x3B'` back to `'bot;'`. A rebuild fixed it and this PR's snapshot is untouched, but it is worth checking that CI builds `lib/*` before running downstream tests — that stale dist is exactly the condition that lets the gateway statement-splitter bug ship green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790508998&installation_model_id=427786&pr_number=668&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F668&signature=f230cafc8c8b5b98282073b235651c20fac67e5200dd7714807f807eb6373e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->