### PR TITLE
feat(landing): redesign the blog post reading experience

### DIFF
--- a/apps/landing/src/pages/blog/[...slug].astro
+++ b/apps/landing/src/pages/blog/[...slug].astro
@@ -61,65 +61,102 @@ const hasToc = toc.length > 0;
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
     <Nav />
 
+    {/* Reading progress — a hairline of amber across the very top. */}
+    <div
+        data-read-progress
+        class="fixed inset-x-0 top-0 z-[60] h-[2px] origin-left scale-x-0 bg-primary"
+        aria-hidden="true"
+    >
+    </div>
+
     <article class="relative pt-[19px]">
         <div class="mx-auto max-w-6xl px-6 pt-20 md:pt-24">
             <div class:list={["lg:grid lg:gap-16", hasToc && "lg:grid-cols-[minmax(0,1fr)_13rem]"]}>
-                {/* ── Main column ── */}
+                {/* ── Main column: one centered reading measure ── */}
                 <div class="min-w-0">
-                    <a href="/blog" class={backLink}>
-                        <span aria-hidden="true">←</span> all posts
-                    </a>
-
-                    <div class="mt-[22px] flex flex-wrap items-center gap-2 font-mono text-xs tabular-nums tracking-[0.02em] text-fg-muted">
-                        {featured && (
-                            <span class="border border-primary/40 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.16em] text-primary">
-                                featured
-                            </span>
-                        )}
-                        <time datetime={isoDate(date)}>{formatDate(date)}</time>
-                        {catLabel && (
-                            <>
-                                <span aria-hidden="true" class="opacity-50">·</span>
-                                <span>{catLabel}</span>
-                            </>
-                        )}
-                        <span aria-hidden="true" class="opacity-50">·</span>
-                        <span>{minutes} min read</span>
-                    </div>
-
-                    <h1 class="mt-3.5 max-w-[20ch] font-display text-[clamp(32px,5vw,52px)] font-semibold leading-[1.04] tracking-[-0.03em] text-balance text-foreground">
-                        {title}
-                    </h1>
-                    <p class="mt-5 max-w-[68ch] font-sans text-[15px] leading-[1.7] text-pretty text-fg-muted">{description}</p>
-
-                    <div class="mt-6 flex items-center gap-2.5 font-mono text-xs text-fg/80">
-                        <MapleMark size={22} className="text-primary" aria-hidden="true" />
-                        <span>{author}</span>
-                        {authorRole && <span class="text-fg-muted">{authorRole}</span>}
-                    </div>
-
-                    {/* Cover banner */}
-                    <div class="mt-10 overflow-hidden rounded-lg border border-border md:mt-12">
-                        <PostCover
-                            title={title}
-                            category={category}
-                            cover={cover}
-                            coverAlt={coverAlt}
-                            variant="banner"
-                            drench={featured}
-                        />
-                    </div>
-
-                    {/* Body */}
-                    {/* blog-content regrows the docs prose to essay scale (global.css) */}
-                    <div class="docs-content blog-content mt-12 md:mt-14">
-                        <Content />
-                    </div>
-
-                    <div class="mt-12 border-t border-border pt-5">
+                    <div class="mx-auto w-full max-w-[42rem]">
                         <a href="/blog" class={backLink}>
-                            <span aria-hidden="true">←</span> back to all posts
+                            <span aria-hidden="true">←</span> all posts
                         </a>
+
+                        <div class="mt-[22px] flex flex-wrap items-center gap-2 font-mono text-xs tabular-nums tracking-[0.02em] text-fg-muted">
+                            {featured && (
+                                <span class="border border-primary/40 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.16em] text-primary">
+                                    featured
+                                </span>
+                            )}
+                            <time datetime={isoDate(date)}>{formatDate(date)}</time>
+                            {catLabel && (
+                                <>
+                                    <span aria-hidden="true" class="opacity-50">·</span>
+                                    <span>{catLabel}</span>
+                                </>
+                            )}
+                            <span aria-hidden="true" class="opacity-50">·</span>
+                            <span>{minutes} min read</span>
+                        </div>
+
+                        <h1 class="mt-3.5 font-display text-[clamp(30px,4.5vw,44px)] font-semibold leading-[1.08] tracking-[-0.025em] text-balance text-foreground">
+                            {title}
+                        </h1>
+                        <p class="mt-5 font-display text-[17px] leading-[1.65] text-pretty text-fg-muted">{description}</p>
+
+                        <div class="mt-6 flex items-center gap-2.5 font-mono text-xs text-fg/80">
+                            <MapleMark size={22} className="text-primary" aria-hidden="true" />
+                            <span>{author}</span>
+                            {authorRole && <span class="text-fg-muted">{authorRole}</span>}
+                        </div>
+
+                        {/* Cover banner — a step wider than the prose for presence. */}
+                        <div class="mt-10 overflow-hidden rounded-lg border border-border md:mt-12 xl:-mx-16">
+                            <PostCover
+                                title={title}
+                                category={category}
+                                cover={cover}
+                                coverAlt={coverAlt}
+                                variant="banner"
+                                drench={featured}
+                            />
+                        </div>
+
+                        {/* On this page — collapsible, small screens only */}
+                        {hasToc && (
+                            <details class="group mt-10 border border-border lg:hidden">
+                                <summary class="flex cursor-pointer list-none items-center justify-between px-4 py-3 font-mono text-[10px] uppercase tracking-[0.14em] text-fg-muted [&::-webkit-details-marker]:hidden">
+                                    On this page
+                                    <span class="transition-transform group-open:rotate-180" aria-hidden="true">▾</span>
+                                </summary>
+                                <ul class="m-0 list-none space-y-2.5 border-t border-border px-4 py-3.5">
+                                    {toc.map((h) => (
+                                        <li class:list={[h.depth === 3 && "pl-4"]}>
+                                            <a href={`#${h.slug}`} class="font-mono text-[13px] leading-snug text-fg-muted transition-colors hover:text-foreground">
+                                                {h.text}
+                                            </a>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </details>
+                        )}
+
+                        {/* Body */}
+                        {/* blog-content regrows the docs prose to essay scale (global.css) */}
+                        <div class="docs-content blog-content mt-12 md:mt-14">
+                            <Content />
+                        </div>
+
+                        <div class="mt-14 flex flex-wrap items-center justify-between gap-4 border-t border-border pt-5">
+                            <a href="/blog" class={backLink}>
+                                <span aria-hidden="true">←</span> back to all posts
+                            </a>
+                            <button
+                                type="button"
+                                data-copy-link
+                                class="inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 font-mono text-xs text-fg-muted transition-colors hover:text-primary"
+                            >
+                                <span data-copy-label>copy link</span>
+                                <span aria-hidden="true">⌁</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
 
@@ -144,6 +181,13 @@ const hasToc = toc.length > 0;
                                     </li>
                                 ))}
                             </ul>
+                            <a
+                                href="#top"
+                                data-back-to-top
+                                class="mt-5 inline-flex items-center gap-1.5 font-mono text-[11px] text-fg-muted transition-colors hover:text-primary"
+                            >
+                                <span aria-hidden="true">↑</span> back to top
+                            </a>
                         </nav>
                     </aside>
                 )}
@@ -172,32 +216,68 @@ const hasToc = toc.length > 0;
     <BottomCTA />
     <Footer />
 
-    {hasToc && (
-        <script is:inline>
-            (() => {
-                const links = Array.from(document.querySelectorAll("[data-toc-link]"));
-                if (!links.length) return;
-                const byId = new Map(links.map((l) => [decodeURIComponent(l.getAttribute("href").slice(1)), l]));
-                const heads = Array.from(document.querySelectorAll(".docs-content h2[id], .docs-content h3[id]"));
-                if (!heads.length) return;
-                const setActive = (id) => {
-                    links.forEach((l) => l.removeAttribute("data-active"));
-                    const a = byId.get(id);
-                    if (a) a.setAttribute("data-active", "true");
-                };
-                const obs = new IntersectionObserver(
-                    (entries) => {
-                        const visible = entries.filter((e) => e.isIntersecting);
-                        if (visible.length) {
-                            visible.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-                            setActive(visible[0].target.id);
-                        }
-                    },
-                    { rootMargin: "-80px 0px -70% 0px", threshold: 0 },
-                );
-                heads.forEach((h) => obs.observe(h));
-                setActive(heads[0].id);
-            })();
-        </script>
-    )}
+    <script is:inline>
+        (() => {
+            const article = document.querySelector("article");
+            const heads = Array.from(document.querySelectorAll(".docs-content h2[id], .docs-content h3[id]"));
+
+            /* Section permalinks — hover-revealed "#" on every heading. */
+            for (const h of heads) {
+                const a = document.createElement("a");
+                a.className = "heading-anchor";
+                a.href = `#${h.id}`;
+                a.textContent = "#";
+                a.setAttribute("aria-label", `Link to “${h.textContent.trim()}”`);
+                h.appendChild(a);
+            }
+
+            /* Reading progress across the article body. */
+            const bar = document.querySelector("[data-read-progress]");
+            const onScroll = () => {
+                if (!bar || !article) return;
+                const rect = article.getBoundingClientRect();
+                const total = rect.height - window.innerHeight;
+                const read = total > 0 ? Math.min(1, Math.max(0, -rect.top / total)) : 0;
+                // Tailwind's scale-x-0 is the CSS `scale` property, so drive that.
+                bar.style.scale = `${read} 1`;
+            };
+
+            /* TOC active state — the last heading above the reading line wins,
+               so scrolling back up hands the highlight back correctly. */
+            const links = Array.from(document.querySelectorAll("[data-toc-link]"));
+            const byId = new Map(links.map((l) => [decodeURIComponent(l.getAttribute("href").slice(1)), l]));
+            const setActive = () => {
+                if (!links.length || !heads.length) return;
+                const line = 96;
+                let current = heads[0];
+                for (const h of heads) {
+                    if (h.getBoundingClientRect().top <= line) current = h;
+                    else break;
+                }
+                links.forEach((l) => l.removeAttribute("data-active"));
+                const a = byId.get(current.id);
+                if (a) a.setAttribute("data-active", "true");
+            };
+
+            let raf = 0;
+            const onFrame = () => {
+                raf = 0;
+                onScroll();
+                setActive();
+            };
+            addEventListener("scroll", () => { if (!raf) raf = requestAnimationFrame(onFrame); }, { passive: true });
+            onFrame();
+
+            /* Copy-link with inline confirmation. */
+            const copy = document.querySelector("[data-copy-link]");
+            const label = document.querySelector("[data-copy-label]");
+            copy?.addEventListener("click", () => {
+                navigator.clipboard.writeText(location.origin + location.pathname).then(() => {
+                    if (!label) return;
+                    label.textContent = "copied";
+                    setTimeout(() => { label.textContent = "copy link"; }, 1600);
+                });
+            });
+        })();
+    </script>
 </Layout>

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -1236,26 +1236,56 @@
    plumbing, this block regrows the type for essay-length reading.
    Same specificity as the docs rules — SOURCE ORDER decides, so this
    block must stay below the .docs-content block.
+
+   The page centers one ~42rem reading column, so the measure lives on
+   the column, not on per-element max-widths. Running prose switches to
+   proportional Geist — the reserved long-form voice — while headings'
+   siblings (code, meta, captions, demos) keep the mono terminal voice.
    ────────────────────────────────────────────────────────────── */
-.blog-content p {
-	@apply text-[16px] leading-[1.75] mb-5 max-w-[70ch];
+.blog-content p,
+.blog-content ul,
+.blog-content ol {
+	font-family: var(--font-display);
+	@apply text-[17px] leading-[1.75] mb-5 text-fg/80;
 }
 
 .blog-content ul,
 .blog-content ol {
-	@apply text-[16px] leading-[1.75] mb-5 space-y-1.5 max-w-[70ch];
+	@apply space-y-2 pl-5;
+}
+
+/* Lede: the opening paragraph carries the post in, one size up. */
+.blog-content > p:first-child {
+	@apply text-[19px] leading-[1.7] text-fg/90;
 }
 
 .blog-content h2 {
-	@apply text-[26px] tracking-[-0.02em] mt-14 mb-5;
+	font-family: var(--font-display);
+	@apply text-[27px] tracking-[-0.02em] mt-16 mb-5;
 }
 
 .blog-content h3 {
-	@apply text-[20px] tracking-[-0.01em] mt-10 mb-4;
+	font-family: var(--font-display);
+	@apply text-[21px] tracking-[-0.015em] mt-11 mb-4;
+}
+
+.blog-content :is(h2, h3) {
+	position: relative;
+}
+
+/* Hover-revealed section permalinks, injected by the post page script. */
+.blog-content .heading-anchor {
+	@apply absolute top-0 -left-7 pr-2 font-mono font-normal text-fg-muted no-underline opacity-0 transition-opacity;
+}
+
+.blog-content :is(h2, h3):hover .heading-anchor,
+.blog-content .heading-anchor:focus-visible {
+	@apply opacity-100 text-primary;
 }
 
 .blog-content blockquote {
-	@apply text-[16px] my-6 max-w-[70ch];
+	font-family: var(--font-display);
+	@apply border-l border-primary/60 pl-5 text-[17px] leading-[1.7] my-7;
 }
 
 .blog-content code:not(pre code) {
@@ -1263,7 +1293,7 @@
 }
 
 .blog-content pre {
-	@apply text-[13.5px] leading-[1.65] p-5 my-6 max-w-[86ch];
+	@apply text-[13.5px] leading-[1.65] p-5 my-7;
 }
 
 /* block + overflow keeps wide markdown tables scrollable instead of
@@ -1282,6 +1312,15 @@
 
 .blog-content figcaption {
 	@apply font-mono text-xs text-fg-muted mt-3;
+}
+
+/* Interactive demos and code breathe past the prose measure on wide
+   viewports — an editorial rhythm, not a second column. Only top-level
+   blocks break out; anything nested inside a demo stays put. */
+@media (min-width: 80rem) {
+	.blog-content > :is(figure, pre) {
+		margin-inline: -4rem;
+	}
 }
 
 /* Essay illustrations keep their intrinsic ratio — undo the docs 1280/660 clamp. */


### PR DESCRIPTION
## What

Reworks the blog post layout (`/blog/[...slug]`) for long-form reading.

- **Centered reading column.** The article now sits in a single ~42rem measure between the page edge and the TOC rail, instead of being pinned hard-left with a dead gutter.
- **Proportional prose.** Running text (paragraphs, lists, blockquotes) switches to proportional Geist at 17px — the voice DESIGN.md reserves for long-form reading — with a larger lede paragraph and brighter body color (the muted gray was borderline on contrast at essay scale). Headings move to the display face; code, meta rows, captions, and the TOC keep the mono terminal voice.
- **Editorial breakouts.** Interactive demos (`<figure>`) and code blocks extend ~4rem past the prose measure on wide viewports.

## UX additions

- 2px amber reading-progress bar across the top of the viewport
- Hover-revealed `#` permalinks on every section heading
- Collapsible "On this page" panel on small screens (the TOC was absent below `lg`)
- "Back to top" link under the sticky TOC
- "Copy link" button at the end of the post with inline "copied" feedback

## Fixes

- TOC active-state tracking is now scroll-position-based; the old IntersectionObserver kept the wrong section highlighted when scrolling back up.
- Blockquote accent reduced from a 2px to a 1px hairline.
- The progress bar drives `style.scale` rather than `style.transform`: Tailwind 4's `scale-x-0` compiles to the CSS `scale` property, which silently multiplies with an inline transform.

## Verification

Verified headlessly at 1440px and 390px (full-scroll passes, TOC toggle, anchor hover, progress bar). `apps/landing` vitest suite passes (31/31).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790586678&installation_model_id=427786&pr_number=680&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F680&signature=676b71e1a869bee57f198c178a553bbdd22607f9e17dd75683f973ab283f2bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->