### PR TITLE
fix(ingest): identify OpenRouter's OTLP export as a vendor

### DIFF
--- a/apps/ingest/src/ai_session.rs
+++ b/apps/ingest/src/ai_session.rs
@@ -243,6 +243,7 @@ struct ScopeFacts {
     agent_framework: bool,
     openai_agents: bool,
     openinference_openai: bool,
+    openrouter: bool,
     crewai: bool,
     openinference_foreign: bool,
     pydantic: bool,
@@ -272,6 +273,7 @@ const SCOPE_NAMES: &[&str] = &[
     "@mastra/otel-exporter",
     "agent_framework",
     "agent_runtime ",
+    "openrouter",
     "crewai.telemetry",
     "pydantic-ai",
     "strands.telemetry.tracer",
@@ -315,6 +317,7 @@ fn scope_facts(scope_name: &str, resource: &ResourceFacts) -> ScopeFacts {
         // openai" is a string prefix of the agents scope.
         "openinference.instrumentation.openai_agents" => facts.openai_agents = true,
         "openinference.instrumentation.openai" => facts.openinference_openai = true,
+        "openrouter" => facts.openrouter = true,
         "openinference.instrumentation.crewai" | "crewai.telemetry" => facts.crewai = true,
         "openinference.instrumentation.smolagents" => facts.smolagents = true,
         "pydantic-ai" => facts.pydantic = true,
@@ -348,6 +351,7 @@ fn scope_facts(scope_name: &str, resource: &ResourceFacts) -> ScopeFacts {
         || facts.agent_framework
         || facts.openai_agents
         || facts.openinference_openai
+        || facts.openrouter
         || facts.crewai
         || facts.pydantic
         || facts.semantic_kernel
@@ -856,6 +860,11 @@ static VENDORS: &[Vendor] = &[
         session_keys: &[],
     },
     Vendor {
+        id: "openrouter",
+        detect: detect_openrouter,
+        session_keys: &["session.id"],
+    },
+    Vendor {
         id: "llamaindex",
         detect: detect_llamaindex,
         session_keys: &[],
@@ -1055,6 +1064,14 @@ fn detect_litellm(c: &Ctx) -> bool {
     // No `litellm.` attr-prefix clause: that would steal the host framework's
     // spans (litellm.call_id rides along inside other frameworks' spans).
     c.scope.litellm
+}
+
+fn detect_openrouter(c: &Ctx) -> bool {
+    // OpenRouter's own OTLP export (scope and service.name are both
+    // "openrouter"). Its `session.id` span attribute echoes the caller-supplied
+    // session tag, so calls tagged by a framework the gateway also stamps join
+    // that framework's session.
+    c.scope.openrouter
 }
 
 fn detect_llamaindex(c: &Ctx) -> bool {
@@ -1301,6 +1318,13 @@ mod tests {
                 &[("session.id", "oo-1")],
                 "openinference-openai",
                 "oo-1",
+            ),
+            (
+                "openrouter",
+                "LLM Generation",
+                &[("session.id", "or-1"), ("gen_ai.operation.name", "chat")],
+                "openrouter",
+                "or-1",
             ),
             (
                 "crewai.telemetry",

--- a/apps/web/src/lib/agent-sessions/vendor-label.ts
+++ b/apps/web/src/lib/agent-sessions/vendor-label.ts
@@ -17,6 +17,7 @@ const VENDOR_LABELS: Record<string, string> = {
 	llamaindex: "LlamaIndex",
 	openai_agents_sdk: "OpenAI Agents SDK",
 	"openinference-openai": "OpenInference · OpenAI",
+	openrouter: "OpenRouter",
 	pydantic_ai: "Pydantic AI",
 	smolagents: "smolagents",
 	spring_ai: "Spring AI",

--- a/packages/query-engine-integrations/src/ai/ai-integrations.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-integrations.test.ts
@@ -198,6 +198,7 @@ describe("legacy aliases", () => {
 		// The registry spelling, not a deprecation: semconv says `cache_write`
 		// where the catalog's primary keeps the Anthropic-era `cache_creation`.
 		["gen_ai.usage.cache_write.input_tokens", "512", "usageCacheCreationInputTokens", 512],
+		["gen_ai.usage.total_cost", "0.00130795", "usageCost", 0.00130795],
 	]
 
 	for (const [key, value, field, expected] of cases) {

--- a/packages/query-engine-integrations/src/ai/ai-integrations.ts
+++ b/packages/query-engine-integrations/src/ai/ai-integrations.ts
@@ -132,11 +132,13 @@ const decodeAttribute = (type: AiFieldDef["type"], raw: string): unknown => {
  * choice, not a spec-blessed rename: in practice they carried exactly that
  * content, and OpenRouter instrumentation in production still emits them.
  *
- * `gen_ai.usage.output_tokens.reasoning` and `gen_ai.usage.input_tokens.cached`
- * are likewise absent from the deprecation table — they are the sub-key spelling
- * OpenRouter emits in production for what the convention calls
- * `gen_ai.usage.reasoning.output_tokens` and `gen_ai.usage.cache_read.input_tokens`.
- * Both were confirmed against the warehouse; the plausible-looking
+ * `gen_ai.usage.output_tokens.reasoning`, `gen_ai.usage.input_tokens.cached`
+ * and `gen_ai.usage.total_cost` are likewise absent from the deprecation table —
+ * they are the spelling OpenRouter emits in production for what the convention
+ * calls `gen_ai.usage.reasoning.output_tokens`,
+ * `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cost` (total_cost is
+ * USD, the sum of the input_cost/output_cost keys beside it). All three were
+ * confirmed against the warehouse; the plausible-looking
  * `gen_ai.usage.reasoning_tokens` was NOT, so it is deliberately not listed.
  */
 const GENAI_LEGACY_ALIASES = {
@@ -149,6 +151,7 @@ const GENAI_LEGACY_ALIASES = {
 	// spelling Anthropic-era emitters (and Maple's own rows before this alias)
 	// used. Both must decode; Maple's agents emit the semconv form.
 	usageCacheCreationInputTokens: ["gen_ai.usage.cache_write.input_tokens"],
+	usageCost: ["gen_ai.usage.total_cost"],
 	inputMessages: ["gen_ai.prompt"],
 	outputMessages: ["gen_ai.completion"],
 	providerName: ["gen_ai.system"],


### PR DESCRIPTION
## Problem

Spans from OpenRouter's own OTLP trace export (instrumentation scope and `service.name` both `openrouter`, span name "LLM Generation") matched no vendor predicate in the ingest gateway, so they all fell into the `unknown:genai` bucket — shown as **Unidentified** in the agent sessions UI — and never received a `maple_ai.session.id` stamp, keeping them out of their sessions entirely.

## Fix

- **`apps/ingest/src/ai_session.rs`** — new `openrouter` vendor, detected on the scope name alone (same shape as `litellm`). Session key is `session.id`: OpenRouter echoes the caller-supplied session tag there, so its generation spans merge into the same agent session as the framework that made the call (verified against live spans, which carry the caller's session ids). Test case added to the vendor table.
- **`packages/query-engine-integrations/src/ai/ai-integrations.ts`** — OpenRouter spells cost `gen_ai.usage.total_cost` (USD; the sum of the `input_cost`/`output_cost` keys beside it), not the semconv `gen_ai.usage.cost`, so cost never decoded for these spans. Added as an alias, warehouse-confirmed like the existing OpenRouter spellings, with a test.
- **`apps/web/src/lib/agent-sessions/vendor-label.ts`** — `openrouter` → "OpenRouter" (the title-case fallback would render "Openrouter").

Existing warehouse rows keep their `unknown:genai` stamp; classification happens at ingest, so this takes effect for newly ingested spans once ingest deploys.

## Verification

- `cargo test ai_session`: 22/22, clippy clean for the file
- query-engine-integrations vitest: 299/299, `tsc --noEmit` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790533358&installation_model_id=427786&pr_number=675&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F675&signature=a707de479c12b950c82b39797638d045a17f719fc39f47f857818604c3fd10ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->