### PR TITLE
feat(ingest): drain the WAL on shutdown and protect backlogged tasks from scale-in

### DIFF
--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -402,7 +402,12 @@ export const createMapleIngest = ({ stage, domains, region, replayBlobs }: Creat
 					{
 						Effect: "Allow",
 						Action: ["ecs:UpdateTaskProtection"],
-						Resource: [`${cluster.clusterArn.replace(":cluster/", ":task/")}/*`],
+						Resource: [
+							Output.map(
+								cluster.clusterArn,
+								(arn) => `${arn.replace(":cluster/", ":task/")}/*`,
+							),
+						],
 					},
 				],
 			},

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -57,22 +57,27 @@ const COLLECTOR_DOCKERFILE = resolve(COLLECTOR_CONTEXT, "Dockerfile")
 const INGEST_PORT = 3474
 
 /**
- * WAL cap, deliberately well below Fargate's 20 GB of included ephemeral
- * storage — that 20 GB also holds the image and the OS, and the gateway's own
- * default (`INGEST_QUEUE_MAX_BYTES` = 20 GiB, `apps/ingest/src/main.rs`) would
- * sit exactly on the line. 8 GiB still buys hours of buffering at current
- * volume; raising it means paying for ephemeral storage beyond the free tier.
+ * WAL cap. Sized against the paid `ephemeralStorage` on the service below
+ * (60 GiB), not Fargate's 20 GB free tier: the lane-full 503s of the shard-46
+ * incident were a capacity limit, and the storage to fix it costs ~$3/task/mo
+ * (~$0.0001/GB-hour beyond the included 20 GB) — cheap against dropping
+ * customer data. 48 GiB over 12 lanes is 4 GiB per lane, and the remaining
+ * ~12 GB of the allowance holds the image and the OS.
  *
  * The per-lane budget is `INGEST_QUEUE_MAX_BYTES / (WAL_SHARDS * lanes)`, so
- * the Tinybird mirror's third lane would have cut every lane's share from 1 GiB
- * to 683 MiB at exactly the moment Tinybird-bound traffic doubled. 12 GiB over
- * 12 lanes restores the 1 GiB per lane that 8 GiB gave across 8, and still
- * leaves ~8 GB of the ephemeral allowance for the image and the OS.
- *
- * Drop back to 8 GiB once the mirror is removed, or every lane silently gains
- * headroom nobody sized for.
+ * removing the Tinybird mirror's lane (8 lanes) silently grows each share to
+ * 6 GiB — resize this when that happens rather than inheriting headroom
+ * nobody chose.
  */
-const WAL_MAX_BYTES = 12 * 1024 * 1024 * 1024
+const WAL_MAX_BYTES = 48 * 1024 * 1024 * 1024
+
+/**
+ * Task-level ephemeral storage, GiB. Must hold WAL_MAX_BYTES plus the image
+ * and OS. The WAL still dies with the task — this buys buffering depth, while
+ * the shutdown drain + scale-in protection (`task_protection.rs`) keep task
+ * replacement from discarding what it holds.
+ */
+const EPHEMERAL_STORAGE_GIB = 60
 
 /**
  * Pinned rather than derived. The gateway defaults to `num_cpus * 2`, which
@@ -384,9 +389,29 @@ export const createMapleIngest = ({ stage, domains, region, replayBlobs }: Creat
 				})
 			: undefined
 
+		// The gateway marks its own task scale-in-protected while the WAL holds
+		// backlog (`apps/ingest/src/task_protection.rs`). The ECS agent endpoint it
+		// PUTs to authorizes against the task role, which therefore needs this
+		// action on the cluster's tasks — the cluster ARN differs from a task ARN
+		// only in the resource prefix.
+		const taskProtectionPolicy = yield* AWS.IAM.Policy("ingest-task-protection", {
+			policyName: name("ingest-task-protection"),
+			policyDocument: {
+				Version: "2012-10-17",
+				Statement: [
+					{
+						Effect: "Allow",
+						Action: ["ecs:UpdateTaskProtection"],
+						Resource: [`${cluster.clusterArn.replace(":cluster/", ":task/")}/*`],
+					},
+				],
+			},
+		})
+
 		const service = yield* AWS.ECS.Service("ingest", {
 			cluster,
 			serviceName: name("ingest"),
+			taskRoleManagedPolicyArns: [taskProtectionPolicy.policyArn],
 
 			// Alchemy creates a private ECR repository and pushes under a content-hash
 			// tag, rebuilding only when the context hash changes — so a deploy that
@@ -420,6 +445,11 @@ export const createMapleIngest = ({ stage, domains, region, replayBlobs }: Creat
 			runtimePlatform: { cpuArchitecture: "ARM64", operatingSystemFamily: "LINUX" },
 			cpu: taskSize.cpu,
 			memory: taskSize.memory,
+			ephemeralStorage: { sizeInGiB: EPHEMERAL_STORAGE_GIB },
+			// SIGTERM → SIGKILL window (Fargate caps it at 120s). The binary's
+			// shutdown drain (`INGEST_SHUTDOWN_DRAIN_SECS`, default 90) must finish
+			// inside it, after axum has drained in-flight requests.
+			container: { stopTimeout: 120 },
 
 			desiredCount: resolveIngestDesiredCount(stage),
 			// prd autoscales on CPU between this count and a burst ceiling; alchemy
@@ -551,6 +581,12 @@ export const createMapleIngest = ({ stage, domains, region, replayBlobs }: Creat
 				// keeps ingesting until its cached decision expires.
 				...(yield* optionalPlain("AUTUMN_ENTITLEMENT_ALLOW_TTL_SECS")),
 				...(yield* optionalPlain("AUTUMN_ENTITLEMENT_DENY_TTL_SECS")),
+				// The binary's default is 1s, sized for the pre-#657 world where the
+				// check/finalize flow did the metering. Batched track flushes only
+				// need to keep Autumn roughly current between reconciliations, and
+				// 30s cuts the ~2M balances.track calls/day by ~30x.
+				...(yield* optionalPlain("AUTUMN_FLUSH_INTERVAL_SECS", "30")),
+				...(yield* optionalPlain("INGEST_SHUTDOWN_DRAIN_SECS")),
 				...(yield* optionalPlain("COMMIT_SHA", process.env.GITHUB_SHA?.trim())),
 				// `satisfies` rather than a bare literal: alchemy types `env` as
 				// `Record<string, any>`, which is what let a spread `Config` object

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -11,6 +11,7 @@
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod autumn;
+mod task_protection;
 
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -168,6 +169,10 @@ struct AppConfig {
     /// terminated by Cloudflare. Off simply writes `''`, which is what the
     /// column held before this existed — it cannot regress anything.
     trust_proxy_geo: bool,
+    /// How long a graceful shutdown may spend exporting the WAL backlog before
+    /// exiting anyway. Must fit inside the ECS `stopTimeout` (SIGTERM → SIGKILL
+    /// window) or the drain is cut off mid-flight.
+    shutdown_drain_secs: u64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -569,6 +574,14 @@ impl AppConfig {
             false,
         )?;
 
+        // 90s fits inside the deployed 120s stopTimeout with margin for the
+        // in-flight-request drain that runs before it.
+        let shutdown_drain_secs = parse_u64(
+            "INGEST_SHUTDOWN_DRAIN_SECS",
+            std::env::var("INGEST_SHUTDOWN_DRAIN_SECS").ok(),
+            90,
+        )?;
+
         Ok(Self {
             port,
             otlp_grpc_port,
@@ -593,6 +606,7 @@ impl AppConfig {
             replay_blob_store,
             internal_org_id,
             trust_proxy_geo,
+            shutdown_drain_secs,
         })
     }
 }
@@ -2038,6 +2052,14 @@ async fn main() {
         None
     };
 
+    // Handle kept out of AppState for the post-shutdown WAL drain, plus the
+    // scale-in protection loop (a no-op off ECS — see `task_protection`).
+    let drain_pipeline = telemetry_pipeline.clone();
+    let drain_deadline = Duration::from_secs(config.shutdown_drain_secs);
+    if let Some(pipeline) = telemetry_pipeline.clone() {
+        task_protection::spawn(pipeline);
+    }
+
     let autumn_tracker = config.autumn_secret_key.as_ref().map(|key| {
         AutumnTracker::spawn(
             key.clone(),
@@ -2227,6 +2249,23 @@ async fn main() {
     let serve_result = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await;
+
+    // Intake has stopped (graceful shutdown drained in-flight requests), but
+    // the WAL sits on ephemeral storage that dies with the task — export what
+    // it still holds before exiting. The export workers stay alive until the
+    // process ends, so this only has to wait for them.
+    if let Some(pipeline) = drain_pipeline {
+        let remaining = pipeline.drain_wal(drain_deadline).await;
+        if remaining == 0 {
+            info!("WAL drained clean on shutdown");
+        } else {
+            warn!(
+                remaining_bytes = remaining,
+                deadline_secs = drain_deadline.as_secs(),
+                "Shutdown drain deadline hit with WAL backlog remaining; frames will replay if this task's storage survives"
+            );
+        }
+    }
 
     if let Some(providers) = telemetry_providers {
         // Flush buffered spans on graceful exit. Errors here are non-fatal —
@@ -7221,6 +7260,7 @@ mod tests {
                 replay_max_session_bytes: 1024 * 1024 * 1024,
                 replay_blob_store: None,
                 trust_proxy_geo: false,
+                shutdown_drain_secs: 1,
             },
             #[expect(
                 clippy::useless_conversion,

--- a/apps/ingest/src/task_protection.rs
+++ b/apps/ingest/src/task_protection.rs
@@ -1,0 +1,121 @@
+//! ECS task scale-in protection driven by WAL backlog.
+//!
+//! The WAL lives on Fargate ephemeral storage, which is destroyed with the
+//! task — so a scale-in that lands on a task holding unexported frames loses
+//! them. Backlog is largest exactly when the autoscaler wants to scale in
+//! (after a burst or a warehouse outage), so this loop marks the task
+//! protected via the ECS agent's task-protection endpoint while the primary
+//! lanes hold meaningful backlog, and releases it once they drain.
+//!
+//! The endpoint is signed by the agent itself; the task role only needs
+//! `ecs:UpdateTaskProtection` (granted in `apps/ingest/alchemy.run.ts`).
+//! Off-ECS (local dev, tests) `ECS_AGENT_URI` is absent and nothing spawns.
+
+use std::time::Duration;
+
+use maple_ingest::telemetry::TelemetryPipeline;
+use serde::Serialize;
+use tracing::{info, warn};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Backlog below this is steady-state churn — frames sitting between append
+/// and export for a few milliseconds. Protecting on it would flap a protection
+/// update against the ECS API on every poll.
+const PROTECT_THRESHOLD_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Refreshed on every protected poll, so expiry only matters if the process
+/// dies without unprotecting — after which the task is fair game anyway.
+const PROTECT_EXPIRES_MINUTES: u32 = 15;
+
+/// Polls this many times below the threshold before releasing protection, so
+/// a backlog oscillating around the threshold doesn't flap the ECS API.
+const RELEASE_AFTER_CLEAR_POLLS: u32 = 2;
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct ProtectionRequest {
+    protection_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_in_minutes: Option<u32>,
+}
+
+pub(crate) fn spawn(pipeline: TelemetryPipeline) {
+    let Some(agent_uri) = std::env::var("ECS_AGENT_URI")
+        .ok()
+        .map(|v| v.trim().trim_end_matches('/').to_owned())
+        .filter(|v| !v.is_empty())
+    else {
+        return;
+    };
+    let endpoint = format!("{agent_uri}/task-protection/v1/state");
+    info!(endpoint = %endpoint, "WAL-backlog scale-in protection started");
+    tokio::spawn(run(pipeline, endpoint));
+}
+
+async fn run(pipeline: TelemetryPipeline, endpoint: String) {
+    let client = reqwest::Client::new();
+    let mut protected = false;
+    let mut clear_polls: u32 = 0;
+    loop {
+        tokio::time::sleep(POLL_INTERVAL).await;
+        let backlog = pipeline.wal_backlog_bytes().await;
+        if backlog >= PROTECT_THRESHOLD_BYTES {
+            clear_polls = 0;
+            // Re-sent every poll while backlogged: the same call both acquires
+            // protection and pushes the expiry window out.
+            if set_protection(&client, &endpoint, true, backlog).await && !protected {
+                protected = true;
+                info!(backlog_bytes = backlog, "WAL backlog above threshold; task protected from scale-in");
+            }
+        } else if protected {
+            clear_polls += 1;
+            if clear_polls >= RELEASE_AFTER_CLEAR_POLLS
+                && set_protection(&client, &endpoint, false, backlog).await
+            {
+                protected = false;
+                info!("WAL drained; task scale-in protection released");
+            }
+        }
+    }
+}
+
+/// Returns whether the agent accepted the state change. Failures are logged
+/// and retried on the next poll — protection is an optimization over losing
+/// data, not a correctness gate, so it must never take the process down.
+async fn set_protection(
+    client: &reqwest::Client,
+    endpoint: &str,
+    enabled: bool,
+    backlog_bytes: u64,
+) -> bool {
+    let body = ProtectionRequest {
+        protection_enabled: enabled,
+        expires_in_minutes: enabled.then_some(PROTECT_EXPIRES_MINUTES),
+    };
+    let result = client
+        .put(endpoint)
+        .timeout(Duration::from_secs(5))
+        .json(&body)
+        .send()
+        .await;
+    match result {
+        Ok(response) if response.status().is_success() => true,
+        Ok(response) => {
+            let status = response.status();
+            let body_text = response.text().await.unwrap_or_default();
+            warn!(
+                enabled,
+                backlog_bytes,
+                status = %status,
+                body = %body_text,
+                "ECS task-protection update rejected"
+            );
+            false
+        }
+        Err(error) => {
+            warn!(enabled, backlog_bytes, error = %error, "ECS task-protection update failed");
+            false
+        }
+    }
+}

--- a/apps/ingest/src/telemetry.rs
+++ b/apps/ingest/src/telemetry.rs
@@ -855,6 +855,26 @@ impl TelemetryPipeline {
         Ok(pipeline)
     }
 
+    /// Bytes committed to the primary WAL lanes and not yet exported.
+    pub async fn wal_backlog_bytes(&self) -> u64 {
+        self.inner.wal.backlog_bytes().await
+    }
+
+    /// Wait for the primary lanes to export everything they hold, up to
+    /// `deadline`. The export workers run until process exit, so this only
+    /// watches the backlog shrink; it returns the bytes still unexported
+    /// (0 means the WAL drained clean).
+    pub async fn drain_wal(&self, deadline: Duration) -> u64 {
+        let started = Instant::now();
+        loop {
+            let backlog = self.wal_backlog_bytes().await;
+            if backlog == 0 || started.elapsed() >= deadline {
+                return backlog;
+            }
+            sleep(Duration::from_millis(250)).await;
+        }
+    }
+
     pub async fn accept_traces(
         &self,
         org_id: &str,
@@ -1488,6 +1508,35 @@ impl ShardedWal {
         })
         .await
         .map_err(|error| format!("join WAL append: {error}"))?
+    }
+
+    /// Unexported bytes across the primary lanes. Mirror lanes are excluded on
+    /// purpose: the mirror is best-effort, so a stalled mirror target must not
+    /// hold shutdown open or pin a task against scale-in.
+    async fn backlog_bytes(&self) -> u64 {
+        let lanes: Vec<Arc<WalShard>> = self
+            .lanes
+            .iter()
+            .filter(|lane| lane.destination != ExportDestination::TinybirdMirror)
+            .map(Arc::clone)
+            .collect();
+        tokio::task::spawn_blocking(move || {
+            lanes
+                .iter()
+                .map(|lane| {
+                    let Ok(file) = lane.file.lock() else { return 0 };
+                    let size = file.metadata().map_or(0, |meta| meta.len());
+                    // The persisted cursor is a plain file offset. Reading it
+                    // under the append mutex keeps it consistent with `size`
+                    // across a concurrent truncate or compaction.
+                    let cursor = read_cursor(&lane.cursor_path);
+                    drop(file);
+                    size.saturating_sub(cursor)
+                })
+                .sum()
+        })
+        .await
+        .unwrap_or(0)
     }
 
     async fn replay(&self, lane: usize) -> Result<Vec<QueuedFrame>, String> {
@@ -4798,6 +4847,79 @@ mod tests {
         assert_eq!(
             mirror.authorization, "Bearer mirror-token",
             "the mirror lane must authenticate against the mirror workspace"
+        );
+
+        drop(std::fs::remove_dir_all(queue_dir));
+    }
+
+    #[tokio::test]
+    async fn drain_wal_reports_zero_once_the_export_workers_catch_up() {
+        let (primary_url, mut primary_rx) = spawn_fake_tinybird().await;
+
+        let queue_dir = unique_test_dir("drain-clean");
+        let mut cfg = test_cfg();
+        cfg.endpoint = primary_url;
+        cfg.queue_dir = queue_dir.clone();
+        cfg.wal_shards = 1;
+        cfg.batch_max_wait = Duration::from_millis(1);
+
+        let pipeline = TelemetryPipeline::new(
+            cfg,
+            Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        pipeline
+            .accept_logs("org_drain", &populated_log_request())
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), primary_rx.recv())
+            .await
+            .expect("the export worker should deliver the batch")
+            .unwrap();
+
+        let remaining = pipeline.drain_wal(Duration::from_secs(5)).await;
+        assert_eq!(remaining, 0, "a delivered batch must leave no backlog");
+
+        drop(std::fs::remove_dir_all(queue_dir));
+    }
+
+    #[tokio::test]
+    async fn drain_wal_reports_the_backlog_when_the_destination_is_unreachable() {
+        let queue_dir = unique_test_dir("drain-stuck");
+        let mut cfg = test_cfg();
+        // Nothing listens here, so the committed frame can never export.
+        cfg.endpoint = "http://127.0.0.1:1".to_owned();
+        cfg.queue_dir = queue_dir.clone();
+        cfg.wal_shards = 1;
+
+        let pipeline = TelemetryPipeline::new(
+            cfg,
+            Client::builder()
+                .timeout(Duration::from_millis(100))
+                .build()
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        pipeline
+            .accept_logs("org_stuck", &populated_log_request())
+            .await
+            .unwrap();
+
+        assert!(
+            pipeline.wal_backlog_bytes().await > 0,
+            "a committed, unexported frame must count as backlog"
+        );
+        let remaining = pipeline.drain_wal(Duration::from_millis(300)).await;
+        assert!(
+            remaining > 0,
+            "the drain deadline must hand back the bytes it could not export"
         );
 
         drop(std::fs::remove_dir_all(queue_dir));


### PR DESCRIPTION
## Why

The gateway's WAL lives on Fargate ephemeral storage, which is destroyed with the task. A deploy, task crash, or autoscaler scale-in discarded whatever the lanes still held — and backlog is largest exactly when the autoscaler wants to scale in (after a burst or a warehouse outage), so the loss window and the kill trigger were correlated. Separately, the lane-full 503s (the shard-46 incident) were a pure capacity limit: 1 GiB per lane under the free ephemeral tier.

## What

**Shutdown drain.** After axum finishes draining in-flight requests on SIGTERM, the gateway now exports the remaining WAL backlog before exiting, bounded by `INGEST_SHUTDOWN_DRAIN_SECS` (default 90s, inside the new 120s `stopTimeout`). `TelemetryPipeline::drain_wal()` watches `wal_backlog_bytes()` — file size minus persisted cursor per primary lane, read under the append mutex. Mirror lanes are excluded: best-effort destinations must not hold shutdown open.

**Scale-in protection.** A new `task_protection` loop polls backlog every 15s and marks the task protected via the ECS agent's task-protection endpoint while it holds >8 MiB, refreshing a 15-minute expiry and releasing after two consecutive clear polls. No-op outside ECS (`ECS_AGENT_URI` unset). The task role gains `ecs:UpdateTaskProtection` scoped to this cluster's tasks via a managed policy.

**Capacity.** WAL cap 12 → 48 GiB (4 GiB/lane) over a paid `ephemeralStorage: 60 GiB` allowance — roughly $3/task/month.

**Metering cadence.** `AUTUMN_FLUSH_INTERVAL_SECS` is now plumbed through the stack with a 30s default (env-overridable). The binary's 1s default predates the #657 entitlement cache and was producing ~2M `balances.track` calls/day; this cuts it ~30×.

## Tests

Two new pipeline tests: drain reaches zero once a fake destination accepts the batch, and the deadline hands back the backlog when the destination is unreachable. Full crate suite: 212 passed, 0 failed. Clippy clean on touched code.

## Deploy notes

- The first deploy doesn't benefit from the drain: the tasks being stopped run the old binary, and the `ephemeralStorage` change forces task replacement. Ship at a quiet moment, ideally with `wal_shard_bytes` near zero.
- Task protection also delays deployments from replacing a protected task (up to 15 min). Intended: a deploy waits for a backlogged task instead of discarding its data — but a deploy during a warehouse outage will visibly stall rather than silently lose frames.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790600327&installation_model_id=427786&pr_number=682&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F682&signature=6005d1bd52c71987e97bbafab3d7fa153439552e03fe309ade69fb9f474d3132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->