### PR TITLE
fix(ios): end suspended screen.load spans at background time

### DIFF
--- a/apps/ios/Maple/Telemetry/Telemetry.swift
+++ b/apps/ios/Maple/Telemetry/Telemetry.swift
@@ -1,6 +1,7 @@
 import Maple
 import MapleAPI
 import SwiftUI
+import UIKit
 
 /// This app's own instrumentation, in one place.
 ///
@@ -406,6 +407,51 @@ extension Telemetry {
 // MARK: - Screen loads
 
 extension Telemetry {
+	/// The `screen.load` spans currently in flight, so backgrounding can end
+	/// them the moment the app suspends.
+	///
+	/// A load in flight when the phone locks does not fail — its task freezes
+	/// with the process and finishes on resume — so its span used to cover the
+	/// whole suspension, and Home's `screen.load` p95 read as minutes of locked
+	/// phone. The SDK already ends `ui.screen` spans on `didEnterBackground`;
+	/// this mirrors that for the load spans it cannot see, ending them with
+	/// `load.outcome = "suspended"` and status left `Unset` — like a superseded
+	/// load, a suspended one neither succeeded nor failed. `Span` ignores
+	/// attribute writes and `end()` after it has ended, so the recording the
+	/// resumed load still does needs no guard.
+	@MainActor
+	enum ActiveLoads {
+		private static var spans: [ObjectIdentifier: Span] = [:]
+		private static var observer: (any NSObjectProtocol)?
+
+		static func began(_ span: Span?) {
+			guard let span else { return }
+			if observer == nil {
+				observer = NotificationCenter.default.addObserver(
+					forName: UIApplication.didEnterBackgroundNotification,
+					object: nil,
+					queue: .main
+				) { _ in
+					MainActor.assumeIsolated { suspendAll() }
+				}
+			}
+			spans[ObjectIdentifier(span)] = span
+		}
+
+		static func ended(_ span: Span?) {
+			guard let span else { return }
+			spans.removeValue(forKey: ObjectIdentifier(span))
+		}
+
+		private static func suspendAll() {
+			for span in spans.values where !span.hasEnded {
+				span.setAttribute(Key.loadOutcome, "suspended")
+				span.end()
+			}
+			spans.removeAll()
+		}
+	}
+
 	/// Wrap a screen's data load in the span every request it makes hangs under.
 	///
 	/// This is the whole reason the app traces at all. `HomeModel.fetch` fans
@@ -433,6 +479,8 @@ extension Telemetry {
 		let parent = PushOpen.parent(for: screen) ?? Visit.parent(for: screen)
 		let state = await withParent(parent) {
 			await Telemetry.span(Name.screenLoad, attributes: attributes) { span in
+				ActiveLoads.began(span)
+				defer { ActiveLoads.ended(span) }
 				let state = await body()
 				record(state, on: span)
 				return state


### PR DESCRIPTION
## What

A `screen.load` span in flight when the app suspends (phone locked, app backgrounded) freezes with the process and only ends when it resumes, so its duration included the whole suspension: Home's `screen.load` p95 read as **1529 s** over 2026-08-21..28 while the true p95 is a few seconds.

This adds a `Telemetry.ActiveLoads` registry of in-flight load spans. `screenLoad` registers its span on entry and deregisters in a `defer`; on `UIApplication.didEnterBackgroundNotification` every still-open load span gets `load.outcome = "suspended"` and is ended at background time.

## Why this shape

- It mirrors what the SDK already does for its `ui.screen` spans (a `didEnterBackground` observer ending open spans) — `screen.load` was the remaining span the SDK cannot see.
- `Span` ignores attribute writes and `end()` once ended, so when the frozen load task resumes, its `record()` and the wrapper's second `end()` are silently dropped — the suspended outcome sticks with no extra guards.
- Status stays `Unset`, matching superseded loads: a suspended load neither succeeded nor failed, so it doesn't skew the screen's success rate.
- `.inactive` (app switcher, Control Center) never reaches `didEnterBackground`, so those spans keep running — same rule the `ui.screen` handling documents.

## Notes for review

- Durations are now honest (start → background), so dashboards need no exclusion; filtering `load.outcome != 'suspended'` additionally drops the truncated measurements from latency percentiles if desired.
- The in-flight `screen.decorate` work (not yet on main) needs the same registration; it carries the identical two-line hook in its branch.

Verified with a full `xcodebuild` of the Maple scheme for the iOS Simulator from a clean checkout of this branch: zero errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790513747&installation_model_id=427786&pr_number=671&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F671&signature=5a397d3e1d2fa9d04acc560a8042e92a089b1230ba52fd87e0d6626a9bb9bfff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->