### PR TITLE
feat(ingest): segment the WAL and back it with S3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,7 @@ there is no Prometheus `/metrics` endpoint. At high QPS set `OTEL_TRACES_SAMPLER
 `api-v2.md` (v2 public API spec) · `error-issue-lifecycle.md` (how an error becomes an issue,
 gets diagnosed, fixed and verified — read before touching `apps/api/src/services/errors/`) ·
 `sampling-throughput.md` · `persistence.md` ·
+`ingest-wal-durability.md` (WAL segments, the S3 tier, and what survives a task dying) ·
 `warehouse-rollups.md` (MV/rollup tiering contract — read before adding a materialized view) ·
 `sst-fork-workflow.md` · `local-mode.md` (single-binary CLI + embedded chDB) ·
 `tinybird-pr-branches.md` · `otel-spec/` (OTel spec map @ v1.58.0 — start at its README).

--- a/apps/ingest/alchemy.run.ts
+++ b/apps/ingest/alchemy.run.ts
@@ -394,6 +394,67 @@ export const createMapleIngest = ({ stage, domains, region, replayBlobs }: Creat
 		// PUTs to authorizes against the task role, which therefore needs this
 		// action on the cluster's tasks — the cluster ARN differs from a task ARN
 		// only in the resource prefix.
+		// Durability tier for the WAL (`apps/ingest/src/wal_store.rs`). The lanes
+		// live on ephemeral storage that dies with the task, so every sealed,
+		// unexported segment is also kept here and claimed by whichever task boots
+		// next. Objects are transient — deleted as soon as their frames export —
+		// so the bucket holds the current backlog, not the traffic.
+		// Named up front so the env var below is a plain string rather than an
+		// Output the container definition cannot take.
+		const walBucketName = name("ingest-wal")
+		const walSegments = yield* AWS.S3.Bucket("ingest-wal-segments", {
+			bucketName: walBucketName,
+			// Nothing here is worth keeping: a segment is either claimed within
+			// minutes or its frames are long gone. The rule is the backstop for
+			// segments whose delete was lost (a task killed between exporting and
+			// retiring the object), which would otherwise be billed forever.
+			lifecycleRules: [
+				{
+					ID: "expire-wal-segments",
+					Status: "Enabled",
+					Filter: { Prefix: "wal/" },
+					Expiration: { Days: 7 },
+					AbortIncompleteMultipartUpload: { DaysAfterInitiation: 1 },
+				},
+			],
+			// The gateway is the only reader and writer, and a WAL segment is raw
+			// customer telemetry.
+			publicAccessBlock: {
+				blockPublicAcls: true,
+				blockPublicPolicy: true,
+				ignorePublicAcls: true,
+				restrictPublicBuckets: true,
+			},
+			encryption: { sseAlgorithm: "AES256" },
+			// Destroying the stack must not fail on leftover segments; anything
+			// still here at that point is backlog nobody is coming back for.
+			forceDestroy: true,
+			tags: { Service: "maple-ingest", Region: region },
+		})
+
+		// Scoped to the one prefix the gateway uses. ListBucket is on the bucket
+		// itself (the others are on objects), which is why it is a separate
+		// statement — orphan claiming lists owners and segments.
+		const walSegmentsPolicy = yield* AWS.IAM.Policy("ingest-wal-segments", {
+			policyName: name("ingest-wal-segments"),
+			policyDocument: {
+				Version: "2012-10-17",
+				Statement: [
+					{
+						Effect: "Allow",
+						Action: ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+						Resource: [Output.map(walSegments.bucketArn, (arn) => `${arn}/wal/*`)],
+					},
+					{
+						Effect: "Allow",
+						Action: ["s3:ListBucket"],
+						Resource: [walSegments.bucketArn],
+						Condition: { StringLike: { "s3:prefix": ["wal/*"] } },
+					},
+				],
+			},
+		})
+
 		const taskProtectionPolicy = yield* AWS.IAM.Policy("ingest-task-protection", {
 			policyName: name("ingest-task-protection"),
 			policyDocument: {
@@ -416,7 +477,7 @@ export const createMapleIngest = ({ stage, domains, region, replayBlobs }: Creat
 		const service = yield* AWS.ECS.Service("ingest", {
 			cluster,
 			serviceName: name("ingest"),
-			taskRoleManagedPolicyArns: [taskProtectionPolicy.policyArn],
+			taskRoleManagedPolicyArns: [taskProtectionPolicy.policyArn, walSegmentsPolicy.policyArn],
 
 			// Alchemy creates a private ECR repository and pushes under a content-hash
 			// tag, rebuilding only when the context hash changes — so a deploy that
@@ -522,6 +583,13 @@ export const createMapleIngest = ({ stage, domains, region, replayBlobs }: Creat
 
 				INGEST_QUEUE_MAX_BYTES: String(WAL_MAX_BYTES),
 				INGEST_WAL_SHARDS: String(WAL_SHARDS),
+				// No credentials: the task role signs these requests, and the VPC's
+				// S3 gateway endpoint keeps the traffic off the public path (there
+				// is no NAT to pay for it).
+				INGEST_WAL_S3_BUCKET: walBucketName,
+				INGEST_WAL_S3_REGION: resolveAwsRegion(region),
+				...(yield* optionalPlain("INGEST_WAL_SEGMENT_MAX_BYTES")),
+				...(yield* optionalPlain("INGEST_WAL_S3_ORPHAN_AFTER_SECS")),
 
 				// R2, not S3: within ~$0.0001/session of each other, and S3 would need
 				// a Worker SigV4 read path that does not exist. Per-object PUTs are

--- a/apps/ingest/benches/ingest_bench.rs
+++ b/apps/ingest/benches/ingest_bench.rs
@@ -118,6 +118,7 @@ impl BenchFixture {
                 org_queue_max_bytes: u64::MAX,
                 queue_channel_capacity: 100_000,
                 wal_shards: 4,
+                wal_segment_max_bytes: maple_ingest::telemetry::WAL_SEGMENT_MAX_BYTES,
                 batch_max_rows: 5_000,
                 batch_max_bytes: 4 * 1024 * 1024,
                 batch_max_wait: Duration::from_millis(10),

--- a/apps/ingest/benches/ingest_bench.rs
+++ b/apps/ingest/benches/ingest_bench.rs
@@ -119,6 +119,7 @@ impl BenchFixture {
                 queue_channel_capacity: 100_000,
                 wal_shards: 4,
                 wal_segment_max_bytes: maple_ingest::telemetry::WAL_SEGMENT_MAX_BYTES,
+                wal_store_heartbeat_interval: maple_ingest::wal_store::DEFAULT_HEARTBEAT_INTERVAL,
                 batch_max_rows: 5_000,
                 batch_max_bytes: 4 * 1024 * 1024,
                 batch_max_wait: Duration::from_millis(10),

--- a/apps/ingest/src/aws.rs
+++ b/apps/ingest/src/aws.rs
@@ -1,0 +1,695 @@
+//! SigV4 signing, ECS credentials, and the handful of S3 verbs this binary
+//! issues.
+//!
+//! Deliberately not `aws-sdk-s3`. The gateway needs PUT/GET/LIST/DELETE against
+//! one bucket, plus the conditional PUT that makes orphan claiming safe; that is
+//! a few hundred lines on top of the `hmac`/`sha2`/`chrono`/`reqwest` crates
+//! already linked for ingest-key hashing, against the whole smithy stack and its
+//! compile time in a binary whose image size is a deploy-latency cost.
+//!
+//! Two callers: `r2.rs` (replay chunks, static keys, Cloudflare R2) and
+//! `wal_store.rs` (WAL segments, task-role credentials, AWS S3).
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+
+use crate::telemetry::HttpClient;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const ALGORITHM: &str = "AWS4-HMAC-SHA256";
+
+/// Credentials for one signed request. `session_token` is present for the
+/// temporary credentials an ECS task role hands out and absent for static keys.
+#[derive(Clone)]
+pub struct Credentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: Option<String>,
+}
+
+/// Hand-written so the secret is not one `{:?}` away from a log line.
+impl std::fmt::Debug for Credentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Credentials")
+            .field("access_key_id", &self.access_key_id)
+            .field("session_token", &self.session_token.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Where a request's credentials come from.
+///
+/// `Static` is a pair of long-lived keys from the environment. `Container`
+/// fetches from the ECS agent's credentials endpoint and refreshes before the
+/// credentials expire — which is what lets the task carry an IAM role instead of
+/// a secret.
+#[derive(Debug)]
+pub enum CredentialsProvider {
+    Static(Credentials),
+    Container {
+        client: HttpClient,
+        url: String,
+        authorization: Option<String>,
+        cached: Mutex<Option<CachedCredentials>>,
+    },
+}
+
+pub struct CachedCredentials {
+    credentials: Credentials,
+    /// Refresh once this passes, rather than at expiry: a request signed with
+    /// credentials that expire mid-flight is a 403 with nothing to retry.
+    refresh_after: Instant,
+}
+
+impl std::fmt::Debug for CachedCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedCredentials").finish_non_exhaustive()
+    }
+}
+
+#[derive(Deserialize)]
+struct ContainerCredentialsResponse {
+    #[serde(rename = "AccessKeyId")]
+    access_key_id: String,
+    #[serde(rename = "SecretAccessKey")]
+    secret_access_key: String,
+    #[serde(rename = "Token")]
+    token: Option<String>,
+    #[serde(rename = "Expiration")]
+    expiration: Option<String>,
+}
+
+/// Refresh this far before the credentials actually expire.
+const CREDENTIAL_REFRESH_MARGIN: Duration = Duration::from_secs(5 * 60);
+/// How long credentials without a parseable expiry are trusted.
+const CREDENTIAL_FALLBACK_TTL: Duration = Duration::from_secs(15 * 60);
+
+impl CredentialsProvider {
+    /// The provider ECS gives a task, or `None` when the environment has no
+    /// container credentials endpoint (a dev machine, or a container without a
+    /// task role).
+    pub fn from_ecs_environment(client: HttpClient) -> Option<Self> {
+        let url = std::env::var("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+            .ok()
+            .or_else(|| {
+                std::env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+                    .ok()
+                    .map(|path| format!("http://169.254.170.2{path}"))
+            })?;
+        Some(Self::Container {
+            client,
+            url,
+            authorization: std::env::var("AWS_CONTAINER_AUTHORIZATION_TOKEN").ok(),
+            cached: Mutex::new(None),
+        })
+    }
+
+    pub fn from_static(access_key_id: String, secret_access_key: String) -> Self {
+        Self::Static(Credentials {
+            access_key_id,
+            secret_access_key,
+            session_token: None,
+        })
+    }
+
+    pub async fn credentials(&self) -> Result<Credentials, String> {
+        match self {
+            Self::Static(credentials) => Ok(credentials.clone()),
+            Self::Container {
+                client,
+                url,
+                authorization,
+                cached,
+            } => {
+                let mut slot = cached.lock().await;
+                if let Some(current) = slot.as_ref() {
+                    if Instant::now() < current.refresh_after {
+                        return Ok(current.credentials.clone());
+                    }
+                }
+                let mut request = client.get(url).timeout(Duration::from_secs(5));
+                if let Some(token) = authorization {
+                    request = request.header("authorization", token);
+                }
+                let response = request
+                    .send()
+                    .await
+                    .map_err(|error| format!("fetch container credentials: {error}"))?;
+                if !response.status().is_success() {
+                    return Err(format!(
+                        "container credentials endpoint responded {}",
+                        response.status().as_u16()
+                    ));
+                }
+                let body: ContainerCredentialsResponse = response
+                    .json()
+                    .await
+                    .map_err(|error| format!("decode container credentials: {error}"))?;
+                let ttl = body
+                    .expiration
+                    .as_deref()
+                    .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
+                    .and_then(|expiry| {
+                        (expiry.with_timezone(&Utc) - Utc::now())
+                            .to_std()
+                            .ok()
+                            .map(|ttl| ttl.saturating_sub(CREDENTIAL_REFRESH_MARGIN))
+                    })
+                    .filter(|ttl| !ttl.is_zero())
+                    .unwrap_or(CREDENTIAL_FALLBACK_TTL);
+                let credentials = Credentials {
+                    access_key_id: body.access_key_id,
+                    secret_access_key: body.secret_access_key,
+                    session_token: body.token,
+                };
+                *slot = Some(CachedCredentials {
+                    credentials: credentials.clone(),
+                    refresh_after: Instant::now() + ttl,
+                });
+                Ok(credentials)
+            }
+        }
+    }
+}
+
+#[expect(
+    missing_debug_implementations,
+    reason = "carries the signing secret; a derived Debug would put it one {:?} from a log line"
+)]
+pub struct SigningParams<'a> {
+    pub method: &'a str,
+    pub canonical_uri: &'a str,
+    pub canonical_query: &'a str,
+    /// Lowercase header names; sorted internally, so call order is free.
+    pub headers: &'a [(String, String)],
+    pub payload_sha256: &'a str,
+    pub now: DateTime<Utc>,
+    pub access_key_id: &'a str,
+    pub secret_access_key: &'a str,
+    pub region: &'a str,
+    pub service: &'a str,
+}
+
+pub fn authorization_header(params: &SigningParams) -> String {
+    let mut headers: Vec<(String, String)> = params
+        .headers
+        .iter()
+        .map(|(name, value)| (name.to_ascii_lowercase(), value.trim().to_owned()))
+        .collect();
+    headers.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let signed_headers = headers
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect::<Vec<_>>()
+        .join(";");
+    let canonical_headers = headers
+        .iter()
+        .fold(String::new(), |mut out, (name, value)| {
+            out.push_str(name);
+            out.push(':');
+            out.push_str(value);
+            out.push('\n');
+            out
+        });
+
+    let canonical_request = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        params.method,
+        params.canonical_uri,
+        params.canonical_query,
+        canonical_headers,
+        signed_headers,
+        params.payload_sha256,
+    );
+
+    let datestamp = params.now.format("%Y%m%d").to_string();
+    let scope = format!(
+        "{}/{}/{}/aws4_request",
+        datestamp, params.region, params.service
+    );
+    let string_to_sign = format!(
+        "{}\n{}\n{}\n{}",
+        ALGORITHM,
+        amz_date(params.now),
+        scope,
+        hex(&Sha256::digest(canonical_request.as_bytes())),
+    );
+
+    let signing_key = signing_key(
+        params.secret_access_key,
+        &datestamp,
+        params.region,
+        params.service,
+    );
+    let signature = hex(&hmac(&signing_key, string_to_sign.as_bytes()));
+
+    format!(
+        "{ALGORITHM} Credential={}/{scope}, SignedHeaders={signed_headers}, Signature={signature}",
+        params.access_key_id,
+    )
+}
+
+fn signing_key(secret_access_key: &str, datestamp: &str, region: &str, service: &str) -> Vec<u8> {
+    let mut key = hmac(
+        format!("AWS4{secret_access_key}").as_bytes(),
+        datestamp.as_bytes(),
+    );
+    key = hmac(&key, region.as_bytes());
+    key = hmac(&key, service.as_bytes());
+    hmac(&key, b"aws4_request")
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "HMAC accepts keys of any length, so `new_from_slice` cannot fail here"
+)]
+fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("hmac accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+pub fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(char::from(HEX_LOWER[usize::from(byte >> 4)]));
+        out.push(char::from(HEX_LOWER[usize::from(byte & 0x0f)]));
+    }
+    out
+}
+
+const HEX_LOWER: &[u8; 16] = b"0123456789abcdef";
+const HEX_UPPER: &[u8; 16] = b"0123456789ABCDEF";
+
+pub fn amz_date(now: DateTime<Utc>) -> String {
+    now.format("%Y%m%dT%H%M%SZ").to_string()
+}
+
+/// RFC 3986 encoding for a URI path: `/` stays a separator, everything outside
+/// the unreserved set is percent-encoded with uppercase hex. A signature that
+/// disagrees with the request line by one byte is a 403 with no useful message,
+/// so encode properly rather than trusting the caller.
+pub fn uri_encode_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for byte in path.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
+                out.push(*byte as char);
+            }
+            _ => {
+                out.push('%');
+                out.push(char::from(HEX_UPPER[usize::from(byte >> 4)]));
+                out.push(char::from(HEX_UPPER[usize::from(byte & 0x0f)]));
+            }
+        }
+    }
+    out
+}
+
+/// Same rules as a path segment, except `/` is also encoded — query values are
+/// not path separators.
+fn uri_encode_query(value: &str) -> String {
+    uri_encode_path(value).replace('/', "%2F")
+}
+
+pub fn host_from_endpoint(endpoint: &str) -> String {
+    endpoint
+        .split_once("://")
+        .map_or(endpoint, |(_, rest)| rest)
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .to_owned()
+}
+
+#[derive(Debug)]
+pub enum S3Error {
+    /// The request never got a response (DNS, TLS, connect, timeout).
+    Transport(String),
+    /// A non-2xx status, with a bounded prefix of the XML error document.
+    Status { status: u16, body: String },
+}
+
+impl std::fmt::Display for S3Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transport(message) => write!(f, "s3 transport error: {message}"),
+            Self::Status { status, body } => write!(f, "s3 responded {status}: {body}"),
+        }
+    }
+}
+
+impl std::error::Error for S3Error {}
+
+impl S3Error {
+    pub fn status(&self) -> Option<u16> {
+        match self {
+            Self::Transport(_) => None,
+            Self::Status { status, .. } => Some(*status),
+        }
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::Transport(_) => true,
+            Self::Status { status, .. } => matches!(status, 429 | 500 | 502 | 503 | 504),
+        }
+    }
+
+    /// Stable low-cardinality label for `error.type`.
+    pub fn error_kind(&self) -> &'static str {
+        match self {
+            Self::Transport(_) => "s3_transport",
+            Self::Status { status, .. } => match status {
+                412 => "s3_precondition_failed",
+                429 => "s3_throttled",
+                500..=599 => "s3_server_error",
+                _ => "s3_rejected",
+            },
+        }
+    }
+}
+
+/// One object in a `ListObjectsV2` page.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct S3Object {
+    pub key: String,
+    pub last_modified: Option<DateTime<Utc>>,
+    pub size: u64,
+}
+
+/// A bucket, addressed path-style, signed per request.
+///
+/// Path-style keeps one host for signing and DNS, which matters for the S3
+/// gateway endpoint the ingest VPC routes through (there is no NAT, so a
+/// virtual-hosted name that resolves outside the endpoint's prefix list would
+/// simply not be reachable).
+pub struct S3Client {
+    client: HttpClient,
+    endpoint: String,
+    host: String,
+    bucket: String,
+    region: String,
+    credentials: Arc<CredentialsProvider>,
+    timeout: Duration,
+}
+
+impl std::fmt::Debug for S3Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Client")
+            .field("endpoint", &self.endpoint)
+            .field("bucket", &self.bucket)
+            .field("region", &self.region)
+            .finish_non_exhaustive()
+    }
+}
+
+impl S3Client {
+    pub fn new(
+        client: impl Into<HttpClient>,
+        endpoint: &str,
+        bucket: String,
+        region: String,
+        credentials: Arc<CredentialsProvider>,
+        timeout: Duration,
+    ) -> Self {
+        let endpoint = endpoint.trim_end_matches('/').to_owned();
+        let host = host_from_endpoint(&endpoint);
+        Self {
+            client: client.into(),
+            endpoint,
+            host,
+            bucket,
+            region,
+            credentials,
+            timeout,
+        }
+    }
+
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    /// PUT an object. `if_none_match` set to `*` makes the write conditional on
+    /// the key not existing, which S3 answers with 412 when it does — the
+    /// primitive orphan claiming is built on.
+    pub async fn put(&self, key: &str, body: Vec<u8>, if_none_match: bool) -> Result<(), S3Error> {
+        let mut headers = vec![(
+            "content-type".to_owned(),
+            "application/octet-stream".to_owned(),
+        )];
+        if if_none_match {
+            headers.push(("if-none-match".to_owned(), "*".to_owned()));
+        }
+        self.send("PUT", key, "", headers, body).await.map(drop)
+    }
+
+    pub async fn get(&self, key: &str) -> Result<Vec<u8>, S3Error> {
+        self.send("GET", key, "", Vec::new(), Vec::new()).await
+    }
+
+    pub async fn delete(&self, key: &str) -> Result<(), S3Error> {
+        match self.send("DELETE", key, "", Vec::new(), Vec::new()).await {
+            // S3 answers 204 for a key that was never there; treat an explicit
+            // 404 the same way so a re-run of a half-finished cleanup is a no-op.
+            Err(S3Error::Status { status: 404, .. }) | Ok(_) => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Every object under `prefix`, following continuation tokens.
+    ///
+    /// `max_keys` bounds one page; the loop is bounded by `max_pages` so a
+    /// pathological prefix cannot turn a boot into an unbounded listing.
+    pub async fn list(&self, prefix: &str, max_pages: usize) -> Result<Vec<S3Object>, S3Error> {
+        let mut objects = Vec::new();
+        let mut token: Option<String> = None;
+        for _ in 0..max_pages {
+            // Query parameters must be sorted by key for the canonical request.
+            let mut query = format!(
+                "continuation-token={}&list-type=2&max-keys=1000&prefix={}",
+                token.as_deref().map(uri_encode_query).unwrap_or_default(),
+                uri_encode_query(prefix),
+            );
+            if token.is_none() {
+                query = format!(
+                    "list-type=2&max-keys=1000&prefix={}",
+                    uri_encode_query(prefix)
+                );
+            }
+            let body = self.send("GET", "", &query, Vec::new(), Vec::new()).await?;
+            let body = String::from_utf8_lossy(&body);
+            objects.extend(parse_list_objects(&body));
+            match parse_tag(&body, "NextContinuationToken") {
+                Some(next) if parse_tag(&body, "IsTruncated").as_deref() == Some("true") => {
+                    token = Some(next);
+                }
+                _ => return Ok(objects),
+            }
+        }
+        Ok(objects)
+    }
+
+    async fn send(
+        &self,
+        method: &str,
+        key: &str,
+        canonical_query: &str,
+        extra_headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    ) -> Result<Vec<u8>, S3Error> {
+        let credentials = self
+            .credentials
+            .credentials()
+            .await
+            .map_err(S3Error::Transport)?;
+        let canonical_uri = if key.is_empty() {
+            format!("/{}", self.bucket)
+        } else {
+            format!("/{}/{}", self.bucket, uri_encode_path(key))
+        };
+        let payload_sha256 = hex(&Sha256::digest(&body));
+        let now = Utc::now();
+
+        let mut headers = extra_headers;
+        headers.push(("host".to_owned(), self.host.clone()));
+        headers.push(("x-amz-content-sha256".to_owned(), payload_sha256.clone()));
+        headers.push(("x-amz-date".to_owned(), amz_date(now)));
+        if let Some(token) = &credentials.session_token {
+            headers.push(("x-amz-security-token".to_owned(), token.clone()));
+        }
+
+        let authorization = authorization_header(&SigningParams {
+            method,
+            canonical_uri: &canonical_uri,
+            canonical_query,
+            headers: &headers,
+            payload_sha256: &payload_sha256,
+            now,
+            access_key_id: &credentials.access_key_id,
+            secret_access_key: &credentials.secret_access_key,
+            region: &self.region,
+            service: "s3",
+        });
+
+        let url = if canonical_query.is_empty() {
+            format!("{}{}", self.endpoint, canonical_uri)
+        } else {
+            format!("{}{}?{}", self.endpoint, canonical_uri, canonical_query)
+        };
+        let mut request = self
+            .client
+            .request(
+                method
+                    .parse()
+                    .map_err(|_| S3Error::Transport(format!("bad method {method}")))?,
+                url,
+            )
+            .timeout(self.timeout)
+            .header("authorization", authorization);
+        for (name, value) in &headers {
+            // `host` is set by reqwest from the URL; re-setting it risks a
+            // mismatch with what we just signed.
+            if name != "host" {
+                request = request.header(name.as_str(), value.as_str());
+            }
+        }
+
+        let response = request
+            .body(body)
+            .send()
+            .await
+            .map_err(|error| S3Error::Transport(error.to_string()))?;
+        let status = response.status();
+        let body = response.bytes().await.unwrap_or_default();
+        if status.is_success() {
+            return Ok(body.to_vec());
+        }
+        Err(S3Error::Status {
+            status: status.as_u16(),
+            body: String::from_utf8_lossy(&body).chars().take(512).collect(),
+        })
+    }
+}
+
+/// First value of `<tag>…</tag>`, or `None`.
+fn parse_tag(xml: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = xml.find(&open)? + open.len();
+    let end = xml[start..].find(&close)? + start;
+    Some(xml[start..end].to_owned())
+}
+
+/// The `<Contents>` entries of a `ListObjectsV2` response.
+///
+/// A hand-rolled reader rather than an XML crate: the response shape is fixed,
+/// the fields are three, and the keys this binary lists are its own — they
+/// contain no characters that would need entity decoding.
+fn parse_list_objects(xml: &str) -> Vec<S3Object> {
+    let mut objects = Vec::new();
+    for chunk in xml.split("<Contents>").skip(1) {
+        let Some(entry) = chunk.split("</Contents>").next() else {
+            continue;
+        };
+        let Some(key) = parse_tag(entry, "Key") else {
+            continue;
+        };
+        objects.push(S3Object {
+            key,
+            last_modified: parse_tag(entry, "LastModified")
+                .and_then(|raw| DateTime::parse_from_rfc3339(&raw).ok())
+                .map(|stamp| stamp.with_timezone(&Utc)),
+            size: parse_tag(entry, "Size")
+                .and_then(|raw| raw.parse::<u64>().ok())
+                .unwrap_or(0),
+        });
+    }
+    objects
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_objects_parses_keys_sizes_and_timestamps() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>wal/v1/segments/task-a/000000000007.seg</Key>
+    <LastModified>2026-08-29T10:11:12.000Z</LastModified>
+    <Size>8388608</Size>
+  </Contents>
+  <Contents>
+    <Key>wal/v1/owners/task-a</Key>
+    <LastModified>2026-08-29T10:12:00.000Z</LastModified>
+    <Size>0</Size>
+  </Contents>
+</ListBucketResult>"#;
+        let objects = parse_list_objects(xml);
+        assert_eq!(objects.len(), 2);
+        assert_eq!(objects[0].key, "wal/v1/segments/task-a/000000000007.seg");
+        assert_eq!(objects[0].size, 8_388_608);
+        assert_eq!(
+            objects[0].last_modified.unwrap().to_rfc3339(),
+            "2026-08-29T10:11:12+00:00"
+        );
+        assert_eq!(objects[1].size, 0);
+    }
+
+    #[test]
+    fn list_objects_ignores_common_prefixes() {
+        // A delimited listing carries <CommonPrefixes>, which has no <Key> and
+        // must not be mistaken for an object.
+        let xml = "<ListBucketResult><CommonPrefixes><Prefix>wal/v1/segments/task-a/</Prefix>\
+                   </CommonPrefixes></ListBucketResult>";
+        assert!(parse_list_objects(xml).is_empty());
+    }
+
+    #[test]
+    fn signing_matches_the_aws_sigv4_get_vanilla_case() {
+        // The canonical example from AWS's SigV4 test suite (get-vanilla), which
+        // pins header sorting, the scope string and the key derivation together.
+        let now = DateTime::parse_from_rfc3339("2015-08-30T12:36:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let headers = vec![
+            ("host".to_owned(), "example.amazonaws.com".to_owned()),
+            ("x-amz-date".to_owned(), amz_date(now)),
+        ];
+        let authorization = authorization_header(&SigningParams {
+            method: "GET",
+            canonical_uri: "/",
+            canonical_query: "",
+            headers: &headers,
+            payload_sha256: &hex(&Sha256::digest(b"")),
+            now,
+            access_key_id: "AKIDEXAMPLE",
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            region: "us-east-1",
+            service: "service",
+        });
+        assert_eq!(
+            authorization,
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, \
+             SignedHeaders=host;x-amz-date, \
+             Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"
+        );
+    }
+
+    #[test]
+    fn query_encoding_escapes_slashes() {
+        assert_eq!(uri_encode_query("wal/v1/a b"), "wal%2Fv1%2Fa%20b");
+        assert_eq!(uri_encode_path("wal/v1/a b"), "wal/v1/a%20b");
+    }
+}

--- a/apps/ingest/src/lib.rs
+++ b/apps/ingest/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod ai_session;
+pub mod aws;
 pub mod clickhouse_insert_mappings;
 pub mod metrics;
 pub mod otel;
@@ -7,3 +8,4 @@ pub mod r2;
 pub mod session_analytics;
 pub mod telemetry;
 pub mod usage_metrics;
+pub mod wal_store;

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -41,6 +41,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use hmac::{Hmac, Mac};
 use maple_ingest::ai_session;
+use maple_ingest::aws::CredentialsProvider as AwsCredentialsProvider;
 use maple_ingest::clickhouse_insert_mappings::SCHEMA_VERSION as CLICKHOUSE_SCHEMA_VERSION;
 use maple_ingest::metrics;
 use maple_ingest::otel::{
@@ -60,6 +61,7 @@ use maple_ingest::telemetry::{
     TinybirdMirrorConfig,
 };
 use maple_ingest::usage_metrics::{billable_gb, usage_cardinality_view, UsageMetrics};
+use maple_ingest::wal_store::WalSegmentStore;
 use moka::future::Cache;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
@@ -125,6 +127,18 @@ struct ReplayBlobStoreConfig {
     timeout: Duration,
 }
 
+/// Where sealed WAL segments are shipped so a task that dies without draining
+/// does not take its backlog with it. Unset means the WAL is local-only, which
+/// is what self-hosted and local runs use.
+#[derive(Clone, Debug)]
+struct WalStoreSettings {
+    store: maple_ingest::wal_store::WalStoreConfig,
+    /// Static credentials, when the deployment supplies them instead of relying
+    /// on the task role.
+    access_key_id: Option<String>,
+    secret_access_key: Option<String>,
+}
+
 #[derive(Clone)]
 struct AppConfig {
     port: u16,
@@ -173,6 +187,7 @@ struct AppConfig {
     /// exiting anyway. Must fit inside the ECS `stopTimeout` (SIGTERM → SIGKILL
     /// window) or the drain is cut off mid-flight.
     shutdown_drain_secs: u64,
+    wal_store: Option<WalStoreSettings>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -315,6 +330,14 @@ impl AppConfig {
             })
         };
 
+        // Shared by the pipeline (which runs the heartbeat task) and the store
+        // config (which decides how stale a heartbeat has to be).
+        let heartbeat_secs = parse_u64(
+            "INGEST_WAL_S3_HEARTBEAT_SECS",
+            std::env::var("INGEST_WAL_S3_HEARTBEAT_SECS").ok(),
+            maple_ingest::wal_store::DEFAULT_HEARTBEAT_INTERVAL.as_secs(),
+        )?;
+
         let tinybird = TinybirdConfig {
             endpoint: std::env::var("TINYBIRD_HOST")
                 .unwrap_or_default()
@@ -355,6 +378,7 @@ impl AppConfig {
                 std::env::var("INGEST_WAL_SEGMENT_MAX_BYTES").ok(),
                 maple_ingest::telemetry::WAL_SEGMENT_MAX_BYTES,
             )?,
+            wal_store_heartbeat_interval: Duration::from_secs(heartbeat_secs),
             batch_max_rows: parse_usize(
                 "INGEST_BATCH_MAX_ROWS",
                 std::env::var("INGEST_BATCH_MAX_ROWS").ok(),
@@ -581,6 +605,58 @@ impl AppConfig {
 
         // 90s fits inside the deployed 120s stopTimeout with margin for the
         // in-flight-request drain that runs before it.
+        // WAL durability tier. An unset bucket keeps the WAL local-only, which
+        // is the self-hosted and local-dev shape; on ECS the task role signs the
+        // requests, so credentials are optional here.
+        let wal_store = match std::env::var("INGEST_WAL_S3_BUCKET")
+            .ok()
+            .map(|v| v.trim().to_owned())
+            .filter(|v| !v.is_empty())
+        {
+            None => None,
+            Some(bucket) => {
+                let region = std::env::var("INGEST_WAL_S3_REGION")
+                    .ok()
+                    .map(|v| v.trim().to_owned())
+                    .filter(|v| !v.is_empty())
+                    .or_else(|| std::env::var("AWS_REGION").ok())
+                    .ok_or_else(|| {
+                        "INGEST_WAL_S3_REGION is required when INGEST_WAL_S3_BUCKET is set"
+                            .to_owned()
+                    })?;
+                let endpoint = std::env::var("INGEST_WAL_S3_ENDPOINT")
+                    .ok()
+                    .map(|v| v.trim().to_owned())
+                    .filter(|v| !v.is_empty())
+                    .unwrap_or_else(|| format!("https://s3.{region}.amazonaws.com"));
+                Some(WalStoreSettings {
+                    store: maple_ingest::wal_store::WalStoreConfig {
+                        endpoint,
+                        bucket,
+                        region,
+                        prefix: std::env::var("INGEST_WAL_S3_PREFIX")
+                            .ok()
+                            .map(|v| v.trim().to_owned())
+                            .filter(|v| !v.is_empty())
+                            .unwrap_or_else(|| "wal".to_owned()),
+                        timeout: Duration::from_millis(parse_u64(
+                            "INGEST_WAL_S3_TIMEOUT_MS",
+                            std::env::var("INGEST_WAL_S3_TIMEOUT_MS").ok(),
+                            10_000,
+                        )?),
+                        orphan_after: Duration::from_secs(parse_u64(
+                            "INGEST_WAL_S3_ORPHAN_AFTER_SECS",
+                            std::env::var("INGEST_WAL_S3_ORPHAN_AFTER_SECS").ok(),
+                            maple_ingest::wal_store::DEFAULT_ORPHAN_AFTER.as_secs(),
+                        )?),
+                        heartbeat_interval: Duration::from_secs(heartbeat_secs),
+                    },
+                    access_key_id: std::env::var("INGEST_WAL_S3_ACCESS_KEY_ID").ok(),
+                    secret_access_key: std::env::var("INGEST_WAL_S3_SECRET_ACCESS_KEY").ok(),
+                })
+            }
+        };
+
         let shutdown_drain_secs = parse_u64(
             "INGEST_SHUTDOWN_DRAIN_SECS",
             std::env::var("INGEST_SHUTDOWN_DRAIN_SECS").ok(),
@@ -612,6 +688,7 @@ impl AppConfig {
             internal_org_id,
             trust_proxy_geo,
             shutdown_drain_secs,
+            wal_store,
         })
     }
 }
@@ -2038,12 +2115,43 @@ async fn main() {
             None
         };
 
+    // Credentials come from the ECS task role unless the deployment supplies a
+    // key pair — the same choice the replay bucket makes, except that on ECS the
+    // role is the default rather than the exception.
+    let wal_segment_store = config.wal_store.as_ref().and_then(|settings| {
+        let credentials = match (&settings.access_key_id, &settings.secret_access_key) {
+            (Some(key), Some(secret)) => Some(AwsCredentialsProvider::from_static(
+                key.clone(),
+                secret.clone(),
+            )),
+            _ => AwsCredentialsProvider::from_ecs_environment(http_client.clone()),
+        };
+        let Some(credentials) = credentials else {
+            warn!(
+                bucket = settings.store.bucket,
+                "INGEST_WAL_S3_BUCKET is set but no credentials are available; the WAL stays local-only"
+            );
+            return None;
+        };
+        info!(
+            bucket = settings.store.bucket,
+            prefix = settings.store.prefix,
+            "WAL segments will be shipped to the durability object store"
+        );
+        Some(Arc::new(WalSegmentStore::new(
+            http_client.clone(),
+            &settings.store,
+            Arc::new(credentials),
+        )))
+    });
+
     let telemetry_pipeline = if config.write_mode.uses_tinybird() || direct_clickhouse_possible {
-        match TelemetryPipeline::new_with_clickhouse_validation(
+        match TelemetryPipeline::new_with_object_store(
             config.tinybird.clone(),
             http_client.clone(),
             clickhouse_target_provider,
             config.write_mode.uses_tinybird(),
+            wal_segment_store,
         )
         .await
         {
@@ -2267,7 +2375,19 @@ async fn main() {
             warn!(
                 remaining_bytes = remaining,
                 deadline_secs = drain_deadline.as_secs(),
-                "Shutdown drain deadline hit with WAL backlog remaining; frames will replay if this task's storage survives"
+                "Shutdown drain deadline hit with WAL backlog remaining"
+            );
+        }
+        // Even a clean drain runs this: it retires the owner heartbeat, so a
+        // successor claims anything left instead of waiting out the staleness
+        // window. With a backlog it also seals and ships the tail, which is the
+        // difference between "replays if this task's storage survives" (it does
+        // not — Fargate ephemeral storage dies with the task) and "replays".
+        let shipped = pipeline.flush_wal_to_object_store().await;
+        if shipped > 0 {
+            info!(
+                shipped_bytes = shipped,
+                "Shipped the undrained WAL tail to the object store"
             );
         }
     }
@@ -7144,6 +7264,7 @@ mod tests {
             queue_channel_capacity: 10,
             wal_shards: 1,
             wal_segment_max_bytes: maple_ingest::telemetry::WAL_SEGMENT_MAX_BYTES,
+            wal_store_heartbeat_interval: maple_ingest::wal_store::DEFAULT_HEARTBEAT_INTERVAL,
             batch_max_rows: 100,
             batch_max_bytes: 1024 * 1024,
             batch_max_wait: Duration::from_millis(1),
@@ -7267,6 +7388,7 @@ mod tests {
                 replay_blob_store: None,
                 trust_proxy_geo: false,
                 shutdown_drain_secs: 1,
+            wal_store: None,
             },
             #[expect(
                 clippy::useless_conversion,

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -350,6 +350,11 @@ impl AppConfig {
                 std::env::var("INGEST_WAL_SHARDS").ok(),
                 (num_cpus::get().max(1) * 2).max(2),
             )?,
+            wal_segment_max_bytes: parse_u64(
+                "INGEST_WAL_SEGMENT_MAX_BYTES",
+                std::env::var("INGEST_WAL_SEGMENT_MAX_BYTES").ok(),
+                maple_ingest::telemetry::WAL_SEGMENT_MAX_BYTES,
+            )?,
             batch_max_rows: parse_usize(
                 "INGEST_BATCH_MAX_ROWS",
                 std::env::var("INGEST_BATCH_MAX_ROWS").ok(),
@@ -7138,6 +7143,7 @@ mod tests {
             org_queue_max_bytes: 1024 * 1024,
             queue_channel_capacity: 10,
             wal_shards: 1,
+            wal_segment_max_bytes: maple_ingest::telemetry::WAL_SEGMENT_MAX_BYTES,
             batch_max_rows: 100,
             batch_max_bytes: 1024 * 1024,
             batch_max_wait: Duration::from_millis(1),

--- a/apps/ingest/src/metrics.rs
+++ b/apps/ingest/src/metrics.rs
@@ -133,6 +133,30 @@ static WAL_SEGMENTS_SEALED_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .build()
 });
 
+static WAL_SHIPPED_BYTES_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("ingest_wal_shipped_bytes_total")
+        .with_description("WAL segment bytes uploaded to the durability object store")
+        .build()
+});
+
+static WAL_SHIP_OUTCOMES_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("ingest_wal_ship_outcomes_total")
+        .with_description(
+            "WAL segments that were not uploaded, by outcome: exported before the upload ran, \
+             dropped because the shipper queue was full, or failed",
+        )
+        .build()
+});
+
+static WAL_FRAMES_RECOVERED_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("ingest_wal_frames_recovered_total")
+        .with_description("Frames re-committed from another task's orphaned WAL segments")
+        .build()
+});
+
 static WAL_RECLAIMED_BYTES_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
         .u64_counter("ingest_wal_reclaimed_bytes_total")
@@ -566,6 +590,51 @@ pub fn wal_segment_sealed(shard: usize, destination: &str) {
             KeyValue::new("destination", destination.to_owned()),
         ],
     );
+}
+
+/// A sealed WAL segment reached the durability object store.
+pub fn wal_segment_shipped(shard: usize, destination: &str, bytes: u64) {
+    WAL_SHIPPED_BYTES_TOTAL.add(
+        bytes,
+        &[
+            KeyValue::new("shard", shard.to_string()),
+            KeyValue::new("destination", destination.to_owned()),
+        ],
+    );
+}
+
+fn wal_ship_outcome(shard: usize, destination: &str, outcome: &'static str, detail: String) {
+    WAL_SHIP_OUTCOMES_TOTAL.add(
+        1,
+        &[
+            KeyValue::new("shard", shard.to_string()),
+            KeyValue::new("destination", destination.to_owned()),
+            KeyValue::new("outcome", outcome),
+            KeyValue::new("error.type", detail),
+        ],
+    );
+}
+
+/// The segment exported before its upload ran, so there was nothing to protect.
+/// The expected outcome for most segments in a healthy pipeline.
+pub fn wal_ship_skipped(shard: usize, destination: &str) {
+    wal_ship_outcome(shard, destination, "exported_first", String::new());
+}
+
+/// The shipper queue was full, so this segment stays local-only. Sustained
+/// non-zero means the object store cannot keep up with segment rotation.
+pub fn wal_ship_dropped(shard: usize, destination: &str) {
+    wal_ship_outcome(shard, destination, "queue_full", String::new());
+}
+
+/// An upload or delete against the object store failed.
+pub fn wal_ship_failed(shard: usize, destination: &str, error_kind: &str) {
+    wal_ship_outcome(shard, destination, "failed", error_kind.to_owned());
+}
+
+/// Frames re-committed from a dead task's orphaned segments.
+pub fn wal_frames_recovered(frames: u64) {
+    WAL_FRAMES_RECOVERED_TOTAL.add(frames, &[]);
 }
 
 /// Bytes freed by deleting segments the export cursor has moved past.

--- a/apps/ingest/src/metrics.rs
+++ b/apps/ingest/src/metrics.rs
@@ -126,10 +126,17 @@ static WAL_SHARD_FULL_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .build()
 });
 
-static WAL_COMPACTED_BYTES_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+static WAL_SEGMENTS_SEALED_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("ingest_wal_compacted_bytes_total")
-        .with_description("Exported WAL bytes reclaimed by rewriting a lane file from its cursor")
+        .u64_counter("ingest_wal_segments_sealed_total")
+        .with_description("WAL segments closed at the size threshold and replaced by a new one")
+        .build()
+});
+
+static WAL_RECLAIMED_BYTES_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("ingest_wal_reclaimed_bytes_total")
+        .with_description("WAL bytes freed by deleting fully exported segments")
         .build()
 });
 
@@ -252,7 +259,7 @@ static WAL_SHARD_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
         .u64_gauge("ingest_wal_shard_bytes")
         .with_unit("By")
-        .with_description("Current WAL shard file size")
+        .with_description("Bytes held by a WAL lane's segments on disk")
         .build()
 });
 
@@ -539,7 +546,7 @@ pub fn wal_commit_bytes(shard: usize, destination: &str, bytes: u64) {
     );
 }
 
-/// Current WAL lane file size.
+/// Bytes a WAL lane currently holds on disk, exported prefix included.
 pub fn wal_shard_bytes(shard: usize, destination: &str, bytes: u64) {
     WAL_SHARD_BYTES.record(
         bytes,
@@ -550,9 +557,20 @@ pub fn wal_shard_bytes(shard: usize, destination: &str, bytes: u64) {
     );
 }
 
-/// Exported bytes reclaimed by compacting a WAL lane file.
-pub fn wal_lane_compacted(shard: usize, destination: &str, reclaimed_bytes: u64) {
-    WAL_COMPACTED_BYTES_TOTAL.add(
+/// A lane sealed its active segment and opened the next one.
+pub fn wal_segment_sealed(shard: usize, destination: &str) {
+    WAL_SEGMENTS_SEALED_TOTAL.add(
+        1,
+        &[
+            KeyValue::new("shard", shard.to_string()),
+            KeyValue::new("destination", destination.to_owned()),
+        ],
+    );
+}
+
+/// Bytes freed by deleting segments the export cursor has moved past.
+pub fn wal_segments_reclaimed(shard: usize, destination: &str, reclaimed_bytes: u64) {
+    WAL_RECLAIMED_BYTES_TOTAL.add(
         reclaimed_bytes,
         &[
             KeyValue::new("shard", shard.to_string()),

--- a/apps/ingest/src/r2.rs
+++ b/apps/ingest/src/r2.rs
@@ -5,22 +5,17 @@
 //! client. That is the whole reason this module exists.
 //!
 //! Deliberately not `aws-sdk-s3`: we issue exactly one verb (`PUT`) against one
-//! bucket with a known-length in-memory payload. Signing that is ~100 lines on
-//! top of the `hmac`/`sha2`/`chrono`/`reqwest` crates the binary already links
-//! for ingest-key hashing, versus pulling the whole smithy stack in for it.
-//!
-//! Scope: replay chunk payloads only. If this ever grows a second caller or a
-//! second verb, that is the moment to reconsider the dependency.
+//! bucket with a known-length in-memory payload. SigV4 signing lives in
+//! `aws.rs`, shared with the WAL segment store, and costs a few hundred lines
+//! against the whole smithy stack.
 
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
 
-type HmacSha256 = Hmac<Sha256>;
+use crate::aws::{amz_date, authorization_header, hex, host_from_endpoint, uri_encode_path, SigningParams};
 
-const ALGORITHM: &str = "AWS4-HMAC-SHA256";
 const SERVICE: &str = "s3";
 
 /// Object-key scheme version. Bumping this is how a future key layout change
@@ -403,147 +398,6 @@ impl ReplayBlobStore {
     }
 }
 
-struct SigningParams<'a> {
-    method: &'a str,
-    canonical_uri: &'a str,
-    canonical_query: &'a str,
-    /// Lowercase header names; sorted internally, so call order is free.
-    headers: &'a [(String, String)],
-    payload_sha256: &'a str,
-    now: DateTime<Utc>,
-    access_key_id: &'a str,
-    secret_access_key: &'a str,
-    region: &'a str,
-    service: &'a str,
-}
-
-fn authorization_header(params: &SigningParams) -> String {
-    let mut headers: Vec<(String, String)> = params
-        .headers
-        .iter()
-        .map(|(name, value)| (name.to_ascii_lowercase(), value.trim().to_owned()))
-        .collect();
-    headers.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let signed_headers = headers
-        .iter()
-        .map(|(name, _)| name.as_str())
-        .collect::<Vec<_>>()
-        .join(";");
-    let canonical_headers = headers
-        .iter()
-        .fold(String::new(), |mut out, (name, value)| {
-            out.push_str(name);
-            out.push(':');
-            out.push_str(value);
-            out.push('\n');
-            out
-        });
-
-    let canonical_request = format!(
-        "{}\n{}\n{}\n{}\n{}\n{}",
-        params.method,
-        params.canonical_uri,
-        params.canonical_query,
-        canonical_headers,
-        signed_headers,
-        params.payload_sha256,
-    );
-
-    let datestamp = params.now.format("%Y%m%d").to_string();
-    let scope = format!(
-        "{}/{}/{}/aws4_request",
-        datestamp, params.region, params.service
-    );
-    let string_to_sign = format!(
-        "{}\n{}\n{}\n{}",
-        ALGORITHM,
-        amz_date(params.now),
-        scope,
-        hex(&Sha256::digest(canonical_request.as_bytes())),
-    );
-
-    let signing_key = signing_key(
-        params.secret_access_key,
-        &datestamp,
-        params.region,
-        params.service,
-    );
-    let signature = hex(&hmac(&signing_key, string_to_sign.as_bytes()));
-
-    format!(
-        "{ALGORITHM} Credential={}/{scope}, SignedHeaders={signed_headers}, Signature={signature}",
-        params.access_key_id,
-    )
-}
-
-fn signing_key(secret_access_key: &str, datestamp: &str, region: &str, service: &str) -> Vec<u8> {
-    let mut key = hmac(
-        format!("AWS4{secret_access_key}").as_bytes(),
-        datestamp.as_bytes(),
-    );
-    key = hmac(&key, region.as_bytes());
-    key = hmac(&key, service.as_bytes());
-    hmac(&key, b"aws4_request")
-}
-
-#[expect(
-    clippy::expect_used,
-    reason = "HMAC accepts keys of any length, so `new_from_slice` cannot fail here"
-)]
-fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
-    let mut mac = HmacSha256::new_from_slice(key).expect("hmac accepts any key length");
-    mac.update(data);
-    mac.finalize().into_bytes().to_vec()
-}
-
-fn hex(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(char::from(HEX_LOWER[usize::from(byte >> 4)]));
-        out.push(char::from(HEX_LOWER[usize::from(byte & 0x0f)]));
-    }
-    out
-}
-
-const HEX_LOWER: &[u8; 16] = b"0123456789abcdef";
-const HEX_UPPER: &[u8; 16] = b"0123456789ABCDEF";
-
-fn amz_date(now: DateTime<Utc>) -> String {
-    now.format("%Y%m%dT%H%M%SZ").to_string()
-}
-
-/// RFC 3986 encoding for a URI path: `/` stays a separator, everything outside
-/// the unreserved set is percent-encoded with uppercase hex. Replay keys only
-/// ever contain unreserved characters, but a signature that disagrees with the
-/// request line by one byte is a 403 with no useful message, so encode properly
-/// rather than trusting the caller.
-fn uri_encode_path(path: &str) -> String {
-    let mut out = String::with_capacity(path.len());
-    for byte in path.as_bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
-                out.push(*byte as char);
-            }
-            _ => {
-                out.push('%');
-                out.push(char::from(HEX_UPPER[usize::from(byte >> 4)]));
-                out.push(char::from(HEX_UPPER[usize::from(byte & 0x0f)]));
-            }
-        }
-    }
-    out
-}
-
-fn host_from_endpoint(endpoint: &str) -> String {
-    endpoint
-        .split_once("://")
-        .map_or(endpoint, |(_, rest)| rest)
-        .split('/')
-        .next()
-        .unwrap_or("")
-        .to_owned()
-}
 
 #[cfg(test)]
 mod tests {

--- a/apps/ingest/src/task_protection.rs
+++ b/apps/ingest/src/task_protection.rs
@@ -59,7 +59,7 @@ async fn run(pipeline: TelemetryPipeline, endpoint: String) {
     let mut clear_polls: u32 = 0;
     loop {
         tokio::time::sleep(POLL_INTERVAL).await;
-        let backlog = pipeline.wal_backlog_bytes().await;
+        let backlog = pipeline.wal_backlog_bytes();
         if backlog >= PROTECT_THRESHOLD_BYTES {
             clear_polls = 0;
             // Re-sent every poll while backlogged: the same call both acquires

--- a/apps/ingest/src/telemetry.rs
+++ b/apps/ingest/src/telemetry.rs
@@ -40,13 +40,13 @@ use tokio::time::sleep;
 use tracing::{error, info, warn, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-/// Most a lane compaction will copy while holding the append mutex. Compaction
-/// rewrites the *unexported tail*, so this bounds the append stall rather than
-/// the reclaim: a healthy lane keeps a tail of near zero (the symptom being
-/// fixed is a huge exported prefix in front of a tiny backlog), and a lane whose
-/// backlog genuinely exceeds this is not holding dead weight — it is full for
-/// real, and rejecting writes is the correct backpressure.
-const WAL_COMPACT_MAX_TAIL_BYTES: u64 = 64 * 1024 * 1024;
+/// Size at which the active segment is sealed and a new one opened.
+///
+/// Small enough that a sealed segment is a cheap object to ship and to delete,
+/// and that a corrupt one costs little; large enough that sealing (an `open` and
+/// a directory fsync) stays far off the per-append path. A production lane is a
+/// gibibyte, so this is ~128 segments per full lane.
+pub const WAL_SEGMENT_MAX_BYTES: u64 = 8 * 1024 * 1024;
 
 const WAL_MAGIC: &[u8; 4] = b"MTW1";
 const WAL_V1_HEADER_LEN: usize = 20;
@@ -466,6 +466,10 @@ pub struct TinybirdConfig {
     pub org_queue_max_bytes: u64,
     pub queue_channel_capacity: usize,
     pub wal_shards: usize,
+    /// Size at which a lane seals its active segment. Defaults to
+    /// `WAL_SEGMENT_MAX_BYTES`; exposed so the object size the S3 tier ships can
+    /// be tuned without a rebuild.
+    pub wal_segment_max_bytes: u64,
     pub batch_max_rows: usize,
     pub batch_max_bytes: usize,
     pub batch_max_wait: Duration,
@@ -558,6 +562,9 @@ impl TinybirdConfig {
         }
         if self.wal_shards == 0 {
             return Err("INGEST_WAL_SHARDS must be greater than 0".to_owned());
+        }
+        if self.wal_segment_max_bytes == 0 {
+            return Err("INGEST_WAL_SEGMENT_MAX_BYTES must be greater than 0".to_owned());
         }
         if self.batch_max_rows == 0 || self.batch_max_bytes == 0 {
             return Err(
@@ -749,6 +756,9 @@ struct QueuedFrame {
     /// WAL shard the frame routed to (for metric labelling). The lane it belongs
     /// to is implied by the worker draining it (one worker per lane).
     shard: usize,
+    /// Segment this frame was appended to, and its byte range inside that
+    /// segment. `(segment, end)` is what the lane's export cursor advances to.
+    segment: u64,
     start: u64,
     end: u64,
     org_id: String,
@@ -806,7 +816,9 @@ impl TelemetryPipeline {
         let wal = Arc::new(ShardedWal::open(&cfg)?);
         // Relocate any single-file-per-shard WAL left by a pre-lanes binary into
         // the new per-destination lanes before workers start draining them.
-        wal.migrate_legacy_shards(&cfg).await;
+        wal.migrate_legacy_files(&cfg).await;
+        // Relocated frames land in the active segment, which replay skips.
+        wal.seal_all();
         let org_queue_bytes = Arc::new(DashMap::new());
         let mirror_org_queue_bytes = Arc::new(DashMap::new());
         let clickhouse_breakers = Arc::new(ClickHouseBreakerRegistry::new(cfg.clickhouse_breaker));
@@ -856,8 +868,8 @@ impl TelemetryPipeline {
     }
 
     /// Bytes committed to the primary WAL lanes and not yet exported.
-    pub async fn wal_backlog_bytes(&self) -> u64 {
-        self.inner.wal.backlog_bytes().await
+    pub fn wal_backlog_bytes(&self) -> u64 {
+        self.inner.wal.backlog_bytes()
     }
 
     /// Wait for the primary lanes to export everything they hold, up to
@@ -867,7 +879,7 @@ impl TelemetryPipeline {
     pub async fn drain_wal(&self, deadline: Duration) -> u64 {
         let started = Instant::now();
         loop {
-            let backlog = self.wal_backlog_bytes().await;
+            let backlog = self.wal_backlog_bytes();
             if backlog == 0 || started.elapsed() >= deadline {
                 return backlog;
             }
@@ -1115,7 +1127,7 @@ impl TelemetryPipeline {
                     metrics::tinybird_mirror_dropped(&frame.datasource, "org_quota", frame.row_count as u64);
                     continue;
                 }
-                let (start, end) = match self.inner.wal.append(lane, &frame).await {
+                let (segment, start, end) = match self.inner.wal.append(lane, &frame).await {
                     Ok(offsets) => offsets,
                     Err(error) => {
                         release_org_queue_bytes(
@@ -1132,6 +1144,7 @@ impl TelemetryPipeline {
                 frames_committed += 1;
                 permit.send(QueuedFrame {
                     shard,
+                    segment,
                     start,
                     end,
                     org_id: frame.org_id,
@@ -1205,7 +1218,7 @@ impl TelemetryPipeline {
                 let queued_bytes = frame.payload.len() as u64;
                 self.reserve_org_queue_bytes(&frame.org_id, queued_bytes)
                     .inspect_err(|_| record_failing_frame(shard, lane, &frame.datasource))?;
-                let (start, end) = self.inner.wal.append(lane, &frame).await.map_err(|error| {
+                let (segment, start, end) = self.inner.wal.append(lane, &frame).await.map_err(|error| {
                     self.release_org_queue_bytes(&frame.org_id, queued_bytes);
                     record_failing_frame(shard, lane, &frame.datasource);
                     PipelineError::QueueUnavailable(error)
@@ -1214,6 +1227,7 @@ impl TelemetryPipeline {
                 frames_committed += 1;
                 permit.send(QueuedFrame {
                     shard,
+                    segment,
                     start,
                     end,
                     org_id: frame.org_id,
@@ -1339,26 +1353,331 @@ impl TelemetryPipeline {
 }
 
 struct ShardedWal {
-    /// One WAL file per lane (`shard × destination`), indexed by `lane_index`.
-    lanes: Vec<Arc<WalShard>>,
+    /// One segment directory per lane (`shard × destination`), indexed by
+    /// `lane_index`.
+    lanes: Vec<Arc<WalLane>>,
 }
 
-struct WalShard {
-    /// Real shard this lane belongs to, and its destination — carried so WAL
-    /// metrics stay labelled by `(shard, destination)` rather than leaking the
-    /// flat lane index as a `shard`.
+/// One lane's log: a directory of sealed segments plus the single segment
+/// appends currently land in.
+///
+/// Appends and exports touch disjoint segments, so they take different locks
+/// and an export can never stall a commit. That is the point of the layout: the
+/// file-per-lane WAL it replaces reclaimed space by rewriting the lane's tail
+/// *while holding the append mutex*, which is what made `wal_commit` p95 swing
+/// between 145ms and 998ms against a flat 3ms p50.
+struct WalLane {
     shard: usize,
     destination: ExportDestination,
-    path: PathBuf,
+    dir: PathBuf,
     cursor_path: PathBuf,
     max_bytes: u64,
-    /// Bytes reclaimed from the front of this lane file since process start, by
-    /// truncation or compaction. Frames carry *virtual* offsets
-    /// (`base_offset + file position`), so a frame already in flight keeps a
-    /// meaningful offset after the bytes underneath it are rewritten. Only read
-    /// or written while holding `file`, which is what makes `Relaxed` sound.
-    base_offset: AtomicU64,
-    file: Mutex<File>,
+    /// Size at which the active segment is sealed.
+    segment_max_bytes: u64,
+    /// Segment the appender is writing to. Stored with `Release` under
+    /// `append`, so a thread that reads a newer sequence with `Acquire` also
+    /// sees the sealed segment at its final length.
+    active_seq: AtomicU64,
+    /// Bytes held by every segment on disk, the exported prefix included. Drives
+    /// the lane cap and the `wal_shard_bytes` gauge.
+    live_bytes: AtomicU64,
+    /// Cumulative bytes appended and marked exported since this lane was opened.
+    /// Their difference is the backlog, and it stays exact across rotation and
+    /// deletion — which nothing derived from file sizes does.
+    committed_bytes: AtomicU64,
+    exported_bytes: AtomicU64,
+    append: Mutex<LaneAppend>,
+    export: Mutex<LaneExport>,
+}
+
+struct LaneAppend {
+    seq: u64,
+    file: File,
+    /// Bytes written to `file`. The handle is append-only and nothing else
+    /// writes it, so this is the offset every frame in it is addressed by.
+    len: u64,
+}
+
+struct LaneExport {
+    /// Oldest segment still on disk. Sequences are contiguous, so this and the
+    /// cursor are the whole delete list.
+    next_delete: u64,
+    cursor: SegmentCursor,
+}
+
+/// How far the exporter has drained a lane: a byte offset inside one segment.
+/// Ordered by `(seq, offset)`, which is the order frames leave the lane in.
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+struct SegmentCursor {
+    seq: u64,
+    offset: u64,
+}
+
+fn segment_path(dir: &Path, seq: u64) -> PathBuf {
+    dir.join(format!("{seq:012}.seg"))
+}
+
+/// Sequence numbers of the segments in `dir`, ascending. Anything that is not a
+/// segment file is ignored — the lane's cursor lives in the same directory.
+fn list_segments(dir: &Path) -> Result<Vec<u64>, String> {
+    let entries = std::fs::read_dir(dir)
+        .map_err(|error| format!("read WAL lane {}: {error}", dir.display()))?;
+    let mut seqs = Vec::new();
+    for entry in entries {
+        let path = entry
+            .map_err(|error| format!("read WAL lane entry: {error}"))?
+            .path();
+        let seq = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_suffix(".seg"))
+            .and_then(|seq| seq.parse::<u64>().ok());
+        if let Some(seq) = seq {
+            seqs.push(seq);
+        }
+    }
+    seqs.sort_unstable();
+    Ok(seqs)
+}
+
+fn file_len(path: &Path) -> u64 {
+    std::fs::metadata(path).map_or(0, |meta| meta.len())
+}
+
+fn open_segment(dir: &Path, seq: u64) -> Result<File, String> {
+    let path = segment_path(dir, seq);
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .append(true)
+        .open(&path)
+        .map_err(|error| format!("open WAL segment {}: {error}", path.display()))?;
+    // Without this the directory entry can be lost across a power failure while
+    // the frames inside it are durable, which reads back as a truncated lane.
+    if let Err(error) = File::open(dir).and_then(|handle| handle.sync_all()) {
+        warn!(dir = %dir.display(), %error, "Failed to fsync WAL lane directory after opening a segment");
+    }
+    Ok(file)
+}
+
+impl WalLane {
+    fn open(
+        shard: usize,
+        destination: ExportDestination,
+        cfg: &TinybirdConfig,
+        max_bytes: u64,
+    ) -> Result<Self, String> {
+        let dir = cfg
+            .queue_dir
+            .join(format!("shard-{shard:03}-{}", destination.as_str()));
+        std::fs::create_dir_all(&dir)
+            .map_err(|error| format!("create ingest WAL lane {}: {error}", dir.display()))?;
+        let cursor_path = dir.join("lane.cursor");
+        let mut cursor = read_cursor(&cursor_path);
+
+        let mut live = Vec::new();
+        for seq in list_segments(&dir)? {
+            let path = segment_path(&dir, seq);
+            // Segments below the cursor are fully exported, and an empty one is
+            // the segment a previous boot opened and never wrote to. Both are
+            // removed here rather than left to accumulate: a crash between the
+            // cursor write and the delete is expected, not exceptional.
+            if seq < cursor.seq || file_len(&path) == 0 {
+                drop(std::fs::remove_file(&path));
+                continue;
+            }
+            live.push(seq);
+        }
+        // A cursor that names a segment which is no longer on disk (its file was
+        // lost, or the cursor file was) resumes at the oldest segment that
+        // survived: replaying an exported frame is at-least-once, which the
+        // export path already tolerates, while skipping one is silent loss.
+        if live.first() != Some(&cursor.seq) {
+            cursor = SegmentCursor {
+                seq: live.first().copied().unwrap_or(cursor.seq),
+                offset: 0,
+            };
+        }
+
+        // Always start a fresh segment rather than re-opening the newest one:
+        // it keeps "sealed" meaning "will never grow again", which is what lets
+        // a sealed segment be shipped or deleted without coordinating with the
+        // appender.
+        let next_seq = live.last().map_or(cursor.seq, |last| last + 1);
+        let file = open_segment(&dir, next_seq)?;
+        let on_disk: u64 = live
+            .iter()
+            .map(|seq| file_len(&segment_path(&dir, *seq)))
+            .sum();
+
+        Ok(Self {
+            shard,
+            destination,
+            dir,
+            cursor_path,
+            max_bytes,
+            segment_max_bytes: cfg.wal_segment_max_bytes,
+            active_seq: AtomicU64::new(next_seq),
+            live_bytes: AtomicU64::new(on_disk),
+            // Whatever survived the last boot is backlog this lane still owes.
+            committed_bytes: AtomicU64::new(on_disk.saturating_sub(cursor.offset)),
+            exported_bytes: AtomicU64::new(0),
+            append: Mutex::new(LaneAppend {
+                seq: next_seq,
+                file,
+                len: 0,
+            }),
+            export: Mutex::new(LaneExport {
+                next_delete: cursor.seq,
+                cursor,
+            }),
+        })
+    }
+
+    /// Append one encoded frame and return where it landed. `enforce_cap` is
+    /// false only for frames being relocated from an older WAL layout, which
+    /// were already accepted and must not be rejected now.
+    fn append_blocking(
+        &self,
+        encoded: &[u8],
+        enforce_cap: bool,
+    ) -> Result<(u64, u64, u64), String> {
+        let added = encoded.len() as u64;
+        let mut state = self
+            .append
+            .lock()
+            .map_err(|_| "WAL lane mutex poisoned".to_owned())?;
+        if enforce_cap
+            && self
+                .live_bytes
+                .load(Ordering::Relaxed)
+                .saturating_add(added)
+                > self.max_bytes
+        {
+            metrics::wal_shard_full(self.shard, self.destination.as_str());
+            return Err("Telemetry WAL lane is full".to_owned());
+        }
+        state
+            .file
+            .write_all(encoded)
+            .map_err(|error| format!("write WAL: {error}"))?;
+        state
+            .file
+            .sync_data()
+            .map_err(|error| format!("sync WAL: {error}"))?;
+        let seq = state.seq;
+        let start = state.len;
+        let end = start + added;
+        state.len = end;
+        let live = self.live_bytes.fetch_add(added, Ordering::Relaxed) + added;
+        self.committed_bytes.fetch_add(added, Ordering::Relaxed);
+        // Sealing is an open() and a directory fsync, paid once per segment —
+        // versus the tail rewrite the previous layout paid here under this lock.
+        if end >= self.segment_max_bytes {
+            self.seal(&mut state)?;
+        }
+        drop(state);
+
+        metrics::wal_commit_bytes(self.shard, self.destination.as_str(), added);
+        metrics::wal_shard_bytes(self.shard, self.destination.as_str(), live);
+        Ok((seq, start, end))
+    }
+
+    /// Close the active segment and open the next one. The caller holds
+    /// `append`; every frame in the outgoing segment is already `sync_data`d.
+    fn seal(&self, state: &mut LaneAppend) -> Result<(), String> {
+        let next = state.seq + 1;
+        let file = open_segment(&self.dir, next)?;
+        // Published before the handle is swapped, so a reader that sees `next`
+        // is looking at a segment whose length can no longer change.
+        self.active_seq.store(next, Ordering::Release);
+        state.seq = next;
+        state.file = file;
+        state.len = 0;
+        metrics::wal_segment_sealed(self.shard, self.destination.as_str());
+        Ok(())
+    }
+
+    /// Advance the export cursor and drop every segment fully behind it.
+    /// `bytes` is what the batch actually drained, which is what the backlog is
+    /// computed from — a cursor jump across a segment boundary is not a byte
+    /// count.
+    fn mark_exported_blocking(&self, cursor: SegmentCursor, bytes: u64) -> Result<(), String> {
+        let mut state = self
+            .export
+            .lock()
+            .map_err(|_| "WAL lane mutex poisoned".to_owned())?;
+        // One worker drains a lane, so batches complete in order; the max is
+        // defensive, and cheaper than reasoning about the alternative.
+        let mut cursor = cursor.max(state.cursor);
+        // A sealed segment the batch finished: step past it so its file (and, in
+        // the S3 tier, its object) is reclaimed now rather than whenever the
+        // lane next exports.
+        if cursor.seq < self.active_seq.load(Ordering::Acquire)
+            && cursor.offset >= file_len(&segment_path(&self.dir, cursor.seq))
+        {
+            cursor = SegmentCursor {
+                seq: cursor.seq + 1,
+                offset: 0,
+            };
+        }
+        write_cursor(&self.cursor_path, cursor)?;
+        state.cursor = cursor;
+
+        // Cursor first, delete second. A crash in between costs a re-delete on
+        // the next boot; the other order strands a cursor pointing at bytes that
+        // no longer exist.
+        let mut reclaimed = 0u64;
+        while state.next_delete < cursor.seq {
+            let path = segment_path(&self.dir, state.next_delete);
+            reclaimed += file_len(&path);
+            if let Err(error) = std::fs::remove_file(&path) {
+                if error.kind() != std::io::ErrorKind::NotFound {
+                    warn!(
+                        shard = self.shard,
+                        destination = self.destination.as_str(),
+                        segment = state.next_delete,
+                        %error,
+                        "Failed to delete an exported WAL segment"
+                    );
+                }
+            }
+            state.next_delete += 1;
+        }
+        drop(state);
+
+        self.exported_bytes.fetch_add(bytes, Ordering::Relaxed);
+        if reclaimed > 0 {
+            let live = self
+                .live_bytes
+                .fetch_sub(reclaimed, Ordering::Relaxed)
+                .saturating_sub(reclaimed);
+            metrics::wal_segments_reclaimed(self.shard, self.destination.as_str(), reclaimed);
+            metrics::wal_shard_bytes(self.shard, self.destination.as_str(), live);
+        }
+        Ok(())
+    }
+
+    /// Seal the active segment if anything has been written to it. Used at the
+    /// end of boot recovery, so frames relocated from an older layout live in a
+    /// sealed segment that replay (and the S3 tier) can see.
+    fn seal_if_dirty(&self) -> Result<(), String> {
+        let mut state = self
+            .append
+            .lock()
+            .map_err(|_| "WAL lane mutex poisoned".to_owned())?;
+        if state.len == 0 {
+            return Ok(());
+        }
+        self.seal(&mut state)
+    }
+
+    /// Bytes committed to this lane that no export has acknowledged.
+    fn backlog_bytes(&self) -> u64 {
+        self.committed_bytes
+            .load(Ordering::Relaxed)
+            .saturating_sub(self.exported_bytes.load(Ordering::Relaxed))
+    }
 }
 
 impl ShardedWal {
@@ -1368,63 +1687,68 @@ impl ShardedWal {
         let max_bytes_per_lane = (cfg.queue_max_bytes / num_lanes as u64).max(1);
         for shard in 0..cfg.wal_shards {
             for destination in ExportDestination::ALL {
-                let dest = destination.as_str();
-                let path = cfg.queue_dir.join(format!("shard-{shard:03}-{dest}.wal"));
-                let cursor_path = cfg
-                    .queue_dir
-                    .join(format!("shard-{shard:03}-{dest}.cursor"));
-                let file = OpenOptions::new()
-                    .create(true)
-                    .read(true)
-                    .append(true)
-                    .open(&path)
-                    .map_err(|error| format!("open ingest WAL {}: {error}", path.display()))?;
                 debug_assert_eq!(lanes.len(), lane_index(shard, destination));
-                lanes.push(Arc::new(WalShard {
+                lanes.push(Arc::new(WalLane::open(
                     shard,
                     destination,
-                    path,
-                    cursor_path,
-                    max_bytes: max_bytes_per_lane,
-                    base_offset: AtomicU64::new(0),
-                    file: Mutex::new(file),
-                }));
+                    cfg,
+                    max_bytes_per_lane,
+                )?));
             }
         }
         Ok(Self { lanes })
     }
 
-    /// Migrate any pre-lanes WAL (a single `shard-NNN.wal` per shard, mixing both
-    /// destinations) into the per-destination lane files. Each surviving frame is
-    /// durably re-appended to its destination's lane, then the legacy file + cursor
-    /// are removed. Best-effort: a failed shard is logged and left in place so the
-    /// next boot retries it — startup never wedges and no frame is dropped.
+    /// Relocate any pre-segment WAL file into the lane's segment directory.
+    ///
+    /// Two shapes exist: `shard-NNN.wal` (before per-destination lanes, mixing
+    /// both destinations in one file) and `shard-NNN-<dest>.wal` (one file per
+    /// lane). Surviving frames are durably re-appended, then the file and its
+    /// cursor are removed. Best-effort per file: a failure is logged and the
+    /// file left in place for the next boot, so startup never wedges and no
+    /// frame is dropped.
     #[expect(
         clippy::cognitive_complexity,
         reason = "WAL recovery: the branches are the recovery cases, and each needs the others' \
                   context to be readable"
     )]
-    async fn migrate_legacy_shards(&self, cfg: &TinybirdConfig) {
+    async fn migrate_legacy_files(&self, cfg: &TinybirdConfig) {
+        let mut legacy: Vec<(usize, PathBuf, PathBuf)> = Vec::new();
         for shard in 0..cfg.wal_shards {
-            let legacy_path = cfg.queue_dir.join(format!("shard-{shard:03}.wal"));
-            let legacy_cursor = cfg.queue_dir.join(format!("shard-{shard:03}.cursor"));
-            if !legacy_path.exists() {
+            legacy.push((
+                shard,
+                cfg.queue_dir.join(format!("shard-{shard:03}.wal")),
+                cfg.queue_dir.join(format!("shard-{shard:03}.cursor")),
+            ));
+            for destination in ExportDestination::ALL {
+                let dest = destination.as_str();
+                legacy.push((
+                    shard,
+                    cfg.queue_dir.join(format!("shard-{shard:03}-{dest}.wal")),
+                    cfg.queue_dir
+                        .join(format!("shard-{shard:03}-{dest}.cursor")),
+                ));
+            }
+        }
+
+        for (shard, path, cursor_path) in legacy {
+            if !path.exists() {
                 continue;
             }
-            let read_path = legacy_path.clone();
-            let read_cursor = legacy_cursor.clone();
+            let read_path = path.clone();
+            let read_cursor_path = cursor_path.clone();
             let frames = match tokio::task::spawn_blocking(move || {
-                read_legacy_frames(&read_path, &read_cursor)
+                read_legacy_frames(&read_path, &read_cursor_path)
             })
             .await
             {
                 Ok(Ok(frames)) => frames,
                 Ok(Err(error)) => {
-                    warn!(shard, error = %error, "Skipping unreadable legacy ingest WAL shard");
+                    warn!(shard, error = %error, "Skipping unreadable legacy ingest WAL file");
                     continue;
                 }
                 Err(error) => {
-                    warn!(shard, error = %error, "Failed to read legacy ingest WAL shard");
+                    warn!(shard, error = %error, "Failed to read legacy ingest WAL file");
                     continue;
                 }
             };
@@ -1450,20 +1774,44 @@ impl ShardedWal {
                 }
             }
             if migrated {
-                drop(std::fs::remove_file(&legacy_path));
-                drop(std::fs::remove_file(&legacy_cursor));
+                drop(std::fs::remove_file(&path));
+                drop(std::fs::remove_file(&cursor_path));
                 if count > 0 {
                     info!(
                         shard,
                         frames = count,
-                        "Migrated legacy ingest WAL shard into per-destination lanes"
+                        file = %path.display(),
+                        "Migrated legacy ingest WAL file into lane segments"
                     );
                 }
             }
         }
     }
 
-    async fn append(&self, lane: usize, frame: &EncodedFrame) -> Result<(u64, u64), String> {
+    /// Seal every lane's active segment. Boot-time only: replay deliberately
+    /// ignores the segment appends are landing in, so anything written during
+    /// recovery has to be sealed before it counts as recoverable.
+    fn seal_all(&self) {
+        for lane in &self.lanes {
+            if let Err(error) = lane.seal_if_dirty() {
+                warn!(
+                    shard = lane.shard,
+                    destination = lane.destination.as_str(),
+                    %error,
+                    "Failed to seal a WAL lane segment after recovery"
+                );
+            }
+        }
+    }
+
+    fn lane(&self, lane: usize) -> Result<Arc<WalLane>, String> {
+        self.lanes
+            .get(lane)
+            .map(Arc::clone)
+            .ok_or_else(|| format!("invalid WAL lane {lane}"))
+    }
+
+    async fn append(&self, lane: usize, frame: &EncodedFrame) -> Result<(u64, u64, u64), String> {
         self.append_inner(lane, frame, true).await
     }
 
@@ -1473,153 +1821,47 @@ impl ShardedWal {
         lane: usize,
         frame: &EncodedFrame,
         enforce_cap: bool,
-    ) -> Result<(u64, u64), String> {
-        let lane_ref = Arc::clone(
-            self.lanes
-                .get(lane)
-                .ok_or_else(|| format!("invalid WAL lane {lane}"))?,
-        );
+    ) -> Result<(u64, u64, u64), String> {
+        let lane_ref = self.lane(lane)?;
         let encoded = encode_wal_frame(frame)?;
-        tokio::task::spawn_blocking(move || {
-            let mut file = lane_ref
-                .file
-                .lock()
-                .map_err(|_| "WAL lane mutex poisoned".to_owned())?;
-            let position = file
-                .seek(SeekFrom::End(0))
-                .map_err(|error| format!("seek WAL: {error}"))?;
-            if enforce_cap && position.saturating_add(encoded.len() as u64) > lane_ref.max_bytes {
-                metrics::wal_shard_full(lane_ref.shard, lane_ref.destination.as_str());
-                return Err("Telemetry WAL lane is full".to_owned());
-            }
-            file.write_all(&encoded)
-                .map_err(|error| format!("write WAL: {error}"))?;
-            file.sync_data()
-                .map_err(|error| format!("sync WAL: {error}"))?;
-            let file_end = position + encoded.len() as u64;
-            let base = lane_ref.base_offset.load(Ordering::Relaxed);
-            metrics::wal_commit_bytes(
-                lane_ref.shard,
-                lane_ref.destination.as_str(),
-                encoded.len() as u64,
-            );
-            metrics::wal_shard_bytes(lane_ref.shard, lane_ref.destination.as_str(), file_end);
-            Ok((base + position, base + file_end))
-        })
-        .await
-        .map_err(|error| format!("join WAL append: {error}"))?
+        tokio::task::spawn_blocking(move || lane_ref.append_blocking(&encoded, enforce_cap))
+            .await
+            .map_err(|error| format!("join WAL append: {error}"))?
     }
 
-    /// Unexported bytes across the primary lanes. Mirror lanes are excluded on
-    /// purpose: the mirror is best-effort, so a stalled mirror target must not
-    /// hold shutdown open or pin a task against scale-in.
-    async fn backlog_bytes(&self) -> u64 {
-        let lanes: Vec<Arc<WalShard>> = self
-            .lanes
+    /// Bytes committed but not yet exported across the primary lanes. Mirror
+    /// lanes are best-effort and excluded, so a stalled mirror cannot hold a
+    /// shutdown drain open.
+    fn backlog_bytes(&self) -> u64 {
+        self.lanes
             .iter()
             .filter(|lane| lane.destination != ExportDestination::TinybirdMirror)
-            .map(Arc::clone)
-            .collect();
-        tokio::task::spawn_blocking(move || {
-            lanes
-                .iter()
-                .map(|lane| {
-                    let Ok(file) = lane.file.lock() else { return 0 };
-                    let size = file.metadata().map_or(0, |meta| meta.len());
-                    // The persisted cursor is a plain file offset. Reading it
-                    // under the append mutex keeps it consistent with `size`
-                    // across a concurrent truncate or compaction.
-                    let cursor = read_cursor(&lane.cursor_path);
-                    drop(file);
-                    size.saturating_sub(cursor)
-                })
-                .sum()
-        })
-        .await
-        .unwrap_or(0)
+            .map(|lane| lane.backlog_bytes())
+            .sum()
     }
 
     async fn replay(&self, lane: usize) -> Result<Vec<QueuedFrame>, String> {
-        let lane_ref = Arc::clone(
-            self.lanes
-                .get(lane)
-                .ok_or_else(|| format!("invalid WAL lane {lane}"))?,
-        );
-        tokio::task::spawn_blocking(move || replay_shard(lane, &lane_ref))
+        let lane_ref = self.lane(lane)?;
+        tokio::task::spawn_blocking(move || replay_lane(lane, &lane_ref))
             .await
             .map_err(|error| format!("join WAL replay: {error}"))?
     }
 
     #[hotpath::measure]
-    async fn mark_exported(&self, lane: usize, offset: u64) -> Result<(), String> {
-        let shard_ref = Arc::clone(
-            self.lanes
-                .get(lane)
-                .ok_or_else(|| format!("invalid WAL lane {lane}"))?,
-        );
-        tokio::task::spawn_blocking(move || {
-            // Holding the append-side mutex serialises us against concurrent
-            // appenders, so nothing can commit bytes into a region we reclaim.
-            let mut file = shard_ref
-                .file
-                .lock()
-                .map_err(|_| "WAL shard mutex poisoned".to_owned())?;
-            let size = file
-                .seek(SeekFrom::End(0))
-                .map_err(|error| format!("seek WAL: {error}"))?;
-            // Frames carry virtual offsets; the file only knows about the bytes
-            // that survived the last reclaim.
-            let base = shard_ref.base_offset.load(Ordering::Relaxed);
-            let file_offset = offset.saturating_sub(base);
-            if file_offset >= size {
-                // The cursor caught up to EOF, so the whole file is dead weight.
-                file.set_len(0)
-                    .map_err(|error| format!("truncate WAL: {error}"))?;
-                file.sync_all()
-                    .map_err(|error| format!("sync WAL truncate: {error}"))?;
-                write_cursor(&shard_ref.cursor_path, 0)?;
-                shard_ref
-                    .base_offset
-                    .store(base.saturating_add(size), Ordering::Relaxed);
-                metrics::wal_shard_bytes(shard_ref.shard, shard_ref.destination.as_str(), 0);
-            } else if file_offset >= shard_ref.max_bytes / 2
-                && size - file_offset <= WAL_COMPACT_MAX_TAIL_BYTES
-            {
-                // A continuously busy lane almost never has a moment where the
-                // cursor sits exactly at EOF, so waiting for the full drain above
-                // means the file grows until it trips `max_bytes` and the lane
-                // starts rejecting writes — while the bytes it is holding are
-                // already exported. Rewrite the file from the cursor instead,
-                // which reclaims that prefix without needing a quiet moment.
-                // Gated on half the lane budget so the rewrite cost is amortised
-                // over a large reclaim rather than paid on every batch, and on
-                // `WAL_COMPACT_MAX_TAIL_BYTES` so the copy cannot hold the append
-                // mutex for long — production lanes are a gibibyte each.
-                compact_lane(&shard_ref, &mut file, file_offset, size)?;
-                shard_ref
-                    .base_offset
-                    .store(base.saturating_add(file_offset), Ordering::Relaxed);
-                metrics::wal_lane_compacted(
-                    shard_ref.shard,
-                    shard_ref.destination.as_str(),
-                    file_offset,
-                );
-                metrics::wal_shard_bytes(
-                    shard_ref.shard,
-                    shard_ref.destination.as_str(),
-                    size - file_offset,
-                );
-            } else {
-                write_cursor(&shard_ref.cursor_path, file_offset)?;
-            }
-            Ok(())
-        })
-        .await
-        .map_err(|error| format!("join WAL cursor: {error}"))?
+    async fn mark_exported(
+        &self,
+        lane: usize,
+        cursor: SegmentCursor,
+        bytes: u64,
+    ) -> Result<(), String> {
+        let lane_ref = self.lane(lane)?;
+        tokio::task::spawn_blocking(move || lane_ref.mark_exported_blocking(cursor, bytes))
+            .await
+            .map_err(|error| format!("join WAL cursor: {error}"))?
     }
 }
 
-fn write_cursor(path: &Path, value: u64) -> Result<(), String> {
+fn write_cursor(path: &Path, cursor: SegmentCursor) -> Result<(), String> {
     let mut cursor_file = OpenOptions::new()
         .create(true)
         .write(true)
@@ -1627,127 +1869,109 @@ fn write_cursor(path: &Path, value: u64) -> Result<(), String> {
         .open(path)
         .map_err(|error| format!("open WAL cursor: {error}"))?;
     cursor_file
-        .write_all(value.to_string().as_bytes())
+        .write_all(format!("{} {}", cursor.seq, cursor.offset).as_bytes())
         .map_err(|error| format!("write WAL cursor: {error}"))?;
     cursor_file
         .sync_data()
         .map_err(|error| format!("sync WAL cursor: {error}"))
 }
 
-/// Rewrite `lane_ref`'s file so it begins at `from`, dropping the exported prefix
-/// in front of it. The caller holds the append mutex, so no writer can race us,
-/// and swaps `base_offset` afterwards so in-flight frames keep resolving.
+/// Read a lane cursor. A missing, empty or unparseable cursor reads as the
+/// origin, which replays the lane from its oldest surviving segment.
+fn read_cursor(path: &Path) -> SegmentCursor {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return SegmentCursor::default();
+    };
+    let mut parts = raw.split_whitespace();
+    let (Some(seq), Some(offset)) = (parts.next(), parts.next()) else {
+        return SegmentCursor::default();
+    };
+    let (Ok(seq), Ok(offset)) = (seq.parse::<u64>(), offset.parse::<u64>()) else {
+        return SegmentCursor::default();
+    };
+    SegmentCursor { seq, offset }
+}
+
+/// Every frame this lane still owes, oldest segment first.
 ///
-/// The cursor is reset to 0 *before* the rename publishes the shorter file. A
-/// crash in that window therefore leaves the original file paired with a zeroed
-/// cursor, which replays already-exported frames — at-least-once, the same
-/// guarantee an export retry already carries. The opposite order would pair a
-/// short file with a large cursor and skip frames that were never exported.
-fn compact_lane(lane_ref: &WalShard, file: &mut File, from: u64, size: u64) -> Result<(), String> {
-    let mut tail = Vec::with_capacity(usize::try_from(size - from).unwrap_or(0));
-    file.seek(SeekFrom::Start(from))
-        .map_err(|error| format!("seek WAL compaction: {error}"))?;
-    file.read_to_end(&mut tail)
-        .map_err(|error| format!("read WAL compaction: {error}"))?;
-
-    let temp_path = lane_ref.path.with_extension("wal.compacting");
-    {
-        let mut temp = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&temp_path)
-            .map_err(|error| format!("open WAL compaction temp: {error}"))?;
-        temp.write_all(&tail)
-            .map_err(|error| format!("write WAL compaction temp: {error}"))?;
-        temp.sync_all()
-            .map_err(|error| format!("sync WAL compaction temp: {error}"))?;
-    }
-    // Opened before the rename so that every fallible step still leaves the lane
-    // exactly as it was; after the swap only the directory fsync remains, and
-    // that one is advisory.
-    let replacement = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .append(true)
-        .open(&temp_path)
-        .map_err(|error| format!("reopen WAL compaction temp: {error}"))?;
-
-    write_cursor(&lane_ref.cursor_path, 0)?;
-    std::fs::rename(&temp_path, &lane_ref.path)
-        .map_err(|error| format!("rename WAL compaction temp: {error}"))?;
-    *file = replacement;
-
-    // Without this a power failure can lose the rename while keeping the zeroed
-    // cursor, which costs a replay of the reclaimed prefix.
-    if let Some(dir) = lane_ref.path.parent() {
-        if let Err(error) = File::open(dir).and_then(|handle| handle.sync_all()) {
-            warn!(
-                shard = lane_ref.shard,
-                destination = lane_ref.destination.as_str(),
-                %error,
-                "Failed to fsync WAL directory after lane compaction"
-            );
-        }
-    }
-    Ok(())
-}
-
-fn read_cursor(path: &Path) -> u64 {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|raw| raw.trim().parse::<u64>().ok())
-        .unwrap_or(0)
-}
-
-fn replay_shard(lane: usize, lane_ref: &WalShard) -> Result<Vec<QueuedFrame>, String> {
-    let mut file = OpenOptions::new()
-        .read(true)
-        .open(&lane_ref.path)
-        .map_err(|error| format!("open WAL replay: {error}"))?;
-    let mut offset = read_cursor(&lane_ref.cursor_path);
-    file.seek(SeekFrom::Start(offset))
-        .map_err(|error| format!("seek WAL replay: {error}"))?;
-
+/// A segment that fails to decode gives up its tail and the next segment is
+/// still replayed: corruption in one 8 MiB file must not cost the whole lane.
+fn replay_lane(lane: usize, lane_ref: &WalLane) -> Result<Vec<QueuedFrame>, String> {
     let shard = lane / LANES_PER_SHARD;
-    // Replay is a startup path, where nothing has been reclaimed yet, but reading
-    // the base keeps replayed frames on the same virtual axis as appended ones.
-    let base = lane_ref.base_offset.load(Ordering::Relaxed);
+    let cursor = lane_ref
+        .export
+        .lock()
+        .map_err(|_| "WAL lane mutex poisoned".to_owned())?
+        .cursor;
+    // The active segment was opened empty by `WalLane::open` and is the one
+    // appends are landing in; nothing in it predates this process.
+    let active = lane_ref.active_seq.load(Ordering::Acquire);
+
     let mut frames = Vec::new();
-    loop {
-        let start = offset;
-        let Some(frame) = read_wal_frame(&mut file, start)? else {
-            break;
-        };
-        frames.push(QueuedFrame {
-            shard,
-            start: base + start,
-            end: base + frame.end,
-            org_id: frame.org_id,
-            queued_bytes: frame.payload.len() as u64,
-            signal: frame.signal,
-            destination: frame.destination,
-            datasource: frame.datasource,
-            row_count: frame.row_count,
-            payload: frame.payload,
-            // Replayed from disk after a restart: the originating trace is gone.
-            source_span: None,
-        });
-        offset = frame.end;
+    for seq in list_segments(&lane_ref.dir)? {
+        if seq < cursor.seq || seq >= active {
+            continue;
+        }
+        let path = segment_path(&lane_ref.dir, seq);
+        let mut file = OpenOptions::new()
+            .read(true)
+            .open(&path)
+            .map_err(|error| format!("open WAL replay {}: {error}", path.display()))?;
+        let mut offset = if seq == cursor.seq { cursor.offset } else { 0 };
+        file.seek(SeekFrom::Start(offset))
+            .map_err(|error| format!("seek WAL replay: {error}"))?;
+        loop {
+            let start = offset;
+            let frame = match read_wal_frame(&mut file, start) {
+                Ok(Some(frame)) => frame,
+                Ok(None) => break,
+                Err(error) => {
+                    warn!(
+                        shard,
+                        destination = lane_ref.destination.as_str(),
+                        segment = seq,
+                        offset = start,
+                        %error,
+                        "Dropping the tail of a corrupt ingest WAL segment"
+                    );
+                    break;
+                }
+            };
+            offset = frame.end;
+            frames.push(QueuedFrame {
+                shard,
+                segment: seq,
+                start,
+                end: frame.end,
+                org_id: frame.org_id,
+                queued_bytes: frame.payload.len() as u64,
+                signal: frame.signal,
+                destination: frame.destination,
+                datasource: frame.datasource,
+                row_count: frame.row_count,
+                payload: frame.payload,
+                // Replayed from disk after a restart: the originating trace is gone.
+                source_span: None,
+            });
+        }
     }
     Ok(frames)
 }
 
-/// Read every surviving frame from a legacy single-file-per-shard WAL, starting
-/// at its persisted cursor. Returns an empty vec if the file is absent. Used by
-/// `migrate_legacy_shards` to relocate frames into the per-destination lanes.
+/// Read every surviving frame from a pre-segment WAL file, starting at its
+/// persisted cursor. Returns an empty vec if the file is absent. Used by
+/// `migrate_legacy_files` to relocate frames into lane segments.
 fn read_legacy_frames(path: &Path, cursor_path: &Path) -> Result<Vec<DecodedWalFrame>, String> {
     let mut file = match OpenOptions::new().read(true).open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(error) => return Err(format!("open legacy WAL: {error}")),
     };
-    let mut offset = read_cursor(cursor_path);
+    // Pre-segment cursors were a bare byte offset.
+    let mut offset = std::fs::read_to_string(cursor_path)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(0);
     file.seek(SeekFrom::Start(offset))
         .map_err(|error| format!("seek legacy WAL: {error}"))?;
     let mut frames = Vec::new();
@@ -2126,7 +2350,6 @@ impl ExportWorker {
 
         let start = Instant::now();
         let first_signal = frames[0].signal;
-        let first_offset = frames[0].start;
         for (datasource, frames) in by_tinybird {
             let (body, rows) = combine_frames(frames);
             self.post_tinybird(&datasource, body, rows).await?;
@@ -2147,8 +2370,24 @@ impl ExportWorker {
             }
         }
 
-        let end = frames.iter().map(|frame| frame.end).max().unwrap_or(0);
-        self.wal.mark_exported(self.lane, end).await?;
+        // The batch drained a contiguous run of this lane, so the furthest
+        // `(segment, end)` is where the cursor belongs; the bytes are summed per
+        // frame because a jump across a segment boundary is not a byte count.
+        let cursor = frames
+            .iter()
+            .map(|frame| SegmentCursor {
+                seq: frame.segment,
+                offset: frame.end,
+            })
+            .max()
+            .unwrap_or_default();
+        let exported_bytes: u64 = frames
+            .iter()
+            .map(|frame| frame.end.saturating_sub(frame.start))
+            .sum();
+        self.wal
+            .mark_exported(self.lane, cursor, exported_bytes)
+            .await?;
         for frame in &frames {
             release_org_queue_bytes(&self.org_queue_bytes, &frame.org_id, frame.queued_bytes);
         }
@@ -2157,7 +2396,7 @@ impl ExportWorker {
             self.destination.as_str(),
             &format!("{first_signal:?}"),
             start.elapsed().as_secs_f64(),
-            end.saturating_sub(first_offset),
+            exported_bytes,
         );
         Ok(())
     }
@@ -3531,6 +3770,7 @@ mod tests {
     fn queued_frame_with_source(source_span: Option<SpanContext>) -> QueuedFrame {
         QueuedFrame {
             shard: 0,
+            segment: 0,
             start: 0,
             end: 0,
             org_id: "org_test".to_owned(),
@@ -3618,6 +3858,7 @@ mod tests {
             org_queue_max_bytes: 1024 * 1024,
             queue_channel_capacity: 10,
             wal_shards: 2,
+            wal_segment_max_bytes: WAL_SEGMENT_MAX_BYTES,
             batch_max_rows: 100,
             batch_max_bytes: 1024 * 1024,
             batch_max_wait: Duration::from_millis(10),
@@ -3756,27 +3997,21 @@ mod tests {
         destination: ExportDestination,
     ) {
         let dest = destination.as_str();
-        let cursor_path = queue_dir.join(format!("shard-{shard:03}-{dest}.cursor"));
-        let shard_path = queue_dir.join(format!("shard-{shard:03}-{dest}.wal"));
+        let dir = queue_dir.join(format!("shard-{shard:03}-{dest}"));
+        let cursor_path = dir.join("lane.cursor");
         tokio::time::timeout(Duration::from_secs(2), async move {
             loop {
-                // Success is either (a) cursor ahead of zero while writer is
-                // still ahead of reader, or (b) shard file truncated to zero
-                // because mark_exported() caught up to EOF and reclaimed disk.
-                let cursor_offset = std::fs::read_to_string(&cursor_path)
-                    .ok()
-                    .and_then(|raw| raw.trim().parse::<u64>().ok())
-                    .unwrap_or(0);
-                let shard_size = std::fs::metadata(&shard_path)
-                    .map_or(u64::MAX, |meta| meta.len());
-                if cursor_offset > 0 || shard_size == 0 {
+                // The lane has drained once its cursor has moved off the origin:
+                // either forward inside the first segment, or onto a later one
+                // whose predecessors have been unlinked.
+                if read_cursor(&cursor_path) != SegmentCursor::default() {
                     return;
                 }
                 sleep(Duration::from_millis(5)).await;
             }
         })
         .await
-        .expect("export worker should drain the shard (cursor advance or truncation) after Tinybird success");
+        .expect("export worker should advance the lane cursor after Tinybird success");
     }
 
     fn string_kv(key: &str, value: &str) -> KeyValue {
@@ -4913,7 +5148,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            pipeline.wal_backlog_bytes().await > 0,
+            pipeline.wal_backlog_bytes() > 0,
             "a committed, unexported frame must count as backlog"
         );
         let remaining = pipeline.drain_wal(Duration::from_millis(300)).await;
@@ -5161,9 +5396,11 @@ mod tests {
 
     #[tokio::test]
     async fn migrate_legacy_shard_relocates_frames_into_lanes() {
-        // A pre-lanes binary wrote a single `shard-NNN.wal` mixing destinations.
-        // On startup we must relocate each surviving frame into its destination
-        // lane and remove the legacy file — without dropping anything.
+        // Two pre-segment shapes have to survive a rollout: `shard-NNN.wal`
+        // (before per-destination lanes, mixing both destinations in one file)
+        // and `shard-NNN-<dest>.wal` (one file per lane). Each surviving frame
+        // is relocated into its lane's segments and the legacy file removed —
+        // without dropping anything.
         let queue_dir = unique_test_dir("legacy-migration");
         std::fs::create_dir_all(&queue_dir).unwrap();
         let mut cfg = test_cfg();
@@ -5192,9 +5429,25 @@ mod tests {
         legacy.extend(encode_wal_frame(&tb_frame).unwrap());
         legacy.extend(encode_wal_frame(&ch_frame).unwrap());
         std::fs::write(queue_dir.join("shard-000.wal"), &legacy).unwrap();
+        // The Phase 1 shape: a per-lane file, already destination-scoped.
+        std::fs::write(
+            queue_dir.join("shard-000-tinybird.wal"),
+            encode_wal_frame(&EncodedFrame {
+                routing_key: 0,
+                org_id: "org_c".to_owned(),
+                signal: TelemetrySignal::Traces,
+                destination: ExportDestination::Tinybird,
+                datasource: "traces".to_owned(),
+                row_count: 1,
+                payload: br#"{"c":3}"#.to_vec(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
 
         let wal = ShardedWal::open(&cfg).expect("open WAL");
-        wal.migrate_legacy_shards(&cfg).await;
+        wal.migrate_legacy_files(&cfg).await;
+        wal.seal_all();
 
         assert!(
             !queue_dir.join("shard-000.wal").exists(),
@@ -5209,10 +5462,16 @@ mod tests {
             .replay(lane_index(0, ExportDestination::ClickHouse))
             .await
             .unwrap();
-        assert_eq!(tb_frames.len(), 1);
+        assert!(
+            !queue_dir.join("shard-000-tinybird.wal").exists(),
+            "the per-lane legacy file should be removed too"
+        );
+        assert_eq!(tb_frames.len(), 2);
         assert_eq!(tb_frames[0].org_id, "org_a");
         assert_eq!(tb_frames[0].destination, ExportDestination::Tinybird);
         assert_eq!(tb_frames[0].payload, br#"{"a":1}"#);
+        assert_eq!(tb_frames[1].org_id, "org_c");
+        assert_eq!(tb_frames[1].payload, br#"{"c":3}"#);
         assert_eq!(ch_frames.len(), 1);
         assert_eq!(ch_frames[0].org_id, "org_b");
         assert_eq!(ch_frames[0].destination, ExportDestination::ClickHouse);
@@ -6135,270 +6394,265 @@ mod tests {
         drop(std::fs::remove_dir_all(queue_dir));
     }
 
-    #[tokio::test]
-    async fn wal_truncates_after_full_drain_allowing_further_appends() {
-        // Regression: pre-fix, ShardedWal::append() only checked file-size-vs-max
-        // and the file was never truncated. After max_bytes was hit, the shard
-        // refused all further appends — even with every prior frame successfully
-        // exported. Now mark_exported() truncates the data file when the cursor
-        // catches up to EOF, so a steady-state pipeline never wedges.
-        let queue_dir = unique_test_dir("wal-truncates-on-drain");
-        std::fs::create_dir_all(&queue_dir).unwrap();
+    /// A lane whose segments seal every ~2 frames, so segment rotation,
+    /// deletion and replay are all reachable from a handful of appends.
+    fn segmented_cfg(queue_dir: PathBuf, lane_bytes: u64, segment_bytes: u64) -> TinybirdConfig {
         let mut cfg = test_cfg();
-        cfg.queue_dir = queue_dir.clone();
+        cfg.queue_dir = queue_dir;
         cfg.wal_shards = 1;
-        // Per-lane budget is queue_max_bytes / LANES_PER_SHARD, so size the total
-        // to leave each lane the ~512-byte budget this test exercises.
-        cfg.queue_max_bytes = 512 * LANES_PER_SHARD as u64;
+        cfg.queue_max_bytes = lane_bytes * LANES_PER_SHARD as u64;
+        cfg.wal_segment_max_bytes = segment_bytes;
+        cfg
+    }
 
-        let wal = ShardedWal::open(&cfg).expect("open WAL");
-
-        let frame = EncodedFrame {
+    fn wal_test_frame(payload_bytes: usize) -> EncodedFrame {
+        EncodedFrame {
             routing_key: 0,
             org_id: "org_contract".to_owned(),
             signal: TelemetrySignal::Traces,
             destination: ExportDestination::Tinybird,
             datasource: "traces".to_owned(),
             row_count: 1,
-            payload: vec![0u8; 200],
-        };
+            payload: vec![0u8; payload_bytes],
+        }
+    }
 
-        // First two appends fit (each ~240 bytes encoded, ≤512 budget).
-        let (start_a, end_a) = wal.append(0, &frame).await.expect("first append");
+    fn lane_dir(queue_dir: &Path) -> PathBuf {
+        queue_dir.join("shard-000-tinybird")
+    }
+
+    #[tokio::test]
+    async fn wal_reclaims_segments_once_the_cursor_passes_them() {
+        // The lane cap counts bytes on disk, so a lane only keeps accepting
+        // writes if exported segments are actually deleted. Before segments this
+        // needed either a moment where the cursor sat exactly at EOF, or a tail
+        // rewrite under the append lock; now it is an unlink.
+        let queue_dir = unique_test_dir("wal-reclaims-segments");
+        std::fs::create_dir_all(&queue_dir).unwrap();
+        let cfg = segmented_cfg(queue_dir.clone(), 800, 240);
+
+        let wal = ShardedWal::open(&cfg).expect("open WAL");
+        let frame = wal_test_frame(200);
+
+        // ~240 bytes encoded, so every frame fills a segment and seals it.
+        let (seg_a, start_a, end_a) = wal.append(0, &frame).await.expect("append a");
+        let (seg_b, _, end_b) = wal.append(0, &frame).await.expect("append b");
+        let (seg_c, _, _) = wal.append(0, &frame).await.expect("append c");
         assert_eq!(start_a, 0);
-        let (start_b, end_b) = wal.append(0, &frame).await.expect("second append");
-        assert_eq!(start_b, end_a);
+        assert_eq!(
+            (seg_a, seg_b, seg_c),
+            (0, 1, 2),
+            "each frame seals a segment"
+        );
 
-        // Third append would overflow before the fix would let us truncate.
         wal.append(0, &frame)
             .await
-            .expect_err("third append exceeds shard budget");
+            .expect_err("a fourth frame exceeds the lane budget");
 
-        // Drain the cursor to EOF — this should truncate the lane file.
-        wal.mark_exported(0, end_b).await.expect("mark_exported");
+        // Retire the first two segments. The third is still the active one, so
+        // its bytes stay.
+        wal.mark_exported(
+            0,
+            SegmentCursor {
+                seq: seg_b,
+                offset: end_b,
+            },
+            end_a + end_b,
+        )
+        .await
+        .expect("mark_exported");
 
-        let shard_path = queue_dir.join("shard-000-tinybird.wal");
-        let size_after_drain = std::fs::metadata(&shard_path).unwrap().len();
+        let dir = lane_dir(&queue_dir);
         assert_eq!(
-            size_after_drain, 0,
-            "lane file should be truncated to 0 after full drain"
-        );
-
-        let cursor_after_drain =
-            std::fs::read_to_string(queue_dir.join("shard-000-tinybird.cursor")).unwrap();
-        assert_eq!(
-            cursor_after_drain.trim(),
-            "0",
-            "cursor should reset to 0 after truncate"
-        );
-
-        // The shard accepts new writes again — previously this would still fail
-        // because the file size, not cursor delta, was the gating signal.
-        let (start_c, _end_c) = wal
-            .append(0, &frame)
-            .await
-            .expect("append after drain should succeed");
-        assert_eq!(
-            start_c, end_b,
-            "offsets stay monotonic across a reclaim so an in-flight frame's \
-             offset is never reused by a fresh file"
+            list_segments(&dir).unwrap(),
+            vec![seg_c, seg_c + 1],
+            "exported segments are unlinked; the active one and its successor remain"
         );
         assert_eq!(
-            std::fs::metadata(&shard_path).unwrap().len(),
-            end_a,
-            "the append lands in a fresh file, one frame long"
-        );
-
-        drop(std::fs::remove_dir_all(queue_dir));
-    }
-
-    #[tokio::test]
-    async fn wal_partial_drain_advances_cursor_without_truncating() {
-        // When mark_exported() lands while writers are still ahead of the cursor,
-        // we must NOT truncate — that would erase frames that haven't been
-        // exported yet. We only persist the offset.
-        let queue_dir = unique_test_dir("wal-partial-drain");
-        std::fs::create_dir_all(&queue_dir).unwrap();
-        let mut cfg = test_cfg();
-        cfg.queue_dir = queue_dir.clone();
-        cfg.wal_shards = 1;
-        cfg.queue_max_bytes = 4096;
-
-        let wal = ShardedWal::open(&cfg).expect("open WAL");
-        let frame = EncodedFrame {
-            routing_key: 0,
-            org_id: "org_contract".to_owned(),
-            signal: TelemetrySignal::Traces,
-            destination: ExportDestination::Tinybird,
-            datasource: "traces".to_owned(),
-            row_count: 1,
-            payload: vec![0u8; 100],
-        };
-
-        let (_, end_a) = wal.append(0, &frame).await.unwrap();
-        let (_, end_b) = wal.append(0, &frame).await.unwrap();
-        assert!(end_b > end_a);
-
-        // Cursor advances to the first frame's end while frame B is still
-        // unexported (writer is ahead of reader).
-        wal.mark_exported(0, end_a).await.unwrap();
-
-        let shard_path = queue_dir.join("shard-000-tinybird.wal");
-        let size_after_partial = std::fs::metadata(&shard_path).unwrap().len();
-        assert_eq!(
-            size_after_partial, end_b,
-            "lane file must keep unexported bytes when cursor is behind EOF"
-        );
-        let cursor_after_partial =
-            std::fs::read_to_string(queue_dir.join("shard-000-tinybird.cursor")).unwrap();
-        assert_eq!(cursor_after_partial.trim(), end_a.to_string());
-
-        drop(std::fs::remove_dir_all(queue_dir));
-    }
-
-    #[tokio::test]
-    async fn wal_compacts_exported_prefix_without_a_full_drain() {
-        // Regression: mark_exported() only reclaimed disk when the cursor landed
-        // exactly at EOF. A continuously busy lane never has that moment, so its
-        // file grew until it tripped max_bytes and started rejecting writes —
-        // "Telemetry WAL lane is full" while export was healthy and the bytes it
-        // held were already exported. The prefix is now reclaimed in place.
-        let queue_dir = unique_test_dir("wal-compacts-prefix");
-        std::fs::create_dir_all(&queue_dir).unwrap();
-        let mut cfg = test_cfg();
-        cfg.queue_dir = queue_dir.clone();
-        cfg.wal_shards = 1;
-        // ~1024 bytes per lane, so compaction arms once 512 bytes are exported.
-        cfg.queue_max_bytes = 1024 * LANES_PER_SHARD as u64;
-
-        let wal = ShardedWal::open(&cfg).expect("open WAL");
-        let frame = EncodedFrame {
-            routing_key: 0,
-            org_id: "org_contract".to_owned(),
-            signal: TelemetrySignal::Traces,
-            destination: ExportDestination::Tinybird,
-            datasource: "traces".to_owned(),
-            row_count: 1,
-            payload: vec![0u8; 200],
-        };
-
-        // Fill the lane, never letting the cursor reach EOF.
-        let (_, _end_a) = wal.append(0, &frame).await.expect("append a");
-        let (_, _end_b) = wal.append(0, &frame).await.expect("append b");
-        let (_, end_c) = wal.append(0, &frame).await.expect("append c");
-        let (_, end_d) = wal.append(0, &frame).await.expect("append d");
-        wal.append(0, &frame)
-            .await
-            .expect_err("lane is full before compaction");
-
-        // Writer is still ahead of the reader — the old code would only persist
-        // the offset here and leave the file at its full size forever.
-        wal.mark_exported(0, end_c).await.expect("mark_exported");
-
-        let shard_path = queue_dir.join("shard-000-tinybird.wal");
-        let unexported = end_d - end_c;
-        assert_eq!(
-            std::fs::metadata(&shard_path).unwrap().len(),
-            unexported,
-            "compaction keeps exactly the unexported tail"
-        );
-        assert_eq!(
-            std::fs::read_to_string(queue_dir.join("shard-000-tinybird.cursor"))
+            std::fs::read_to_string(dir.join("lane.cursor"))
                 .unwrap()
                 .trim(),
-            "0",
-            "the surviving tail starts at the front of the compacted file"
+            format!("{seg_c} 0"),
+            "a fully drained sealed segment leaves the cursor at the next segment's origin"
         );
-        assert!(
-            !queue_dir.join("shard-000-tinybird.wal.compacting").exists(),
-            "the compaction temp file is renamed away, not left behind"
-        );
+        assert_eq!(wal.backlog_bytes(), end_a, "one frame is still unexported");
 
-        // The lane accepts writes again, and offsets stay on one monotonic axis
-        // so the frames still in flight resolve against the rewritten file.
-        let (start_e, _end_e) = wal
-            .append(0, &frame)
+        // The reclaim freed budget, so the lane accepts writes again.
+        wal.append(0, &frame)
             .await
-            .expect("append after compaction should succeed");
-        assert_eq!(start_e, end_d, "virtual offsets survive the rewrite");
+            .expect("append after reclaim should succeed");
 
-        // Exactly the unexported frames replay — no loss, no duplicates.
-        let replayed = wal.replay(0).await.expect("replay");
+        drop(std::fs::remove_dir_all(queue_dir));
+    }
+
+    #[tokio::test]
+    async fn wal_partial_drain_keeps_the_unexported_tail() {
+        // A cursor landing mid-segment must persist the offset and nothing else:
+        // deleting or rewriting the file here would drop frames that were never
+        // exported.
+        let queue_dir = unique_test_dir("wal-partial-drain");
+        std::fs::create_dir_all(&queue_dir).unwrap();
+        let cfg = segmented_cfg(queue_dir.clone(), 4096, WAL_SEGMENT_MAX_BYTES);
+
+        let wal = ShardedWal::open(&cfg).expect("open WAL");
+        let frame = wal_test_frame(100);
+
+        let (seg_a, _, end_a) = wal.append(0, &frame).await.unwrap();
+        let (seg_b, _, end_b) = wal.append(0, &frame).await.unwrap();
+        assert_eq!(seg_a, seg_b, "both frames fit one segment");
+        assert!(end_b > end_a);
+
+        wal.mark_exported(
+            0,
+            SegmentCursor {
+                seq: seg_a,
+                offset: end_a,
+            },
+            end_a,
+        )
+        .await
+        .unwrap();
+
+        let dir = lane_dir(&queue_dir);
         assert_eq!(
-            replayed.len(),
-            2,
-            "only frame d and frame e survive the compaction"
+            file_len(&segment_path(&dir, seg_a)),
+            end_b,
+            "the segment keeps its unexported bytes"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.join("lane.cursor"))
+                .unwrap()
+                .trim(),
+            format!("{seg_a} {end_a}")
+        );
+        assert_eq!(wal.backlog_bytes(), end_b - end_a);
+
+        drop(std::fs::remove_dir_all(queue_dir));
+    }
+
+    #[tokio::test]
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "holding the export lock across the append IS the assertion: the two sides must \
+                  not share a mutex"
+    )]
+    async fn wal_appends_do_not_wait_on_an_export() {
+        // The regression this layout exists for: reclaiming space used to run
+        // under the append mutex, so a commit could sit behind a multi-megabyte
+        // copy — a flat 3ms p50 with a p95 swinging between 145ms and 998ms.
+        // Holding the export side must not stall a commit.
+        let queue_dir = unique_test_dir("wal-append-during-export");
+        std::fs::create_dir_all(&queue_dir).unwrap();
+        let cfg = segmented_cfg(queue_dir.clone(), 64 * 1024, 240);
+
+        let wal = ShardedWal::open(&cfg).expect("open WAL");
+        let frame = wal_test_frame(200);
+        wal.append(0, &frame).await.expect("seed append");
+
+        let held = Arc::clone(&wal.lanes[0]);
+        let guard = held.export.lock().expect("export lock");
+        let appended = tokio::time::timeout(Duration::from_secs(2), wal.append(0, &frame)).await;
+        drop(guard);
+
+        appended
+            .expect("an append must not block on the export lock")
+            .expect("append while the export side is held");
+
+        drop(std::fs::remove_dir_all(queue_dir));
+    }
+
+    #[tokio::test]
+    async fn wal_replays_exactly_the_unexported_frames_after_a_restart() {
+        // What survives a task replacement: everything the export cursor has not
+        // passed, across segment boundaries, and nothing it has.
+        let queue_dir = unique_test_dir("wal-replay-across-segments");
+        std::fs::create_dir_all(&queue_dir).unwrap();
+        let cfg = segmented_cfg(queue_dir.clone(), 64 * 1024, 240);
+
+        let frame = wal_test_frame(200);
+        let (mid_seq, mid_end) = {
+            let wal = ShardedWal::open(&cfg).expect("open WAL");
+            wal.append(0, &frame).await.expect("append a");
+            let (seq, _, end) = wal.append(0, &frame).await.expect("append b");
+            wal.append(0, &frame).await.expect("append c");
+            wal.append(0, &frame).await.expect("append d");
+            (seq, end)
+        };
+
+        // Frames a and b are exported; c and d are not.
+        {
+            let wal = ShardedWal::open(&cfg).expect("reopen WAL");
+            wal.mark_exported(
+                0,
+                SegmentCursor {
+                    seq: mid_seq,
+                    offset: mid_end,
+                },
+                mid_end,
+            )
+            .await
+            .expect("mark_exported");
+        }
+
+        let wal = ShardedWal::open(&cfg).expect("reopen WAL after export");
+        let replayed = wal.replay(0).await.expect("replay");
+        assert_eq!(replayed.len(), 2, "only the unexported frames come back");
+        assert!(
+            replayed.iter().all(|frame| frame.segment > mid_seq),
+            "replayed frames sit past the cursor's segment"
+        );
+        assert_eq!(
+            wal.backlog_bytes(),
+            replayed.iter().map(|f| f.end - f.start).sum::<u64>(),
+            "the recovered backlog is what a shutdown drain would wait for"
+        );
+
+        // Retiring them drains the lane for real.
+        let last = replayed.last().unwrap();
+        wal.mark_exported(
+            0,
+            SegmentCursor {
+                seq: last.segment,
+                offset: last.end,
+            },
+            wal.backlog_bytes(),
+        )
+        .await
+        .expect("final drain");
+        assert_eq!(wal.backlog_bytes(), 0);
+        assert!(
+            wal.replay(0).await.expect("replay after drain").is_empty(),
+            "a drained lane replays nothing"
         );
 
         drop(std::fs::remove_dir_all(queue_dir));
     }
 
     #[tokio::test]
-    async fn wal_compaction_does_not_strand_frames_already_in_flight() {
-        // The hazard compaction introduces: a frame is appended, its offsets are
-        // handed to the export worker, and only *then* is the file rewritten
-        // underneath it. If those offsets were file-relative, the worker's later
-        // mark_exported() would carry a number far past the rewritten file's end,
-        // read as a full drain, and truncate away frames that were never
-        // exported. Frames therefore carry virtual offsets; this test fails with
-        // silent data loss if that translation is dropped.
-        let queue_dir = unique_test_dir("wal-compaction-in-flight");
+    async fn wal_recovers_when_the_cursor_file_is_lost() {
+        // Losing the cursor must replay the lane, not skip it: a duplicate
+        // export is at-least-once, which every destination already tolerates,
+        // and a skipped frame is silent loss.
+        let queue_dir = unique_test_dir("wal-lost-cursor");
         std::fs::create_dir_all(&queue_dir).unwrap();
-        let mut cfg = test_cfg();
-        cfg.queue_dir = queue_dir.clone();
-        cfg.wal_shards = 1;
-        cfg.queue_max_bytes = 1024 * LANES_PER_SHARD as u64;
+        let cfg = segmented_cfg(queue_dir.clone(), 64 * 1024, 240);
 
-        let wal = ShardedWal::open(&cfg).expect("open WAL");
-        let frame = EncodedFrame {
-            routing_key: 0,
-            org_id: "org_contract".to_owned(),
-            signal: TelemetrySignal::Traces,
-            destination: ExportDestination::Tinybird,
-            datasource: "traces".to_owned(),
-            row_count: 1,
-            payload: vec![0u8; 200],
-        };
+        let frame = wal_test_frame(200);
+        {
+            let wal = ShardedWal::open(&cfg).expect("open WAL");
+            let (seq, _, end) = wal.append(0, &frame).await.expect("append a");
+            wal.append(0, &frame).await.expect("append b");
+            wal.mark_exported(0, SegmentCursor { seq, offset: end }, end)
+                .await
+                .expect("mark_exported");
+        }
+        std::fs::remove_file(lane_dir(&queue_dir).join("lane.cursor")).expect("drop cursor");
 
-        let (_, _end_a) = wal.append(0, &frame).await.expect("append a");
-        let (_, _end_b) = wal.append(0, &frame).await.expect("append b");
-        let (_, end_c) = wal.append(0, &frame).await.expect("append c");
-        // Frame d is "in flight": appended, offsets handed out, not yet exported.
-        let (_, end_d) = wal.append(0, &frame).await.expect("append d");
-
-        wal.mark_exported(0, end_c).await.expect("compacting drain");
-
-        // A frame that arrives after the rewrite, which the stale-offset bug
-        // would destroy along with everything else in the file.
-        let (_, end_e) = wal.append(0, &frame).await.expect("append e");
-
-        // The worker now retires frame d using the offset it captured *before*
-        // compaction. Frame e must survive.
-        wal.mark_exported(0, end_d).await.expect("in-flight drain");
-
-        let shard_path = queue_dir.join("shard-000-tinybird.wal");
-        assert_ne!(
-            std::fs::metadata(&shard_path).unwrap().len(),
-            0,
-            "a stale in-flight offset must not read as a full drain"
-        );
-        let replayed = wal.replay(0).await.expect("replay");
+        let wal = ShardedWal::open(&cfg).expect("reopen WAL");
         assert_eq!(
-            replayed.len(),
+            wal.replay(0).await.expect("replay").len(),
             1,
-            "frame e is unexported and must still be replayable"
-        );
-        assert_eq!(
-            replayed[0].end, end_e,
-            "the surviving frame keeps its original virtual offset"
-        );
-
-        // Retiring frame e too now drains the lane for real.
-        wal.mark_exported(0, end_e).await.expect("final drain");
-        assert_eq!(
-            std::fs::metadata(&shard_path).unwrap().len(),
-            0,
-            "a genuine full drain still truncates"
+            "the surviving segment replays from its start"
         );
 
         drop(std::fs::remove_dir_all(queue_dir));

--- a/apps/ingest/src/telemetry.rs
+++ b/apps/ingest/src/telemetry.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use crate::clickhouse_insert_mappings::{self, InsertMapping};
@@ -12,6 +12,8 @@ use crate::metrics;
 use crate::otel::{
     encode_rows_internal_span, export_client_span, record_stage_error, wal_commit_internal_span,
 };
+use crate::wal_store::WalSegmentStore;
+use chrono::Utc;
 use crc32fast::Hasher as Crc32;
 use dashmap::DashMap;
 use flate2::write::GzEncoder;
@@ -470,6 +472,8 @@ pub struct TinybirdConfig {
     /// `WAL_SEGMENT_MAX_BYTES`; exposed so the object size the S3 tier ships can
     /// be tuned without a rebuild.
     pub wal_segment_max_bytes: u64,
+    /// How often this task refreshes its owner marker in the durability tier.
+    pub wal_store_heartbeat_interval: Duration,
     pub batch_max_rows: usize,
     pub batch_max_bytes: usize,
     pub batch_max_wait: Duration,
@@ -808,6 +812,26 @@ impl TelemetryPipeline {
         clickhouse_targets: Option<Arc<dyn ClickHouseTargetProvider>>,
         require_tinybird_credentials: bool,
     ) -> Result<Self, String> {
+        Self::new_with_object_store(
+            cfg,
+            http,
+            clickhouse_targets,
+            require_tinybird_credentials,
+            None,
+        )
+        .await
+    }
+
+    /// The full constructor. `segment_store` adds the durability tier: sealed
+    /// segments are shipped to it as they close, and on startup this task claims
+    /// and replays whatever a dead one left behind.
+    pub async fn new_with_object_store(
+        cfg: TinybirdConfig,
+        http: impl Into<HttpClient>,
+        clickhouse_targets: Option<Arc<dyn ClickHouseTargetProvider>>,
+        require_tinybird_credentials: bool,
+        segment_store: Option<Arc<WalSegmentStore>>,
+    ) -> Result<Self, String> {
         let http: HttpClient = http.into();
         cfg.validate_for_pipeline(require_tinybird_credentials)?;
         std::fs::create_dir_all(&cfg.queue_dir)
@@ -819,6 +843,17 @@ impl TelemetryPipeline {
         wal.migrate_legacy_files(&cfg).await;
         // Relocated frames land in the active segment, which replay skips.
         wal.seal_all();
+        if let Some(store) = &segment_store {
+            wal.recover_orphans(&cfg, store).await;
+            // Attached after recovery so the shipper starts from a settled set
+            // of segments, and before any request is accepted so no lane ever
+            // seals a segment the shipper cannot see.
+            wal.attach_object_store(store);
+            tokio::spawn(run_owner_heartbeat(
+                Arc::clone(store),
+                cfg.wal_store_heartbeat_interval,
+            ));
+        }
         let org_queue_bytes = Arc::new(DashMap::new());
         let mirror_org_queue_bytes = Arc::new(DashMap::new());
         let clickhouse_breakers = Arc::new(ClickHouseBreakerRegistry::new(cfg.clickhouse_breaker));
@@ -865,6 +900,23 @@ impl TelemetryPipeline {
         };
         pipeline.replay_committed_frames().await;
         Ok(pipeline)
+    }
+
+    /// Seal and ship every segment the lanes still owe, and stop advertising
+    /// this task as alive.
+    ///
+    /// Shutdown calls this once the drain has done what it can: whatever did not
+    /// export is now in the object store under an owner whose heartbeat is gone,
+    /// so the next task claims it immediately instead of waiting out the
+    /// staleness window. Returns the bytes shipped.
+    pub async fn flush_wal_to_object_store(&self) -> u64 {
+        let shipped = self.inner.wal.flush_to_object_store().await;
+        if let Some(store) = self.inner.wal.store.get() {
+            if let Err(error) = store.retire().await {
+                warn!(error = %error, "Failed to retire the WAL owner heartbeat");
+            }
+        }
+        shipped
     }
 
     /// Bytes committed to the primary WAL lanes and not yet exported.
@@ -1356,7 +1408,20 @@ struct ShardedWal {
     /// One segment directory per lane (`shard × destination`), indexed by
     /// `lane_index`.
     lanes: Vec<Arc<WalLane>>,
+    /// The durability tier, when one is configured. Set once during startup,
+    /// before any traffic is accepted.
+    store: OnceLock<Arc<WalSegmentStore>>,
 }
+
+/// Shipper tasks. Lanes are assigned `lane % SEGMENT_SHIPPER_WORKERS`, so one
+/// lane's events stay ordered — a segment can never be deleted from the bucket
+/// by an event that overtakes its own upload — while different lanes still ship
+/// concurrently.
+const SEGMENT_SHIPPER_WORKERS: usize = 4;
+
+/// Events one shipper task will hold before it starts dropping them. Generous:
+/// the alternative to a drop is stalling an append on S3.
+const SEGMENT_SHIPPER_QUEUE: usize = 1024;
 
 /// One lane's log: a directory of sealed segments plus the single segment
 /// appends currently land in.
@@ -1369,6 +1434,11 @@ struct ShardedWal {
 struct WalLane {
     shard: usize,
     destination: ExportDestination,
+    /// This lane's index, and the `shard-NNN-<destination>` name its segments
+    /// are stored under — the object key has to survive the task that wrote it,
+    /// so it cannot be a process-local index.
+    index: usize,
+    lane_key: String,
     dir: PathBuf,
     cursor_path: PathBuf,
     max_bytes: u64,
@@ -1388,6 +1458,21 @@ struct WalLane {
     exported_bytes: AtomicU64,
     append: Mutex<LaneAppend>,
     export: Mutex<LaneExport>,
+    /// Set once, if a durability tier is configured, before any traffic is
+    /// accepted. Segments are announced to it as they seal and as they are
+    /// unlinked.
+    shipper: OnceLock<mpsc::Sender<SegmentEvent>>,
+}
+
+/// A segment's lifecycle as the object-store shipper sees it. Events for one
+/// lane are processed in order, so a segment is never deleted from the bucket
+/// before the upload that put it there.
+#[derive(Clone, Copy, Debug)]
+enum SegmentEvent {
+    /// Sealed and final. Shipped unless the exporter gets there first.
+    Sealed { lane: usize, seq: u64 },
+    /// Exported and unlinked locally; the object is now dead weight.
+    Exported { lane: usize, seq: u64 },
 }
 
 struct LaneAppend {
@@ -1467,9 +1552,8 @@ impl WalLane {
         cfg: &TinybirdConfig,
         max_bytes: u64,
     ) -> Result<Self, String> {
-        let dir = cfg
-            .queue_dir
-            .join(format!("shard-{shard:03}-{}", destination.as_str()));
+        let lane_key = format!("shard-{shard:03}-{}", destination.as_str());
+        let dir = cfg.queue_dir.join(&lane_key);
         std::fs::create_dir_all(&dir)
             .map_err(|error| format!("create ingest WAL lane {}: {error}", dir.display()))?;
         let cursor_path = dir.join("lane.cursor");
@@ -1513,6 +1597,8 @@ impl WalLane {
         Ok(Self {
             shard,
             destination,
+            index: lane_index(shard, destination),
+            lane_key,
             dir,
             cursor_path,
             max_bytes,
@@ -1531,6 +1617,7 @@ impl WalLane {
                 next_delete: cursor.seq,
                 cursor,
             }),
+            shipper: OnceLock::new(),
         })
     }
 
@@ -1586,7 +1673,8 @@ impl WalLane {
     /// Close the active segment and open the next one. The caller holds
     /// `append`; every frame in the outgoing segment is already `sync_data`d.
     fn seal(&self, state: &mut LaneAppend) -> Result<(), String> {
-        let next = state.seq + 1;
+        let sealed = state.seq;
+        let next = sealed + 1;
         let file = open_segment(&self.dir, next)?;
         // Published before the handle is swapped, so a reader that sees `next`
         // is looking at a segment whose length can no longer change.
@@ -1595,7 +1683,49 @@ impl WalLane {
         state.file = file;
         state.len = 0;
         metrics::wal_segment_sealed(self.shard, self.destination.as_str());
+        self.notify(SegmentEvent::Sealed {
+            lane: self.index,
+            seq: sealed,
+        });
         Ok(())
+    }
+
+    /// Hand a segment event to the shipper, if one is attached.
+    ///
+    /// A full channel drops the event rather than blocking the caller — an
+    /// append must not wait on S3. A dropped `Sealed` leaves that segment local
+    /// only; a dropped `Exported` leaves an object behind that a later claim
+    /// replays, which is the at-least-once this whole tier is built on.
+    fn notify(&self, event: SegmentEvent) {
+        let Some(shipper) = self.shipper.get() else {
+            return;
+        };
+        if shipper.try_send(event).is_err() {
+            metrics::wal_ship_dropped(self.shard, self.destination.as_str());
+        }
+    }
+
+    /// Whether the exporter has already moved past this segment.
+    fn is_exported(&self, seq: u64) -> bool {
+        self.export.lock().is_ok_and(|state| seq < state.cursor.seq)
+    }
+
+    /// Sealed segments this lane still owes, oldest first.
+    fn unexported_segments(&self) -> Vec<u64> {
+        let cursor_seq = match self.export.lock() {
+            Ok(state) => state.cursor.seq,
+            Err(_) => return Vec::new(),
+        };
+        let active = self.active_seq.load(Ordering::Acquire);
+        list_segments(&self.dir)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|seq| *seq >= cursor_seq && *seq < active)
+            .collect()
+    }
+
+    fn read_segment(&self, seq: u64) -> Option<Vec<u8>> {
+        std::fs::read(segment_path(&self.dir, seq)).ok()
     }
 
     /// Advance the export cursor and drop every segment fully behind it.
@@ -1642,6 +1772,10 @@ impl WalLane {
                     );
                 }
             }
+            self.notify(SegmentEvent::Exported {
+                lane: self.index,
+                seq: state.next_delete,
+            });
             state.next_delete += 1;
         }
         drop(state);
@@ -1696,7 +1830,80 @@ impl ShardedWal {
                 )?));
             }
         }
-        Ok(Self { lanes })
+        Ok(Self {
+            lanes,
+            store: OnceLock::new(),
+        })
+    }
+
+    /// Attach the durability tier and start shipping sealed segments.
+    ///
+    /// Called during startup, after recovery and before the first request, so a
+    /// lane either has a shipper for its whole life or never has one.
+    fn attach_object_store(&self, store: &Arc<WalSegmentStore>) {
+        drop(self.store.set(Arc::clone(store)));
+        let mut senders = Vec::with_capacity(SEGMENT_SHIPPER_WORKERS);
+        for _ in 0..SEGMENT_SHIPPER_WORKERS {
+            let (sender, receiver) = mpsc::channel(SEGMENT_SHIPPER_QUEUE);
+            senders.push(sender);
+            tokio::spawn(run_segment_shipper(
+                self.lanes.clone(),
+                Arc::clone(store),
+                receiver,
+            ));
+        }
+        for (index, lane) in self.lanes.iter().enumerate() {
+            drop(
+                lane.shipper
+                    .set(senders[index % SEGMENT_SHIPPER_WORKERS].clone()),
+            );
+        }
+    }
+
+    /// Seal every lane and ship everything it still owes, synchronously.
+    ///
+    /// The shipper only ever sees *sealed* segments, so the segment appends are
+    /// landing in is local-only until this runs. That is the gap a SIGKILL after
+    /// an incomplete drain would otherwise fall into, so shutdown calls this
+    /// once the drain gives up. Returns the bytes shipped.
+    async fn flush_to_object_store(&self) -> u64 {
+        let Some(store) = self.store.get() else {
+            return 0;
+        };
+        self.flush_segments_to(store).await
+    }
+
+    /// The flush itself, against an explicit store — recovery runs it before the
+    /// store handle is attached, and re-shipping the frames it just recovered is
+    /// what lets it delete the objects it took them from.
+    async fn flush_segments_to(&self, store: &WalSegmentStore) -> u64 {
+        self.seal_all();
+        let mut shipped = 0;
+        for lane in &self.lanes {
+            for seq in lane.unexported_segments() {
+                let Some(bytes) = lane.read_segment(seq) else {
+                    continue;
+                };
+                let len = bytes.len() as u64;
+                match store.put_segment(&lane.lane_key, seq, bytes).await {
+                    Ok(()) => {
+                        shipped += len;
+                        metrics::wal_segment_shipped(lane.shard, lane.destination.as_str(), len);
+                    }
+                    Err(error) => {
+                        warn!(
+                            shard = lane.shard,
+                            destination = lane.destination.as_str(),
+                            segment = seq,
+                            error_kind = error.error_kind(),
+                            %error,
+                            "Failed to ship a WAL segment during shutdown flush"
+                        );
+                    }
+                }
+            }
+        }
+        shipped
     }
 
     /// Relocate any pre-segment WAL file into the lane's segment directory.
@@ -1804,6 +2011,122 @@ impl ShardedWal {
         }
     }
 
+    /// The local lane a recovered `shard-NNN-<destination>` key belongs to.
+    ///
+    /// The shard count can differ from the task that wrote the segment (it
+    /// follows the CPU count), so the shard is folded into the local range. The
+    /// destination is not: a frame must never change where it is exported to.
+    fn lane_for_key(lane_key: &str, cfg: &TinybirdConfig) -> Option<usize> {
+        let rest = lane_key.strip_prefix("shard-")?;
+        let (shard, destination) = rest.split_once('-')?;
+        let shard = shard.parse::<usize>().ok()? % cfg.wal_shards;
+        let destination = ExportDestination::ALL
+            .into_iter()
+            .find(|candidate| candidate.as_str() == destination)?;
+        Some(lane_index(shard, destination))
+    }
+
+    /// Claim and re-commit the segments a dead task left in the object store.
+    ///
+    /// Runs before the export workers start, so recovered frames are picked up
+    /// by the same replay path as anything this task's own disk was holding.
+    /// Every step is best-effort: a bucket that is unreachable must not stop the
+    /// gateway from booting and accepting traffic.
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "WAL recovery: the branches are the recovery cases, and each needs the others' \
+                  context to be readable"
+    )]
+    async fn recover_orphans(&self, cfg: &TinybirdConfig, store: &WalSegmentStore) {
+        let now = Utc::now();
+        let owners = match store.stale_owners(now).await {
+            Ok(owners) => owners,
+            Err(error) => {
+                warn!(error = %error, "Failed to list WAL owners; skipping orphan recovery");
+                return;
+            }
+        };
+        for owner in owners {
+            match store.claim(&owner, now).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    info!(owner, "Another task is already recovering this WAL owner");
+                    continue;
+                }
+                Err(error) => {
+                    warn!(owner, error = %error, "Failed to claim orphaned WAL segments");
+                    continue;
+                }
+            }
+            let segments = match store.take_segments(&owner).await {
+                Ok(segments) => segments,
+                Err(error) => {
+                    warn!(owner, error = %error, "Failed to read orphaned WAL segments");
+                    continue;
+                }
+            };
+            let mut recovered_frames = 0usize;
+            let mut keys = Vec::with_capacity(segments.len());
+            for segment in segments {
+                let Some(lane) = Self::lane_for_key(&segment.lane_key, cfg) else {
+                    warn!(
+                        owner,
+                        lane_key = segment.lane_key,
+                        "Skipping an orphaned WAL segment for an unknown lane"
+                    );
+                    continue;
+                };
+                let frames = decode_segment_frames(&segment.bytes);
+                let mut committed = true;
+                for frame in frames {
+                    let encoded = EncodedFrame {
+                        routing_key: 0, // the lane is already decided by the key
+                        org_id: frame.org_id,
+                        signal: frame.signal,
+                        destination: frame.destination,
+                        datasource: frame.datasource,
+                        row_count: frame.row_count,
+                        payload: frame.payload,
+                    };
+                    // Bypass the lane cap: these frames were accepted by the
+                    // task that died, and rejecting them here is the loss this
+                    // whole tier exists to prevent.
+                    if let Err(error) = self.append_inner(lane, &encoded, false).await {
+                        warn!(owner, error = %error, "Failed to re-commit an orphaned WAL frame");
+                        committed = false;
+                        break;
+                    }
+                    recovered_frames += 1;
+                }
+                if committed {
+                    keys.push(segment.key);
+                }
+            }
+            if recovered_frames == 0 && keys.is_empty() {
+                drop(store.release_owner(&owner).await);
+                continue;
+            }
+            // Sealed and re-shipped under our own owner id *before* the source
+            // objects are dropped, so the frames are never only on this task's
+            // disk.
+            self.flush_segments_to(store).await;
+            for key in keys {
+                if let Err(error) = store.release_key(&key).await {
+                    warn!(owner, key, error = %error, "Failed to delete a recovered WAL segment");
+                }
+            }
+            if let Err(error) = store.release_owner(&owner).await {
+                warn!(owner, error = %error, "Failed to retire a recovered WAL owner");
+            }
+            metrics::wal_frames_recovered(recovered_frames as u64);
+            info!(
+                owner,
+                frames = recovered_frames,
+                "Recovered orphaned WAL segments from the object store"
+            );
+        }
+    }
+
     fn lane(&self, lane: usize) -> Result<Arc<WalLane>, String> {
         self.lanes
             .get(lane)
@@ -1858,6 +2181,75 @@ impl ShardedWal {
         tokio::task::spawn_blocking(move || lane_ref.mark_exported_blocking(cursor, bytes))
             .await
             .map_err(|error| format!("join WAL cursor: {error}"))?
+    }
+}
+
+/// Keep this task's owner marker fresh, so a booting task can tell a live
+/// writer's segments from a dead one's.
+async fn run_owner_heartbeat(store: Arc<WalSegmentStore>, interval: Duration) {
+    loop {
+        if let Err(error) = store.heartbeat().await {
+            warn!(error = %error, "Failed to refresh the WAL owner heartbeat");
+        }
+        sleep(interval).await;
+    }
+}
+
+/// Ship and retire segments for one shipper's share of the lanes.
+///
+/// Events arrive in the order their lane produced them, so an `Exported` for a
+/// segment always follows the `Sealed` that uploaded it.
+async fn run_segment_shipper(
+    lanes: Vec<Arc<WalLane>>,
+    store: Arc<WalSegmentStore>,
+    mut receiver: mpsc::Receiver<SegmentEvent>,
+) {
+    while let Some(event) = receiver.recv().await {
+        let (SegmentEvent::Sealed { lane, seq } | SegmentEvent::Exported { lane, seq }) = event;
+        let Some(lane_ref) = lanes.get(lane) else {
+            continue;
+        };
+        let result = match event {
+            SegmentEvent::Sealed { .. } => {
+                // A healthy pipeline exports a segment well before its upload
+                // comes up, and a segment already in the warehouse needs no
+                // backup — which is why this tier costs almost nothing.
+                if lane_ref.is_exported(seq) {
+                    metrics::wal_ship_skipped(lane_ref.shard, lane_ref.destination.as_str());
+                    continue;
+                }
+                let Some(bytes) = lane_ref.read_segment(seq) else {
+                    continue;
+                };
+                let len = bytes.len() as u64;
+                store
+                    .put_segment(&lane_ref.lane_key, seq, bytes)
+                    .await
+                    .inspect(|()| {
+                        metrics::wal_segment_shipped(
+                            lane_ref.shard,
+                            lane_ref.destination.as_str(),
+                            len,
+                        );
+                    })
+            }
+            SegmentEvent::Exported { .. } => store.delete_segment(&lane_ref.lane_key, seq).await,
+        };
+        if let Err(error) = result {
+            metrics::wal_ship_failed(
+                lane_ref.shard,
+                lane_ref.destination.as_str(),
+                error.error_kind(),
+            );
+            warn!(
+                shard = lane_ref.shard,
+                destination = lane_ref.destination.as_str(),
+                segment = seq,
+                error_kind = error.error_kind(),
+                %error,
+                "WAL segment shipping failed"
+            );
+        }
     }
 }
 
@@ -1958,6 +2350,30 @@ fn replay_lane(lane: usize, lane_ref: &WalLane) -> Result<Vec<QueuedFrame>, Stri
     Ok(frames)
 }
 
+/// Every frame in a segment downloaded from the object store.
+///
+/// A segment is a plain frame stream, so this is the replay reader over bytes
+/// instead of a file. A truncated or corrupt tail ends the segment rather than
+/// failing it: the frames before it are still good.
+fn decode_segment_frames(bytes: &[u8]) -> Vec<DecodedWalFrame> {
+    let mut reader = std::io::Cursor::new(bytes);
+    let mut offset = 0u64;
+    let mut frames = Vec::new();
+    loop {
+        match read_wal_frame(&mut reader, offset) {
+            Ok(Some(frame)) => {
+                offset = frame.end;
+                frames.push(frame);
+            }
+            Ok(None) => return frames,
+            Err(error) => {
+                warn!(offset, %error, "Dropping the tail of a corrupt recovered WAL segment");
+                return frames;
+            }
+        }
+    }
+}
+
 /// Read every surviving frame from a pre-segment WAL file, starting at its
 /// persisted cursor. Returns an empty vec if the file is absent. Used by
 /// `migrate_legacy_files` to relocate frames into lane segments.
@@ -2038,7 +2454,7 @@ struct DecodedWalFrame {
     clippy::too_many_lines,
     reason = "a binary header parsed field by field, each with its own bounds check"
 )]
-fn read_wal_frame(file: &mut File, start: u64) -> Result<Option<DecodedWalFrame>, String> {
+fn read_wal_frame(file: &mut impl Read, start: u64) -> Result<Option<DecodedWalFrame>, String> {
     let mut prefix = [0u8; 6];
     let read = file
         .read(&mut prefix)
@@ -3859,6 +4275,7 @@ mod tests {
             queue_channel_capacity: 10,
             wal_shards: 2,
             wal_segment_max_bytes: WAL_SEGMENT_MAX_BYTES,
+            wal_store_heartbeat_interval: crate::wal_store::DEFAULT_HEARTBEAT_INTERVAL,
             batch_max_rows: 100,
             batch_max_bytes: 1024 * 1024,
             batch_max_wait: Duration::from_millis(10),
@@ -6656,6 +7073,289 @@ mod tests {
         );
 
         drop(std::fs::remove_dir_all(queue_dir));
+    }
+
+    /// An in-memory S3 good enough for the WAL segment protocol: PUT (with the
+    /// conditional `If-None-Match: *` that claiming depends on), GET, DELETE, and
+    /// a `list-type=2` listing.
+    ///
+    /// The point of testing against this rather than mocking the store is that the
+    /// protocol *is* the feature — a claim that does not actually exclude, or a
+    /// listing whose order is not the write order, is the whole bug class here.
+    mod fake_s3 {
+        use super::*;
+        use axum::body::Bytes as AxumBytes;
+        use axum::extract::{Path as AxumPath, Query, State};
+        use axum::http::{HeaderMap, StatusCode};
+        use axum::routing::get;
+        use chrono::DateTime;
+        use std::collections::BTreeMap;
+        use std::sync::Mutex as StdMutex;
+
+        /// Objects carry their write time: claim expiry is a real branch in the
+        /// protocol, and a fake that stamped everything old would make every
+        /// claim look abandoned.
+        type Objects = BTreeMap<String, (Vec<u8>, DateTime<Utc>)>;
+
+        #[derive(Clone, Default)]
+        pub(super) struct FakeS3 {
+            objects: Arc<StdMutex<Objects>>,
+        }
+
+        impl FakeS3 {
+            pub(super) fn keys(&self) -> Vec<String> {
+                self.objects.lock().unwrap().keys().cloned().collect()
+            }
+
+            pub(super) fn get(&self, key: &str) -> Option<Vec<u8>> {
+                self.objects
+                    .lock()
+                    .unwrap()
+                    .get(key)
+                    .map(|(body, _)| body.clone())
+            }
+
+            /// Write an object as it would look after `age` — how a test stages
+            /// a dead task's leftovers.
+            pub(super) fn put_aged(&self, key: &str, body: Vec<u8>, age: chrono::Duration) {
+                self.objects
+                    .lock()
+                    .unwrap()
+                    .insert(key.to_owned(), (body, Utc::now() - age));
+            }
+        }
+
+        async fn handle(
+            AxumPath(key): AxumPath<String>,
+            State(state): State<FakeS3>,
+            headers: HeaderMap,
+            method: axum::http::Method,
+            body: AxumBytes,
+        ) -> (StatusCode, Vec<u8>) {
+            let mut objects = state.objects.lock().unwrap();
+            match method {
+                axum::http::Method::PUT => {
+                    if headers.contains_key("if-none-match") && objects.contains_key(&key) {
+                        return (StatusCode::PRECONDITION_FAILED, Vec::new());
+                    }
+                    objects.insert(key, (body.to_vec(), Utc::now()));
+                    (StatusCode::OK, Vec::new())
+                }
+                axum::http::Method::DELETE => {
+                    objects.remove(&key);
+                    (StatusCode::NO_CONTENT, Vec::new())
+                }
+                _ => match objects.get(&key) {
+                    Some((body, _)) => (StatusCode::OK, body.clone()),
+                    None => (StatusCode::NOT_FOUND, Vec::new()),
+                },
+            }
+        }
+
+        async fn list(
+            State(state): State<FakeS3>,
+            Query(params): Query<BTreeMap<String, String>>,
+        ) -> (StatusCode, String) {
+            let prefix = params.get("prefix").cloned().unwrap_or_default();
+            let objects = state.objects.lock().unwrap();
+            let contents = objects
+                .iter()
+                .filter(|(key, _)| key.starts_with(&prefix))
+                .fold(String::new(), |mut out, (key, (body, written))| {
+                    use std::fmt::Write as _;
+                    let _unused: Result<(), std::fmt::Error> = write!(
+                        out,
+                        "<Contents><Key>{key}</Key><LastModified>{}</LastModified>\
+                         <Size>{}</Size></Contents>",
+                        written.to_rfc3339(),
+                        body.len()
+                    );
+                    out
+                });
+            (
+                StatusCode::OK,
+                format!(
+                    "<?xml version=\"1.0\"?><ListBucketResult><IsTruncated>false</IsTruncated>\
+                     {contents}</ListBucketResult>"
+                ),
+            )
+        }
+
+        /// Serve one bucket and return its endpoint.
+        pub(super) async fn spawn(bucket: &str) -> (String, FakeS3) {
+            let state = FakeS3::default();
+            let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+                .await
+                .unwrap();
+            let addr = listener.local_addr().unwrap();
+            let app = Router::new()
+                .route(&format!("/{bucket}"), get(list))
+                .route(
+                    &format!("/{bucket}/{{*key}}"),
+                    get(handle).put(handle).delete(handle),
+                )
+                .with_state(state.clone());
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            (format!("http://{addr}"), state)
+        }
+    }
+
+    fn test_wal_store(endpoint: &str) -> Arc<WalSegmentStore> {
+        Arc::new(WalSegmentStore::new(
+            Client::new(),
+            &crate::wal_store::WalStoreConfig {
+                endpoint: endpoint.to_owned(),
+                bucket: "maple-wal-test".to_owned(),
+                region: "us-east-1".to_owned(),
+                prefix: "wal".to_owned(),
+                timeout: Duration::from_secs(5),
+                orphan_after: Duration::from_secs(600),
+                heartbeat_interval: Duration::from_secs(60),
+            },
+            Arc::new(crate::aws::CredentialsProvider::from_static(
+                "test-key".to_owned(),
+                "test-secret".to_owned(),
+            )),
+        ))
+    }
+
+    /// Poll until `predicate` holds, so a test never races the shipper task.
+    async fn wait_for(label: &str, mut predicate: impl FnMut() -> bool) {
+        tokio::time::timeout(Duration::from_secs(3), async {
+            while !predicate() {
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {label}"));
+    }
+
+    #[tokio::test]
+    async fn sealed_segments_are_shipped_and_dropped_again_once_exported() {
+        // The durability contract in one pass: a segment that seals while it still
+        // owes frames reaches the bucket, and the object goes away as soon as those
+        // frames export — which is why the bucket holds the backlog rather than the
+        // traffic.
+        let queue_dir = unique_test_dir("wal-ship-and-retire");
+        std::fs::create_dir_all(&queue_dir).unwrap();
+        let cfg = segmented_cfg(queue_dir.clone(), 64 * 1024, 240);
+        let (endpoint, bucket) = fake_s3::spawn("maple-wal-test").await;
+
+        let wal = ShardedWal::open(&cfg).expect("open WAL");
+        wal.attach_object_store(&test_wal_store(&endpoint));
+        let store_owner = wal.store.get().unwrap().owner().to_owned();
+        let frame = wal_test_frame(200);
+
+        // Two frames, so the first segment seals with the second still unexported.
+        let (seg_a, _, end_a) = wal.append(0, &frame).await.expect("append a");
+        wal.append(0, &frame).await.expect("append b");
+
+        let shipped_key =
+            format!("wal/v1/segments/{store_owner}/shard-000-tinybird/{seg_a:012}.seg");
+        wait_for("the sealed segment to ship", || {
+            bucket.get(&shipped_key).is_some()
+        })
+        .await;
+        assert_eq!(
+            bucket.get(&shipped_key).unwrap().len() as u64,
+            end_a,
+            "the object is the segment, byte for byte"
+        );
+
+        wal.mark_exported(
+            0,
+            SegmentCursor {
+                seq: seg_a,
+                offset: end_a,
+            },
+            end_a,
+        )
+        .await
+        .expect("mark_exported");
+        wait_for("the exported segment's object to be dropped", || {
+            bucket.get(&shipped_key).is_none()
+        })
+        .await;
+
+        drop(std::fs::remove_dir_all(queue_dir));
+    }
+
+    #[tokio::test]
+    async fn a_dead_task_s_segments_are_claimed_and_re_committed() {
+        // What happens when a task dies without draining: its segments are still in
+        // the bucket, and the next task to boot claims them, re-commits the frames
+        // to its own lanes, and drops the objects.
+        let (endpoint, bucket) = fake_s3::spawn("maple-wal-test").await;
+        let dead_owner = "task-that-died";
+
+        // The dead task's segment: two frames, in the lane's own on-disk format.
+        let frame = wal_test_frame(64);
+        let mut segment = encode_wal_frame(&frame).unwrap();
+        segment.extend(encode_wal_frame(&frame).unwrap());
+        let long_dead = chrono::Duration::hours(1);
+        bucket.put_aged(
+            &format!("wal/v1/segments/{dead_owner}/shard-000-tinybird/000000000003.seg"),
+            segment,
+            long_dead,
+        );
+        bucket.put_aged(
+            &format!("wal/v1/owners/{dead_owner}"),
+            Vec::new(),
+            long_dead,
+        );
+
+        let queue_dir = unique_test_dir("wal-claim-orphans");
+        std::fs::create_dir_all(&queue_dir).unwrap();
+        let cfg = segmented_cfg(queue_dir.clone(), 64 * 1024, WAL_SEGMENT_MAX_BYTES);
+        let wal = ShardedWal::open(&cfg).expect("open WAL");
+        let store = test_wal_store(&endpoint);
+        let survivor = store.owner().to_owned();
+        wal.recover_orphans(&cfg, &store).await;
+
+        let replayed = wal.replay(0).await.expect("replay");
+        assert_eq!(replayed.len(), 2, "both frames are recoverable locally");
+        assert_eq!(replayed[0].payload, frame.payload);
+
+        let keys = bucket.keys();
+        assert!(
+            keys.iter().all(|key| !key.contains(dead_owner)),
+            "the dead owner's segments, heartbeat and claim are all cleaned up: {keys:?}"
+        );
+        assert!(
+            keys.iter()
+                .any(|key| key.starts_with(&format!("wal/v1/segments/{survivor}/"))),
+            "the recovered frames are re-shipped under the survivor before the source is dropped: \
+             {keys:?}"
+        );
+
+        drop(std::fs::remove_dir_all(queue_dir));
+    }
+
+    #[tokio::test]
+    async fn only_one_task_can_claim_an_owner() {
+        // Two tasks booting into the same bucket at once must not both replay the
+        // same segments. The conditional PUT is what makes that exclusive.
+        let (endpoint, bucket) = fake_s3::spawn("maple-wal-test").await;
+        bucket.put_aged(
+            "wal/v1/owners/task-that-died",
+            Vec::new(),
+            chrono::Duration::hours(1),
+        );
+
+        let first = test_wal_store(&endpoint);
+        let second = test_wal_store(&endpoint);
+        let now = Utc::now();
+
+        assert!(
+            first.claim("task-that-died", now).await.unwrap(),
+            "the first claimant wins"
+        );
+        assert!(
+            !second.claim("task-that-died", now).await.unwrap(),
+            "the second is told someone else has it"
+        );
     }
 
     /// Cross-language contract with the Prometheus scraper (apps/scraper).

--- a/apps/ingest/src/wal_store.rs
+++ b/apps/ingest/src/wal_store.rs
@@ -1,0 +1,317 @@
+//! The WAL's durability tier: sealed segments shipped to S3, and the claiming
+//! protocol that lets a booting task recover a dead one's.
+//!
+//! The local WAL lives on Fargate ephemeral storage, which is destroyed with the
+//! task. A drain on SIGTERM covers a graceful stop; this covers everything else
+//! — a crash, a spot reclaim, an AZ event — by keeping every sealed, unexported
+//! segment in an object store too.
+//!
+//! Cost is small because segments are transient: a segment is deleted from the
+//! bucket as soon as its frames export, so the bucket holds roughly the current
+//! backlog rather than the traffic. At ~8 MiB per object and a healthy pipeline,
+//! most segments are exported before their upload is even attempted.
+//!
+//! Ownership is per boot, not per task ARN: an owner id is a fresh UUID, so a
+//! sequence number is never reused across boots and a claim can never race a
+//! live writer for the same key.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+use crate::aws::{CredentialsProvider, S3Client, S3Error, S3Object};
+use crate::telemetry::HttpClient;
+
+/// Object-key scheme version. A future layout change lands under `v2/` while
+/// `v1/` keys stay decodable for as long as a task could still be holding them.
+const KEY_SCHEME: &str = "v1";
+
+/// Pages of a listing we will walk. A boot lists its own prefix and each dead
+/// owner's; 1000 keys a page makes this 100k segments, far past any real
+/// backlog, and bounds a pathological prefix instead of hanging startup.
+const MAX_LIST_PAGES: usize = 100;
+
+/// How stale an owner's heartbeat must be before its segments are claimable.
+///
+/// Well past the heartbeat interval: claiming a live task's segments is not
+/// unsafe (the frames replay at-least-once, which every destination tolerates)
+/// but it is wasted work and duplicated rows, so the bar is deliberately high.
+pub const DEFAULT_ORPHAN_AFTER: Duration = Duration::from_secs(10 * 60);
+
+/// How often a live task refreshes its heartbeat object.
+pub const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long a claim marker holds an owner before another task may take it over.
+///
+/// A claimer that dies mid-recovery would otherwise strand those segments
+/// forever. Taking over an expired claim can replay frames the first claimer had
+/// already exported — at-least-once again, and the alternative is loss.
+const CLAIM_LEASE: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Clone, Debug)]
+pub struct WalStoreConfig {
+    pub endpoint: String,
+    pub bucket: String,
+    pub region: String,
+    /// Key prefix inside the bucket, without a trailing slash.
+    pub prefix: String,
+    pub timeout: Duration,
+    pub orphan_after: Duration,
+    pub heartbeat_interval: Duration,
+}
+
+/// A segment recovered from the object store, with the key it came from so the
+/// caller can delete it once its frames are durable locally again.
+#[derive(Debug)]
+pub struct RecoveredSegment {
+    pub key: String,
+    /// `shard-NNN-<destination>`, as written by the task that owned it.
+    pub lane_key: String,
+    pub bytes: Vec<u8>,
+}
+
+pub struct WalSegmentStore {
+    s3: S3Client,
+    prefix: String,
+    /// This boot's identity. Fresh per process, so no other task can be writing
+    /// under it and its segments are unambiguously ours to delete.
+    owner: String,
+    orphan_after: Duration,
+}
+
+impl std::fmt::Debug for WalSegmentStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WalSegmentStore")
+            .field("bucket", &self.s3.bucket())
+            .field("prefix", &self.prefix)
+            .field("owner", &self.owner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WalSegmentStore {
+    pub fn new(
+        client: impl Into<HttpClient>,
+        cfg: &WalStoreConfig,
+        credentials: Arc<CredentialsProvider>,
+    ) -> Self {
+        Self {
+            s3: S3Client::new(
+                client,
+                &cfg.endpoint,
+                cfg.bucket.clone(),
+                cfg.region.clone(),
+                credentials,
+                cfg.timeout,
+            ),
+            prefix: cfg.prefix.trim_end_matches('/').to_owned(),
+            owner: uuid::Uuid::new_v4().to_string(),
+            orphan_after: cfg.orphan_after,
+        }
+    }
+
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    fn segment_key(&self, owner: &str, lane_key: &str, seq: u64) -> String {
+        format!(
+            "{}/{KEY_SCHEME}/segments/{owner}/{lane_key}/{seq:012}.seg",
+            self.prefix
+        )
+    }
+
+    fn owner_key(&self, owner: &str) -> String {
+        format!("{}/{KEY_SCHEME}/owners/{owner}", self.prefix)
+    }
+
+    fn claim_key(&self, owner: &str) -> String {
+        format!("{}/{KEY_SCHEME}/claims/{owner}", self.prefix)
+    }
+
+    /// Ship one sealed segment. Overwrites unconditionally: the only writer for
+    /// this key is this process, and a retry of a partial PUT must win.
+    pub async fn put_segment(
+        &self,
+        lane_key: &str,
+        seq: u64,
+        bytes: Vec<u8>,
+    ) -> Result<(), S3Error> {
+        let key = self.segment_key(&self.owner, lane_key, seq);
+        self.s3.put(&key, bytes, false).await
+    }
+
+    /// Drop a segment whose frames have exported. Missing is success — the
+    /// upload may simply never have happened.
+    pub async fn delete_segment(&self, lane_key: &str, seq: u64) -> Result<(), S3Error> {
+        let key = self.segment_key(&self.owner, lane_key, seq);
+        self.s3.delete(&key).await
+    }
+
+    /// Refresh this owner's heartbeat. Liveness is the object's `LastModified`,
+    /// so the body carries nothing.
+    pub async fn heartbeat(&self) -> Result<(), S3Error> {
+        self.s3
+            .put(&self.owner_key(&self.owner), Vec::new(), false)
+            .await
+    }
+
+    /// Remove this owner's heartbeat, so a successor does not have to wait out
+    /// `orphan_after` before claiming whatever we failed to drain.
+    pub async fn retire(&self) -> Result<(), S3Error> {
+        self.s3.delete(&self.owner_key(&self.owner)).await
+    }
+
+    /// Owners whose heartbeat has gone stale, newest-stale first.
+    pub async fn stale_owners(&self, now: DateTime<Utc>) -> Result<Vec<String>, S3Error> {
+        let prefix = format!("{}/{KEY_SCHEME}/owners/", self.prefix);
+        let objects = self.s3.list(&prefix, MAX_LIST_PAGES).await?;
+        Ok(objects
+            .into_iter()
+            .filter(|object| !object.key.ends_with(&self.owner))
+            .filter(|object| is_older_than(object, now, self.orphan_after))
+            .filter_map(|object| {
+                object
+                    .key
+                    .rsplit('/')
+                    .next()
+                    .filter(|owner| !owner.is_empty())
+                    .map(str::to_owned)
+            })
+            .collect())
+    }
+
+    /// Take ownership of a dead task's segments, or report that someone else
+    /// already has.
+    ///
+    /// The claim is a conditional PUT: S3 answers 412 when the key exists, which
+    /// makes exactly one booting task the winner without a lock service. A claim
+    /// older than `CLAIM_LEASE` is taken over unconditionally, because the task
+    /// that wrote it evidently died before finishing.
+    pub async fn claim(&self, owner: &str, now: DateTime<Utc>) -> Result<bool, S3Error> {
+        let key = self.claim_key(owner);
+        match self
+            .s3
+            .put(&key, self.owner.as_bytes().to_vec(), true)
+            .await
+        {
+            Ok(()) => Ok(true),
+            Err(error) if error.status() == Some(412) => {
+                let existing = self.s3.list(&key, 1).await?;
+                let expired = existing
+                    .first()
+                    .is_some_and(|object| is_older_than(object, now, CLAIM_LEASE));
+                if !expired {
+                    return Ok(false);
+                }
+                self.s3
+                    .put(&key, self.owner.as_bytes().to_vec(), false)
+                    .await?;
+                Ok(true)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Every segment a claimed owner left behind, oldest first, with its bytes.
+    ///
+    /// Keys sort by `(lane, sequence)` and sequences are zero-padded, so the
+    /// listing order is the order the frames were written.
+    pub async fn take_segments(&self, owner: &str) -> Result<Vec<RecoveredSegment>, S3Error> {
+        let prefix = format!("{}/{KEY_SCHEME}/segments/{owner}/", self.prefix);
+        let mut objects = self.s3.list(&prefix, MAX_LIST_PAGES).await?;
+        objects.sort_by(|a, b| a.key.cmp(&b.key));
+        let mut segments = Vec::with_capacity(objects.len());
+        for object in objects {
+            let Some(lane_key) = lane_key_of(&object.key) else {
+                continue;
+            };
+            let bytes = self.s3.get(&object.key).await?;
+            segments.push(RecoveredSegment {
+                key: object.key,
+                lane_key,
+                bytes,
+            });
+        }
+        Ok(segments)
+    }
+
+    /// Finish a claim: drop the recovered object and, once every segment is
+    /// gone, the owner's heartbeat and claim marker.
+    pub async fn release_key(&self, key: &str) -> Result<(), S3Error> {
+        self.s3.delete(key).await
+    }
+
+    pub async fn release_owner(&self, owner: &str) -> Result<(), S3Error> {
+        self.s3.delete(&self.owner_key(owner)).await?;
+        self.s3.delete(&self.claim_key(owner)).await
+    }
+}
+
+fn is_older_than(object: &S3Object, now: DateTime<Utc>, age: Duration) -> bool {
+    let Some(modified) = object.last_modified else {
+        // No timestamp is not evidence of life; treat it as stale so a listing
+        // this parser did not understand cannot strand segments forever.
+        return true;
+    };
+    (now - modified)
+        .to_std()
+        .is_ok_and(|elapsed| elapsed >= age)
+}
+
+/// `…/segments/<owner>/<lane_key>/<seq>.seg` → `<lane_key>`.
+fn lane_key_of(key: &str) -> Option<String> {
+    let mut parts = key.rsplit('/');
+    parts.next()?; // the segment file
+    parts.next().map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn object(key: &str, minutes_ago: i64) -> S3Object {
+        S3Object {
+            key: key.to_owned(),
+            last_modified: Some(Utc::now() - chrono::Duration::minutes(minutes_ago)),
+            size: 0,
+        }
+    }
+
+    #[test]
+    fn lane_key_is_the_directory_above_the_segment() {
+        assert_eq!(
+            lane_key_of("wal/v1/segments/owner-a/shard-003-clickhouse/000000000012.seg").as_deref(),
+            Some("shard-003-clickhouse")
+        );
+        assert_eq!(lane_key_of("nodirectory.seg").as_deref(), None);
+    }
+
+    #[test]
+    fn staleness_is_measured_against_the_heartbeat() {
+        let now = Utc::now();
+        assert!(is_older_than(
+            &object("owners/a", 30),
+            now,
+            DEFAULT_ORPHAN_AFTER
+        ));
+        assert!(!is_older_than(
+            &object("owners/b", 1),
+            now,
+            DEFAULT_ORPHAN_AFTER
+        ));
+    }
+
+    #[test]
+    fn a_listing_without_a_timestamp_reads_as_stale() {
+        // Otherwise an unparsed LastModified would strand the segments under it
+        // for good: nobody would ever claim them.
+        let unparsed = S3Object {
+            key: "owners/c".to_owned(),
+            last_modified: None,
+            size: 0,
+        };
+        assert!(is_older_than(&unparsed, Utc::now(), DEFAULT_ORPHAN_AFTER));
+    }
+}

--- a/docs/ingest-wal-durability.md
+++ b/docs/ingest-wal-durability.md
@@ -1,0 +1,123 @@
+# Ingest WAL durability
+
+The ingest gateway (`apps/ingest`, Rust) acknowledges a request once the rows are committed to a
+local write-ahead log, then exports them to Tinybird or ClickHouse in the background. That WAL is
+the only copy of an accepted row until it reaches the warehouse, and it lives on Fargate ephemeral
+storage, which is destroyed with the task.
+
+This is how it stays durable.
+
+## The log
+
+One **lane** per `(shard, destination)` — see `lane_index` in `apps/ingest/src/telemetry.rs`. Lanes
+are independent so a stalled ClickHouse export cannot back up the Tinybird lane sharing its shard.
+
+Each lane is a directory of sealed segments:
+
+```
+$INGEST_QUEUE_DIR/shard-003-clickhouse/
+  000000000041.seg     ← sealed, waiting to export
+  000000000042.seg     ← sealed
+  000000000043.seg     ← active; appends land here
+  lane.cursor          ← "42 1048576": exported through segment 42, byte 1048576
+```
+
+Appends go to the active segment and `sync_data` before the request is acknowledged. At
+`INGEST_WAL_SEGMENT_MAX_BYTES` (8 MiB) the segment is **sealed**: the file is closed and the next
+one opened. Sealing is an `open` plus a directory fsync — there is no copy on the append path.
+
+The exporter advances `lane.cursor` and unlinks every segment behind it. **Appends and exports take
+different locks**, so an export can never stall a commit. That separation is the fix for the
+`ingest.wal_commit` p95 that used to swing between 145ms and 998ms against a flat 3ms p50: the
+previous layout was one file per lane, reclaimed by rewriting the unexported tail while holding the
+append mutex.
+
+Ordering rules that matter:
+
+- The cursor is written **before** segments are unlinked. A crash in between costs a re-delete on
+  the next boot; the other order strands a cursor pointing at bytes that are gone.
+- Boot always opens a **fresh** segment, so "sealed" means "will never grow again" — which is what
+  lets a sealed segment be shipped or deleted without coordinating with the appender.
+- A lost or unparseable cursor replays the lane from its oldest surviving segment. Everything here
+  is **at-least-once**: replaying an exported frame is a duplicate row, skipping one is silent loss.
+- Backlog is `committed - exported` bytes per lane, not anything derived from file sizes, so it
+  stays exact across rotation and deletion. The shutdown drain and scale-in protection read it.
+
+## The durability tier
+
+Sealed segments are also shipped to S3 (`apps/ingest/src/wal_store.rs`), so a task that dies without
+draining does not take its backlog with it.
+
+```
+s3://<bucket>/wal/v1/
+  owners/<owner>                              ← heartbeat, refreshed every 60s
+  claims/<owner>                              ← conditional-PUT claim marker
+  segments/<owner>/shard-003-clickhouse/000000000041.seg
+```
+
+An **owner** is one boot, identified by a fresh UUID — never a task ARN — so a sequence number can
+never be reused across boots and a claim can never race a live writer for the same key.
+
+**Shipping.** A sealed segment is announced to a shipper task (`SEGMENT_SHIPPER_WORKERS`, one lane
+always handled by the same worker so its events stay ordered). The shipper skips any segment the
+exporter has already passed, which in a healthy pipeline is nearly all of them — this is why the
+tier costs single-digit dollars a month at ~2B traces: the bucket holds the current backlog, not the
+traffic. When a segment exports, its object is deleted.
+
+**Claiming.** On boot, a task lists `owners/`, takes every owner whose heartbeat is older than
+`INGEST_WAL_S3_ORPHAN_AFTER_SECS` (10 min), and claims it with a conditional `PUT … If-None-Match: *`.
+S3 answers 412 when the key exists, so exactly one task wins without a lock service. The winner
+downloads that owner's segments, re-commits their frames to its own lanes, **re-ships them under its
+own owner id, and only then** deletes the source objects — so the frames are never only on one
+task's disk. A claim older than 30 minutes is taken over unconditionally, because the task that
+wrote it evidently died before finishing.
+
+**Shutdown.** After `INGEST_SHUTDOWN_DRAIN_SECS`, whatever did not export is sealed and shipped, and
+the owner heartbeat is deleted — so the next task claims it immediately instead of waiting out the
+staleness window.
+
+Credentials come from the ECS task role (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, refreshed 5
+minutes before expiry) unless `INGEST_WAL_S3_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` are set. The VPC
+has an S3 gateway endpoint and no NAT, so this traffic is free.
+
+## Configuration
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `INGEST_QUEUE_MAX_BYTES` | — | Total WAL budget; divided evenly across lanes |
+| `INGEST_WAL_SHARDS` | `max(cpus × 2, 2)` | Shards, not lanes — lanes are `shards × destinations` |
+| `INGEST_WAL_SEGMENT_MAX_BYTES` | 8 MiB | Seal threshold, and so the shipped object size |
+| `INGEST_WAL_S3_BUCKET` | unset | Unset keeps the WAL local-only (self-hosted, local dev) |
+| `INGEST_WAL_S3_REGION` | `$AWS_REGION` | Required with a bucket |
+| `INGEST_WAL_S3_ENDPOINT` | `https://s3.<region>.amazonaws.com` | For an S3-compatible target |
+| `INGEST_WAL_S3_PREFIX` | `wal` | Key prefix inside the bucket |
+| `INGEST_WAL_S3_ORPHAN_AFTER_SECS` | 600 | How stale a heartbeat must be to be claimable |
+| `INGEST_WAL_S3_HEARTBEAT_SECS` | 60 | Owner heartbeat interval |
+| `INGEST_WAL_S3_TIMEOUT_MS` | 10000 | Per-request timeout |
+| `INGEST_SHUTDOWN_DRAIN_SECS` | 90 | Must stay inside the task's 120s `stopTimeout` |
+
+The bucket, its lifecycle rule (7-day expiry as a backstop for deletes that were lost) and the
+task-role policy are in `apps/ingest/alchemy.run.ts`.
+
+## Metrics
+
+| Metric | Read it for |
+| --- | --- |
+| `ingest_wal_shard_bytes` | Bytes a lane holds on disk, exported prefix included |
+| `ingest_wal_shard_full_total` | Appends rejected because a lane hit its cap — customer-visible 429s |
+| `ingest_wal_segments_sealed_total` | Segment rotation rate |
+| `ingest_wal_reclaimed_bytes_total` | Bytes freed by deleting exported segments |
+| `ingest_wal_shipped_bytes_total` | Bytes that reached the bucket |
+| `ingest_wal_ship_outcomes_total` | `outcome=exported_first` (healthy), `queue_full`, `failed` |
+| `ingest_wal_frames_recovered_total` | Frames claimed from a dead task — non-zero means a task died dirty |
+| `ingest_wal_commit_bytes` | Per-append size; the `ingest.wal_commit` span carries the latency |
+
+`queue_full` means the object store cannot keep up with segment rotation, and those segments stay
+local-only. Sustained non-zero is the signal that the durability tier is not actually covering the
+backlog.
+
+## What is deliberately not here
+
+A real stream (Kinesis, MSK, S2) buys ordered replay for multiple independent consumers. There is
+one consumer, per-GB pricing hurts at trace volume, and MSK has a ~$500/month floor. Revisit only
+when a second consumer or replay-as-a-feature is a requirement.


### PR DESCRIPTION
Phase 2 of the WAL durability work, on top of #682. Two commits, reviewable in order.

## Why

The WAL is the only copy of an accepted row until it reaches the warehouse, and it sits on Fargate ephemeral storage that dies with the task. Two problems fall out of the old layout:

1. **Latency.** A lane was one append-only file, reclaimed by rewriting its unexported tail *while holding the append mutex*. `ingest.wal_commit` measured a flat 3ms p50 against a p95 swinging between 145ms and 998ms seven times a day — contention, not a slow disk.
2. **Durability.** #682's drain covers a graceful stop. A crash, a spot reclaim or an AZ event still took whatever the lanes held.

## `457b4dab9b` — a lane is a log of sealed segments

A lane is now a directory of `NNNNNNNNNNNN.seg` files plus a `lane.cursor` of `"seq offset"`. Appends land in the active segment and seal it at `INGEST_WAL_SEGMENT_MAX_BYTES` (8 MiB) by opening the next one; the exporter advances the cursor and unlinks what it passes. **The two sides take different locks**, so an export can no longer stall a commit, and there is no byte copy left on the append path at all.

Invariants worth reviewing closely:

- Backlog is `committed - exported` bytes per lane, **not** anything derived from file sizes. A fully-exported sealed segment can linger until the next batch, and a size-derived backlog would mean `drain_wal` never returns 0 and scale-in protection never releases.
- The cursor is written **before** segments are unlinked. A crash in between costs a re-delete next boot; the other order strands a cursor pointing at bytes that are gone.
- Boot always opens a **fresh** segment, so "sealed" means "will never grow again" — that is what lets a sealed segment be shipped or deleted without coordinating with the appender.
- A lost or unparseable cursor replays the lane from its oldest surviving segment. Everything here is at-least-once: a duplicate row is a cost every destination already absorbs, a skipped frame is silent loss.
- A corrupt segment now costs its own tail instead of the whole lane.

Both pre-segment layouts (`shard-NNN.wal` and `shard-NNN-<dest>.wal`) are migrated on startup, so the rollout loses nothing. `ingest_wal_compacted_bytes_total` is replaced by `ingest_wal_segments_sealed_total` and `ingest_wal_reclaimed_bytes_total`.

## `e1a93e930e` — sealed segments go to S3, and a dead task's are claimed

- Sealed segments are announced to a shipper task. One lane is always handled by the same worker, so a segment can never be deleted from the bucket by an event that overtook its own upload.
- The shipper skips any segment the exporter already passed — in a healthy pipeline that is nearly all of them, which is why the bucket holds the current backlog rather than the traffic, and why this costs single-digit dollars a month.
- An **owner** is one boot, a fresh UUID rather than a task ARN, so a sequence number is never reused and a claim cannot race a live writer. Liveness is a heartbeat object refreshed every 60s.
- Claiming is a conditional `PUT … If-None-Match: *`: S3 answers 412 when the key exists, so exactly one booting task wins without a lock service. A claim older than 30 minutes is taken over unconditionally, because the task that wrote it evidently died before finishing.
- The winner re-commits the frames, **re-ships them under its own owner id, and only then** deletes the source objects — so the frames are never only on one task's disk.
- Shutdown seals and ships whatever the drain could not export, then deletes the heartbeat so a successor claims immediately rather than waiting out the staleness window.

SigV4 signing moves out of `r2.rs` into a shared `aws.rs` (ECS task-role credentials with refresh, plus the S3 verbs this needs). Still hand-rolled rather than `aws-sdk-s3` — same reasoning as `r2.rs`, and it is now pinned against AWS's own `get-vanilla` test vector.

## Infra

Bucket, a 7-day lifecycle rule as a backstop for deletes that were lost, and a task-role policy scoped to the one `wal/*` prefix. No credentials in the task definition, and the VPC's existing S3 gateway endpoint keeps the traffic off the public path.

**Ships dark:** `INGEST_WAL_S3_BUCKET` unset keeps the WAL local-only, which is what self-hosted and local runs get.

## Testing

213 tests pass. Eight are new, and the S3 ones run against an in-memory fake that implements the conditional PUT and the listing rather than mocking the store — the protocol *is* the feature. That caught recovery flushing through a store handle that is not attached until after recovery, which would have deleted claimed objects while the frames were only on local disk.

`cargo clippy --all-targets` clean on every file touched, `cargo fmt --check` clean on the changed hunks, `tsc -p tsconfig.alchemy.json` and oxlint clean.

## After deploy

- `ingest.wal_commit` p95 should collapse toward the 3ms p50. Only revisit EC2/NVMe if the tail survives this.
- `ingest_wal_ship_outcomes_total{outcome="queue_full"}` should stay at zero; non-zero means the object store cannot keep up with segment rotation and those segments are local-only.
- `ingest_wal_frames_recovered_total` going non-zero means a task died dirty and recovery worked.

Docs: `docs/ingest-wal-durability.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790634073&installation_model_id=427786&pr_number=685&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F685&signature=cc2968841350f859dacbbb924d041ee393f2d5d32ca7255ed3bde8ba07007ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->