### PR TITLE
feat(integrations): accept Cloudflare OAuth grants spanning multiple accounts

### DIFF
--- a/apps/api/src/routes/v1/integrations.http.ts
+++ b/apps/api/src/routes/v1/integrations.http.ts
@@ -42,7 +42,7 @@ import {
 } from "@maple/domain/http"
 import { cloudflareAnalyticsState } from "@maple/db"
 import { EdgeCacheService } from "@maple/cache"
-import { and, eq } from "drizzle-orm"
+import { and, desc, eq } from "drizzle-orm"
 import { Effect, Option, Schema } from "effect"
 import { Database } from "@/platform/DatabaseLive"
 import { Env } from "@/platform/Env"
@@ -312,8 +312,14 @@ export const HttpIntegrationsLive = HttpApiBuilder.group(MapleApi, "integrations
 												eq(cloudflareAnalyticsState.orgId, tenant.orgId),
 												eq(cloudflareAnalyticsState.dataset, HTTP_DATASET),
 												eq(cloudflareAnalyticsState.zoneName, payload.zoneName),
+												// A zone that moved between accounts (or belongs to one
+												// the grant no longer covers) leaves a disabled row
+												// behind; picking it would address the token to an
+												// account outside the grant and hard-fail the request.
+												eq(cloudflareAnalyticsState.enabled, true),
 											),
 										)
+										.orderBy(desc(cloudflareAnalyticsState.updatedAt))
 										.limit(1),
 								)
 								.pipe(

--- a/apps/api/src/routes/v1/integrations.http.ts
+++ b/apps/api/src/routes/v1/integrations.http.ts
@@ -42,7 +42,7 @@ import {
 } from "@maple/domain/http"
 import { cloudflareAnalyticsState } from "@maple/db"
 import { EdgeCacheService } from "@maple/cache"
-import { and, desc, eq } from "drizzle-orm"
+import { and, desc, eq, ne } from "drizzle-orm"
 import { Effect, Option, Schema } from "effect"
 import { Database } from "@/platform/DatabaseLive"
 import { Env } from "@/platform/Env"
@@ -317,6 +317,10 @@ export const HttpIntegrationsLive = HttpApiBuilder.group(MapleApi, "integrations
 												// behind; picking it would address the token to an
 												// account outside the grant and hard-fail the request.
 												eq(cloudflareAnalyticsState.enabled, true),
+												// "" is a pre-multi-account orphan (its org had no
+												// connection when the backfill ran) and names no
+												// account to address the token to.
+												ne(cloudflareAnalyticsState.accountId, ""),
 											),
 										)
 										.orderBy(desc(cloudflareAnalyticsState.updatedAt))
@@ -344,9 +348,7 @@ export const HttpIntegrationsLive = HttpApiBuilder.group(MapleApi, "integrations
 							const zoneId = zoneRow.zoneId
 							const { accessToken } = yield* cloudflare.getValidAccessToken(
 								tenant.orgId,
-								// "" only on orphaned pre-multi-account rows — fall back to the
-								// single-connection lookup for those.
-								zoneRow.accountId === "" ? undefined : zoneRow.accountId,
+								zoneRow.accountId,
 							)
 							const result = yield* graphqlQuery(
 								accessToken,

--- a/apps/api/src/routes/v1/integrations.http.ts
+++ b/apps/api/src/routes/v1/integrations.http.ts
@@ -297,11 +297,15 @@ export const HttpIntegrationsLive = HttpApiBuilder.group(MapleApi, "integrations
 						const startMs = Math.floor(payload.startTime / MINUTE) * MINUTE
 						const endMs = Math.max(Math.ceil(payload.endTime / MINUTE) * MINUTE, startMs + MINUTE)
 						const compute = Effect.gen(function* () {
-							const { accessToken } = yield* cloudflare.getValidAccessToken(tenant.orgId)
+							// The zone's state row also names the account that owns it, so the token
+							// is minted for the right connection when several accounts are connected.
 							const zoneRows = yield* database
 								.execute((db) =>
 									db
-										.select({ zoneId: cloudflareAnalyticsState.zoneId })
+										.select({
+											zoneId: cloudflareAnalyticsState.zoneId,
+											accountId: cloudflareAnalyticsState.accountId,
+										})
 										.from(cloudflareAnalyticsState)
 										.where(
 											and(
@@ -323,14 +327,21 @@ export const HttpIntegrationsLive = HttpApiBuilder.group(MapleApi, "integrations
 											}),
 									),
 								)
-							const zoneId = zoneRows[0]?.zoneId
-							if (zoneId == null) {
+							const zoneRow = zoneRows[0]
+							if (zoneRow == null) {
 								return yield* Effect.fail(
 									new IntegrationsValidationError({
 										message: `Unknown Cloudflare zone: ${payload.zoneName}`,
 									}),
 								)
 							}
+							const zoneId = zoneRow.zoneId
+							const { accessToken } = yield* cloudflare.getValidAccessToken(
+								tenant.orgId,
+								// "" only on orphaned pre-multi-account rows — fall back to the
+								// single-connection lookup for those.
+								zoneRow.accountId === "" ? undefined : zoneRow.accountId,
+							)
 							const result = yield* graphqlQuery(
 								accessToken,
 								{
@@ -555,8 +566,7 @@ export const HttpIntegrationsLive = HttpApiBuilder.group(MapleApi, "integrations
 								// mid-session.
 								Effect.catchTag(
 									"@maple/api/vcs/VcsSourceRepositoryNotFoundError",
-									(error) =>
-										new IntegrationsValidationError({ message: error.message }),
+									(error) => new IntegrationsValidationError({ message: error.message }),
 								),
 							)
 						yield* Effect.annotateCurrentSpan({ "result.rowCount": pullRequests.length })

--- a/apps/api/src/services/auth/CloudflareOAuthService.test.ts
+++ b/apps/api/src/services/auth/CloudflareOAuthService.test.ts
@@ -265,13 +265,11 @@ describe("CloudflareOAuthService", () => {
 			])
 
 			// Account-addressed tokens resolve for every granted account; an account outside
-			// the grant and the ambiguous account-less lookup both refuse.
+			// the grant refuses.
 			const token = yield* service.getValidAccessToken(asOrgId("org_a"), "acc_2")
 			assert.strictEqual(token.accountId, "acc_2")
 			const outside = yield* service.getValidAccessToken(asOrgId("org_a"), "acc_3").pipe(Effect.flip)
 			assert.strictEqual(outside._tag, "@maple/http/errors/IntegrationsValidationError")
-			const ambiguous = yield* service.getValidAccessToken(asOrgId("org_a")).pipe(Effect.flip)
-			assert.strictEqual(ambiguous._tag, "@maple/http/errors/IntegrationsValidationError")
 		}).pipe(Effect.provide(Layer.mergeAll(makeLayer(testDb, withOAuthApp), withMockFetch(accounts))))
 	})
 
@@ -403,8 +401,8 @@ describe("CloudflareOAuthService", () => {
 			// rotated-token 400 falsely surfaces as IntegrationsRevokedError.
 			const [a, b] = yield* Effect.all(
 				[
-					service.getValidAccessToken(asOrgId("org_a")),
-					service.getValidAccessToken(asOrgId("org_a")),
+					service.getValidAccessToken(asOrgId("org_a"), "acc_1"),
+					service.getValidAccessToken(asOrgId("org_a"), "acc_1"),
 				],
 				{ concurrency: 2 },
 			)
@@ -465,7 +463,7 @@ describe("CloudflareOAuthService", () => {
 			})
 			yield* service.completeConnect("auth-code", state)
 
-			const error = yield* service.getValidAccessToken(asOrgId("org_a")).pipe(Effect.flip)
+			const error = yield* service.getValidAccessToken(asOrgId("org_a"), "acc_1").pipe(Effect.flip)
 			// 400/401 on the refresh grant means the grant itself is gone — classified as
 			// revoked (reconnect required), not a transient upstream failure.
 			assert.strictEqual(error._tag, "@maple/http/errors/IntegrationsRevokedError")

--- a/apps/api/src/services/auth/CloudflareOAuthService.test.ts
+++ b/apps/api/src/services/auth/CloudflareOAuthService.test.ts
@@ -3,7 +3,7 @@ import { ConfigProvider, Effect, Layer, Schema } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { OrgId, UserId } from "@maple/domain/http"
 import { Env } from "@/platform/Env"
-import { CloudflareOAuthService } from "./CloudflareOAuthService"
+import { CloudflareOAuthService, type CloudflareOAuthServiceApi } from "./CloudflareOAuthService"
 import { cleanupTestDbs, createTestDb, queryFirstRow, type TestDb } from "@/platform/test-pglite"
 
 const trackedDbs: TestDb[] = []
@@ -183,10 +183,10 @@ describe("CloudflareOAuthService", () => {
 
 			const status = yield* service.getStatus(asOrgId("org_a"))
 			assert.strictEqual(status.connected, true)
-			if (status.connected) {
-				assert.strictEqual(status.accountId, "acc_1")
-				assert.strictEqual(status.accountName, "Acme Inc")
-			}
+			assert.strictEqual(status.accounts.length, 1)
+			assert.strictEqual(status.accounts[0]?.accountId, "acc_1")
+			assert.strictEqual(status.accounts[0]?.accountName, "Acme Inc")
+			assert.strictEqual(status.accounts[0]?.revoked, false)
 
 			const row = yield* Effect.promise(() =>
 				queryFirstRow<{
@@ -227,30 +227,52 @@ describe("CloudflareOAuthService", () => {
 		}).pipe(Effect.provide(Layer.mergeAll(makeLayer(testDb, withOAuthApp), withMockFetch([]))))
 	})
 
-	it.effect("completeConnect rejects a token that spans multiple accounts and revokes it", () => {
+	it.effect("completeConnect accepts a grant spanning multiple accounts as one connection", () => {
 		const testDb = createTestDb(trackedDbs)
 		const accounts = [
 			{ id: "acc_1", name: "Acme Inc", type: "standard" },
 			{ id: "acc_2", name: "Beta LLC", type: "standard" },
 		]
-		const counters = { revoked: 0 }
 		return Effect.gen(function* () {
 			const service = yield* CloudflareOAuthService
 			const { state } = yield* service.startConnect(asOrgId("org_a"), asUserId("user_a"), {
 				callbackUrl: "https://api.example.com/api/integrations/cloudflare/callback",
 			})
-			const error = yield* service.completeConnect("auth-code", state).pipe(Effect.flip)
-			assert.strictEqual(error._tag, "@maple/http/errors/IntegrationsValidationError")
+			const result = yield* service.completeConnect("auth-code", state)
+			assert.strictEqual(result.orgId, "org_a")
 
+			// Both accounts surface, in the grant's order.
 			const status = yield* service.getStatus(asOrgId("org_a"))
-			assert.strictEqual(status.connected, false)
-			// The rejected token is never stored, so it must be revoked upstream right away.
-			assert.strictEqual(counters.revoked, 1)
-		}).pipe(
-			Effect.provide(
-				Layer.mergeAll(makeLayer(testDb, withOAuthApp), withMockFetch(accounts, counters)),
-			),
-		)
+			assert.strictEqual(status.connected, true)
+			assert.deepStrictEqual(
+				status.accounts.map((account) => account.accountId),
+				["acc_1", "acc_2"],
+			)
+			assert.strictEqual(status.accounts[1]?.accountName, "Beta LLC")
+
+			// One grant is one row; the account fan-out lives in granted_accounts_json.
+			const row = yield* Effect.promise(() =>
+				queryFirstRow<{ external_user_id: string; granted_accounts_json: string | null }>(
+					testDb,
+					"SELECT external_user_id, granted_accounts_json FROM oauth_connections WHERE org_id = $1 AND provider = 'cloudflare'",
+					["org_a"],
+				),
+			)
+			assert.strictEqual(row?.external_user_id, "acc_1")
+			assert.deepStrictEqual(JSON.parse(row?.granted_accounts_json ?? "[]"), [
+				{ id: "acc_1", name: "Acme Inc" },
+				{ id: "acc_2", name: "Beta LLC" },
+			])
+
+			// Account-addressed tokens resolve for every granted account; an account outside
+			// the grant and the ambiguous account-less lookup both refuse.
+			const token = yield* service.getValidAccessToken(asOrgId("org_a"), "acc_2")
+			assert.strictEqual(token.accountId, "acc_2")
+			const outside = yield* service.getValidAccessToken(asOrgId("org_a"), "acc_3").pipe(Effect.flip)
+			assert.strictEqual(outside._tag, "@maple/http/errors/IntegrationsValidationError")
+			const ambiguous = yield* service.getValidAccessToken(asOrgId("org_a")).pipe(Effect.flip)
+			assert.strictEqual(ambiguous._tag, "@maple/http/errors/IntegrationsValidationError")
+		}).pipe(Effect.provide(Layer.mergeAll(makeLayer(testDb, withOAuthApp), withMockFetch(accounts))))
 	})
 
 	it.effect("completeConnect refuses a token with no refresh token and revokes it", () => {
@@ -500,5 +522,97 @@ describe("CloudflareOAuthService", () => {
 			const result = yield* service.disconnect(asOrgId("org_a"))
 			assert.strictEqual(result.disconnected, false)
 		}).pipe(Effect.provide(makeLayer(testDb, withOAuthApp)))
+	})
+
+	it.effect("reconnecting with a different grant replaces the account set", () => {
+		const testDb = createTestDb(trackedDbs)
+		// Mutable fixture: each OAuth round-trip "grants" whatever accounts the test sets next,
+		// mirroring the user re-ticking accounts in Cloudflare's authorize screen.
+		const granted = { current: [{ id: "acc_1", name: "Acme Inc", type: "standard" }] }
+		const fetchImpl: typeof globalThis.fetch = (input) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
+			if (url.includes("/oauth2/revoke")) {
+				return Promise.resolve(new Response(null, { status: 200 }))
+			}
+			if (url.includes("/oauth2/token")) {
+				return Promise.resolve(
+					jsonResponse({
+						access_token: `cf-access-token-${granted.current[0]?.id}`,
+						refresh_token: `cf-refresh-token-${granted.current[0]?.id}`,
+						token_type: "bearer",
+						expires_in: 3600,
+						scope: "account.settings:read",
+					}),
+				)
+			}
+			if (url.includes("/accounts")) {
+				return Promise.resolve(
+					jsonResponse({
+						success: true,
+						errors: [],
+						messages: [],
+						result: granted.current,
+						result_info: {
+							count: granted.current.length,
+							page: 1,
+							per_page: 50,
+							total_count: granted.current.length,
+						},
+					}),
+				)
+			}
+			return Promise.resolve(
+				jsonResponse({ success: false, errors: [], messages: [], result: null }, 404),
+			)
+		}
+		const connect = (service: CloudflareOAuthServiceApi) =>
+			Effect.gen(function* () {
+				const { state } = yield* service.startConnect(asOrgId("org_a"), asUserId("user_a"), {
+					callbackUrl: "https://api.example.com/api/integrations/cloudflare/callback",
+				})
+				return yield* service.completeConnect("auth-code", state)
+			})
+
+		return Effect.gen(function* () {
+			const service = yield* CloudflareOAuthService
+			yield* connect(service)
+
+			// Reconnecting with a different grant REPLACES the account set — the old grant's
+			// token is superseded, so its accounts must not linger as connected.
+			granted.current = [
+				{ id: "acc_2", name: "Beta LLC", type: "standard" },
+				{ id: "acc_3", name: "Gamma GmbH", type: "standard" },
+			]
+			yield* connect(service)
+			const status = yield* service.getStatus(asOrgId("org_a"))
+			assert.strictEqual(status.connected, true)
+			assert.deepStrictEqual(
+				status.accounts.map((account) => account.accountId),
+				["acc_2", "acc_3"],
+			)
+
+			// Still one row: the new grant overwrote the old connection in place.
+			const rowCount = yield* Effect.promise(() =>
+				queryFirstRow<{ n: number }>(
+					testDb,
+					"SELECT count(*)::int AS n FROM oauth_connections WHERE org_id = $1 AND provider = 'cloudflare'",
+					["org_a"],
+				),
+			)
+			assert.strictEqual(rowCount?.n, 1)
+
+			// Tokens are the new grant's, for every account it covers.
+			const token = yield* service.getValidAccessToken(asOrgId("org_a"), "acc_3")
+			assert.strictEqual(token.accessToken, "cf-access-token-acc_2")
+			const stale = yield* service.getValidAccessToken(asOrgId("org_a"), "acc_1").pipe(Effect.flip)
+			assert.strictEqual(stale._tag, "@maple/http/errors/IntegrationsValidationError")
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeLayer(testDb, withOAuthApp),
+					Layer.succeed(FetchHttpClient.Fetch, fetchImpl),
+				),
+			),
+		)
 	})
 })

--- a/apps/api/src/services/auth/CloudflareOAuthService.ts
+++ b/apps/api/src/services/auth/CloudflareOAuthService.ts
@@ -156,13 +156,12 @@ export interface CloudflareOAuthServiceApi {
 		orgId: OrgId,
 	) => Effect.Effect<CloudflareConnectionStatus, IntegrationsPersistenceError>
 	/**
-	 * Fresh access token addressed to one granted account. Without `accountId` the
-	 * grant must cover exactly one account — ambiguous lookups fail rather than
-	 * silently picking an account.
+	 * Fresh access token addressed to one granted account. The account is always named: a grant
+	 * may cover several, so there is no unambiguous default to fall back to.
 	 */
 	readonly getValidAccessToken: (
 		orgId: OrgId,
-		accountId?: string,
+		accountId: string,
 	) => Effect.Effect<
 		CloudflareAccessToken,
 		| IntegrationsNotConnectedError
@@ -230,8 +229,8 @@ export class CloudflareOAuthService extends Context.Service<
 					redirectUri: options.callbackUrl,
 					returnTo: options.returnTo ?? null,
 					codeVerifier,
-					createdAt: new Date(currentTime),
-					expiresAt: new Date(currentTime + OAUTH_STATE_TTL_MS),
+					createdAt: msToDate(currentTime),
+					expiresAt: msToDate(currentTime + OAUTH_STATE_TTL_MS),
 				}),
 			)
 
@@ -345,38 +344,21 @@ export class CloudflareOAuthService extends Context.Service<
 
 		const getValidAccessToken = Effect.fn("CloudflareOAuthService.getValidAccessToken")(function* (
 			orgId: OrgId,
-			accountId?: string,
+			accountId: string,
 		) {
-			yield* Effect.annotateCurrentSpan({ orgId })
+			yield* Effect.annotateCurrentSpan({ orgId, "maple.cloudflare.account_id": accountId })
 			const config = yield* resolveConfig(env)
 			const { accessToken, row } = yield* oauth.getValidConnectionToken(config, orgId)
-			const granted = grantedAccountsOfRow(row)
-			// No account given: legacy single-account lookup. Refuse an ambiguous grant
-			// instead of silently picking an account.
-			if (accountId === undefined) {
-				if (granted.length > 1) {
-					return yield* Effect.fail(
-						new IntegrationsValidationError({
-							message:
-								"The Cloudflare grant covers multiple accounts — specify which account to use",
-						}),
-					)
-				}
-			} else {
-				yield* Effect.annotateCurrentSpan("maple.cloudflare.account_id", accountId)
-				if (!granted.some((account) => account.id === accountId)) {
-					return yield* Effect.fail(
-						new IntegrationsValidationError({
-							message: "The Cloudflare grant does not cover the requested account",
-						}),
-					)
-				}
+			// A token is always addressed to one account of the grant. Callers name it — there is
+			// no "the org's account" to fall back to once a grant can cover several.
+			if (!Arr.some(grantedAccountsOfRow(row), (account) => account.id === accountId)) {
+				return yield* Effect.fail(
+					new IntegrationsValidationError({
+						message: "The Cloudflare grant does not cover the requested account",
+					}),
+				)
 			}
-			return {
-				accessToken,
-				accountId: accountId ?? Arr.headNonEmpty(granted).id,
-				scope: row.scope,
-			} satisfies CloudflareAccessToken
+			return { accessToken, accountId, scope: row.scope } satisfies CloudflareAccessToken
 		})
 
 		const getStatus = Effect.fn("CloudflareOAuthService.getStatus")(function* (orgId: OrgId) {

--- a/apps/api/src/services/auth/CloudflareOAuthService.ts
+++ b/apps/api/src/services/auth/CloudflareOAuthService.ts
@@ -22,6 +22,29 @@ const CLOUDFLARE_PROVIDER = "cloudflare"
 const decodeOrgId = Schema.decodeUnknownSync(OrgId)
 
 /**
+ * The Cloudflare accounts one OAuth grant covers, persisted as
+ * `oauth_connections.grantedAccountsJson`. A single consent screen may tick several accounts;
+ * the one token then reaches all of them, so the org's connection stays one row and this list
+ * is the account fan-out the poller iterates.
+ */
+const GrantedAccounts = Schema.Array(Schema.Struct({ id: Schema.String, name: Schema.NullOr(Schema.String) }))
+const decodeGrantedAccounts = Schema.decodeUnknownOption(Schema.fromJsonString(GrantedAccounts))
+
+/** Stored grant list, falling back to the row's own principal for pre-list rows. */
+const grantedAccountsOfRow = (row: {
+	readonly grantedAccountsJson: string | null
+	readonly externalUserId: string
+	readonly externalAccountName: string | null
+}): ReadonlyArray<{ readonly id: string; readonly name: string | null }> => {
+	const fallback = [{ id: row.externalUserId, name: row.externalAccountName }]
+	if (row.grantedAccountsJson == null) return fallback
+	return Option.match(decodeGrantedAccounts(row.grantedAccountsJson), {
+		onNone: () => fallback,
+		onSome: (accounts) => (accounts.length === 0 ? fallback : accounts),
+	})
+}
+
+/**
  * PKCE (RFC 7636). Cloudflare's OAuth requires PKCE (S256) for public clients — a multi-tenant SaaS
  * that any Cloudflare user can connect — and accepts it for confidential clients too, so we always
  * send it. The `code_verifier` is stashed on the auth-state row and replayed at token exchange.
@@ -73,6 +96,19 @@ interface CloudflareAccessToken {
 	readonly scope: string
 }
 
+/**
+ * One Cloudflare account covered by the org's grant. All accounts share the org's single
+ * connection row, so `connectedByUserId`/`scope`/`revoked` are grant-wide.
+ */
+export interface CloudflareConnectedAccount {
+	readonly accountId: string
+	readonly accountName: string | null
+	readonly connectedByUserId: string
+	readonly scope: string
+	/** True when Cloudflare rejected the stored grant — pollers skip it until reconnect. */
+	readonly revoked: boolean
+}
+
 export interface CloudflareOAuthServiceApi {
 	readonly startConnect: (
 		orgId: OrgId,
@@ -92,19 +128,22 @@ export interface CloudflareOAuthServiceApi {
 		| IntegrationsRevokedError
 		| IntegrationsPersistenceError
 	>
+	/** Every account the org's grant covers, in the order the grant listed them. */
 	readonly getStatus: (orgId: OrgId) => Effect.Effect<
-		| { readonly connected: false }
-		| {
-				readonly connected: true
-				readonly accountId: string
-				readonly accountName: string | null
-				readonly connectedByUserId: string
-				readonly scope: string
-		  },
+		{
+			readonly connected: boolean
+			readonly accounts: ReadonlyArray<CloudflareConnectedAccount>
+		},
 		IntegrationsPersistenceError
 	>
+	/**
+	 * Fresh access token addressed to one granted account. Without `accountId` the
+	 * grant must cover exactly one account — ambiguous lookups fail rather than
+	 * silently picking an account.
+	 */
 	readonly getValidAccessToken: (
 		orgId: OrgId,
+		accountId?: string,
 	) => Effect.Effect<
 		CloudflareAccessToken,
 		| IntegrationsNotConnectedError
@@ -117,10 +156,12 @@ export interface CloudflareOAuthServiceApi {
 		orgId: OrgId,
 	) => Effect.Effect<{ readonly disconnected: boolean }, IntegrationsPersistenceError>
 	/**
-	 * Stamp the org's connection as revoked so pollers stop retrying it every
-	 * tick; cleared automatically when the org reconnects. Best-effort.
+	 * Stamp the org's grant as revoked so pollers stop retrying it every tick;
+	 * cleared automatically on reconnect. Best-effort. The grant is one token, so
+	 * revocation is always grant-wide — `accountId` only annotates which account
+	 * surfaced the rejection.
 	 */
-	readonly markConnectionRevoked: (orgId: OrgId) => Effect.Effect<void>
+	readonly markConnectionRevoked: (orgId: OrgId, accountId?: string) => Effect.Effect<void>
 }
 
 export class CloudflareOAuthService extends Context.Service<
@@ -212,10 +253,10 @@ export class CloudflareOAuthService extends Context.Service<
 				code_verifier: stateRow.codeVerifier,
 			})
 
-			// Resolve — and require exactly one — Cloudflare account. A token that spans multiple
-			// accounts is ambiguous for org→account scoping, so we refuse it (Superlog's rule).
-			// On refusal, best-effort revoke the just-issued tokens: they are never persisted, so
-			// this is the only moment we can invalidate them upstream.
+			// Resolve every account the grant covers — the consent screen lets the user tick
+			// several, and the one token reaches all of them. An empty grant is refused: best-effort
+			// revoke the just-issued tokens, which are never persisted, so this is the only moment
+			// we can invalidate them upstream.
 			const accounts = yield* listAccounts(
 				tokenResponse.access_token,
 				env.MAPLE_CLOUDFLARE_API_BASE_URL,
@@ -228,16 +269,7 @@ export class CloudflareOAuthService extends Context.Service<
 					}),
 				)
 			}
-			if (accounts.length > 1) {
-				yield* revokeToken(config, tokenResponse.access_token)
-				return yield* Effect.fail(
-					new IntegrationsValidationError({
-						message:
-							"The Cloudflare authorization spans multiple accounts — reconnect and grant access to a single account",
-					}),
-				)
-			}
-			const account = accounts[0]!
+			const primaryAccount = accounts[0]!
 
 			const accessEnc = yield* oauth.encryptValue(tokenResponse.access_token)
 			const refreshEnc = tokenResponse.refresh_token
@@ -253,7 +285,7 @@ export class CloudflareOAuthService extends Context.Service<
 			// dies at the ~16h access-token expiry and disables every state row (the 31h outage).
 			// Refuse it loudly at connect time instead of storing a doomed connection. Best-effort
 			// revoke the just-issued access token first — it is never persisted, so this is the only
-			// moment we can invalidate it upstream (mirrors the multi-account refusal above).
+			// moment we can invalidate it upstream (mirrors the no-account refusal above).
 			if (!tokenResponse.refresh_token) {
 				yield* Effect.logWarning(
 					"Cloudflare OAuth token exchange returned no refresh token — refusing connection",
@@ -269,10 +301,15 @@ export class CloudflareOAuthService extends Context.Service<
 			}
 
 			yield* oauth.upsertConnection(orgId, currentTime, {
-				externalUserId: account.id,
+				externalUserId: primaryAccount.id,
 				// Cloudflare has no user email in this flow; the account name is a display label.
 				externalUserEmail: null,
-				externalAccountName: account.name,
+				externalAccountName: primaryAccount.name,
+				// The full account fan-out of the grant; externalUserId keeps the first account for
+				// the shared helpers' single-principal columns.
+				grantedAccountsJson: JSON.stringify(
+					accounts.map((account) => ({ id: account.id, name: account.name })),
+				),
 				connectedByUserId: stateRow.initiatedByUserId,
 				scope: tokenResponse.scope ?? config.scopes,
 				accessTokenCiphertext: accessEnc.ciphertext,
@@ -289,13 +326,36 @@ export class CloudflareOAuthService extends Context.Service<
 
 		const getValidAccessToken = Effect.fn("CloudflareOAuthService.getValidAccessToken")(function* (
 			orgId: OrgId,
+			accountId?: string,
 		) {
 			yield* Effect.annotateCurrentSpan({ orgId })
 			const config = yield* resolveConfig(env)
 			const { accessToken, row } = yield* oauth.getValidConnectionToken(config, orgId)
+			const granted = grantedAccountsOfRow(row)
+			// No account given: legacy single-account lookup. Refuse an ambiguous grant
+			// instead of silently picking an account.
+			if (accountId === undefined) {
+				if (granted.length > 1) {
+					return yield* Effect.fail(
+						new IntegrationsValidationError({
+							message:
+								"The Cloudflare grant covers multiple accounts — specify which account to use",
+						}),
+					)
+				}
+			} else {
+				yield* Effect.annotateCurrentSpan("maple.cloudflare.account_id", accountId)
+				if (!granted.some((account) => account.id === accountId)) {
+					return yield* Effect.fail(
+						new IntegrationsValidationError({
+							message: "The Cloudflare grant does not cover the requested account",
+						}),
+					)
+				}
+			}
 			return {
 				accessToken,
-				accountId: row.externalUserId,
+				accountId: accountId ?? granted[0]!.id,
 				scope: row.scope,
 			} satisfies CloudflareAccessToken
 		})
@@ -303,15 +363,20 @@ export class CloudflareOAuthService extends Context.Service<
 		const getStatus = Effect.fn("CloudflareOAuthService.getStatus")(function* (orgId: OrgId) {
 			const row = yield* oauth.loadConnection(orgId)
 			if (!row) {
-				return { connected: false } as const
+				return { connected: false, accounts: [] }
 			}
 			return {
 				connected: true,
-				accountId: row.externalUserId,
-				accountName: row.externalAccountName,
-				connectedByUserId: row.connectedByUserId,
-				scope: row.scope,
-			} as const
+				accounts: grantedAccountsOfRow(row).map(
+					(account): CloudflareConnectedAccount => ({
+						accountId: account.id,
+						accountName: account.name,
+						connectedByUserId: row.connectedByUserId,
+						scope: row.scope,
+						revoked: row.revokedAt != null,
+					}),
+				),
+			}
 		})
 
 		const disconnect = Effect.fn("CloudflareOAuthService.disconnect")(function* (orgId: OrgId) {
@@ -335,13 +400,23 @@ export class CloudflareOAuthService extends Context.Service<
 			return yield* oauth.deleteConnection(orgId)
 		})
 
+		const markConnectionRevoked = Effect.fn("CloudflareOAuthService.markConnectionRevoked")(function* (
+			orgId: OrgId,
+			accountId?: string,
+		) {
+			if (accountId !== undefined) {
+				yield* Effect.annotateCurrentSpan("maple.cloudflare.account_id", accountId)
+			}
+			yield* oauth.markConnectionRevoked(orgId)
+		})
+
 		return {
 			startConnect,
 			completeConnect,
 			getStatus,
 			getValidAccessToken,
 			disconnect,
-			markConnectionRevoked: oauth.markConnectionRevoked,
+			markConnectionRevoked,
 		} satisfies CloudflareOAuthServiceApi
 	}),
 }) {

--- a/apps/api/src/services/auth/CloudflareOAuthService.ts
+++ b/apps/api/src/services/auth/CloudflareOAuthService.ts
@@ -9,7 +9,7 @@ import {
 	type UserId,
 } from "@maple/domain/http"
 import { oauthAuthStates } from "@maple/db"
-import { Clock, Context, Effect, Layer, Option, Redacted, Schema } from "effect"
+import { Array as Arr, Clock, Context, Effect, Layer, Option, Redacted, Schema } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { listAccounts } from "@/services/integrations/CloudflareApi"
 import { Database } from "@/platform/DatabaseLive"
@@ -30,17 +30,28 @@ const decodeOrgId = Schema.decodeUnknownSync(OrgId)
 const GrantedAccounts = Schema.Array(Schema.Struct({ id: Schema.String, name: Schema.NullOr(Schema.String) }))
 const decodeGrantedAccounts = Schema.decodeUnknownOption(Schema.fromJsonString(GrantedAccounts))
 
-/** Stored grant list, falling back to the row's own principal for pre-list rows. */
+interface GrantedAccount {
+	readonly id: string
+	readonly name: string | null
+}
+
+/**
+ * Stored grant list, falling back to the row's own principal for pre-list rows (and for a list
+ * that decodes to nothing). A connection row therefore always names at least one account, and
+ * saying so in the type is what lets callers take the primary without a null assertion.
+ */
 const grantedAccountsOfRow = (row: {
 	readonly grantedAccountsJson: string | null
 	readonly externalUserId: string
 	readonly externalAccountName: string | null
-}): ReadonlyArray<{ readonly id: string; readonly name: string | null }> => {
-	const fallback = [{ id: row.externalUserId, name: row.externalAccountName }]
+}): Arr.NonEmptyReadonlyArray<GrantedAccount> => {
+	const fallback: Arr.NonEmptyReadonlyArray<GrantedAccount> = [
+		{ id: row.externalUserId, name: row.externalAccountName },
+	]
 	if (row.grantedAccountsJson == null) return fallback
 	return Option.match(decodeGrantedAccounts(row.grantedAccountsJson), {
 		onNone: () => fallback,
-		onSome: (accounts) => (accounts.length === 0 ? fallback : accounts),
+		onSome: (accounts) => (Arr.isReadonlyArrayNonEmpty(accounts) ? accounts : fallback),
 	})
 }
 
@@ -109,6 +120,18 @@ export interface CloudflareConnectedAccount {
 	readonly revoked: boolean
 }
 
+/**
+ * The org's Cloudflare grant: either absent, or present covering at least one account. The
+ * connected branch carries a non-empty list so callers can take the primary account (the row's
+ * own principal, first in grant order) without asserting an index is there.
+ */
+export type CloudflareConnectionStatus =
+	| { readonly connected: false; readonly accounts: readonly [] }
+	| {
+			readonly connected: true
+			readonly accounts: Arr.NonEmptyReadonlyArray<CloudflareConnectedAccount>
+	  }
+
 export interface CloudflareOAuthServiceApi {
 	readonly startConnect: (
 		orgId: OrgId,
@@ -129,13 +152,9 @@ export interface CloudflareOAuthServiceApi {
 		| IntegrationsPersistenceError
 	>
 	/** Every account the org's grant covers, in the order the grant listed them. */
-	readonly getStatus: (orgId: OrgId) => Effect.Effect<
-		{
-			readonly connected: boolean
-			readonly accounts: ReadonlyArray<CloudflareConnectedAccount>
-		},
-		IntegrationsPersistenceError
-	>
+	readonly getStatus: (
+		orgId: OrgId,
+	) => Effect.Effect<CloudflareConnectionStatus, IntegrationsPersistenceError>
 	/**
 	 * Fresh access token addressed to one granted account. Without `accountId` the
 	 * grant must cover exactly one account — ambiguous lookups fail rather than
@@ -261,7 +280,7 @@ export class CloudflareOAuthService extends Context.Service<
 				tokenResponse.access_token,
 				env.MAPLE_CLOUDFLARE_API_BASE_URL,
 			)
-			if (accounts.length === 0) {
+			if (!Arr.isReadonlyArrayNonEmpty(accounts)) {
 				yield* revokeToken(config, tokenResponse.access_token)
 				return yield* Effect.fail(
 					new IntegrationsValidationError({
@@ -269,7 +288,7 @@ export class CloudflareOAuthService extends Context.Service<
 					}),
 				)
 			}
-			const primaryAccount = accounts[0]!
+			const primaryAccount = Arr.headNonEmpty(accounts)
 
 			const accessEnc = yield* oauth.encryptValue(tokenResponse.access_token)
 			const refreshEnc = tokenResponse.refresh_token
@@ -355,7 +374,7 @@ export class CloudflareOAuthService extends Context.Service<
 			}
 			return {
 				accessToken,
-				accountId: accountId ?? granted[0]!.id,
+				accountId: accountId ?? Arr.headNonEmpty(granted).id,
 				scope: row.scope,
 			} satisfies CloudflareAccessToken
 		})
@@ -363,11 +382,14 @@ export class CloudflareOAuthService extends Context.Service<
 		const getStatus = Effect.fn("CloudflareOAuthService.getStatus")(function* (orgId: OrgId) {
 			const row = yield* oauth.loadConnection(orgId)
 			if (!row) {
-				return { connected: false, accounts: [] }
+				return { connected: false, accounts: [] } satisfies CloudflareConnectionStatus
 			}
 			return {
 				connected: true,
-				accounts: grantedAccountsOfRow(row).map(
+				// `Arr.map` carries the non-emptiness through, so the connected branch keeps its
+				// at-least-one-account guarantee.
+				accounts: Arr.map(
+					grantedAccountsOfRow(row),
 					(account): CloudflareConnectedAccount => ({
 						accountId: account.id,
 						accountName: account.name,
@@ -376,7 +398,7 @@ export class CloudflareOAuthService extends Context.Service<
 						revoked: row.revokedAt != null,
 					}),
 				),
-			}
+			} satisfies CloudflareConnectionStatus
 		})
 
 		const disconnect = Effect.fn("CloudflareOAuthService.disconnect")(function* (orgId: OrgId) {

--- a/apps/api/src/services/integrations/CloudflareAnalyticsService.test.ts
+++ b/apps/api/src/services/integrations/CloudflareAnalyticsService.test.ts
@@ -193,6 +193,11 @@ interface HyperdriveConfigFixture {
 
 interface FetchOptions {
 	readonly zones?: ReadonlyArray<typeof zoneFixture>
+	/**
+	 * When set, the `/zones` listing serves only the zones of the account whose id appears
+	 * in the request URL (the listing is account-filtered upstream) — multi-account tests.
+	 */
+	readonly zonesByAccount?: Record<string, ReadonlyArray<typeof zoneFixture>>
 	readonly zonesStatus?: number
 	readonly graphqlErrors?: ReadonlyArray<{ message: string; path?: ReadonlyArray<string | number> }>
 	/** When set, every outbound GraphQL document is captured here (batching assertions). */
@@ -303,7 +308,13 @@ const mockCloudflareFetch =
 				)
 			}
 			const page = Number(new URL(url).searchParams.get("page") ?? "1")
-			const zones = page === 1 ? (options.zones ?? [zoneFixture]) : []
+			const forAccount =
+				options.zonesByAccount == null
+					? null
+					: (Object.entries(options.zonesByAccount).find(([accountId]) =>
+							url.includes(accountId),
+						)?.[1] ?? [])
+			const zones = page === 1 ? (forAccount ?? options.zones ?? [zoneFixture]) : []
 			return jsonResponse({
 				success: true,
 				errors: [],
@@ -399,8 +410,14 @@ const makeLayer = (
 		Layer.provideMerge(Layer.succeed(Retry.Retry, { while: () => false })),
 	)
 
-/** Insert a connected Cloudflare org with a non-expiring encrypted access token. */
-const seedConnection = (scope: string = ANALYTICS_SCOPE) =>
+/**
+ * Insert the org's Cloudflare connection with a non-expiring encrypted access token. One grant
+ * may cover several accounts — pass them all; the first is the row's principal.
+ */
+const seedConnection = (
+	scope: string = ANALYTICS_SCOPE,
+	accounts: ReadonlyArray<{ id: string; name: string }> = [{ id: ACCOUNT_ID, name: "Test Account" }],
+) =>
 	Effect.gen(function* () {
 		const database = yield* Database
 		const key = yield* parseBase64Aes256GcmKey(ENCRYPTION_KEY_B64, (message) => new Error(message))
@@ -410,8 +427,12 @@ const seedConnection = (scope: string = ANALYTICS_SCOPE) =>
 				id: randomUUID(),
 				orgId: ORG,
 				provider: "cloudflare",
-				externalUserId: ACCOUNT_ID,
-				externalAccountName: "Test Account",
+				externalUserId: accounts[0]!.id,
+				externalAccountName: accounts[0]!.name,
+				grantedAccountsJson:
+					accounts.length > 1
+						? JSON.stringify(accounts.map((account) => ({ id: account.id, name: account.name })))
+						: null,
 				connectedByUserId: "user_1",
 				scope,
 				accessTokenCiphertext: accessEnc.ciphertext,
@@ -457,6 +478,7 @@ const seedStateRow = (values: Partial<typeof cloudflareAnalyticsState.$inferInse
 			db.insert(cloudflareAnalyticsState).values({
 				id: randomUUID(),
 				orgId: ORG,
+				accountId: ACCOUNT_ID,
 				zoneId: "",
 				createdAt: new Date(T0 - 60 * MIN),
 				updatedAt: new Date(T0 - 60 * MIN),
@@ -525,7 +547,7 @@ describe("CloudflareAnalyticsService", () => {
 		}).pipe(Effect.provide(makeLayer(testDb, captured)))
 	})
 
-	it.effect("pollOrg records missing analytics scopes instead of calling the API", () => {
+	it.effect("pollOrg skips a scope-incapable account without calling the API or touching state", () => {
 		const testDb = createTestDb(trackedDbs)
 		const captured: CapturedIngest[] = []
 		return Effect.gen(function* () {
@@ -535,10 +557,11 @@ describe("CloudflareAnalyticsService", () => {
 			const summary = yield* service.pollOrg(ORG)
 			assert.strictEqual(summary.skipped, "missing analytics scopes")
 			assert.strictEqual(summary.callsMade, 0)
+			// The account is skipped before any state rows exist — capability is surfaced
+			// per account by the status endpoint (analyticsCapable), not by error stamps
+			// rewritten every tick.
 			const rows = yield* loadStateRows
-			// One row per account-scoped dataset (workers + queues×2 + durable objects).
-			assert.strictEqual(rows.length, 4)
-			for (const row of rows) assert.include(row.lastError ?? "", "scopes")
+			assert.strictEqual(rows.length, 0)
 			assert.strictEqual(captured.length, 0)
 		}).pipe(Effect.provide(makeLayer(testDb, captured)))
 	})
@@ -600,6 +623,62 @@ describe("CloudflareAnalyticsService", () => {
 			// Nothing bypassed the gateway via a direct warehouse ingest.
 			assert.strictEqual(captured.length, 0)
 		}).pipe(Effect.provide(makeLayer(testDb, captured, { otlpCalls })))
+	})
+
+	it.effect("pollOrg polls every account of the grant, each with its own state rows and zones", () => {
+		const testDb = createTestDb(trackedDbs)
+		const captured: CapturedIngest[] = []
+		const SECOND_ACCOUNT = "acct-2"
+		const secondZone = {
+			...zoneFixture,
+			id: "zone-2",
+			name: "beta.example",
+			account: { id: SECOND_ACCOUNT, name: "Second Account" },
+		}
+		return Effect.gen(function* () {
+			yield* TestClock.setTime(T0)
+			// One grant covering both accounts — the order here is the status order.
+			yield* seedConnection(ANALYTICS_SCOPE, [
+				{ id: ACCOUNT_ID, name: "Test Account" },
+				{ id: SECOND_ACCOUNT, name: "Second Account" },
+			])
+			const service = yield* CloudflareAnalyticsService
+			const summary = yield* service.pollOrg(ORG)
+			assert.isNull(summary.skipped)
+			assert.isAbove(summary.rowsIngested, 0)
+
+			// Each account discovered ITS zones and owns its state rows — including its own
+			// workers anchor, so leases and discovery run per account.
+			const rows = yield* loadStateRows
+			const httpRows = rows.filter((row) => row.dataset === "http_requests")
+			assert.deepStrictEqual(httpRows.map((row) => `${row.accountId}:${row.zoneId}`).sort(), [
+				`${ACCOUNT_ID}:${ZONE_ID}`,
+				`${SECOND_ACCOUNT}:zone-2`,
+			])
+			const anchors = rows.filter((row) => row.dataset === "workers_invocations")
+			assert.deepStrictEqual(anchors.map((row) => row.accountId).sort(), [ACCOUNT_ID, SECOND_ACCOUNT])
+
+			// The integration status breaks the same state down per account, while the
+			// legacy top-level view merges both accounts' zones.
+			const status = yield* service.getIntegrationStatus(ORG)
+			assert.strictEqual(status.connected, true)
+			assert.deepStrictEqual(
+				(status.accounts ?? []).map((account) => account.accountId),
+				[ACCOUNT_ID, SECOND_ACCOUNT],
+			)
+			assert.deepStrictEqual(
+				(status.accounts ?? []).map((account) => account.zones.map((zone) => zone.id)),
+				[[ZONE_ID], ["zone-2"]],
+			)
+			assert.deepStrictEqual(status.zones.map((zone) => zone.id).sort(), [ZONE_ID, "zone-2"].sort())
+			assert.strictEqual(status.accountId, ACCOUNT_ID)
+		}).pipe(
+			Effect.provide(
+				makeLayer(testDb, captured, {
+					zonesByAccount: { [ACCOUNT_ID]: [zoneFixture], [SECOND_ACCOUNT]: [secondZone] },
+				}),
+			),
+		)
 	})
 
 	const hyperdriveMysqlFixture: HyperdriveConfigFixture = {

--- a/apps/api/src/services/integrations/CloudflareAnalyticsService.test.ts
+++ b/apps/api/src/services/integrations/CloudflareAnalyticsService.test.ts
@@ -10,7 +10,7 @@ import {
 	oauthConnections,
 	orgClickHouseSettings,
 } from "@maple/db"
-import { ConfigProvider, Effect, Layer, Schema } from "effect"
+import { Array as Arr, ConfigProvider, Effect, Layer, Schema } from "effect"
 import { EdgeCacheService, MemoryCacheBackendLive } from "@maple/cache"
 import { TestClock } from "effect/testing"
 import { FetchHttpClient } from "effect/unstable/http"
@@ -416,7 +416,9 @@ const makeLayer = (
  */
 const seedConnection = (
 	scope: string = ANALYTICS_SCOPE,
-	accounts: ReadonlyArray<{ id: string; name: string }> = [{ id: ACCOUNT_ID, name: "Test Account" }],
+	accounts: Arr.NonEmptyReadonlyArray<{ id: string; name: string }> = [
+		{ id: ACCOUNT_ID, name: "Test Account" },
+	],
 ) =>
 	Effect.gen(function* () {
 		const database = yield* Database
@@ -427,8 +429,8 @@ const seedConnection = (
 				id: randomUUID(),
 				orgId: ORG,
 				provider: "cloudflare",
-				externalUserId: accounts[0]!.id,
-				externalAccountName: accounts[0]!.name,
+				externalUserId: Arr.headNonEmpty(accounts).id,
+				externalAccountName: Arr.headNonEmpty(accounts).name,
 				grantedAccountsJson:
 					accounts.length > 1
 						? JSON.stringify(accounts.map((account) => ({ id: account.id, name: account.name })))

--- a/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
@@ -2640,7 +2640,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 			// Legacy top-level view: first (oldest) connection's identity + every CONNECTED
 			// account's zones. State rows of since-disconnected accounts stay in Postgres
 			// (they resume the watermark on reconnect) but must not render as live zones.
-			const primary = connection.accounts[0]!
+			const primary = Arr.headNonEmpty(connection.accounts)
 			const mergedZones = accounts
 				.flatMap((account) => account.zones)
 				.sort((a, b) => a.name.localeCompare(b.name))

--- a/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
@@ -15,9 +15,11 @@
  * - `workers_invocations` (account-scoped `workersInvocationsAdaptive`): Worker requests/errors
  *   and CPU-time/duration percentiles per script.
  *
- * State lives in `cloudflare_analytics_state` (one row per org × dataset × zone): watermark of
- * the last fully-ingested bucket, cached dataset `settings` (Cloudflare's per-plan limits), a
- * lease column as the tick-overlap guard, and last success/error for the integration UI. The
+ * State lives in `cloudflare_analytics_state` (one row per org × account × dataset × zone —
+ * orgs connect multiple Cloudflare accounts, each polled as its own unit with its own lease,
+ * call budget and discovery): watermark of the last fully-ingested bucket, cached dataset
+ * `settings` (Cloudflare's per-plan limits), a lease column as the tick-overlap guard, and
+ * last success/error for the integration UI. The
  * poll loop is resumable by construction — a budget-exhausted backfill simply continues from
  * its watermark on the next tick. Metrics rows are written exactly once because a window is
  * only ever ingested before its watermark advances, and windows never overlap.
@@ -26,6 +28,7 @@ import { randomUUID } from "node:crypto"
 import {
 	CloudflareAnalyticsWorkersStatus,
 	CloudflareAnalyticsZoneStatus,
+	CloudflareConnectedAccountStatus,
 	CloudflareIntegrationStatus,
 	CloudflareServiceUsage,
 	CloudflareUsageBucket,
@@ -1008,14 +1011,27 @@ interface CloudflareAnalyticsZoneStatusFields {
 	readonly watermarkAt: number | null
 }
 
-interface CloudflareAnalyticsStatus {
+interface CloudflareAnalyticsWorkersStatusFields {
+	readonly enabled: boolean
+	readonly lastSyncedAt: number | null
+	readonly lastError: string | null
+	readonly watermarkAt: number | null
+}
+
+/** One connected account's collection state. */
+interface CloudflareAnalyticsAccountStatus {
+	readonly accountId: string
 	readonly zones: ReadonlyArray<CloudflareAnalyticsZoneStatusFields>
-	readonly workers: {
-		readonly enabled: boolean
-		readonly lastSyncedAt: number | null
-		readonly lastError: string | null
-		readonly watermarkAt: number | null
-	} | null
+	readonly workers: CloudflareAnalyticsWorkersStatusFields | null
+}
+
+interface CloudflareAnalyticsStatus {
+	/** Per-account breakdown, ordered by accountId for stability. */
+	readonly accounts: ReadonlyArray<CloudflareAnalyticsAccountStatus>
+	/** All accounts' zones merged — the pre-multi-account org-wide view. */
+	readonly zones: ReadonlyArray<CloudflareAnalyticsZoneStatusFields>
+	/** Merged workers state across accounts (first account's when several exist). */
+	readonly workers: CloudflareAnalyticsWorkersStatusFields | null
 }
 
 interface PollOrgSummary {
@@ -1054,8 +1070,14 @@ export interface CloudflareAnalyticsServiceApi {
 	readonly listHyperdriveConfigs: (
 		orgId: OrgId,
 	) => Effect.Effect<ReadonlyArray<CloudflareHyperdriveConfigRow>, IntegrationsPersistenceError>
-	/** Recovery hook for reconnect — see the implementation below for why this exists. */
-	readonly resetOrgState: (orgId: OrgId) => Effect.Effect<void, IntegrationsPersistenceError>
+	/**
+	 * Recovery hook for reconnect — see the implementation below for why this exists.
+	 * Scoped to one account when `accountId` is given (the reconnect callback knows it).
+	 */
+	readonly resetOrgState: (
+		orgId: OrgId,
+		accountId?: string,
+	) => Effect.Effect<void, IntegrationsPersistenceError>
 }
 
 export class CloudflareAnalyticsService extends Context.Service<
@@ -1084,9 +1106,19 @@ export class CloudflareAnalyticsService extends Context.Service<
 			authMode: "self_hosted",
 		})
 
-		const loadStateRows = (orgId: OrgId) =>
+		const loadStateRows = (orgId: OrgId, accountId?: string) =>
 			dbExecute((db) =>
-				db.select().from(cloudflareAnalyticsState).where(eq(cloudflareAnalyticsState.orgId, orgId)),
+				db
+					.select()
+					.from(cloudflareAnalyticsState)
+					.where(
+						and(
+							eq(cloudflareAnalyticsState.orgId, orgId),
+							...(accountId === undefined
+								? []
+								: [eq(cloudflareAnalyticsState.accountId, accountId)]),
+						),
+					),
 			)
 
 		/** One IN-list UPDATE over the given state rows; no-op on an empty id list. */
@@ -1113,8 +1145,10 @@ export class CloudflareAnalyticsService extends Context.Service<
 				updatedAt: new Date(now),
 			})
 
-		const recordOrgError = (
+		/** Stamp an error on every state row of one connection (org × account). */
+		const recordConnectionError = (
 			orgId: OrgId,
+			accountId: string,
 			message: string,
 			now: number,
 			options?: { disable?: boolean },
@@ -1128,7 +1162,12 @@ export class CloudflareAnalyticsService extends Context.Service<
 						...(options?.disable ? { enabled: false } : undefined),
 						updatedAt: new Date(now),
 					})
-					.where(eq(cloudflareAnalyticsState.orgId, orgId)),
+					.where(
+						and(
+							eq(cloudflareAnalyticsState.orgId, orgId),
+							eq(cloudflareAnalyticsState.accountId, accountId),
+						),
+					),
 			)
 
 		/**
@@ -1181,7 +1220,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 		 * stays the org's lease anchor and gives scope errors somewhere to land even before zone
 		 * discovery has ever succeeded; sibling account datasets ride along here.
 		 */
-		const ensureAccountRows = (orgId: OrgId, now: number) =>
+		const ensureAccountRows = (orgId: OrgId, accountId: string, now: number) =>
 			dbExecute((db) =>
 				db
 					.insert(cloudflareAnalyticsState)
@@ -1189,6 +1228,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 						ACCOUNT_DATASETS.map((dataset) => ({
 							id: randomUUID(),
 							orgId,
+							accountId,
 							dataset: dataset.id,
 							zoneId: "",
 							createdAt: new Date(now),
@@ -1199,10 +1239,10 @@ export class CloudflareAnalyticsService extends Context.Service<
 			)
 
 		/**
-		 * Claim the org's tick lease via the workers anchor row. Returns the claimed anchor (it
-		 * carries the zone-discovery timestamp) or null — no anchor yet, or another tick owns it.
+		 * Claim the connection's tick lease via its workers anchor row. Returns the claimed anchor
+		 * (it carries the zone-discovery timestamp) or null — no anchor yet, or another tick owns it.
 		 */
-		const claimLease = (orgId: OrgId, now: number) =>
+		const claimLease = (orgId: OrgId, accountId: string, now: number) =>
 			dbExecute((db) =>
 				db
 					.update(cloudflareAnalyticsState)
@@ -1210,6 +1250,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 					.where(
 						and(
 							eq(cloudflareAnalyticsState.orgId, orgId),
+							eq(cloudflareAnalyticsState.accountId, accountId),
 							eq(cloudflareAnalyticsState.dataset, WORKERS_DATASET),
 							eq(cloudflareAnalyticsState.zoneId, ""),
 							or(
@@ -1231,7 +1272,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 		 * rate-limited org sits out the next tick(s) — `claimLease` already refuses a live lease, and
 		 * a hold under `2 * LEASE_MS` stays inside its corrupt-lease escape hatch.
 		 */
-		const releaseLease = (orgId: OrgId, now: number, holdUntilMs?: number) =>
+		const releaseLease = (orgId: OrgId, accountId: string, now: number, holdUntilMs?: number) =>
 			dbExecute((db) =>
 				db
 					.update(cloudflareAnalyticsState)
@@ -1242,6 +1283,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 					.where(
 						and(
 							eq(cloudflareAnalyticsState.orgId, orgId),
+							eq(cloudflareAnalyticsState.accountId, accountId),
 							eq(cloudflareAnalyticsState.dataset, WORKERS_DATASET),
 							eq(cloudflareAnalyticsState.zoneId, ""),
 						),
@@ -1254,11 +1296,12 @@ export class CloudflareAnalyticsService extends Context.Service<
 		 */
 		const reconcileZones = Effect.fn("CloudflareAnalyticsService.reconcileZones")(function* (
 			orgId: OrgId,
+			accountId: string,
 			zones: ReadonlyArray<CloudflareZone>,
 			anchorId: string,
 			now: number,
 		) {
-			const rows = yield* loadStateRows(orgId)
+			const rows = yield* loadStateRows(orgId, accountId)
 			// Every zone-scoped dataset gets one state row per discovered zone — reconcile them all.
 			const byDatasetZone = new Map<string, CloudflareAnalyticsStateRow>()
 			for (const row of rows) {
@@ -1273,6 +1316,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 					.map((zone) => ({
 						id: randomUUID(),
 						orgId,
+						accountId,
 						dataset: dataset.id,
 						zoneId: zone.id,
 						zoneName: zone.name,
@@ -1307,6 +1351,8 @@ export class CloudflareAnalyticsService extends Context.Service<
 				}
 			}
 
+			// `rows` is already scoped to this connection's account, so a zone that moved to a
+			// sibling account is disabled here and freshly discovered by that account's tick.
 			const seen = new Set(zones.map((zone) => zone.id))
 			const vanished = rows.filter(
 				(row) =>
@@ -1729,9 +1775,15 @@ export class CloudflareAnalyticsService extends Context.Service<
 		 * is kept if a config re-appears.
 		 */
 		const reconcileHyperdriveConfigs = Effect.fn("CloudflareAnalyticsService.reconcileHyperdriveConfigs")(
-			function* (orgId: OrgId, configs: ReadonlyArray<CloudflareHyperdriveConfig>, now: number) {
+			function* (
+				orgId: OrgId,
+				accountId: string,
+				configs: ReadonlyArray<CloudflareHyperdriveConfig>,
+				now: number,
+			) {
 				yield* Effect.annotateCurrentSpan({
 					orgId,
+					"maple.cloudflare.account_id": accountId,
 					"maple.cloudflare.hyperdrive_config_count": configs.length,
 				})
 				const existingRows = yield* dbExecute((db) =>
@@ -1747,6 +1799,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 					configs,
 					(config) => {
 						const values = {
+							accountId,
 							name: config.name,
 							originHost: config.origin.host,
 							originPort: config.origin.port,
@@ -1777,8 +1830,16 @@ export class CloudflareAnalyticsService extends Context.Service<
 					{ concurrency: 4, discard: true },
 				)
 
+				// Soft-delete only THIS account's vanished configs — a sibling account's inventory
+				// is invisible to this listing and must not be reaped by it. Pre-multi-account rows
+				// (null accountId) are adopted by whichever account's reconcile still sees them.
 				yield* Effect.forEach(
-					existingRows.filter((row) => !upstreamIds.has(row.configId) && row.deletedAt === null),
+					existingRows.filter(
+						(row) =>
+							!upstreamIds.has(row.configId) &&
+							row.deletedAt === null &&
+							(row.accountId == null || row.accountId === accountId),
+					),
 					(row) =>
 						dbExecute((db) =>
 							db
@@ -1808,10 +1869,22 @@ export class CloudflareAnalyticsService extends Context.Service<
 			},
 		)
 
-		const pollOrg = Effect.fn("CloudflareAnalyticsService.pollOrg")(function* (orgId: OrgId) {
-			yield* Effect.annotateCurrentSpan("orgId", orgId)
+		/** One connection's (org × account) poll summary — merged into the org summary. */
+		interface PollConnectionSummary {
+			readonly accountId: string
+			readonly skipped: string | null
+			readonly callsMade: number
+			readonly rowsIngested: number
+			readonly failures: ReadonlyArray<DatasetPollFailure>
+		}
+
+		const pollConnection = Effect.fn("CloudflareAnalyticsService.pollConnection")(function* (
+			orgId: OrgId,
+			accountId: string,
+		) {
+			yield* Effect.annotateCurrentSpan({ orgId, "maple.cloudflare.account_id": accountId })
 			// A skip used to be silent — the reason only ever landed in the returned summary, which
-			// nothing read for a plain tick. Annotating pollOrg's own span means every skip is now
+			// nothing read for a plain tick. Annotating the poll span means every skip is now
 			// visible on the trace even when the tick rollup below doesn't (yet) escalate it.
 			const skip = (reason: string) =>
 				Effect.annotateCurrentSpan({
@@ -1820,18 +1893,18 @@ export class CloudflareAnalyticsService extends Context.Service<
 					"maple.cloudflare.rows_ingested": 0,
 				}).pipe(
 					Effect.as({
-						orgId,
+						accountId,
 						skipped: reason,
 						callsMade: 0,
 						rowsIngested: 0,
 						failures: [],
-					} satisfies PollOrgSummary),
+					} satisfies PollConnectionSummary),
 				)
 
 			const now = yield* Clock.currentTimeMillis
 
 			// One connection read resolves connected-ness, capability (scope), and a fresh token.
-			const tokenResult = yield* Effect.result(oauth.getValidAccessToken(orgId))
+			const tokenResult = yield* Effect.result(oauth.getValidAccessToken(orgId, accountId))
 			if (
 				Result.isFailure(tokenResult) &&
 				tokenResult.failure instanceof IntegrationsNotConnectedError
@@ -1839,11 +1912,12 @@ export class CloudflareAnalyticsService extends Context.Service<
 				return yield* skip("not connected")
 			}
 
-			// Claim the tick lease; the anchor row is created lazily the first time an org is polled.
-			let claimed = yield* claimLease(orgId, now)
+			// Claim the tick lease; the anchor row is created lazily the first time a connection
+			// is polled. Leases are per account, so sibling accounts of one org tick independently.
+			let claimed = yield* claimLease(orgId, accountId, now)
 			if (claimed == null) {
-				yield* ensureAccountRows(orgId, now)
-				claimed = yield* claimLease(orgId, now)
+				yield* ensureAccountRows(orgId, accountId, now)
+				claimed = yield* claimLease(orgId, accountId, now)
 			}
 			if (claimed == null) return yield* skip("lease held by another tick")
 			const anchor = claimed
@@ -1853,22 +1927,22 @@ export class CloudflareAnalyticsService extends Context.Service<
 			const rateLimitedRef = yield* Ref.make(false)
 
 			return yield* Effect.gen(function* () {
-				// Token failures: revocation disables all rows until reconnect; transient upstream
-				// failures record and retry next tick.
+				// Token failures: revocation disables the connection's rows until reconnect;
+				// transient upstream failures record and retry next tick.
 				if (Result.isFailure(tokenResult)) {
 					const error = tokenResult.failure
 					if (error instanceof IntegrationsRevokedError) {
-						yield* oauth.markConnectionRevoked(orgId)
+						yield* oauth.markConnectionRevoked(orgId, accountId)
 					}
-					yield* recordOrgError(orgId, error.message, now, {
+					yield* recordConnectionError(orgId, accountId, error.message, now, {
 						disable: error instanceof IntegrationsRevokedError,
 					})
 					return yield* skip(`token unavailable: ${error._tag}`)
 				}
-				const { accessToken, accountId, scope } = tokenResult.success
+				const { accessToken, scope } = tokenResult.success
 
 				if (!hasAnalyticsScopes(scope)) {
-					yield* recordOrgError(orgId, MISSING_SCOPES_ERROR, now)
+					yield* recordConnectionError(orgId, accountId, MISSING_SCOPES_ERROR, now)
 					return yield* skip("missing analytics scopes")
 				}
 
@@ -1881,17 +1955,17 @@ export class CloudflareAnalyticsService extends Context.Service<
 					if (Result.isFailure(zonesResult)) {
 						const error = zonesResult.failure
 						if (error instanceof IntegrationsRevokedError) {
-							yield* oauth.markConnectionRevoked(orgId)
+							yield* oauth.markConnectionRevoked(orgId, accountId)
 						}
-						yield* recordOrgError(orgId, error.message, now, {
+						yield* recordConnectionError(orgId, accountId, error.message, now, {
 							disable: error instanceof IntegrationsRevokedError,
 						})
 						return yield* skip(`zone discovery failed: ${error._tag}`)
 					}
 					// Newly-registered account datasets get their rows on the discovery cadence —
 					// before reconcileZones, whose loadStateRows picks them up for this tick.
-					yield* ensureAccountRows(orgId, now)
-					rows = yield* reconcileZones(orgId, zonesResult.success, anchor.id, now)
+					yield* ensureAccountRows(orgId, accountId, now)
+					rows = yield* reconcileZones(orgId, accountId, zonesResult.success, anchor.id, now)
 					// Script enumeration rides the same discovery TTL. It filters deleted scripts out of
 					// the workers dataset; a failure (typically a pre-workers-scripts.read grant) degrades
 					// open — emit everything rather than wedge the org, and keep the last known set.
@@ -1925,21 +1999,22 @@ export class CloudflareAnalyticsService extends Context.Service<
 							error: hyperdriveResult.failure.message,
 						})
 					} else {
-						yield* reconcileHyperdriveConfigs(orgId, hyperdriveResult.success, now)
+						yield* reconcileHyperdriveConfigs(orgId, accountId, hyperdriveResult.success, now)
 					}
 				} else {
-					rows = yield* loadStateRows(orgId)
+					rows = yield* loadStateRows(orgId, accountId)
 				}
 
 				const budget = { calls: 0 }
 				const settingsWrote = yield* refreshSettings(accessToken, accountId, rows, now, budget)
-				if (settingsWrote) rows = yield* loadStateRows(orgId)
+				if (settingsWrote) rows = yield* loadStateRows(orgId, accountId)
 
 				// The org's public ingest key authenticates the gateway POSTs (minted on first use).
 				const keyResult = yield* Effect.result(getOrgIngestKey(orgId))
 				if (Result.isFailure(keyResult)) {
-					yield* recordOrgError(
+					yield* recordConnectionError(
 						orgId,
+						accountId,
 						`Cloudflare ingest key unavailable: ${keyResult.failure.message}`,
 						now,
 					)
@@ -1986,10 +2061,11 @@ export class CloudflareAnalyticsService extends Context.Service<
 						).pipe(
 							Effect.catchTags({
 								"@maple/http/errors/IntegrationsRevokedError": (error) =>
-									// Stop this org's loop; the seam disables + records health org-wide.
-									// Also stamp the connection so pollAllOrgs skips it until reconnect
-									// (a mid-poll 401 never goes through the refresh path that stamps).
-									oauth.markConnectionRevoked(orgId).pipe(
+									// Stop this connection's loop; the seam disables + records health
+									// connection-wide. Also stamp the connection so pollAllOrgs skips it
+									// until reconnect (a mid-poll 401 never goes through the refresh path
+									// that stamps).
+									oauth.markConnectionRevoked(orgId, accountId).pipe(
 										Effect.andThen(Ref.set(revokedRef, true)),
 										Effect.as(
 											allPartsFailed(item, "revoked", error.message, {
@@ -2072,9 +2148,15 @@ export class CloudflareAnalyticsService extends Context.Service<
 									failed: ({ failure }) =>
 										Effect.gen(function* () {
 											if (failure.orgWide) {
-												yield* recordOrgError(orgId, failure.message, now, {
-													disable: failure.disable,
-												})
+												yield* recordConnectionError(
+													orgId,
+													accountId,
+													failure.message,
+													now,
+													{
+														disable: failure.disable,
+													},
+												)
 												for (const row of rows)
 													if (failure.disable) row.enabled = false
 											} else {
@@ -2100,31 +2182,33 @@ export class CloudflareAnalyticsService extends Context.Service<
 				yield* Effect.annotateCurrentSpan("maple.cloudflare.rows_ingested", rowsIngested)
 				yield* Effect.annotateCurrentSpan("maple.cloudflare.dataset_failures", datasetFailures.length)
 				return {
-					orgId,
+					accountId,
 					skipped: null,
 					callsMade: budget.calls,
 					rowsIngested,
 					failures: datasetFailures,
-				} satisfies PollOrgSummary
+				} satisfies PollConnectionSummary
 			}).pipe(
 				Effect.ensuring(
 					Effect.all([Clock.currentTimeMillis, Ref.get(rateLimitedRef)]).pipe(
 						Effect.flatMap(([end, rateLimited]) =>
 							// A rate-limited tick doesn't release the lease — it holds it for the backoff
-							// window, so the next cron tick skips this org instead of re-depleting the
-							// account's GraphQL budget.
+							// window, so the next cron tick skips this connection instead of re-depleting
+							// the account's GraphQL budget.
 							releaseLease(
 								orgId,
+								accountId,
 								end,
 								rateLimited ? end + RATE_LIMIT_BACKOFF_MS : undefined,
 							).pipe(
 								// The ensuring must never fail (that would mask whatever this tick actually
 								// did), but a lease release failure is not nothing — it silently wedges the
-								// org behind a lease until the corrupt-lease escape hatch reclaims it, so log
-								// loudly instead of swallowing it via Effect.ignore.
+								// connection behind a lease until the corrupt-lease escape hatch reclaims it,
+								// so log loudly instead of swallowing it via Effect.ignore.
 								Effect.catchCause((cause) =>
 									Effect.logWarning("cloudflare-analytics lease release failed", {
 										orgId,
+										accountId,
 										error: summarizeCause(cause),
 									}),
 								),
@@ -2135,21 +2219,80 @@ export class CloudflareAnalyticsService extends Context.Service<
 			)
 		})
 
+		/**
+		 * Poll every connected account of one org, sequentially — Cloudflare's GraphQL
+		 * budget is per account, so sequencing accounts costs nothing on rate limits
+		 * while keeping one org's Postgres traffic bounded. Revoked and
+		 * scope-incapable connections are skipped without touching their state rows
+		 * (the status endpoint already surfaces both conditions per account).
+		 */
+		const pollOrg = Effect.fn("CloudflareAnalyticsService.pollOrg")(function* (orgId: OrgId) {
+			yield* Effect.annotateCurrentSpan("orgId", orgId)
+			const status = yield* oauth.getStatus(orgId)
+			const summaries: Array<PollConnectionSummary> = []
+			for (const account of status.accounts) {
+				if (account.revoked) continue
+				if (!hasAnalyticsScopes(account.scope)) {
+					summaries.push({
+						accountId: account.accountId,
+						skipped: "missing analytics scopes",
+						callsMade: 0,
+						rowsIngested: 0,
+						failures: [],
+					})
+					continue
+				}
+				summaries.push(yield* pollConnection(orgId, account.accountId))
+			}
+			if (summaries.length === 0) {
+				yield* Effect.annotateCurrentSpan("maple.cloudflare.skip_reason", "not connected")
+				return {
+					orgId,
+					skipped: "not connected",
+					callsMade: 0,
+					rowsIngested: 0,
+					failures: [],
+				} satisfies PollOrgSummary
+			}
+			// The org counts as skipped only when EVERY connection skipped — a single
+			// polling account keeps the org out of the zero-rows tick warning.
+			const allSkipped = summaries.every((summary) => summary.skipped != null)
+			return {
+				orgId,
+				skipped: allSkipped
+					? summaries
+							.map((summary) =>
+								summaries.length === 1
+									? summary.skipped
+									: `${summary.accountId}: ${summary.skipped}`,
+							)
+							.join("; ")
+					: null,
+				callsMade: summaries.reduce((sum, summary) => sum + summary.callsMade, 0),
+				rowsIngested: summaries.reduce((sum, summary) => sum + summary.rowsIngested, 0),
+				failures: summaries.flatMap((summary) => summary.failures),
+			} satisfies PollOrgSummary
+		})
+
 		const pollAllOrgs = Effect.fn("CloudflareAnalyticsService.pollAllOrgs")(function* () {
-			const orgRows = yield* dbExecute((db) =>
+			const connectionRows = yield* dbExecute((db) =>
 				db
 					.selectDistinct({ orgId: oauthConnections.orgId, scope: oauthConnections.scope })
 					.from(oauthConnections)
-					// Revoked grants fail identically every tick until the org reconnects
+					// Revoked grants fail identically every tick until the account reconnects
 					// (which clears revokedAt) — skip them instead of re-erroring forever.
 					.where(
 						and(eq(oauthConnections.provider, "cloudflare"), isNull(oauthConnections.revokedAt)),
 					),
 			)
-			// Orgs whose grant lacks the analytics scopes can't be polled — the status endpoint
-			// already surfaces that (analyticsCapable: false), so skipping them here avoids
-			// rewriting the same scope error into their state rows every tick.
-			const capable = orgRows.filter((row) => hasAnalyticsScopes(row.scope))
+			// Orgs where NO connection carries the analytics scopes can't be polled — the status
+			// endpoint already surfaces that (analyticsCapable: false), so skipping them here avoids
+			// rewriting the same scope error into their state rows every tick. `pollOrg` itself
+			// filters incapable accounts of an otherwise-capable org.
+			const capableOrgIds = new Set(
+				connectionRows.filter((row) => hasAnalyticsScopes(row.scope)).map((row) => row.orgId),
+			)
+			const capable = [...capableOrgIds].map((orgId) => ({ orgId }))
 			// Concurrent fan-out below — must be a Ref rather than a mutable closure variable.
 			const rowsIngestedRef = yield* Ref.make(0)
 			const failuresRef = yield* Ref.make(0)
@@ -2250,30 +2393,43 @@ export class CloudflareAnalyticsService extends Context.Service<
 
 		const getStatus = Effect.fn("CloudflareAnalyticsService.getStatus")(function* (orgId: OrgId) {
 			const rows = yield* loadStateRows(orgId)
-			const zones = rows
-				.filter((row) => row.dataset === HTTP_DATASET)
-				.map((row) => ({
-					id: row.zoneId,
-					name: row.zoneName ?? row.zoneId,
-					enabled: row.enabled,
-					lastSyncedAt: row.lastSuccessAt == null ? null : dateToMs(row.lastSuccessAt),
-					lastError: row.lastError,
-					watermarkAt: row.watermarkAt == null ? null : dateToMs(row.watermarkAt),
-				}))
-				.sort((a, b) => a.name.localeCompare(b.name))
+			const toZone = (row: CloudflareAnalyticsStateRow): CloudflareAnalyticsZoneStatusFields => ({
+				id: row.zoneId,
+				name: row.zoneName ?? row.zoneId,
+				enabled: row.enabled,
+				lastSyncedAt: row.lastSuccessAt == null ? null : dateToMs(row.lastSuccessAt),
+				lastError: row.lastError,
+				watermarkAt: row.watermarkAt == null ? null : dateToMs(row.watermarkAt),
+			})
+			const toWorkers = (row: CloudflareAnalyticsStateRow): CloudflareAnalyticsWorkersStatusFields => ({
+				enabled: row.enabled,
+				lastSyncedAt: row.lastSuccessAt == null ? null : dateToMs(row.lastSuccessAt),
+				lastError: row.lastError,
+				watermarkAt: row.watermarkAt == null ? null : dateToMs(row.watermarkAt),
+			})
+			const accountIds = [...new Set(rows.map((row) => row.accountId))].sort()
+			const accounts = accountIds.map((accountId): CloudflareAnalyticsAccountStatus => {
+				const accountRows = rows.filter((row) => row.accountId === accountId)
+				const workersRow = accountRows.find((row) => row.dataset === WORKERS_DATASET)
+				return {
+					accountId,
+					zones: accountRows
+						.filter((row) => row.dataset === HTTP_DATASET)
+						.map(toZone)
+						.sort((a, b) => a.name.localeCompare(b.name)),
+					workers: workersRow ? toWorkers(workersRow) : null,
+				}
+			})
+			// Merged legacy view: all accounts' zones (zone ids are globally unique), and the
+			// first workers row — matching the single-account shape existing consumers render.
 			const workersRow = rows.find((row) => row.dataset === WORKERS_DATASET)
 			return {
-				zones,
-				workers: workersRow
-					? {
-							enabled: workersRow.enabled,
-							lastSyncedAt:
-								workersRow.lastSuccessAt == null ? null : dateToMs(workersRow.lastSuccessAt),
-							lastError: workersRow.lastError,
-							watermarkAt:
-								workersRow.watermarkAt == null ? null : dateToMs(workersRow.watermarkAt),
-						}
-					: null,
+				accounts,
+				zones: rows
+					.filter((row) => row.dataset === HTTP_DATASET)
+					.map(toZone)
+					.sort((a, b) => a.name.localeCompare(b.name)),
+				workers: workersRow ? toWorkers(workersRow) : null,
 			} satisfies CloudflareAnalyticsStatus
 		})
 
@@ -2430,7 +2586,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 			})
 		})
 
-		/** The full HTTP-facing integration status (connection + analytics collection state). */
+		/** The full HTTP-facing integration status (connections + analytics collection state). */
 		const getIntegrationStatus = Effect.fn("CloudflareAnalyticsService.getIntegrationStatus")(function* (
 			orgId: OrgId,
 		) {
@@ -2443,20 +2599,50 @@ export class CloudflareAnalyticsService extends Context.Service<
 					connectedByUserId: null,
 					scope: null,
 					analyticsCapable: false,
+					accounts: [],
 					zones: [],
 					workers: null,
 				})
 			}
 			const analytics = yield* getStatus(orgId)
+			const analyticsByAccount = new Map(
+				analytics.accounts.map((account) => [account.accountId, account]),
+			)
+			const accounts = connection.accounts.map((account) => {
+				const accountAnalytics = analyticsByAccount.get(account.accountId)
+				return new CloudflareConnectedAccountStatus({
+					accountId: account.accountId,
+					accountName: account.accountName,
+					connectedByUserId: decodeUserIdSync(account.connectedByUserId),
+					scope: account.scope,
+					analyticsCapable: hasAnalyticsScopes(account.scope),
+					revoked: account.revoked,
+					zones: (accountAnalytics?.zones ?? []).map(
+						(zone) => new CloudflareAnalyticsZoneStatus(zone),
+					),
+					workers: accountAnalytics?.workers
+						? new CloudflareAnalyticsWorkersStatus(accountAnalytics.workers)
+						: null,
+				})
+			})
+			// Legacy top-level view: first (oldest) connection's identity + every CONNECTED
+			// account's zones. State rows of since-disconnected accounts stay in Postgres
+			// (they resume the watermark on reconnect) but must not render as live zones.
+			const primary = connection.accounts[0]!
+			const mergedZones = accounts
+				.flatMap((account) => account.zones)
+				.sort((a, b) => a.name.localeCompare(b.name))
+			const mergedWorkers = accounts.find((account) => account.workers != null)?.workers ?? null
 			return new CloudflareIntegrationStatus({
 				connected: true,
-				accountId: connection.accountId,
-				accountName: connection.accountName,
-				connectedByUserId: decodeUserIdSync(connection.connectedByUserId),
-				scope: connection.scope,
-				analyticsCapable: hasAnalyticsScopes(connection.scope),
-				zones: analytics.zones.map((zone) => new CloudflareAnalyticsZoneStatus(zone)),
-				workers: analytics.workers ? new CloudflareAnalyticsWorkersStatus(analytics.workers) : null,
+				accountId: primary.accountId,
+				accountName: primary.accountName,
+				connectedByUserId: decodeUserIdSync(primary.connectedByUserId),
+				scope: primary.scope,
+				analyticsCapable: accounts.some((account) => account.analyticsCapable && !account.revoked),
+				accounts,
+				zones: mergedZones,
+				workers: mergedWorkers,
 			})
 		})
 
@@ -2469,9 +2655,17 @@ export class CloudflareAnalyticsService extends Context.Service<
 		 * recover via the discovery reconcile once polling resumes, but the account-scoped workers
 		 * anchor row has no other re-enable path.
 		 */
-		const resetOrgState = Effect.fn("CloudflareAnalyticsService.resetOrgState")(function* (orgId: OrgId) {
+		const resetOrgState = Effect.fn("CloudflareAnalyticsService.resetOrgState")(function* (
+			orgId: OrgId,
+			accountId?: string,
+		) {
 			yield* Effect.annotateCurrentSpan("orgId", orgId)
+			if (accountId !== undefined) {
+				yield* Effect.annotateCurrentSpan("maple.cloudflare.account_id", accountId)
+			}
 			const now = yield* Clock.currentTimeMillis
+			const accountFilter =
+				accountId === undefined ? [] : [eq(cloudflareAnalyticsState.accountId, accountId)]
 			yield* dbExecute((db) =>
 				db
 					.update(cloudflareAnalyticsState)
@@ -2483,17 +2677,23 @@ export class CloudflareAnalyticsService extends Context.Service<
 						leaseUntil: null,
 						updatedAt: new Date(now),
 					})
-					.where(eq(cloudflareAnalyticsState.orgId, orgId)),
+					.where(and(eq(cloudflareAnalyticsState.orgId, orgId), ...accountFilter)),
 			)
 			// Manual recovery path: also clear the revocation stamp so pollAllOrgs
-			// picks the org up again (reconnect clears it via upsertConnection, but
-			// resetOrgState may be invoked without a fresh OAuth round-trip).
+			// picks the connection up again (reconnect clears it via upsertConnection,
+			// but resetOrgState may be invoked without a fresh OAuth round-trip).
 			yield* dbExecute((db) =>
 				db
 					.update(oauthConnections)
 					.set({ revokedAt: null })
 					.where(
-						and(eq(oauthConnections.orgId, orgId), eq(oauthConnections.provider, "cloudflare")),
+						and(
+							eq(oauthConnections.orgId, orgId),
+							eq(oauthConnections.provider, "cloudflare"),
+							...(accountId === undefined
+								? []
+								: [eq(oauthConnections.externalUserId, accountId)]),
+						),
 					),
 			)
 		})

--- a/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
@@ -170,14 +170,16 @@ const BACKFILL_MS = 24 * 60 * 60_000
  */
 const MAX_WINDOW_MS = 60 * 60_000
 /**
- * Hard per-org call budget per tick so a pathological backfill can't blow the 300/5min limit.
- * Cloudflare's GraphQL rate limit is per ACCOUNT-holder, but our budget is per org and the tick
- * runs `ORG_CONCURRENCY` orgs at a time: at 50 the six polled orgs could ask for 300 queries in
- * one tick — exactly the limit — which is how we rate-limited ourselves into ~1.7k
- * `Rate limiter budget depleted` errors a day. 20 keeps a full tick well under the ceiling;
- * backfill is resumable by construction, so a smaller budget only makes history land slower.
+ * Hard per-GRANT call budget per tick so a pathological backfill can't blow the 300/5min limit.
+ * Cloudflare's GraphQL rate limit is per ACCOUNT-holder — one grant is one holder however many
+ * accounts it covers — and the tick runs `ORG_CONCURRENCY` orgs at a time: at 50 the six polled
+ * orgs could ask for 300 queries in one tick — exactly the limit — which is how we rate-limited
+ * ourselves into ~1.7k `Rate limiter budget depleted` errors a day. 20 keeps a full tick well
+ * under the ceiling; backfill is resumable by construction, so a smaller budget only makes
+ * history land slower. The budget is therefore shared across a grant's accounts (threaded from
+ * `pollOrg` into each `pollConnection`), never one budget per account.
  */
-const MAX_CALLS_PER_ORG_TICK = 20
+const MAX_CALLS_PER_GRANT_TICK = 20
 const LEASE_MS = 4 * 60_000
 /**
  * How long an org sits out after Cloudflare rate-limits it — Cloudflare's own message says "try
@@ -1422,7 +1424,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 						: []
 
 			for (const plan of plans) {
-				if (budget.calls >= MAX_CALLS_PER_ORG_TICK) return wrote
+				if (budget.calls >= MAX_CALLS_PER_GRANT_TICK) return wrote
 				budget.calls += 1
 				const result = yield* graphqlQuery(
 					accessToken,
@@ -1881,8 +1883,14 @@ export class CloudflareAnalyticsService extends Context.Service<
 		const pollConnection = Effect.fn("CloudflareAnalyticsService.pollConnection")(function* (
 			orgId: OrgId,
 			accountId: string,
+			// Shared across every account of the grant — Cloudflare meters the grant's holder, so
+			// a per-account budget would multiply a tick's calls by the account count.
+			budget: { calls: number },
 		) {
 			yield* Effect.annotateCurrentSpan({ orgId, "maple.cloudflare.account_id": accountId })
+			// The budget is the grant's running total; this account's own spend is the delta, so
+			// the org summary's `callsMade` stays a sum rather than counting siblings' calls again.
+			const callsAtStart = budget.calls
 			// A skip used to be silent — the reason only ever landed in the returned summary, which
 			// nothing read for a plain tick. Annotating the poll span means every skip is now
 			// visible on the trace even when the tick rollup below doesn't (yet) escalate it.
@@ -1954,9 +1962,11 @@ export class CloudflareAnalyticsService extends Context.Service<
 					const zonesResult = yield* Effect.result(listZones(accessToken, accountId, apiBaseUrl))
 					if (Result.isFailure(zonesResult)) {
 						const error = zonesResult.failure
-						if (error instanceof IntegrationsRevokedError) {
-							yield* oauth.markConnectionRevoked(orgId, accountId)
-						}
+						// A 401/403 on an ACCOUNT-scoped call means Maple lost access to this
+						// account, not that the grant died — losing an account must not stamp the
+						// shared connection revoked and stop the grant's other accounts. Disabling
+						// this account's rows is what stops it being re-polled; only a failed token
+						// refresh (above) is grant-wide.
 						yield* recordConnectionError(orgId, accountId, error.message, now, {
 							disable: error instanceof IntegrationsRevokedError,
 						})
@@ -2005,7 +2015,6 @@ export class CloudflareAnalyticsService extends Context.Service<
 					rows = yield* loadStateRows(orgId, accountId)
 				}
 
-				const budget = { calls: 0 }
 				const settingsWrote = yield* refreshSettings(accessToken, accountId, rows, now, budget)
 				if (settingsWrote) rows = yield* loadStateRows(orgId, accountId)
 
@@ -2039,7 +2048,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 					!(yield* Ref.get(revokedRef)) &&
 					!(yield* Ref.get(deliveryBlockedRef)) &&
 					!(yield* Ref.get(rateLimitedRef)) &&
-					budget.calls < MAX_CALLS_PER_ORG_TICK
+					budget.calls < MAX_CALLS_PER_GRANT_TICK
 				) {
 					const work = buildWorkItems(rows, now)
 					if (work.length === 0) break
@@ -2047,7 +2056,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 
 					for (const item of work) {
 						if (
-							budget.calls >= MAX_CALLS_PER_ORG_TICK ||
+							budget.calls >= MAX_CALLS_PER_GRANT_TICK ||
 							(yield* Ref.get(revokedRef)) ||
 							(yield* Ref.get(deliveryBlockedRef)) ||
 							(yield* Ref.get(rateLimitedRef))
@@ -2062,11 +2071,11 @@ export class CloudflareAnalyticsService extends Context.Service<
 							Effect.catchTags({
 								"@maple/http/errors/IntegrationsRevokedError": (error) =>
 									// Stop this connection's loop; the seam disables + records health
-									// connection-wide. Also stamp the connection so pollAllOrgs skips it
-									// until reconnect (a mid-poll 401 never goes through the refresh path
-									// that stamps).
-									oauth.markConnectionRevoked(orgId, accountId).pipe(
-										Effect.andThen(Ref.set(revokedRef, true)),
+									// connection-wide. The grant is NOT stamped revoked: a mid-poll
+									// 401/403 is account-scoped (access to this account was removed),
+									// and stamping would stop the grant's other accounts too. Disabling
+									// this account's rows is what keeps it from being re-polled.
+									Ref.set(revokedRef, true).pipe(
 										Effect.as(
 											allPartsFailed(item, "revoked", error.message, {
 												orgWide: true,
@@ -2178,13 +2187,13 @@ export class CloudflareAnalyticsService extends Context.Service<
 				const rowsIngested = yield* Ref.get(rowsIngestedRef)
 				// Metrics ship through the ingest gateway (see emitMetrics), so Autumn metering
 				// happens there — no self-report here.
-				yield* Effect.annotateCurrentSpan("maple.cloudflare.calls", budget.calls)
+				yield* Effect.annotateCurrentSpan("maple.cloudflare.calls", budget.calls - callsAtStart)
 				yield* Effect.annotateCurrentSpan("maple.cloudflare.rows_ingested", rowsIngested)
 				yield* Effect.annotateCurrentSpan("maple.cloudflare.dataset_failures", datasetFailures.length)
 				return {
 					accountId,
 					skipped: null,
-					callsMade: budget.calls,
+					callsMade: budget.calls - callsAtStart,
 					rowsIngested,
 					failures: datasetFailures,
 				} satisfies PollConnectionSummary
@@ -2220,9 +2229,9 @@ export class CloudflareAnalyticsService extends Context.Service<
 		})
 
 		/**
-		 * Poll every connected account of one org, sequentially — Cloudflare's GraphQL
-		 * budget is per account, so sequencing accounts costs nothing on rate limits
-		 * while keeping one org's Postgres traffic bounded. Revoked and
+		 * Poll every connected account of one org, sequentially, sharing ONE call budget —
+		 * Cloudflare meters the grant's holder, not the individual accounts, so a per-account
+		 * budget would multiply a tick's calls by the account count. Revoked and
 		 * scope-incapable connections are skipped without touching their state rows
 		 * (the status endpoint already surfaces both conditions per account).
 		 */
@@ -2230,19 +2239,22 @@ export class CloudflareAnalyticsService extends Context.Service<
 			yield* Effect.annotateCurrentSpan("orgId", orgId)
 			const status = yield* oauth.getStatus(orgId)
 			const summaries: Array<PollConnectionSummary> = []
+			// One budget for the whole grant, spent by the accounts in order.
+			const budget = { calls: 0 }
 			for (const account of status.accounts) {
-				if (account.revoked) continue
-				if (!hasAnalyticsScopes(account.scope)) {
+				// Revocation is grant-wide (one token), but record it per account so the tick
+				// rollup names the real cause instead of falling through to "not connected".
+				if (account.revoked || !hasAnalyticsScopes(account.scope)) {
 					summaries.push({
 						accountId: account.accountId,
-						skipped: "missing analytics scopes",
+						skipped: account.revoked ? "revoked" : "missing analytics scopes",
 						callsMade: 0,
 						rowsIngested: 0,
 						failures: [],
 					})
 					continue
 				}
-				summaries.push(yield* pollConnection(orgId, account.accountId))
+				summaries.push(yield* pollConnection(orgId, account.accountId, budget))
 			}
 			if (summaries.length === 0) {
 				yield* Effect.annotateCurrentSpan("maple.cloudflare.skip_reason", "not connected")
@@ -2682,18 +2694,15 @@ export class CloudflareAnalyticsService extends Context.Service<
 			// Manual recovery path: also clear the revocation stamp so pollAllOrgs
 			// picks the connection up again (reconnect clears it via upsertConnection,
 			// but resetOrgState may be invoked without a fresh OAuth round-trip).
+			// Never filtered by `accountId`: the stamp lives on the org's single grant row,
+			// whose externalUserId only ever holds the grant's FIRST account — filtering by it
+			// would match nothing for every other account and leave the org stuck revoked.
 			yield* dbExecute((db) =>
 				db
 					.update(oauthConnections)
 					.set({ revokedAt: null })
 					.where(
-						and(
-							eq(oauthConnections.orgId, orgId),
-							eq(oauthConnections.provider, "cloudflare"),
-							...(accountId === undefined
-								? []
-								: [eq(oauthConnections.externalUserId, accountId)]),
-						),
+						and(eq(oauthConnections.orgId, orgId), eq(oauthConnections.provider, "cloudflare")),
 					),
 			)
 		})

--- a/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
+++ b/apps/api/src/services/integrations/CloudflareAnalyticsService.ts
@@ -78,7 +78,7 @@ import {
 import { Database } from "@/platform/DatabaseLive"
 import { makeDbExecute, makePersistenceErrorMapper } from "@/platform/db-execute"
 import { Env } from "@/platform/Env"
-import { dateToMs } from "@/platform/time"
+import { dateToMs, msToDate } from "@/platform/time"
 import { WarehouseQueryService } from "@/services/warehouse/WarehouseQueryService"
 import { CloudflareOAuthService } from "@/services/auth/CloudflareOAuthService"
 import { OrgClickHouseSettingsService } from "@/services/org/OrgClickHouseSettingsService"
@@ -1142,9 +1142,9 @@ export class CloudflareAnalyticsService extends Context.Service<
 		) =>
 			updateRows(rowIds, {
 				lastError: message.slice(0, 500),
-				lastErrorAt: new Date(now),
+				lastErrorAt: msToDate(now),
 				...(options?.disable ? { enabled: false } : undefined),
-				updatedAt: new Date(now),
+				updatedAt: msToDate(now),
 			})
 
 		/** Stamp an error on every state row of one connection (org × account). */
@@ -1160,9 +1160,9 @@ export class CloudflareAnalyticsService extends Context.Service<
 					.update(cloudflareAnalyticsState)
 					.set({
 						lastError: message.slice(0, 500),
-						lastErrorAt: new Date(now),
+						lastErrorAt: msToDate(now),
 						...(options?.disable ? { enabled: false } : undefined),
-						updatedAt: new Date(now),
+						updatedAt: msToDate(now),
 					})
 					.where(
 						and(
@@ -1184,11 +1184,11 @@ export class CloudflareAnalyticsService extends Context.Service<
 			now: number,
 		) =>
 			updateRows(rowIds, {
-				watermarkAt: new Date(headEndMs),
-				lastSuccessAt: new Date(now),
+				watermarkAt: msToDate(headEndMs),
+				lastSuccessAt: msToDate(now),
 				lastError: null,
 				lastErrorAt: null,
-				updatedAt: new Date(now),
+				updatedAt: msToDate(now),
 			}).pipe(
 				Effect.andThen(
 					rowIds.length === 0
@@ -1196,7 +1196,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 						: dbExecute((db) =>
 								db
 									.update(cloudflareAnalyticsState)
-									.set({ backfillAt: new Date(headStartMs), updatedAt: new Date(now) })
+									.set({ backfillAt: msToDate(headStartMs), updatedAt: msToDate(now) })
 									.where(
 										and(
 											inArray(cloudflareAnalyticsState.id, [...rowIds]),
@@ -1210,11 +1210,11 @@ export class CloudflareAnalyticsService extends Context.Service<
 		/** Advance the BACKFILL frontier down after an older history window landed. */
 		const advanceBackfill = (rowIds: ReadonlyArray<string>, backfillStartMs: number, now: number) =>
 			updateRows(rowIds, {
-				backfillAt: new Date(backfillStartMs),
-				lastSuccessAt: new Date(now),
+				backfillAt: msToDate(backfillStartMs),
+				lastSuccessAt: msToDate(now),
 				lastError: null,
 				lastErrorAt: null,
-				updatedAt: new Date(now),
+				updatedAt: msToDate(now),
 			})
 
 		/**
@@ -1233,8 +1233,8 @@ export class CloudflareAnalyticsService extends Context.Service<
 							accountId,
 							dataset: dataset.id,
 							zoneId: "",
-							createdAt: new Date(now),
-							updatedAt: new Date(now),
+							createdAt: msToDate(now),
+							updatedAt: msToDate(now),
 						})),
 					)
 					.onConflictDoNothing(),
@@ -1248,7 +1248,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 			dbExecute((db) =>
 				db
 					.update(cloudflareAnalyticsState)
-					.set({ leaseUntil: new Date(now + LEASE_MS), updatedAt: new Date(now) })
+					.set({ leaseUntil: msToDate(now + LEASE_MS), updatedAt: msToDate(now) })
 					.where(
 						and(
 							eq(cloudflareAnalyticsState.orgId, orgId),
@@ -1257,12 +1257,12 @@ export class CloudflareAnalyticsService extends Context.Service<
 							eq(cloudflareAnalyticsState.zoneId, ""),
 							or(
 								isNull(cloudflareAnalyticsState.leaseUntil),
-								lt(cloudflareAnalyticsState.leaseUntil, new Date(now)),
+								lt(cloudflareAnalyticsState.leaseUntil, msToDate(now)),
 								// Corrupt-lease escape hatch: a live lease is always bounded by now+LEASE_MS,
 								// so anything beyond 2x that is impossible under normal operation (e.g. a
 								// clock jump or a crashed writer that left a bogus far-future value) and is
 								// safe to reclaim rather than let it wedge the org forever.
-								gt(cloudflareAnalyticsState.leaseUntil, new Date(now + 2 * LEASE_MS)),
+								gt(cloudflareAnalyticsState.leaseUntil, msToDate(now + 2 * LEASE_MS)),
 							),
 						),
 					)
@@ -1279,8 +1279,8 @@ export class CloudflareAnalyticsService extends Context.Service<
 				db
 					.update(cloudflareAnalyticsState)
 					.set({
-						leaseUntil: holdUntilMs == null ? null : new Date(holdUntilMs),
-						updatedAt: new Date(now),
+						leaseUntil: holdUntilMs == null ? null : msToDate(holdUntilMs),
+						updatedAt: msToDate(now),
 					})
 					.where(
 						and(
@@ -1322,8 +1322,8 @@ export class CloudflareAnalyticsService extends Context.Service<
 						dataset: dataset.id,
 						zoneId: zone.id,
 						zoneName: zone.name,
-						createdAt: new Date(now),
-						updatedAt: new Date(now),
+						createdAt: msToDate(now),
+						updatedAt: msToDate(now),
 					})),
 			)
 			const inserted =
@@ -1346,7 +1346,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 					yield* updateRows([existing.id], {
 						zoneName: zone.name,
 						enabled: true,
-						updatedAt: new Date(now),
+						updatedAt: msToDate(now),
 					})
 					existing.zoneName = zone.name
 					existing.enabled = true
@@ -1365,13 +1365,13 @@ export class CloudflareAnalyticsService extends Context.Service<
 				{
 					enabled: false,
 					lastError: "Zone no longer present on the Cloudflare account",
-					lastErrorAt: new Date(now),
-					updatedAt: new Date(now),
+					lastErrorAt: msToDate(now),
+					updatedAt: msToDate(now),
 				},
 			)
 			for (const row of vanished) row.enabled = false
 
-			yield* updateRows([anchorId], { discoveredAt: new Date(now), updatedAt: new Date(now) })
+			yield* updateRows([anchorId], { discoveredAt: msToDate(now), updatedAt: msToDate(now) })
 
 			return [...rows, ...inserted]
 		})
@@ -1392,7 +1392,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 				(row) =>
 					row.enabled &&
 					(row.settingsFetchedAt == null ||
-						now - row.settingsFetchedAt.getTime() > SETTINGS_TTL_MS),
+						now - dateToMs(row.settingsFetchedAt) > SETTINGS_TTL_MS),
 			)
 			if (stale.length === 0) return wrote
 
@@ -1477,13 +1477,13 @@ export class CloudflareAnalyticsService extends Context.Service<
 					if (settings === undefined) continue
 					const set: Partial<CloudflareAnalyticsStateInsert> = {
 						settingsJson: settings == null ? null : JSON.stringify(settings),
-						settingsFetchedAt: new Date(now),
+						settingsFetchedAt: msToDate(now),
 						quantilesAvailable: quantilesFromAvailableFields(
 							settings,
 							dataset.availableFieldsNeedle,
 						),
 						...(settings?.enabled === false ? { enabled: false } : undefined),
-						updatedAt: new Date(now),
+						updatedAt: msToDate(now),
 					}
 					const key = `${set.settingsJson}|${set.quantilesAvailable}|${set.enabled ?? ""}`
 					const group = updates.get(key)
@@ -1640,7 +1640,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 					kind = "other"
 				}
 				if (kind === "quantiles-unavailable") {
-					yield* updateRows(rowIds, { quantilesAvailable: false, updatedAt: new Date(now) })
+					yield* updateRows(rowIds, { quantilesAvailable: false, updatedAt: msToDate(now) })
 					// The next round rebuilds the document without the quantile fields — retry.
 					results.push({ part, outcome: { kind: "quantiles-downgraded" } })
 				} else if (kind === "disabled") {
@@ -1809,7 +1809,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 							originDatabase: config.origin.database,
 							originUser: config.origin.user,
 							deletedAt: null,
-							updatedAt: new Date(now),
+							updatedAt: msToDate(now),
 						}
 						const existing = existingByConfigId.get(config.id)
 						return existing !== undefined
@@ -1824,7 +1824,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 										id: randomUUID(),
 										orgId,
 										configId: config.id,
-										createdAt: new Date(now),
+										createdAt: msToDate(now),
 										...values,
 									}),
 								)
@@ -1846,7 +1846,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 						dbExecute((db) =>
 							db
 								.update(cloudflareHyperdriveConfigs)
-								.set({ deletedAt: new Date(now), updatedAt: new Date(now) })
+								.set({ deletedAt: msToDate(now), updatedAt: msToDate(now) })
 								.where(eq(cloudflareHyperdriveConfigs.id, row.id)),
 						),
 					{ concurrency: 4, discard: true },
@@ -1958,7 +1958,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 				// between reuse the reconciled state rows.
 				let rows: CloudflareAnalyticsStateRow[]
 				let liveScripts = parseLiveScripts(anchor.liveScriptsJson)
-				if (anchor.discoveredAt == null || now - anchor.discoveredAt.getTime() > DISCOVERY_TTL_MS) {
+				if (anchor.discoveredAt == null || now - dateToMs(anchor.discoveredAt) > DISCOVERY_TTL_MS) {
 					const zonesResult = yield* Effect.result(listZones(accessToken, accountId, apiBaseUrl))
 					if (Result.isFailure(zonesResult)) {
 						const error = zonesResult.failure
@@ -1992,7 +1992,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 						liveScripts = new Set(scriptsResult.success)
 						yield* updateRows([anchor.id], {
 							liveScriptsJson: JSON.stringify(scriptsResult.success),
-							updatedAt: new Date(now),
+							updatedAt: msToDate(now),
 						})
 					}
 					// Hyperdrive config inventory rides the same discovery TTL. It only feeds the
@@ -2107,8 +2107,8 @@ export class CloudflareAnalyticsService extends Context.Service<
 											Effect.map(() => {
 												progressed = true
 												if (item.phase === "head") {
-													const watermark = new Date(item.window.end)
-													const seed = new Date(item.window.start)
+													const watermark = msToDate(item.window.end)
+													const seed = msToDate(item.window.start)
 													for (const row of part.rows) {
 														row.watermarkAt = watermark
 														// Seed the backfill frontier once (mirrors advanceHead's
@@ -2116,7 +2116,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 														if (row.backfillAt == null) row.backfillAt = seed
 													}
 												} else {
-													const frontier = new Date(item.window.start)
+													const frontier = msToDate(item.window.start)
 													for (const row of part.rows) row.backfillAt = frontier
 												}
 											}),
@@ -2687,7 +2687,7 @@ export class CloudflareAnalyticsService extends Context.Service<
 						lastErrorAt: null,
 						discoveredAt: null,
 						leaseUntil: null,
-						updatedAt: new Date(now),
+						updatedAt: msToDate(now),
 					})
 					.where(and(eq(cloudflareAnalyticsState.orgId, orgId), ...accountFilter)),
 			)

--- a/apps/web/src/components/integrations/cloudflare-account-card.tsx
+++ b/apps/web/src/components/integrations/cloudflare-account-card.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react"
 import { Exit } from "effect"
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "@maple/ui/components/ui/alert"
+import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@maple/ui/components/ui/tooltip"
@@ -33,6 +34,58 @@ import {
 } from "./cloudflare-zone-board"
 
 const EMPTY_USAGE: RowUsage = { totalRequests: 0, lastDataAt: null, points: [] }
+
+/** The slice of a connected account the strip renders (schema class or legacy fallback). */
+interface ConnectedAccountEntry {
+	readonly accountId: string
+	readonly accountName: string | null
+	readonly analyticsCapable: boolean
+	readonly revoked: boolean
+	readonly zoneCount: number
+}
+
+/**
+ * The accounts the org's grant covers, one row per account with its health badges. One OAuth
+ * grant carries every account, so there is no per-account disconnect — changing the set means
+ * reconnecting and ticking different accounts on Cloudflare's consent screen.
+ */
+function CloudflareAccountsStrip({ accounts }: { readonly accounts: ReadonlyArray<ConnectedAccountEntry> }) {
+	if (accounts.length < 2) return null
+	return (
+		<div className="rounded-lg border border-border/60 bg-card">
+			<div className="border-b border-border/60 px-4 py-2.5">
+				<h3 className="text-xs font-medium text-muted-foreground">
+					Connected accounts ({accounts.length})
+				</h3>
+			</div>
+			<ul className="divide-y divide-border/60">
+				{accounts.map((account) => (
+					<li key={account.accountId} className="flex items-center gap-3 px-4 py-2.5">
+						<CloudflareMonoIcon size={16} className="shrink-0 text-muted-foreground" />
+						<div className="flex min-w-0 flex-col">
+							<span className="truncate text-sm font-medium">
+								{account.accountName ?? account.accountId}
+							</span>
+							<span className="truncate font-mono text-[11px] text-muted-foreground">
+								{account.accountId}
+							</span>
+						</div>
+						<div className="flex items-center gap-1.5">
+							{account.revoked ? (
+								<Badge variant="error">Reconnect required</Badge>
+							) : !account.analyticsCapable ? (
+								<Badge variant="warning">Needs updated access</Badge>
+							) : null}
+						</div>
+						<span className="ml-auto text-xs text-muted-foreground">
+							{account.zoneCount === 1 ? "1 zone" : `${account.zoneCount} zones`}
+						</span>
+					</li>
+				))}
+			</ul>
+		</div>
+	)
+}
 
 /**
  * Account-level Cloudflare OAuth connection (Authorization Code + PKCE). Distinct from the
@@ -94,6 +147,33 @@ export function CloudflareAccountCard() {
 		const known = new Set(status.zones.map((zone) => zone.name))
 		return usage.services.filter((service) => service.kind === "zone" && !known.has(service.displayName))
 	}, [usage, status])
+
+	// Connected accounts for the strip. Older API responses predate `accounts`; synthesize
+	// the single-connection entry from the legacy top-level fields during a deploy window.
+	const connectedAccounts = useMemo((): ReadonlyArray<ConnectedAccountEntry> => {
+		if (status?.connected !== true) return []
+		const list = status.accounts ?? []
+		if (list.length > 0) {
+			return list.map((account) => ({
+				accountId: account.accountId,
+				accountName: account.accountName,
+				analyticsCapable: account.analyticsCapable,
+				revoked: account.revoked,
+				zoneCount: account.zones.length,
+			}))
+		}
+		return status.accountId == null
+			? []
+			: [
+					{
+						accountId: status.accountId,
+						accountName: status.accountName,
+						analyticsCapable: status.analyticsCapable,
+						revoked: false,
+						zoneCount: status.zones.length,
+					},
+				]
+	}, [status])
 
 	// The first account-wide failure across zones/workers (revoked token, missing config, denied
 	// auth). Surfaced once as a banner instead of repeated — and unreadable — on every row.
@@ -258,6 +338,7 @@ export function CloudflareAccountCard() {
 
 	return (
 		<div className="flex flex-col gap-4">
+			<CloudflareAccountsStrip accounts={connectedAccounts} />
 			{hasReadout ? (
 				<>
 					{!usageFailed ? (
@@ -306,11 +387,21 @@ export function CloudflareHeaderActions() {
 	const disconnect = useAtomSet(MapleApiAtomClient.mutation("integrations", "cloudflareDisconnect"), {
 		mode: "promiseExit",
 	})
+	// Same memoized atom as the card — no extra fetch, just the account count for labels.
+	const statusResult = useAtomValue(
+		retainedQuery("integrations", "cloudflareStatus", {
+			reactivityKeys: ["cloudflareIntegrationStatus"],
+		}),
+	)
+	const accountCount = Result.builder(statusResult)
+		.onSuccess((s) => s.accounts?.length ?? (s.connected ? 1 : 0))
+		.orElse(() => 1)
 	const [disconnectBusy, setDisconnectBusy] = useState(false)
 	if (connectFlow === null) {
 		throw new Error("CloudflareHeaderActions must be rendered inside IntegrationConnectProvider")
 	}
 	const actionBusy = connectFlow.busy || disconnectBusy
+	const multiAccount = accountCount > 1
 
 	async function handleDisconnect() {
 		setDisconnectBusy(true)
@@ -319,9 +410,12 @@ export function CloudflareHeaderActions() {
 		})
 		setDisconnectBusy(false)
 		if (Exit.isSuccess(result)) {
-			toastManager.add({ title: "Cloudflare account disconnected", type: "success" })
+			toastManager.add({
+				title: multiAccount ? "Cloudflare accounts disconnected" : "Cloudflare account disconnected",
+				type: "success",
+			})
 		} else {
-			toastManager.add({ title: "Failed to disconnect Cloudflare account", type: "error" })
+			toastManager.add({ title: "Failed to disconnect Cloudflare", type: "error" })
 		}
 	}
 
@@ -329,7 +423,7 @@ export function CloudflareHeaderActions() {
 		<div className="flex items-center gap-2">
 			<Button size="sm" variant="outline" onClick={connectFlow.connect} disabled={actionBusy}>
 				{connectFlow.busy ? <LoaderIcon size={14} className="animate-spin" /> : null}
-				Reconnect
+				{multiAccount ? "Edit accounts" : "Reconnect"}
 			</Button>
 			<Button
 				size="sm"
@@ -339,7 +433,7 @@ export function CloudflareHeaderActions() {
 				className="border-destructive/40 text-destructive-foreground hover:bg-destructive/10 hover:text-destructive-foreground"
 			>
 				{disconnectBusy ? <LoaderIcon size={14} className="animate-spin" /> : null}
-				Disconnect
+				{multiAccount ? "Disconnect all" : "Disconnect"}
 			</Button>
 		</div>
 	)

--- a/packages/db/drizzle/0050_cloudflare_grant_accounts.sql
+++ b/packages/db/drizzle/0050_cloudflare_grant_accounts.sql
@@ -1,0 +1,9 @@
+DROP INDEX "cf_analytics_state_org_dataset_zone_idx";--> statement-breakpoint
+ALTER TABLE "cloudflare_analytics_state" ADD COLUMN "account_id" text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "cloudflare_hyperdrive_configs" ADD COLUMN "account_id" text;--> statement-breakpoint
+ALTER TABLE "oauth_connections" ADD COLUMN "granted_accounts_json" text;--> statement-breakpoint
+-- Backfill the new account dimension from the org's (single-account, pre-grant-list) Cloudflare
+-- connection. Runs before the unique index lands; rows of orgs with no connection keep ''.
+UPDATE "cloudflare_analytics_state" SET "account_id" = c."external_user_id" FROM "oauth_connections" c WHERE c."org_id" = "cloudflare_analytics_state"."org_id" AND c."provider" = 'cloudflare';--> statement-breakpoint
+UPDATE "cloudflare_hyperdrive_configs" SET "account_id" = c."external_user_id" FROM "oauth_connections" c WHERE c."org_id" = "cloudflare_hyperdrive_configs"."org_id" AND c."provider" = 'cloudflare';--> statement-breakpoint
+CREATE UNIQUE INDEX "cf_analytics_state_org_account_dataset_zone_idx" ON "cloudflare_analytics_state" USING btree ("org_id","account_id","dataset","zone_id");

--- a/packages/db/drizzle/meta/0050_snapshot.json
+++ b/packages/db/drizzle/meta/0050_snapshot.json
@@ -1,0 +1,8747 @@
+{
+  "id": "4c8a2222-430b-45e3-883e-1b3d57661ac1",
+  "prevId": "d60d7088-c27b-48cd-94b6-6d9fd59a02ff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_triage_settings": {
+      "name": "ai_triage_settings",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_runs_per_day": {
+          "name": "max_runs_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "max_passes_per_day": {
+          "name": "max_passes_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_delivery_events": {
+      "name": "alert_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_key": {
+          "name": "delivery_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message": {
+          "name": "provider_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "alert_delivery_events_org_idx": {
+          "name": "alert_delivery_events_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_delivery_events_org_incident_idx": {
+          "name": "alert_delivery_events_org_incident_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_delivery_events_due_idx": {
+          "name": "alert_delivery_events_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_delivery_events_claim_idx": {
+          "name": "alert_delivery_events_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_delivery_events_delivery_attempt_idx": {
+          "name": "alert_delivery_events_delivery_attempt_idx",
+          "columns": [
+            {
+              "expression": "delivery_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_destinations": {
+      "name": "alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_tag": {
+          "name": "secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_error": {
+          "name": "last_test_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "alert_destinations_org_idx": {
+          "name": "alert_destinations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_org_enabled_idx": {
+          "name": "alert_destinations_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_org_name_idx": {
+          "name": "alert_destinations_org_name_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_incidents": {
+      "name": "alert_incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incident_key": {
+          "name": "incident_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signal_type": {
+          "name": "signal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_upper": {
+          "name": "threshold_upper",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_triggered_at": {
+          "name": "first_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_value": {
+          "name": "last_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sample_count": {
+          "name": "last_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_delivered_event_type": {
+          "name": "last_delivered_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_notified_at": {
+          "name": "last_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_issue_id": {
+          "name": "error_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "alert_incidents_org_idx": {
+          "name": "alert_incidents_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_incidents_org_status_idx": {
+          "name": "alert_incidents_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_incidents_org_rule_idx": {
+          "name": "alert_incidents_org_rule_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_incidents_org_issue_idx": {
+          "name": "alert_incidents_org_issue_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "error_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_incidents_incident_key_idx": {
+          "name": "alert_incidents_incident_key_idx",
+          "columns": [
+            {
+              "expression": "incident_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_rule_claims": {
+      "name": "alert_rule_claims",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_scheduled_at": {
+          "name": "last_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "alert_rule_claims_org_idx": {
+          "name": "alert_rule_claims_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_rule_states": {
+      "name": "alert_rule_states",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'__total__'"
+        },
+        "consecutive_breaches": {
+          "name": "consecutive_breaches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "consecutive_healthy": {
+          "name": "consecutive_healthy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_value": {
+          "name": "last_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sample_count": {
+          "name": "last_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "alert_rule_states_org_idx": {
+          "name": "alert_rule_states_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "alert_rule_states_org_id_rule_id_group_key_pk": {
+          "name": "alert_rule_states_org_id_rule_id_group_key_pk",
+          "columns": [
+            "org_id",
+            "rule_id",
+            "group_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_rules": {
+      "name": "alert_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_template_json": {
+          "name": "notification_template_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_names_json": {
+          "name": "service_names_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_service_names_json": {
+          "name": "exclude_service_names_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environments_json": {
+          "name": "environments_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signal_type": {
+          "name": "signal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comparator": {
+          "name": "comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_upper": {
+          "name": "threshold_upper",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minimum_sample_count": {
+          "name": "minimum_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "consecutive_breaches_required": {
+          "name": "consecutive_breaches_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "consecutive_healthy_required": {
+          "name": "consecutive_healthy_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "renotify_interval_minutes": {
+          "name": "renotify_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "apdex_threshold_ms": {
+          "name": "apdex_threshold_ms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_builder_draft_json": {
+          "name": "query_builder_draft_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_query_sql": {
+          "name": "raw_query_sql",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_by": {
+          "name": "group_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_ids_json": {
+          "name": "destination_ids_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_spec_json": {
+          "name": "query_spec_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reducer": {
+          "name": "reducer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_count_strategy": {
+          "name": "sample_count_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_data_behavior": {
+          "name": "no_data_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_scheduled_at": {
+          "name": "last_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "alert_rules_org_idx": {
+          "name": "alert_rules_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_rules_org_enabled_idx": {
+          "name": "alert_rules_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_rules_org_name_idx": {
+          "name": "alert_rules_org_name_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_detector_settings": {
+      "name": "anomaly_detector_settings",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sensitivity": {
+          "name": "sensitivity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "muted_signals_json": {
+          "name": "muted_signals_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_detector_states": {
+      "name": "anomaly_detector_states",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detector_key": {
+          "name": "detector_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_type": {
+          "name": "signal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_env": {
+          "name": "deployment_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fingerprint_hash": {
+          "name": "fingerprint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_breaches": {
+          "name": "consecutive_breaches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "consecutive_healthy": {
+          "name": "consecutive_healthy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_value": {
+          "name": "last_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline_median": {
+          "name": "baseline_median",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sample_count": {
+          "name": "last_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_incident_id": {
+          "name": "open_incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_resolved_at": {
+          "name": "last_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_incident_id": {
+          "name": "last_incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "anomaly_detector_states_open_incident_idx": {
+          "name": "anomaly_detector_states_open_incident_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "open_incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"anomaly_detector_states\".\"open_incident_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anomaly_detector_states_evaluated_idx": {
+          "name": "anomaly_detector_states_evaluated_idx",
+          "columns": [
+            {
+              "expression": "last_evaluated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anomaly_detector_states_org_id_detector_key_pk": {
+          "name": "anomaly_detector_states_org_id_detector_key_pk",
+          "columns": [
+            "org_id",
+            "detector_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anomaly_incidents": {
+      "name": "anomaly_incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detector_key": {
+          "name": "detector_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signal_type": {
+          "name": "signal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_env": {
+          "name": "deployment_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fingerprint_hash": {
+          "name": "fingerprint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_issue_id": {
+          "name": "error_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_value": {
+          "name": "opened_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baseline_median": {
+          "name": "baseline_median",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baseline_sigma": {
+          "name": "baseline_sigma",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_value": {
+          "name": "threshold_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_value": {
+          "name": "last_observed_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sample_count": {
+          "name": "last_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_triggered_at": {
+          "name": "first_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolve_reason": {
+          "name": "resolve_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triage_status": {
+          "name": "triage_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprints_json": {
+          "name": "fingerprints_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reopen_count": {
+          "name": "reopen_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_reopened_at": {
+          "name": "last_reopened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "anomaly_incidents_org_status_triggered_idx": {
+          "name": "anomaly_incidents_org_status_triggered_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anomaly_incidents_org_triggered_idx": {
+          "name": "anomaly_incidents_org_triggered_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anomaly_incidents_org_detector_idx": {
+          "name": "anomaly_incidents_org_detector_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detector_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anomaly_incidents_org_issue_idx": {
+          "name": "anomaly_incidents_org_issue_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "error_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_email": {
+          "name": "created_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_org_id_idx": {
+          "name": "api_keys_org_id_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_analytics_state": {
+      "name": "cloudflare_analytics_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "dataset": {
+          "name": "dataset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "watermark_at": {
+          "name": "watermark_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_at": {
+          "name": "backfill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_json": {
+          "name": "settings_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_fetched_at": {
+          "name": "settings_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantiles_available": {
+          "name": "quantiles_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_scripts_json": {
+          "name": "live_scripts_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cf_analytics_state_org_account_dataset_zone_idx": {
+          "name": "cf_analytics_state_org_account_dataset_zone_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dataset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cf_analytics_state_org_idx": {
+          "name": "cf_analytics_state_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_hyperdrive_configs": {
+      "name": "cloudflare_hyperdrive_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_host": {
+          "name": "origin_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_port": {
+          "name": "origin_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_scheme": {
+          "name": "origin_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_database": {
+          "name": "origin_database",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_user": {
+          "name": "origin_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cloudflare_hyperdrive_configs_org_config_idx": {
+          "name": "cloudflare_hyperdrive_configs_org_config_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_hyperdrive_configs_org_idx": {
+          "name": "cloudflare_hyperdrive_configs_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_logpush_connectors": {
+      "name": "cloudflare_logpush_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset": {
+          "name": "dataset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http_requests'"
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_tag": {
+          "name": "secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_received_at": {
+          "name": "last_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_rotated_at": {
+          "name": "secret_rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cloudflare_logpush_connectors_org_idx": {
+          "name": "cloudflare_logpush_connectors_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_logpush_connectors_org_enabled_idx": {
+          "name": "cloudflare_logpush_connectors_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_logpush_connectors_secret_hash_unique": {
+          "name": "cloudflare_logpush_connectors_secret_hash_unique",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_device_authorizations": {
+      "name": "cli_device_authorizations",
+      "schema": "",
+      "columns": {
+        "device_code_hash": {
+          "name": "device_code_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_code_hash": {
+          "name": "user_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_org_id": {
+          "name": "approved_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_user_id": {
+          "name": "approved_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_roles": {
+          "name": "approved_roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_user_email": {
+          "name": "approved_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cli_device_authorizations_user_code_unique": {
+          "name": "cli_device_authorizations_user_code_unique",
+          "columns": [
+            {
+              "expression": "user_code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_device_authorizations_expires_idx": {
+          "name": "cli_device_authorizations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_authorizations": {
+      "name": "mcp_oauth_authorizations",
+      "schema": "",
+      "columns": {
+        "request_id_hash": {
+          "name": "request_id_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_code_hash": {
+          "name": "authorization_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_org_id": {
+          "name": "approved_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_user_id": {
+          "name": "approved_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_roles": {
+          "name": "approved_roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_user_email": {
+          "name": "approved_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_oauth_authorizations_code_unique": {
+          "name": "mcp_oauth_authorizations_code_unique",
+          "columns": [
+            {
+              "expression": "authorization_code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_authorizations_expires_idx": {
+          "name": "mcp_oauth_authorizations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_refresh_tokens": {
+      "name": "mcp_oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_key_id": {
+          "name": "access_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replaced_by_id": {
+          "name": "replaced_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_oauth_refresh_tokens_hash_unique": {
+          "name": "mcp_oauth_refresh_tokens_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_refresh_tokens_family_idx": {
+          "name": "mcp_oauth_refresh_tokens_family_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_refresh_tokens_expires_idx": {
+          "name": "mcp_oauth_refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_devices": {
+      "name": "mobile_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_activity_start_token": {
+          "name": "live_activity_start_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_pushed_at": {
+          "name": "last_pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mobile_devices_org_platform_token_unique": {
+          "name": "mobile_devices_org_platform_token_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_devices_org_idx": {
+          "name": "mobile_devices_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_devices_user_idx": {
+          "name": "mobile_devices_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_shares": {
+      "name": "dashboard_shares",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "widget_id": {
+          "name": "widget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_iv": {
+          "name": "token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_tag": {
+          "name": "token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_suffix": {
+          "name": "token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dashboard_shares_token_hash_unq": {
+          "name": "dashboard_shares_token_hash_unq",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_shares_live_unq": {
+          "name": "dashboard_shares_live_unq",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(widget_id, '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "revoked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_shares_org_dashboard_idx": {
+          "name": "dashboard_shares_org_dashboard_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_shares_id_idx": {
+          "name": "dashboard_shares_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_shares_dashboard_fk": {
+          "name": "dashboard_shares_dashboard_fk",
+          "tableFrom": "dashboard_shares",
+          "tableTo": "dashboards",
+          "columnsFrom": [
+            "org_id",
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "org_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dashboard_shares_org_id_id_pk": {
+          "name": "dashboard_shares_org_id_id_pk",
+          "columns": [
+            "org_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_versions": {
+      "name": "dashboard_versions",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_kind": {
+          "name": "change_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_version_id": {
+          "name": "source_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dashboard_versions_org_dashboard_idx": {
+          "name": "dashboard_versions_org_dashboard_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_versions_org_dashboard_version_unq": {
+          "name": "dashboard_versions_org_dashboard_version_unq",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_versions_org_id_id_pk": {
+          "name": "dashboard_versions_org_id_id_pk",
+          "columns": [
+            "org_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "dashboards_org_updated_idx": {
+          "name": "dashboards_org_updated_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_org_name_idx": {
+          "name": "dashboards_org_name_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboards_org_id_id_pk": {
+          "name": "dashboards_org_id_id_pk",
+          "columns": [
+            "org_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.digest_subscriptions": {
+      "name": "digest_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "digest_subscriptions_org_user_idx": {
+          "name": "digest_subscriptions_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "digest_subscriptions_org_enabled_idx": {
+          "name": "digest_subscriptions_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actors": {
+      "name": "actors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "actors_org_user_idx": {
+          "name": "actors_org_user_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "actors_org_agent_name_idx": {
+          "name": "actors_org_agent_name_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "actors_org_type_idx": {
+          "name": "actors_org_type_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_fingerprint_candidates": {
+      "name": "error_fingerprint_candidates",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_hash": {
+          "name": "fingerprint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exception_message": {
+          "name": "exception_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_label": {
+          "name": "error_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_versions_json": {
+          "name": "service_versions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "error_fingerprint_candidates_last_seen_idx": {
+          "name": "error_fingerprint_candidates_last_seen_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "error_fingerprint_candidates_org_id_fingerprint_hash_pk": {
+          "name": "error_fingerprint_candidates_org_id_fingerprint_hash_pk",
+          "columns": [
+            "org_id",
+            "fingerprint_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_incidents": {
+      "name": "error_incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_triggered_at": {
+          "name": "first_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "error_incidents_org_issue_idx": {
+          "name": "error_incidents_org_issue_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_incidents_org_status_idx": {
+          "name": "error_incidents_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_issue_events": {
+      "name": "error_issue_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_state": {
+          "name": "from_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_state": {
+          "name": "to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "error_issue_events_issue_idx": {
+          "name": "error_issue_events_issue_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issue_events_actor_idx": {
+          "name": "error_issue_events_actor_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issue_events_type_idx": {
+          "name": "error_issue_events_type_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_issue_pull_requests": {
+      "name": "error_issue_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_repo_id": {
+          "name": "external_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_commit_sha": {
+          "name": "merge_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_source": {
+          "name": "link_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_by_actor_id": {
+          "name": "linked_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "error_issue_pull_requests_issue_pr_idx": {
+          "name": "error_issue_pull_requests_issue_pr_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issue_pull_requests_repo_number_idx": {
+          "name": "error_issue_pull_requests_repo_number_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issue_pull_requests_issue_idx": {
+          "name": "error_issue_pull_requests_issue_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_issue_states": {
+      "name": "error_issue_states",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_occurrence_at": {
+          "name": "last_observed_occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_incident_id": {
+          "name": "open_incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "error_issue_states_org_id_issue_id_pk": {
+          "name": "error_issue_states_org_id_issue_id_pk",
+          "columns": [
+            "org_id",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_issue_verifications": {
+      "name": "error_issue_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verify_after": {
+          "name": "verify_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baseline_versions_json": {
+          "name": "baseline_versions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "baseline_occurrence_count": {
+          "name": "baseline_occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "baseline_rate_per_hour": {
+          "name": "baseline_rate_per_hour",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_note": {
+          "name": "verdict_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_merge_occurrence_count": {
+          "name": "post_merge_occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "error_issue_verifications_due_idx": {
+          "name": "error_issue_verifications_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verify_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issue_verifications_issue_idx": {
+          "name": "error_issue_verifications_issue_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issue_verifications_open_idx": {
+          "name": "error_issue_verifications_open_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"error_issue_verifications\".\"status\" in ('waiting', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_issues": {
+      "name": "error_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'error'"
+        },
+        "source_ref_json": {
+          "name": "source_ref_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint_hash": {
+          "name": "fingerprint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_version": {
+          "name": "fingerprint_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exception_type": {
+          "name": "exception_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exception_message": {
+          "name": "exception_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_label": {
+          "name": "error_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "top_frame": {
+          "name": "top_frame",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_state": {
+          "name": "workflow_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'triage'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity_source": {
+          "name": "severity_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_actor_id": {
+          "name": "assigned_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_holder_actor_id": {
+          "name": "lease_holder_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_actor_id": {
+          "name": "resolved_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_resolved_at": {
+          "name": "last_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_regressed_at": {
+          "name": "last_regressed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regression_count": {
+          "name": "regression_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "seen_versions_json": {
+          "name": "seen_versions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resolved_versions_json": {
+          "name": "resolved_versions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "snooze_until": {
+          "name": "snooze_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "error_issues_org_fp_idx": {
+          "name": "error_issues_org_fp_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issues_org_workflow_idx": {
+          "name": "error_issues_org_workflow_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issues_org_severity_idx": {
+          "name": "error_issues_org_severity_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issues_org_live_seen_idx": {
+          "name": "error_issues_org_live_seen_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"error_issues\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issues_org_fp_version_idx": {
+          "name": "error_issues_org_fp_version_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issues_org_assignee_idx": {
+          "name": "error_issues_org_assignee_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issues_lease_expiry_idx": {
+          "name": "error_issues_lease_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_issues_org_archived_idx": {
+          "name": "error_issues_org_archived_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"error_issues\".\"archived_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_notification_deliveries": {
+      "name": "error_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_key": {
+          "name": "delivery_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "error_notification_deliveries_due_idx": {
+          "name": "error_notification_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_notification_deliveries_org_idx": {
+          "name": "error_notification_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_notification_deliveries_key_destination_idx": {
+          "name": "error_notification_deliveries_key_destination_idx",
+          "columns": [
+            {
+              "expression": "delivery_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_notification_policies": {
+      "name": "error_notification_policies",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "destination_ids_json": {
+          "name": "destination_ids_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notify_on_first_seen": {
+          "name": "notify_on_first_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_on_regression": {
+          "name": "notify_on_regression",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_on_resolve": {
+          "name": "notify_on_resolve",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_on_transition_in_review": {
+          "name": "notify_on_transition_in_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_on_transition_done": {
+          "name": "notify_on_transition_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_on_claim": {
+          "name": "notify_on_claim",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "min_occurrence_count": {
+          "name": "min_occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'warning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_tick_states": {
+      "name": "error_tick_states",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "processed_through": {
+          "name": "processed_through",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bootstrap_completed": {
+          "name": "bootstrap_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "error_tick_states_claim_idx": {
+          "name": "error_tick_states_claim_idx",
+          "columns": [
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_escalation_policies": {
+      "name": "issue_escalation_policies",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_escalations": {
+      "name": "issue_escalations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "delivery_results_json": {
+          "name": "delivery_results_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_escalations_dedupe_idx": {
+          "name": "issue_escalations_dedupe_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_escalations_due_idx": {
+          "name": "issue_escalations_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_escalations_org_issue_idx": {
+          "name": "issue_escalations_org_issue_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_lens_runs": {
+      "name": "investigation_lens_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lens_id": {
+          "name": "lens_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claim": {
+          "name": "claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_note": {
+          "name": "progress_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_count": {
+          "name": "tool_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "elapsed_ms": {
+          "name": "elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens_name": {
+          "name": "lens_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens_question": {
+          "name": "lens_question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_hit": {
+          "name": "deadline_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hypothesis_json": {
+          "name": "hypothesis_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_json": {
+          "name": "evidence_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mechanism": {
+          "name": "mechanism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "self_doubt": {
+          "name": "self_doubt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_actions_json": {
+          "name": "suggested_actions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranked_at": {
+          "name": "ranked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "investigation_lens_runs_lens_idx": {
+          "name": "investigation_lens_runs_lens_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lens_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_lens_runs_org_inv_idx": {
+          "name": "investigation_lens_runs_org_inv_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_lens_runs_investigation_id_investigations_id_fk": {
+          "name": "investigation_lens_runs_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_lens_runs",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigations": {
+      "name": "investigations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'investigating'"
+        },
+        "seeded_by": {
+          "name": "seeded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "subject_json": {
+          "name": "subject_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_kind": {
+          "name": "incident_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_json": {
+          "name": "report_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fanout_state": {
+          "name": "fanout_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "fanout_size": {
+          "name": "fanout_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plan_json": {
+          "name": "plan_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planner_model": {
+          "name": "planner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planner_elapsed_ms": {
+          "name": "planner_elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validator_note": {
+          "name": "validator_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validator_elapsed_ms": {
+          "name": "validator_elapsed_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fanout_deadline_at": {
+          "name": "fanout_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fanout_attempt": {
+          "name": "fanout_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autonomous_turns": {
+          "name": "autonomous_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diagnosed_at": {
+          "name": "diagnosed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "investigations_incident_idx": {
+          "name": "investigations_incident_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incident_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"investigations\".\"incident_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_org_created_idx": {
+          "name": "investigations_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_org_issue_idx": {
+          "name": "investigations_org_issue_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_org_status_idx": {
+          "name": "investigations_org_status_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_activities": {
+      "name": "live_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "push_token": {
+          "name": "push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "live_activities_device_incident_unique": {
+          "name": "live_activities_device_incident_unique",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "live_activities_incident_idx": {
+          "name": "live_activities_incident_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_auth_states": {
+      "name": "oauth_auth_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_auth_states_expires_idx": {
+          "name": "oauth_auth_states_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_connections": {
+      "name": "oauth_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_email": {
+          "name": "external_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_name": {
+          "name": "external_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_accounts_json": {
+          "name": "granted_accounts_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_iv": {
+          "name": "access_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_tag": {
+          "name": "access_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_ciphertext": {
+          "name": "refresh_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_iv": {
+          "name": "refresh_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_tag": {
+          "name": "refresh_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_connections_org_provider_idx": {
+          "name": "oauth_connections_org_provider_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_connections_org_idx": {
+          "name": "oauth_connections_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_onboarding_state": {
+      "name": "org_onboarding_state",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_data_requested": {
+          "name": "demo_data_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checklist_dismissed_at": {
+          "name": "checklist_dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_data_received_at": {
+          "name": "first_data_received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "welcome_email_sent_at": {
+          "name": "welcome_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connect_nudge_email_sent_at": {
+          "name": "connect_nudge_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stalled_email_sent_at": {
+          "name": "stalled_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activation_email_sent_at": {
+          "name": "activation_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_ingest_attribute_mappings": {
+      "name": "org_ingest_attribute_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_context": {
+          "name": "source_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_ingest_attribute_mappings_org_idx": {
+          "name": "org_ingest_attribute_mappings_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_recommendation_issues": {
+      "name": "org_recommendation_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation_key": {
+          "name": "recommendation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_key": {
+          "name": "canonical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_recommendation_issues_org_idx": {
+          "name": "org_recommendation_issues_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_recommendation_issues_org_key_idx": {
+          "name": "org_recommendation_issues_org_key_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommendation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_ingest_keys": {
+      "name": "org_ingest_keys",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_hash": {
+          "name": "public_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_ciphertext": {
+          "name": "private_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_iv": {
+          "name": "private_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_tag": {
+          "name": "private_key_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_hash": {
+          "name": "private_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_rotated_at": {
+          "name": "public_rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_rotated_at": {
+          "name": "private_rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "org_ingest_keys_public_key_unique": {
+          "name": "org_ingest_keys_public_key_unique",
+          "columns": [
+            {
+              "expression": "public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_ingest_keys_public_key_hash_unique": {
+          "name": "org_ingest_keys_public_key_hash_unique",
+          "columns": [
+            {
+              "expression": "public_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_ingest_keys_private_key_hash_unique": {
+          "name": "org_ingest_keys_private_key_hash_unique",
+          "columns": [
+            {
+              "expression": "private_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_ingest_keys_org_id_pk": {
+          "name": "org_ingest_keys_org_id_pk",
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_ingest_sampling_policies": {
+      "name": "org_ingest_sampling_policies",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trace_sample_ratio": {
+          "name": "trace_sample_ratio",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "always_keep_error_spans": {
+          "name": "always_keep_error_spans",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "always_keep_slow_spans_ms": {
+          "name": "always_keep_slow_spans_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_clickhouse_settings": {
+      "name": "org_clickhouse_settings",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ch_url": {
+          "name": "ch_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ch_user": {
+          "name": "ch_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ch_password_ciphertext": {
+          "name": "ch_password_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ch_password_iv": {
+          "name": "ch_password_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ch_password_tag": {
+          "name": "ch_password_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ch_database": {
+          "name": "ch_database",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_clickhouse_settings_org_id_pk": {
+          "name": "org_clickhouse_settings_org_id_pk",
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_clickhouse_schema_apply_runs": {
+      "name": "org_clickhouse_schema_apply_runs",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_migration": {
+          "name": "current_migration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps_total": {
+          "name": "steps_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps_done": {
+          "name": "steps_done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_versions": {
+          "name": "applied_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_clickhouse_schema_apply_runs_org_id_pk": {
+          "name": "org_clickhouse_schema_apply_runs_org_id_pk",
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planetscale_connections": {
+      "name": "planetscale_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ps_organization": {
+          "name": "ps_organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scrape_target_id": {
+          "name": "scrape_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_ciphertext": {
+          "name": "webhook_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_iv": {
+          "name": "webhook_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_tag": {
+          "name": "webhook_secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_permissions_json": {
+          "name": "detected_permissions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inventory_at": {
+          "name": "last_inventory_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_inventory_error": {
+          "name": "last_inventory_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "planetscale_connections_org_idx": {
+          "name": "planetscale_connections_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planetscale_databases": {
+      "name": "planetscale_databases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mysql'"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branches_json": {
+          "name": "branches_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "planetscale_databases_org_db_idx": {
+          "name": "planetscale_databases_org_db_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "database_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "planetscale_databases_org_idx": {
+          "name": "planetscale_databases_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planetscale_events": {
+      "name": "planetscale_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "database_name": {
+          "name": "database_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "planetscale_events_dedupe_idx": {
+          "name": "planetscale_events_dedupe_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "database_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "planetscale_events_org_db_time_idx": {
+          "name": "planetscale_events_org_db_time_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "database_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "planetscale_events_org_time_idx": {
+          "name": "planetscale_events_org_time_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planetscale_poll_state": {
+      "name": "planetscale_poll_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset": {
+          "name": "dataset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "database_id": {
+          "name": "database_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "watermark_at": {
+          "name": "watermark_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "planetscale_poll_state_org_dataset_db_idx": {
+          "name": "planetscale_poll_state_org_dataset_db_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dataset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "database_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "planetscale_poll_state_org_idx": {
+          "name": "planetscale_poll_state_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scrape_target_checks": {
+      "name": "scrape_target_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "scrape_target_checks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_target_key": {
+          "name": "sub_target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "samples_scraped": {
+          "name": "samples_scraped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "samples_post_relabel": {
+          "name": "samples_post_relabel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scrape_target_checks_target_checked_idx": {
+          "name": "scrape_target_checks_target_checked_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scrape_target_checks_target_id_scrape_targets_id_fk": {
+          "name": "scrape_target_checks_target_id_scrape_targets_id_fk",
+          "tableFrom": "scrape_target_checks",
+          "tableTo": "scrape_targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scrape_targets": {
+      "name": "scrape_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prometheus'"
+        },
+        "discovery_config_json": {
+          "name": "discovery_config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scrape_interval_seconds": {
+          "name": "scrape_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "labels_json": {
+          "name": "labels_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_credentials_ciphertext": {
+          "name": "auth_credentials_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_credentials_iv": {
+          "name": "auth_credentials_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_credentials_tag": {
+          "name": "auth_credentials_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_scrape_at": {
+          "name": "last_scrape_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_scrape_error": {
+          "name": "last_scrape_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scrape_targets_org_idx": {
+          "name": "scrape_targets_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scrape_targets_org_enabled_idx": {
+          "name": "scrape_targets_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_workspaces": {
+      "name": "slack_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_token_iv": {
+          "name": "bot_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_token_tag": {
+          "name": "bot_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_secret_ciphertext": {
+          "name": "api_key_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_secret_iv": {
+          "name": "api_key_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_secret_tag": {
+          "name": "api_key_secret_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slack_workspaces_team_id_idx": {
+          "name": "slack_workspaces_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_workspaces_org_idx": {
+          "name": "slack_workspaces_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_workspaces_active_org_idx": {
+          "name": "slack_workspaces_active_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slack_workspaces\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vcs_commits": {
+      "name": "vcs_commits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authored_at": {
+          "name": "authored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vcs_commits_repo_sha_idx": {
+          "name": "vcs_commits_repo_sha_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vcs_commits_org_sha_idx": {
+          "name": "vcs_commits_org_sha_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vcs_installations": {
+      "name": "vcs_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_installation_id": {
+          "name": "external_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_avatar_url": {
+          "name": "account_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vcs_installations_provider_external_idx": {
+          "name": "vcs_installations_provider_external_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vcs_installations_org_idx": {
+          "name": "vcs_installations_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vcs_repositories": {
+      "name": "vcs_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_repo_id": {
+          "name": "external_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "tracked_branch": {
+          "name": "tracked_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vcs_repositories_org_repo_idx": {
+          "name": "vcs_repositories_org_repo_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vcs_repositories_org_idx": {
+          "name": "vcs_repositories_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vcs_repositories_installation_idx": {
+          "name": "vcs_repositories_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vcs_repository_branches": {
+      "name": "vcs_repository_branches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vcs_repository_branches_repo_name_idx": {
+          "name": "vcs_repository_branches_repo_name_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vcs_repository_branches_org_idx": {
+          "name": "vcs_repository_branches_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1787920777688,
       "tag": "0049_home_list_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1788008344968,
+      "tag": "0050_cloudflare_grant_accounts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/cloudflare-analytics-state.ts
+++ b/packages/db/src/schema/cloudflare-analytics-state.ts
@@ -11,6 +11,9 @@ export const cloudflareAnalyticsState = pgTable(
 	{
 		id: text("id").notNull().primaryKey(),
 		orgId: text("org_id").$type<OrgId>().notNull(),
+		// Cloudflare account the row belongs to (one of the org grant's accounts). "" only on
+		// orphaned pre-multi-account rows whose org had no connection when the backfill ran.
+		accountId: text("account_id").notNull().default(""),
 		dataset: text("dataset").notNull(),
 		// "" for account-scoped datasets — kept NOT NULL so the (org, dataset, zone) unique index
 		// treats the account row like any other.
@@ -51,7 +54,12 @@ export const cloudflareAnalyticsState = pgTable(
 		updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull(),
 	},
 	(table) => [
-		uniqueIndex("cf_analytics_state_org_dataset_zone_idx").on(table.orgId, table.dataset, table.zoneId),
+		uniqueIndex("cf_analytics_state_org_account_dataset_zone_idx").on(
+			table.orgId,
+			table.accountId,
+			table.dataset,
+			table.zoneId,
+		),
 		index("cf_analytics_state_org_idx").on(table.orgId),
 	],
 )

--- a/packages/db/src/schema/cloudflare-hyperdrive-configs.ts
+++ b/packages/db/src/schema/cloudflare-hyperdrive-configs.ts
@@ -13,6 +13,8 @@ export const cloudflareHyperdriveConfigs = pgTable(
 	{
 		id: text("id").notNull().primaryKey(),
 		orgId: text("org_id").$type<OrgId>().notNull(),
+		/** Cloudflare account the config was discovered on; null on pre-multi-account rows. */
+		accountId: text("account_id"),
 		/** Cloudflare's 32-hex Hyperdrive config id (what `db.namespace` collapses from). */
 		configId: text("config_id").notNull(),
 		name: text("name").notNull(),

--- a/packages/db/src/schema/oauth-connections.ts
+++ b/packages/db/src/schema/oauth-connections.ts
@@ -12,6 +12,10 @@ export const oauthConnections = pgTable(
 		// Provider-agnostic display label for the connected principal (e.g. a Cloudflare account
 		// name). Kept separate from externalUserEmail so that column only ever holds real emails.
 		externalAccountName: text("external_account_name"),
+		// JSON array of every external principal the grant covers ([{ id, name }]) for providers
+		// whose single OAuth grant may span several (Cloudflare accounts). Null when the grant
+		// covers only the principal in externalUserId.
+		grantedAccountsJson: text("granted_accounts_json"),
 		connectedByUserId: text("connected_by_user_id").$type<UserId>().notNull(),
 		scope: text("scope").notNull().default(""),
 		accessTokenCiphertext: text("access_token_ciphertext").notNull(),

--- a/packages/domain/src/http/integrations.ts
+++ b/packages/domain/src/http/integrations.ts
@@ -102,10 +102,30 @@ export class CloudflareAnalyticsWorkersStatus extends Schema.Class<CloudflareAna
 }) {}
 
 /**
- * Connection state of the Cloudflare integration. `accountId`/`accountName` identify the single
- * Cloudflare account the OAuth token is scoped to (Maple enforces exactly one account per org).
- * `analyticsCapable` is false when the stored grant predates the analytics scopes — the UI offers
- * an "Update permissions" reconnect; `zones`/`workers` surface the poller's per-dataset state.
+ * One Cloudflare account covered by the org's OAuth grant (a single consent screen may tick
+ * several) with its collection state. `analyticsCapable` is false when the stored grant
+ * predates the analytics scopes — the UI offers an "Update access" reconnect; `revoked` means
+ * Cloudflare rejected the grant (which is grant-wide: one token covers every account) and the
+ * poller skips it until reconnect.
+ */
+export class CloudflareConnectedAccountStatus extends Schema.Class<CloudflareConnectedAccountStatus>(
+	"CloudflareConnectedAccountStatus",
+)({
+	accountId: Schema.String,
+	accountName: Schema.NullOr(Schema.String),
+	connectedByUserId: Schema.NullOr(UserId),
+	scope: Schema.String,
+	analyticsCapable: Schema.Boolean,
+	revoked: Schema.Boolean,
+	zones: Schema.Array(CloudflareAnalyticsZoneStatus),
+	workers: Schema.NullOr(CloudflareAnalyticsWorkersStatus),
+}) {}
+
+/**
+ * Connection state of the Cloudflare integration. `accounts` carries every account the org's
+ * grant covers; the top-level `accountId`/`accountName`/`scope`/`zones`/`workers` fields are
+ * the pre-multi-account single-account view (first account + all accounts' zones merged),
+ * kept so bundles from before `accounts` existed keep rendering during a deploy window.
  */
 export class CloudflareIntegrationStatus extends Schema.Class<CloudflareIntegrationStatus>(
 	"CloudflareIntegrationStatus",
@@ -116,6 +136,8 @@ export class CloudflareIntegrationStatus extends Schema.Class<CloudflareIntegrat
 	connectedByUserId: Schema.NullOr(UserId),
 	scope: Schema.NullOr(Schema.String),
 	analyticsCapable: Schema.Boolean,
+	/** optionalKey only for deploy-window compat; always sent. */
+	accounts: Schema.optionalKey(Schema.Array(CloudflareConnectedAccountStatus)),
 	zones: Schema.Array(CloudflareAnalyticsZoneStatus),
 	workers: Schema.NullOr(CloudflareAnalyticsWorkersStatus),
 }) {}
@@ -675,12 +697,12 @@ export const VCS_PULL_REQUESTS_DEFAULT_LIMIT = 50
  * picker lists. Read straight from the provider, never persisted: a stale PR
  * state in a picker is worse than a slightly slower one.
  */
-export class VcsPullRequestsResponse extends Schema.Class<VcsPullRequestsResponse>(
-	"VcsPullRequestsResponse",
-)({
-	repository: Schema.String,
-	pullRequests: Schema.Array(PullRequestSummary),
-}) {}
+export class VcsPullRequestsResponse extends Schema.Class<VcsPullRequestsResponse>("VcsPullRequestsResponse")(
+	{
+		repository: Schema.String,
+		pullRequests: Schema.Array(PullRequestSummary),
+	},
+) {}
 
 export class VcsCommitDetailResponse extends Schema.Class<VcsCommitDetailResponse>("VcsCommitDetailResponse")(
 	{
@@ -1034,7 +1056,9 @@ export class IntegrationsApiGroup extends HttpApiGroup.make("integrations")
 			query: Schema.Struct({
 				repository: Schema.String.check(Schema.isMinLength(1)),
 				limit: Schema.optional(
-					Schema.FiniteFromString.check(Schema.isBetween({ minimum: 1, maximum: VCS_PULL_REQUESTS_MAX_LIMIT })),
+					Schema.FiniteFromString.check(
+						Schema.isBetween({ minimum: 1, maximum: VCS_PULL_REQUESTS_MAX_LIMIT }),
+					),
 				),
 			}),
 			success: VcsPullRequestsResponse,


### PR DESCRIPTION
## What

A customer who ticks several Cloudflare accounts on the OAuth consent screen currently gets a hard refusal ("The Cloudflare authorization spans multiple accounts — reconnect and grant access to a single account"). This PR makes that grant connect and poll every account it covers, while keeping **one connection row per org** — one grant, one token, one refresh chain, so the token-rotation race that motivated the refusal doesn't exist.

Supersedes #673, which modeled multi-account as one single-account grant per connection row ("add accounts one round-trip at a time"). We only need the single-grant flow, so that model — the per-account `oauth_connections` unique index, `connectionScope` helper changes, per-account disconnect endpoint and "Add account" UI — is dropped; its account-parameterized analytics/poller/status work is kept.

## How

- `oauth_connections` gains a nullable `granted_accounts_json` column (`[{id, name}]` for every account the grant covers); `externalUserId`/`externalAccountName` keep the first account. Readers fall back to the row's own principal for pre-existing rows.
- `completeConnect` accepts N≥1 accounts (still refuses zero accounts and a missing refresh token, revoking the unpersisted token upstream). Reconnecting replaces the whole grant/account set.
- `getValidAccessToken(orgId, accountId?)` validates `accountId` against the grant; the account-less lookup fails as ambiguous when the grant covers more than one account. The top-traffic route resolves the owning account from the zone's state row.
- The analytics poller polls each granted account as its own unit — per-account lease anchor, 20-call budget, discovery, and state rows (`account_id` on `cloudflare_analytics_state`, unique index now org/account/dataset/zone, and on `cloudflare_hyperdrive_configs`).
- `CloudflareIntegrationStatus.accounts` (optionalKey for deploy-window compat) breaks collection state down per account; legacy top-level fields stay as first account + merged zones. Revocation is grant-wide (one token), so there is no per-account disconnect.
- Web: read-only "Connected accounts" strip when the grant covers ≥2 accounts; header shows "Edit accounts" / "Disconnect all" — both act on the whole grant via the existing reconnect/disconnect flows.

## Migration

`0050_cloudflare_grant_accounts.sql` hand-carries backfill UPDATEs (`account_id` from each org's existing single-account connection) between the generated statements — do not regenerate it from schema alone. **Prod migrations are manual: apply 0050 before deploying**; the poller ignores `account_id = ''` rows, so deploying first would stall existing orgs' polling.

## Known tradeoff

Same-named Workers in two accounts still merge under one warehouse service name; the `cloudflare.account.id` resource attribute is the disambiguator (unchanged from #673's design).

## Tests

- `completeConnect` accepts a two-account grant: both accounts listed in order, one row, fan-out persisted, per-account token addressing, refusals for out-of-grant and ambiguous lookups.
- Reconnecting with a different grant replaces the account set (still one row; old accounts' tokens refuse).
- `pollOrg` polls every account of the grant with its own state rows, zones, and workers anchors; integration status breaks it down per account and merges the legacy view.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790600837&installation_model_id=427786&pr_number=684&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F684&signature=bd9a776f2a182438a38c9bf9dcfcb21917aa9fcbe28cdd75724679858a835aa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->