### PR TITLE
fix(ingest): negative-cache unknown key lookups and permit-gate the browser endpoints

### DIFF
--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -665,6 +665,9 @@ struct IngestKeyResolver {
     store: Arc<dyn KeyStore>,
     lookup_hmac_key: String,
     cache: Cache<String, IngestKeyIdentity>,
+    // Authoritative "no such key" results, so an unknown-key flood is absorbed
+    // here instead of amplifying into a Postgres lookup per request.
+    negative_cache: Cache<String, ()>,
     routing: Arc<OrgRoutingResolver>,
 }
 
@@ -2059,6 +2062,12 @@ async fn main() {
         .time_to_live(Duration::from_secs(config.ingest_key_cache_ttl_secs))
         .max_capacity(1_000)
         .build();
+    // Short TTL so a freshly created key starts working within seconds even
+    // after the SDK raced ahead of provisioning.
+    let ingest_key_negative_cache = Cache::builder()
+        .time_to_live(Duration::from_secs(30))
+        .max_capacity(10_000)
+        .build();
 
     let cloudflare_connector_cache = Cache::builder()
         .time_to_live(Duration::from_secs(config.ingest_key_cache_ttl_secs))
@@ -2093,6 +2102,7 @@ async fn main() {
             store: Arc::clone(&store),
             lookup_hmac_key: config.lookup_hmac_key.clone(),
             cache: ingest_key_cache,
+            negative_cache: ingest_key_negative_cache,
             routing: Arc::clone(&org_routing_resolver),
         },
         org_inflight_limiter: OrgInFlightLimiter::new(config.org_max_in_flight),
@@ -2867,6 +2877,14 @@ async fn handle_replay_meta_inner(
     let destination = native_destination_for(&resolved_key);
     Span::current().record("maple.ingest.destination", destination.as_str());
 
+    let _org_inflight_permit = state
+        .org_inflight_limiter
+        .try_acquire(&org_id)
+        .ok_or_else(|| {
+            warn!(org_id = %org_id, "Per-org in-flight ingest limit exceeded");
+            ApiError::too_many_requests("Per-org ingest limit exceeded")
+        })?;
+
     let pipeline = native_rows_pipeline_for(
         state,
         destination,
@@ -3044,6 +3062,14 @@ async fn handle_session_events_inner(
     let destination = native_destination_for(&resolved_key);
     Span::current().record("maple.ingest.destination", destination.as_str());
 
+    let _org_inflight_permit = state
+        .org_inflight_limiter
+        .try_acquire(&org_id)
+        .ok_or_else(|| {
+            warn!(org_id = %org_id, "Per-org in-flight ingest limit exceeded");
+            ApiError::too_many_requests("Per-org ingest limit exceeded")
+        })?;
+
     // Same Autumn gate as the metadata endpoint. Automatic session events
     // (clicks, navigations, errors, ...) are not separately metered —
     // `browser_sessions` remains their billed unit — but they must still be
@@ -3220,6 +3246,14 @@ async fn handle_product_events_inner(
     );
     let destination = native_destination_for(&resolved_key);
     Span::current().record("maple.ingest.destination", destination.as_str());
+
+    let _org_inflight_permit = state
+        .org_inflight_limiter
+        .try_acquire(&org_id)
+        .ok_or_else(|| {
+            warn!(org_id = %org_id, "Per-org in-flight ingest limit exceeded");
+            ApiError::too_many_requests("Per-org ingest limit exceeded")
+        })?;
 
     // Product events are their own metered feature, but they are NOT gated on
     // it — same reasoning as the `type == "custom"` rows on `/v1/sessionEvents`.
@@ -3408,6 +3442,14 @@ async fn handle_replay_blob_inner(
     );
     let destination = native_destination_for(&resolved_key);
     Span::current().record("maple.ingest.destination", destination.as_str());
+
+    let _org_inflight_permit = state
+        .org_inflight_limiter
+        .try_acquire(&org_id)
+        .ok_or_else(|| {
+            warn!(org_id = %org_id, "Per-org in-flight ingest limit exceeded");
+            ApiError::too_many_requests("Per-org ingest limit exceeded")
+        })?;
 
     let pipeline = native_rows_pipeline_for(
         state,
@@ -5115,6 +5157,10 @@ impl IngestKeyResolver {
         }
         Span::current().record("maple.ingest.cache_hit", false);
 
+        if self.negative_cache.get(raw_key).await.is_some() {
+            return Ok(None);
+        }
+
         let key_type = infer_ingest_key_type(raw_key);
         let Some(key_type) = key_type else {
             return Ok(None);
@@ -5132,6 +5178,9 @@ impl IngestKeyResolver {
         // the key identity cached while the separate org-routing cache refreshes
         // ClickHouse readiness on its own TTL.
         let Some(row) = self.store.fetch_ingest_key(&key_hash, hash_column).await? else {
+            // Only a genuine "no row" is cached — store errors surface above and
+            // must stay retryable.
+            self.negative_cache.insert(raw_key.to_owned(), ()).await;
             return Ok(None);
         };
 
@@ -6953,6 +7002,10 @@ mod tests {
                 .time_to_live(Duration::from_mins(1))
                 .max_capacity(16)
                 .build(),
+            negative_cache: Cache::builder()
+                .time_to_live(Duration::from_secs(30))
+                .max_capacity(16)
+                .build(),
             routing,
         }
     }
@@ -7181,6 +7234,10 @@ mod tests {
                 lookup_hmac_key: "test-hmac-key".to_owned(),
                 cache: Cache::builder()
                     .time_to_live(Duration::from_mins(1))
+                    .max_capacity(16)
+                    .build(),
+                negative_cache: Cache::builder()
+                    .time_to_live(Duration::from_secs(30))
                     .max_capacity(16)
                     .build(),
                 routing: Arc::clone(&routing),
@@ -8588,5 +8645,22 @@ mod tests {
             .await
             .expect("resolve should succeed");
         assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_ingest_key_negative_caches_unknown_keys() {
+        // A repeated unknown key must be answered from the negative cache, not
+        // by a store lookup per request — that's the unauthenticated
+        // DB-amplification path.
+        let store = Arc::new(FakeKeyStore::default());
+        let resolver = make_resolver(Arc::clone(&store));
+        for _ in 0..3 {
+            let resolved = resolver
+                .resolve_ingest_key("maple_sk_unknown")
+                .await
+                .expect("resolve should succeed");
+            assert!(resolved.is_none());
+        }
+        assert_eq!(store.ingest_key_fetches.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
## What

Two abuse-hardening fixes in the ingest gateway, both scoped to unpaid/pre-auth traffic — no effect on authenticated, metered senders:

1. **Negative caching in `IngestKeyResolver`.** A well-formed but unknown ingest key previously hit the key store on every request, so an unauthenticated flood (revoked key, misconfigured SDK, garbage spray) amplified into one DB lookup per request. Failed lookups are now cached for 30s (capacity 10k). Only an authoritative "no row" result is cached — store errors still propagate and stay retryable, so a transient DB failure cannot lock out a valid key.

2. **Per-org in-flight permits on the four browser-facing endpoints.** `/v1/sessionReplays/meta`, `/v1/sessionReplays/blob`, `/v1/sessionEvents`, and `/v1/events` never acquired the `org_inflight_limiter` permit the OTLP handlers use, so they were billing-gated but not concurrency-bounded. They now take the same permit right after auth, return the same 429 over the cap, and fire the existing `org_throttled` metric.

## Why

These endpoints are CORS-open and browser-facing, and the key-resolution path runs before any billing or quota check — both were cheap unauthenticated load paths into shared infrastructure.

## Notes for review

- The 30s negative TTL means a freshly provisioned key that races ahead of the SDK sees at most ~30s of 401s, which SDK retry already covers.
- Permit acquisition is placed after key resolution (matching the OTLP handlers) so unauthenticated requests can't consume an org's slots.
- Added `resolve_ingest_key_negative_caches_unknown_keys` asserting three resolves of an unknown key reach the store exactly once. `cargo check --tests` is clean; I have not run the crate's test binary locally, so CI is the first full test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790553666&installation_model_id=427786&pr_number=678&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F678&signature=ae21953830f9aaf1fb05a49a342cea944c6921cd4917e30dd38d4c7e0d16b839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->