### PR TITLE
fix(errors): keep the status chip on one line in the issues list

### DIFF
--- a/apps/web/src/components/errors/error-signal-row.tsx
+++ b/apps/web/src/components/errors/error-signal-row.tsx
@@ -98,7 +98,9 @@ const LANE = {
 	spark: "hidden w-[56px] shrink-0 @lg/page:block",
 	count: "hidden w-[52px] shrink-0 @xl/page:block",
 	service: "hidden w-[92px] shrink-0 @md/page:block",
-	state: "hidden w-[92px] shrink-0 @2xl/page:block",
+	// Sized to the longest label: "Open incident"/"Investigating" run ~98px in
+	// 11px Geist Mono plus the dot — 92px forced them onto two lines.
+	state: "hidden w-[104px] shrink-0 @2xl/page:block",
 	activity: "hidden w-[64px] shrink-0 @xl/page:block",
 	actor: "w-5 shrink-0",
 	lastSeen: "w-[64px] shrink-0",
@@ -268,7 +270,7 @@ export function ErrorSignalRow({
 				</span>
 
 				<span className={LANE.state}>
-					<SignalStateChip state={signal.state} />
+					<SignalStateChip state={signal.state} withConfidence={false} />
 				</span>
 
 				<span className={cn(LANE.activity, "items-center gap-2 @xl/page:flex")}>

--- a/apps/web/src/components/errors/signal-state-chip.tsx
+++ b/apps/web/src/components/errors/signal-state-chip.tsx
@@ -29,20 +29,30 @@ const INVESTIGATION_LABEL = {
 	resolved: "Resolved",
 } satisfies Record<V2Investigation["status"], string>
 
-export function SignalStateChip({ state, className }: { state: SignalState; className?: string }) {
+export function SignalStateChip({
+	state,
+	withConfidence = true,
+	className,
+}: {
+	state: SignalState
+	/** Inline `· medium` after "Diagnosed". The list row turns it off — its fixed
+	 *  lane cannot fit the suffix on one line, and the tooltip still carries it. */
+	withConfidence?: boolean
+	className?: string
+}) {
 	const navigate = useNavigate()
 
 	if (state.kind === "incident") {
 		return (
 			<span
 				className={cn(
-					"inline-flex items-center gap-1.5 text-[11px] font-medium text-destructive",
+					"inline-flex max-w-full items-center gap-1.5 text-[11px] font-medium whitespace-nowrap text-destructive",
 					className,
 				)}
 				title="An incident is open for this error"
 			>
 				<span className="size-1.5 shrink-0 rounded-full bg-destructive" />
-				Open incident
+				<span className="truncate">Open incident</span>
 			</span>
 		)
 	}
@@ -63,7 +73,7 @@ export function SignalStateChip({ state, className }: { state: SignalState; clas
 					navigate({ to: "/investigations/$id", params: { id: state.investigationId } })
 				}}
 				className={cn(
-					"inline-flex items-center gap-1.5 text-[11px] font-medium",
+					"inline-flex max-w-full items-center gap-1.5 text-[11px] font-medium whitespace-nowrap",
 					"text-muted-foreground hover:text-foreground hover:underline",
 					"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm",
 					className,
@@ -80,8 +90,8 @@ export function SignalStateChip({ state, className }: { state: SignalState; clas
 						isLive && "motion-safe:animate-pulse",
 					)}
 				/>
-				{label}
-				{state.confidence && state.status === "diagnosed" ? (
+				<span className="truncate">{label}</span>
+				{withConfidence && state.confidence && state.status === "diagnosed" ? (
 					<span className="text-muted-foreground/60">· {state.confidence}</span>
 				) : null}
 			</button>
@@ -90,11 +100,14 @@ export function SignalStateChip({ state, className }: { state: SignalState; clas
 
 	return (
 		<span
-			className={cn("inline-flex items-center gap-1.5 text-[11px] text-muted-foreground", className)}
+			className={cn(
+				"inline-flex max-w-full items-center gap-1.5 text-[11px] whitespace-nowrap text-muted-foreground",
+				className,
+			)}
 			title={`Workflow state: ${WORKFLOW_LABEL[state.state]}`}
 		>
 			<WorkflowRingIcon state={state.state} size={12} />
-			{WORKFLOW_LABEL[state.state]}
+			<span className="truncate">{WORKFLOW_LABEL[state.state]}</span>
 		</span>
 	)
 }


### PR DESCRIPTION
## What

On the errors issues list, the Status lane wrapped its chips into two stacked lines — "Open incident" broke after "Open", and diagnosed rows dangled a dim "medium"/"low" confidence fragment under the Activity column.

## Why

The lane is fixed at 92px, but in 11px Geist Mono "Open incident" / "Investigating" need ~98px (13 chars × the font's exact 0.6em advance = 6.6px, plus the 6px dot and 6px gap), and "Diagnosed · medium" needs ~137px. Flex items shrink to min-content, so the labels wrapped instead of overflowing. Widths verified against the glyph advance read from the shipped Geist Mono woff2.

## How

- Widen the Status lane to 104px — fits every state label (longest workflow label, "In progress", is ~91px with its icon) with slack.
- `whitespace-nowrap` + a truncating label span on all three `SignalStateChip` variants, so a chip can never wrap mid-label anywhere; a hypothetical too-long label ellipsizes on one line.
- New `withConfidence` prop (default true): list rows pass `false`, dropping the inline `· medium` suffix that no list-affordable lane fits — the chip's tooltip already carries the confidence. The issue-page header keeps the inline suffix, where it has room.

## Reviewer notes

- `tsc --noEmit` on apps/web is clean.
- No live-browser check: local /errors needs seeded issues plus a manual error tick, and the fix is pure fixed-width arithmetic in a monospaced font.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790538351&installation_model_id=427786&pr_number=676&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F676&signature=4d4ae020f714d7c7c505952ceea8f6d91a8f3af2eecd3b6f8407b6ce24dbf46a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->