### PR TITLE
perf(cache): skip contended edge reads deterministically via outbound slot tracking

### DIFF
--- a/apps/api/src/platform/pg-connection-scope.ts
+++ b/apps/api/src/platform/pg-connection-scope.ts
@@ -4,6 +4,7 @@ import {
 	type MaplePgSocketOptions,
 	wrapMaplePgClient,
 } from "@maple/db/client"
+import { trackOutboundSlot } from "@maple/cache"
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
 import { Context, Effect, Schema } from "effect"
 import type { HttpMiddleware } from "effect/unstable/http"
@@ -160,13 +161,18 @@ export const makePgConnectionScope = (
 				const reused = state._tag === "Open"
 				const open = state._tag === "Open" ? state.handle : openSocket()
 				state = { _tag: "Open", handle: open }
-				return executeWithSpan(async (hooks) => {
-					hooks.record({ "db.connect.reused": reused })
-					// Wrapped per call so each call's statements land in its own span.
-					// One shared wrapper would cross-attribute `db.query.text` between
-					// concurrent calls; the wrapper is cheap (relational config only).
-					return await fn(wrapMaplePgClient(open.sql, { onQuery: hooks.collect }))
-				}, extraAttributes)
+				// `trackOutboundSlot` scopes to the statement, not the socket: an idle
+				// kept-open connection doesn't starve `cache.match()`, an in-flight
+				// statement does.
+				return trackOutboundSlot(
+					executeWithSpan(async (hooks) => {
+						hooks.record({ "db.connect.reused": reused })
+						// Wrapped per call so each call's statements land in its own span.
+						// One shared wrapper would cross-attribute `db.query.text` between
+						// concurrent calls; the wrapper is cheap (relational config only).
+						return await fn(wrapMaplePgClient(open.sql, { onQuery: hooks.collect }))
+					}, extraAttributes),
+				)
 			}),
 
 		// Closed first, then release: a call racing the teardown is refused

--- a/apps/api/src/services/org/OrgClickHouseSettingsService.ts
+++ b/apps/api/src/services/org/OrgClickHouseSettingsService.ts
@@ -1586,6 +1586,14 @@ export class OrgClickHouseSettingsService extends Context.Service<
 		// done so by ~20ms, the entire 40-249ms band is 0.5% of reads, and anything
 		// past that is hung rather than slow. A longer deadline would buy almost no
 		// extra hits and charge the full deadline to every hung read.
+		//
+		// `skipReadWhenSlotsHeld` because this bucket's timeouts are exactly the
+		// reads issued while other outbound I/O holds a connection slot — a shape
+		// the per-isolate breaker can never learn, since each isolate reads this
+		// bucket at most once per memo window (measured: the most timeouts of any
+		// bucket, zero breaker skips). With `compute` a ~20ms indexed row read,
+		// skipping straight to Postgres beats a 40ms deadline gamble that loses
+		// 27% of the time at a p50 of 621ms per loss.
 		const readSharedOrPostgres = (orgId: OrgId) =>
 			edgeCache
 				.getOrCompute(
@@ -1594,6 +1602,7 @@ export class OrgClickHouseSettingsService extends Context.Service<
 						key: orgId,
 						ttlSeconds: ORG_CH_CONFIG_CACHE_TTL_SECONDS,
 						schema: CachedChSettingsEnvelope,
+						skipReadWhenSlotsHeld: true,
 					},
 					readSettingsFromPostgres(orgId).pipe(Effect.map((settings) => ({ settings }))),
 				)

--- a/lib/cache/src/edge-cache.test.ts
+++ b/lib/cache/src/edge-cache.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Option, Schema } from "effect"
 import { EdgeCacheIOError, EdgeCacheService, makeEdgeCacheService, type EdgeCacheBackend } from "./edge-cache"
+import { makeOutboundSlotsCell, trackOutboundSlot, type OutboundSlotsCell } from "./outbound-slots"
 
 // A stand-in for whatever a caller caches. These tests used to reach for
 // `CachedPayload`, which tied a generic cache to a query type; the
@@ -47,8 +48,8 @@ const makeJsonRoundtripBackend = (): EdgeCacheBackend & {
 	}
 }
 
-const makeLayer = (backend: EdgeCacheBackend, readTimeoutMs?: number) =>
-	Layer.succeed(EdgeCacheService, makeEdgeCacheService(backend, readTimeoutMs))
+const makeLayer = (backend: EdgeCacheBackend, readTimeoutMs?: number, slots?: OutboundSlotsCell) =>
+	Layer.succeed(EdgeCacheService, makeEdgeCacheService(backend, readTimeoutMs, slots))
 
 describe("EdgeCacheService.getOrCompute (no schema)", () => {
 	it.live("fails open to computation when a backend read exceeds its deadline", () => {
@@ -558,6 +559,111 @@ describe("EdgeCacheService read deadline", () => {
 			yield* cache.getOrCompute(opts, compute)
 			assert.strictEqual(call, 5, "breaker opened despite the interleaved successes")
 		}).pipe(Effect.provide(makeLayer(backend, 10)), Effect.timeout(2000))
+	})
+
+	it.live("skips the read when outbound slots are held and the bucket opts in", () => {
+		const slots = makeOutboundSlotsCell()
+		let getCalls = 0
+		const backend: EdgeCacheBackend = {
+			name: "memory",
+			get: async () => {
+				getCalls += 1
+				return { cached: true }
+			},
+			put: async () => {},
+			delete: async () => {},
+		}
+
+		return Effect.gen(function* () {
+			const cache = yield* EdgeCacheService
+			slots.acquire()
+
+			// Opted-in bucket under pressure: no read, straight to compute.
+			const skipped = yield* cache.getOrCompute(
+				{ bucket: "cfg", key: "k", ttlSeconds: 30, skipReadWhenSlotsHeld: true },
+				Effect.succeed("computed"),
+			)
+			assert.deepStrictEqual(skipped, { value: "computed", hit: false })
+			assert.strictEqual(getCalls, 0)
+
+			// The same pressure leaves a bucket that did NOT opt in untouched.
+			const read = yield* cache.getOrCompute(
+				{ bucket: "qe", key: "k", ttlSeconds: 30 },
+				Effect.succeed("computed"),
+			)
+			assert.strictEqual(getCalls, 1)
+			assert.strictEqual(read.hit, true)
+
+			// Pressure gone: the opted-in bucket reads again.
+			slots.release()
+			yield* cache.getOrCompute(
+				{ bucket: "cfg", key: "k", ttlSeconds: 30, skipReadWhenSlotsHeld: true },
+				Effect.succeed("computed"),
+			)
+			assert.strictEqual(getCalls, 2)
+		}).pipe(Effect.provide(makeLayer(backend, 50, slots)), Effect.timeout(2000))
+	})
+
+	it.live("counts an abandoned read as a held slot until the backend settles", () => {
+		const slots = makeOutboundSlotsCell()
+		let getCalls = 0
+		let settleFirstRead: (() => void) | undefined
+		const backend: EdgeCacheBackend = {
+			name: "memory",
+			get: async () => {
+				getCalls += 1
+				if (getCalls === 1) {
+					// Hangs past the deadline; the test settles it explicitly later —
+					// the shape of an uncancellable cache.match that resolves long
+					// after the read abandoned it.
+					return await new Promise<undefined>((resolve) => {
+						settleFirstRead = () => resolve(undefined)
+					})
+				}
+				return undefined
+			},
+			put: async () => {},
+			delete: async () => {},
+		}
+		const opts = { bucket: "cfg", key: "k", ttlSeconds: 30, skipReadWhenSlotsHeld: true } as const
+
+		return Effect.gen(function* () {
+			const cache = yield* EdgeCacheService
+
+			// No pressure yet, so the opted-in bucket reads — and the read hangs.
+			const first = yield* cache.getOrCompute(opts, Effect.succeed("computed"))
+			assert.strictEqual(first.hit, false)
+			assert.strictEqual(getCalls, 1)
+			assert.strictEqual(slots.held(), 1, "abandoned read still holds its slot")
+
+			// The zombie alone is pressure: the next read is skipped, not issued.
+			yield* cache.getOrCompute(opts, Effect.succeed("computed"))
+			assert.strictEqual(getCalls, 1)
+
+			// Once the underlying read finally settles, the slot frees and reads resume.
+			settleFirstRead?.()
+			// Macrotask hop: the release is chained a few microtasks behind the settle.
+			yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 0)))
+			assert.strictEqual(slots.held(), 0)
+			yield* cache.getOrCompute(opts, Effect.succeed("computed"))
+			assert.strictEqual(getCalls, 2)
+		}).pipe(Effect.provide(makeLayer(backend, 10, slots)), Effect.timeout(2000))
+	})
+
+	it.effect("trackOutboundSlot holds the slot for exactly the effect's lifetime", () => {
+		const slots = makeOutboundSlotsCell()
+		return Effect.gen(function* () {
+			const during = yield* trackOutboundSlot(
+				Effect.sync(() => slots.held()),
+				slots,
+			)
+			assert.strictEqual(during, 1)
+			assert.strictEqual(slots.held(), 0)
+
+			// Released on failure too.
+			yield* trackOutboundSlot(Effect.fail("boom" as const), slots).pipe(Effect.flip)
+			assert.strictEqual(slots.held(), 0)
+		})
 	})
 
 	it.live("keeps serving hits from a bucket that never times out", () => {

--- a/lib/cache/src/edge-cache.ts
+++ b/lib/cache/src/edge-cache.ts
@@ -1,6 +1,7 @@
 // BOUNDARY: This module owns unparsed external values and narrows them before domain use.
 import { Clock, Config, Context, Effect, Layer, Option, Schema } from "effect"
 import { CacheBackend, type EdgeCacheBackend } from "./cache-backend"
+import { isolateOutboundSlots, trackOutboundSlot, type OutboundSlotsCell } from "./outbound-slots"
 
 export { CacheBackend, type EdgeCacheBackend } from "./cache-backend"
 
@@ -46,6 +47,23 @@ export interface EdgeCacheGetOrComputeOptions<A = unknown, I = unknown> {
 	 * `DEFAULT_EDGE_CACHE_READ_TIMEOUT_MS`.
 	 */
 	readonly readTimeoutMs?: number
+	/**
+	 * Skip the backend read whenever outbound I/O is already holding one of the
+	 * runtime's connection slots (see `OutboundSlotsCell`), and go straight to
+	 * `compute`.
+	 *
+	 * Opt in when `compute` is cheap relative to the read gamble. A read issued
+	 * while a slot is held is the read most likely to queue past its deadline —
+	 * and an abandoned read is worse than no read, because `cache.match()` is
+	 * not cancellable and keeps its slot until it settles. For a bucket whose
+	 * `compute` is a ~20ms indexed row lookup, betting a 40ms deadline plus a
+	 * possible held slot to save that lookup never pays.
+	 *
+	 * This is the deterministic sibling of the timeout-rate breaker below, and
+	 * the only protection available to buckets whose reads land one-per-isolate
+	 * — the breaker needs samples those buckets can never accumulate.
+	 */
+	readonly skipReadWhenSlotsHeld?: boolean
 }
 
 export interface EdgeCacheResult<A> {
@@ -202,6 +220,7 @@ const READ_BREAKER_MIN_SAMPLES = 2
 export const makeEdgeCacheService = (
 	backend: EdgeCacheBackend,
 	readTimeoutMs = DEFAULT_EDGE_CACHE_READ_TIMEOUT_MS,
+	slots: OutboundSlotsCell = isolateOutboundSlots,
 ): EdgeCacheServiceApi => {
 	const boundedReadTimeoutMs = Number.isFinite(readTimeoutMs)
 		? Math.max(1, Math.floor(readTimeoutMs))
@@ -242,9 +261,18 @@ export const makeEdgeCacheService = (
 		const deadline = new Promise<{ readonly value: undefined; readonly timedOut: true }>((resolve) => {
 			timer = setTimeout(() => resolve({ value: undefined, timedOut: true }), timeoutMs)
 		})
-		const read = Promise.resolve()
-			.then(() => backend.get(bucket, key, nowMs))
-			.then((value) => ({ value, timedOut: false as const }))
+		// The slot is held until the UNDERLYING read settles, not until the race
+		// does: an abandoned `cache.match()` cannot be cancelled and keeps its
+		// connection slot long after the deadline gave up on it. Tying release to
+		// the backend promise makes `slots.held()` reflect that zombie for exactly
+		// as long as it is real.
+		slots.acquire()
+		const backendRead = Promise.resolve().then(() => backend.get(bucket, key, nowMs))
+		backendRead.then(
+			() => slots.release(),
+			() => slots.release(),
+		)
+		const read = backendRead.then((value) => ({ value, timedOut: false as const }))
 		return Promise.race([read, deadline]).finally(() => {
 			if (timer !== undefined) clearTimeout(timer)
 		})
@@ -282,16 +310,19 @@ export const makeEdgeCacheService = (
 			const ttlSeconds =
 				typeof options.ttlSeconds === "function" ? options.ttlSeconds(value) : options.ttlSeconds
 			const writeNowMs = yield* Clock.currentTimeMillis
-			yield* Effect.tryPromise({
-				try: () => backend.put(options.bucket, hash, stored, ttlSeconds, writeNowMs),
-				catch: (cause) =>
-					new EdgeCacheIOError({
-						op: "put",
-						bucket: options.bucket,
-						key: options.key,
-						cause: cause instanceof Error ? cause.message : String(cause),
-					}),
-			}).pipe(
+			yield* trackOutboundSlot(
+				Effect.tryPromise({
+					try: () => backend.put(options.bucket, hash, stored, ttlSeconds, writeNowMs),
+					catch: (cause) =>
+						new EdgeCacheIOError({
+							op: "put",
+							bucket: options.bucket,
+							key: options.key,
+							cause: cause instanceof Error ? cause.message : String(cause),
+						}),
+				}),
+				slots,
+			).pipe(
 				Effect.tapError((error) =>
 					Effect.logWarning("Edge cache put failed; continuing without cache").pipe(
 						Effect.annotateLogs({
@@ -311,10 +342,20 @@ export const makeEdgeCacheService = (
 			const nowMs = readStartedAt
 			const timeoutMs = resolveReadTimeoutMs(options.readTimeoutMs)
 			yield* Effect.annotateCurrentSpan("cache.read_timeout_ms", timeoutMs)
-			// The breaker is checked before the read, not after: the point is to NOT
+			// Both gates are checked before the read, not after: the point is to NOT
 			// occupy a connection slot on a bucket that is currently failing to
 			// return one.
-			const skipRead = shouldSkipRead(options.bucket, nowMs)
+			const slotsHeld = slots.held()
+			const skipForSlots = options.skipReadWhenSlotsHeld === true && slotsHeld > 0
+			const skipForBreaker = shouldSkipRead(options.bucket, nowMs)
+			const skipRead = skipForBreaker || skipForSlots
+			yield* Effect.annotateCurrentSpan("cache.slots_held", slotsHeld)
+			if (skipRead) {
+				yield* Effect.annotateCurrentSpan(
+					"cache.skip_reason",
+					skipForBreaker ? "breaker" : "slots_held",
+				)
+			}
 			const read = skipRead
 				? { value: undefined, timedOut: false as const }
 				: yield* Effect.tryPromise({
@@ -470,16 +511,19 @@ export const makeEdgeCacheService = (
 		ttlSeconds: number,
 	) {
 		const nowMs = yield* Clock.currentTimeMillis
-		return yield* Effect.tryPromise({
-			try: () => backend.put(bucket, key, value, ttlSeconds, nowMs),
-			catch: (cause) =>
-				new EdgeCacheIOError({
-					op: "put",
-					bucket,
-					key,
-					cause: cause instanceof Error ? cause.message : String(cause),
-				}),
-		})
+		return yield* trackOutboundSlot(
+			Effect.tryPromise({
+				try: () => backend.put(bucket, key, value, ttlSeconds, nowMs),
+				catch: (cause) =>
+					new EdgeCacheIOError({
+						op: "put",
+						bucket,
+						key,
+						cause: cause instanceof Error ? cause.message : String(cause),
+					}),
+			}),
+			slots,
+		)
 	})
 
 	return {

--- a/lib/cache/src/index.ts
+++ b/lib/cache/src/index.ts
@@ -11,3 +11,4 @@
 
 export * from "./cache-backend"
 export * from "./edge-cache"
+export * from "./outbound-slots"

--- a/lib/cache/src/outbound-slots.ts
+++ b/lib/cache/src/outbound-slots.ts
@@ -1,0 +1,71 @@
+import { Effect } from "effect"
+
+/**
+ * A count of outbound I/O currently holding one of the runtime's simultaneous
+ * connection slots (Cloudflare Workers caps these at six per invocation:
+ * https://developers.cloudflare.com/workers/platform/limits/).
+ *
+ * This exists as a *deterministic* alternative to the per-bucket timeout-rate
+ * breaker in `edge-cache.ts`. That breaker needs samples, and a bucket whose
+ * reads land one-per-isolate across a request fan-out never accumulates any —
+ * measured on the org-config bucket: the most timeouts of any bucket (508 in a
+ * day) and zero breaker skips, because each isolate reads it at most once per
+ * memo window. A signal that predicts the *next* read's fate from the present
+ * — "is a connection slot held right now?" — needs no history at all, so it
+ * works on the very first read of a cold isolate.
+ *
+ * Isolate-scoped rather than request-scoped, deliberately. Slot budgets are
+ * per-invocation, so an isolate-wide count over-reports pressure when
+ * concurrent requests share the isolate — but the measured timeouts are not
+ * explained by in-request activity alone (only ~30% of timed-out config reads
+ * had a warehouse query in flight in their own trace), and the cost asymmetry
+ * absorbs the imprecision: a wrongly skipped read costs its caller the compute
+ * (~20ms for the buckets that opt in), an avoided timeout saves ~600ms and a
+ * held slot. Being module state also means no per-request wiring: every entry
+ * point — HTTP, cron, workflows — is covered by construction.
+ */
+export interface OutboundSlotsCell {
+	/** How many outbound calls currently hold a connection slot. */
+	readonly held: () => number
+	readonly acquire: () => void
+	readonly release: () => void
+}
+
+export const makeOutboundSlotsCell = (): OutboundSlotsCell => {
+	let held = 0
+	return {
+		held: () => held,
+		acquire: () => {
+			held += 1
+		},
+		// Floored at zero so a double-release bug degrades the signal instead of
+		// poisoning it into permanently negative territory.
+		release: () => {
+			held = Math.max(0, held - 1)
+		},
+	}
+}
+
+/** The isolate-wide cell. Production code shares this one; tests inject their own. */
+export const isolateOutboundSlots: OutboundSlotsCell = makeOutboundSlotsCell()
+
+/**
+ * Count `effect` as holding an outbound connection slot while it runs.
+ *
+ * Wrap the narrowest effect that actually has a connection open — a driver
+ * call, a client fetch — not a span that includes preamble or retry sleeps.
+ * Release is exit-agnostic (success, failure, interruption). One caveat:
+ * interrupting a wrapped `Effect.tryPromise` releases the slot even though the
+ * underlying promise (and its connection) may still be in flight — the wrapper
+ * cannot see promise settlement from out here, so an interrupted call
+ * under-reports for as long as its fetch lingers.
+ */
+export const trackOutboundSlot = <A, E, R>(
+	effect: Effect.Effect<A, E, R>,
+	cell: OutboundSlotsCell = isolateOutboundSlots,
+): Effect.Effect<A, E, R> =>
+	Effect.acquireUseRelease(
+		Effect.sync(() => cell.acquire()),
+		() => effect,
+		() => Effect.sync(() => cell.release()),
+	)

--- a/packages/query-engine/src/execution/executor.ts
+++ b/packages/query-engine/src/execution/executor.ts
@@ -1,4 +1,5 @@
 import { Cause, Clock, Duration, Effect, HashMap, Option, Ref, Schedule, Schema } from "effect"
+import { trackOutboundSlot } from "@maple/cache"
 import {
 	MAX_RAW_SQL_RESULT_BYTES,
 	MAX_RAW_SQL_RESULT_ROWS,
@@ -179,10 +180,12 @@ export const makeWarehouseExecutor = (deps: WarehouseExecutorDeps): WarehouseQue
 				cause,
 			})
 		const queryRows = (target: WarehouseCapabilityMetadataTarget, sql: string) =>
-			Effect.tryPromise({
-				try: () => client.sql(parseStatement(sql)),
-				catch: (cause) => probeError(target, cause),
-			}).pipe(Effect.map((result) => result.data))
+			trackOutboundSlot(
+				Effect.tryPromise({
+					try: () => client.sql(parseStatement(sql)),
+					catch: (cause) => probeError(target, cause),
+				}),
+			).pipe(Effect.map((result) => result.data))
 		const logProbeFailure = (error: WarehouseCapabilityProbeError) =>
 			Effect.logWarning("Warehouse capability metadata probe failed").pipe(
 				Effect.annotateLogs({
@@ -476,30 +479,34 @@ WHERE name = 'enable_full_text_index'`,
 			(execution === "raw"
 				? { maxRows: MAX_RAW_SQL_RESULT_ROWS, maxBytes: MAX_RAW_SQL_RESULT_BYTES }
 				: undefined)
-		const queryAttempt = Effect.tryPromise({
-			try: () =>
-				client.sql(
-					statement,
-					effectiveResponseLimits === undefined
-						? undefined
-						: { responseLimits: effectiveResponseLimits },
-				),
-			catch: (error) =>
-				error instanceof WarehouseResponseLimitError
-					? // Only raw SQL restates this as a validation error — there the
-						// oversized result IS the caller's query problem. For a trusted
-						// query the limit is ours, so it propagates unchanged and the
-						// caller maps it to a domain error. Either way it never becomes a
-						// WarehouseUpstreamError, so the transient retry loop skips it
-						// instead of re-running a read that already exhausted the heap.
-						execution === "raw"
-						? new RawSqlValidationError({ code: "ResourceLimit", message: error.message })
-						: error
-					: // `execution` decides authorship: raw SQL comes from the caller (the
-						// raw_sql widget, the `run_sql` MCP tool), so an analyzer complaint
-						// about it is their typo and must keep the database's own message.
-						mapWarehouseError(pipe, error, execution === "raw" ? "caller" : "maple"),
-		})
+		// `trackOutboundSlot` covers each attempt (retries re-enter it), so the
+		// slot count reflects the connection, not the retry schedule's sleeps.
+		const queryAttempt = trackOutboundSlot(
+			Effect.tryPromise({
+				try: () =>
+					client.sql(
+						statement,
+						effectiveResponseLimits === undefined
+							? undefined
+							: { responseLimits: effectiveResponseLimits },
+					),
+				catch: (error) =>
+					error instanceof WarehouseResponseLimitError
+						? // Only raw SQL restates this as a validation error — there the
+							// oversized result IS the caller's query problem. For a trusted
+							// query the limit is ours, so it propagates unchanged and the
+							// caller maps it to a domain error. Either way it never becomes a
+							// WarehouseUpstreamError, so the transient retry loop skips it
+							// instead of re-running a read that already exhausted the heap.
+							execution === "raw"
+							? new RawSqlValidationError({ code: "ResourceLimit", message: error.message })
+							: error
+						: // `execution` decides authorship: raw SQL comes from the caller (the
+							// raw_sql widget, the `run_sql` MCP tool), so an analyzer complaint
+							// about it is their typo and must keep the database's own message.
+							mapWarehouseError(pipe, error, execution === "raw" ? "caller" : "maple"),
+			}),
+		)
 		// `db.duration_ms` measures warehouse execution only — captured here, after
 		// config resolution + settings/client-cache preamble, immediately before the
 		// query runs. `startedAtMs` (captured at span entry) feeds the separate


### PR DESCRIPTION
## Problem

The edge cache's per-bucket timeout-rate breaker fires for `qe-execute` but has never fired for `org-ch-config` — the bucket with the most read timeouts. Last 24h (Aug 27 08:00 → Aug 28 08:00 UTC), `EdgeCacheService.getOrCompute` on `org-ch-config`:

| read_status | n | span p50 | span p95 |
|---|---|---|---|
| hit | 1050 | 16ms | 40ms |
| **timeout** | **438 (26.6%)** | **621ms** | **1312ms** |
| pending | 113 | 7ms | — |
| miss | 43 | 60ms | 395ms |
| skipped | 0 | — | — |

The breaker is structurally blind here, twice over:

- An isolate reads `org-ch-config` at most once per 300s memo window, so the per-isolate EWMA never accumulates its 2-sample minimum — and even if it opened, its 2s skip window would expire ~298s before the isolate's next read.
- The failure isn't per-bucket history anyway: a trace join shows the timed-out reads are the ones issued while other outbound I/O holds one of the invocation's six connection slots (warehouse queries, PG statements, MCP/LLM tool activity, and abandoned reads from concurrent requests in the same isolate).

At the current rate the shared tier is net-negative for this bucket: hits save ~46s/day over the ~20ms Postgres compute, timeouts cost ~272s/day.

## Change

Replace history with the present: a deterministic, sample-free skip signal that works on the very first read of a cold isolate.

- **`lib/cache/src/outbound-slots.ts`** (new): an isolate-scoped counter of outbound I/O currently holding connection slots, plus `trackOutboundSlot` to wrap any effect that has a connection open. Module state — HTTP, cron, and workflow entry points are covered with no per-request wiring. Isolate-scoped rather than request-scoped deliberately: it over-reports when concurrent requests share the isolate, but a wrong skip costs the opted-in bucket ~20ms while an avoided timeout saves ~600ms and a held slot.
- **`edge-cache.ts`**: reads and puts count toward the signal, and an abandoned read keeps its slot counted until the underlying `cache.match()` actually settles — the uncancellable zombie is visible for exactly as long as it is real. New `getOrCompute` option `skipReadWhenSlotsHeld` skips the read when any slot is held. New span attributes `cache.slots_held` (every call) and `cache.skip_reason` (`"breaker" | "slots_held"`). The EWMA breaker is unchanged for the buckets it does help.
- **Slot markers at the measured contenders**: the warehouse driver call and capability probes (`query-engine/execution/executor.ts`, scoped to each attempt, not retry sleeps) and PG statements (`pg-connection-scope.ts`, scoped to the statement, not the kept-open socket).
- **Only `org-ch-config` opts in**: its compute is a ~20ms indexed row read, so skipping straight to Postgres beats a 40ms deadline gamble that loses 27% of the time at 621ms per loss. `qe-*` (compute = warehouse query) and `autumn-customer` (compute = ~100ms upstream fetch) deliberately do not.

## Verification

- `lib/cache`: 21 tests (3 new: pressure skip + opt-in scoping, zombie slot retention until backend settle, `trackOutboundSlot` release on success/failure), typecheck clean.
- `packages/query-engine`: 1317 tests, typecheck clean.
- `apps/api`: targeted OrgClickHouseSettingsService / pg-connection-scope / QueryEngineCache suites (89 tests), typecheck clean.

## After deploy

Re-run the before-query (spans `EdgeCacheService.getOrCompute` grouped by `cache.bucket` × `cache.read_status`, filtered to the newest `service.version`). Expect the `org-ch-config` timeout share to collapse into `skipped` rows with `cache.skip_reason = 'slots_held'` at ~miss cost. Residual timeouts with `cache.slots_held = 0` are pressure the signal cannot see — next levers are marking the LLM seam in `platform/Llm.ts`, or dropping the edge tier for this bucket entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516143&installation_model_id=427786&pr_number=672&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F672&signature=d8a1e90d64fe6b21df65714e005a1daf3126dd6acb7af8565359469a6bcabfb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->