### PR TITLE
fix(web): the panel's door into Traces closes it and lands on the row

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -299,6 +299,7 @@ function Waterfall(props: {
 	collapsedTurns?: ReadonlySet<string>
 	onToggleTurn?: (turnId: string) => void
 	selectedSpanId?: string
+	revealedSpanId?: string
 	onSelectSpan?: (spanId: string | undefined) => void
 	spanTab?: SpanDetailTab
 }) {
@@ -312,6 +313,7 @@ function Waterfall(props: {
 			collapsedTurns={props.collapsedTurns ?? EMPTY}
 			onToggleTurn={props.onToggleTurn ?? noop}
 			selectedSpanId={props.selectedSpanId}
+			revealedSpanId={props.revealedSpanId}
 			onSelectSpan={props.onSelectSpan ?? noop}
 			spanTab={props.spanTab}
 			onSpanTabChange={noop}
@@ -1064,23 +1066,35 @@ describe("SessionViews", () => {
 		expect(screen.getByRole("button", { name: /Turn 1/ }).getAttribute("aria-expanded")).toBe("false")
 	})
 
-	// One panel for the whole page, and the page behind it is scrimmed, so the
-	// way to cross views with a span still open is the panel's own door — which
-	// keeps both the span and the reader's tab.
-	it("carries the open span and its tab through the panel's door into Traces", () => {
+	// The panel's door exists to show the span in its waterfall, so the panel
+	// closes on the way through: crossing views only to find the same overlay
+	// still covering the rows was the one thing the door could not do.
+	it("closes the panel and marks the row it sent the reader to", () => {
 		render(<Views view="flow" />)
 
 		fireEvent.click(screen.getByText("grep_repo"))
-		fireEvent.click(within(spanPopover()).getByRole("button", { name: "Details" }))
-
 		fireEvent.click(within(spanPopover()).getByRole("button", { name: "Open in Traces view" }))
 
 		// The waterfall's own column header: the Traces view is what is on screen.
 		expect(screen.getByText("Model / target")).toBeTruthy()
-		expect(spanPopoverCount()).toBe(1)
-		expect(
-			within(spanPopover()).getByRole("button", { name: "Details" }).getAttribute("aria-pressed"),
-		).toBe("true")
+		expect(spanPopoverCount()).toBe(0)
+
+		// And the row the reader crossed for is the one carrying the mark.
+		const marked = document.querySelectorAll("[data-revealed]")
+		expect(marked.length).toBe(1)
+		expect(marked[0]!.textContent).toContain("grep_repo")
+	})
+
+	// The mark says "this is the row you were sent to", so it comes off the
+	// moment the reader goes somewhere else themselves.
+	it("takes the mark off once the reader opens another span", () => {
+		render(<Views view="flow" />)
+
+		fireEvent.click(screen.getByText("grep_repo"))
+		fireEvent.click(within(spanPopover()).getByRole("button", { name: "Open in Traces view" }))
+
+		fireEvent.click(screen.getAllByText("read_file")[0]!)
+		expect(document.querySelector("[data-revealed]")).toBeNull()
 	})
 
 	// The tab choice lives beside the other cross-view state in SessionViews:

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -86,13 +86,37 @@ export function SessionViews({
 	// spans — or views — keeps the reader on the tab they chose. `undefined`
 	// means no choice yet, and the panel picks by content.
 	const [spanTab, setSpanTab] = useState<SpanDetailTab | undefined>(undefined)
+	// The span the reader was sent to the Traces view to look at. The panel
+	// closes on the way — the whole point of the door is to see the row in its
+	// waterfall — so the waterfall needs to be told which row that was, or the
+	// reader lands at the top of six hundred of them. Component state rather
+	// than the URL: it is where the reader was just sent, not a place to link to.
+	const [revealedSpanId, setRevealedSpanId] = useState<string | undefined>(undefined)
+
+	// Opening the panel on any span — or picking another view by hand — is the
+	// reader moving on, and the mark comes off the row they were sent to.
+	const selectSpan = (spanId: string | undefined) => {
+		setRevealedSpanId(undefined)
+		onSelectSpan(spanId)
+	}
+	const changeView = (next: SessionView) => {
+		setRevealedSpanId(undefined)
+		onViewChange(next)
+	}
+
+	/** The panel's "Open in Traces view": close it, cross, and land on the row. */
+	const openInTraceView = () => {
+		setRevealedSpanId(selectedSpanId)
+		onSelectSpan(undefined)
+		onViewChange("trace")
+	}
 
 	// 1/2/3/4 switch views from anywhere on the page — the switcher stays
 	// reachable without the mouse, which is the point of pinning it up here.
-	useAppHotkey("session.viewOverview", () => onViewChange("overview"))
-	useAppHotkey("session.viewTrace", () => onViewChange("trace"))
-	useAppHotkey("session.viewFlow", () => onViewChange("flow"))
-	useAppHotkey("session.viewTranscript", () => onViewChange("transcript"))
+	useAppHotkey("session.viewOverview", () => changeView("overview"))
+	useAppHotkey("session.viewTrace", () => changeView("trace"))
+	useAppHotkey("session.viewFlow", () => changeView("flow"))
+	useAppHotkey("session.viewTranscript", () => changeView("transcript"))
 
 	// The sticky control bar wraps at narrow widths, so the views stack under its
 	// measured height rather than an assumed one.
@@ -117,7 +141,7 @@ export function SessionViews({
 		<Tabs
 			value={view}
 			onValueChange={(value) => {
-				if (isSessionView(value)) onViewChange(value)
+				if (isSessionView(value)) changeView(value)
 			}}
 			// `grow` with its auto basis, never `flex-1`: a zero basis makes every
 			// ancestor between here and the page scroller report ~zero intrinsic
@@ -217,11 +241,11 @@ export function SessionViews({
 					turns={turns}
 					summary={summary}
 					selectedSpanId={view === "overview" ? selectedSpanId : undefined}
-					onSelectSpan={onSelectSpan}
+					onSelectSpan={selectSpan}
 					spanTab={spanTab}
 					onSpanTabChange={setSpanTab}
 					toolResults={toolResults}
-					onOpenTraceView={() => onViewChange("trace")}
+					onOpenTraceView={openInTraceView}
 				/>
 			</TabsContent>
 			<TabsContent value="trace" className="flex flex-[1_1_auto] flex-col pb-4">
@@ -234,7 +258,8 @@ export function SessionViews({
 					collapsedTurns={collapsedTurns}
 					onToggleTurn={(turnId) => setCollapsedTurns((previous) => toggled(previous, turnId))}
 					selectedSpanId={view === "trace" ? selectedSpanId : undefined}
-					onSelectSpan={onSelectSpan}
+					revealedSpanId={revealedSpanId}
+					onSelectSpan={selectSpan}
 					spanTab={spanTab}
 					onSpanTabChange={setSpanTab}
 					toolResults={toolResults}
@@ -249,11 +274,11 @@ export function SessionViews({
 					zoom={zoom}
 					onZoomChange={setZoom}
 					selectedSpanId={view === "flow" ? selectedSpanId : undefined}
-					onSelectSpan={onSelectSpan}
+					onSelectSpan={selectSpan}
 					spanTab={spanTab}
 					onSpanTabChange={setSpanTab}
 					toolResults={toolResults}
-					onOpenTraceView={() => onViewChange("trace")}
+					onOpenTraceView={openInTraceView}
 				/>
 			</TabsContent>
 			<TabsContent value="transcript" className="flex flex-[1_1_auto] flex-col pb-4">
@@ -269,8 +294,8 @@ export function SessionViews({
 					openRows={openRows}
 					onToggleRow={(key) => setOpenRows((previous) => toggled(previous, key))}
 					selectedSpanId={selectedSpanId}
-					onSelectSpan={onSelectSpan}
-					onOpenTraceView={() => onViewChange("trace")}
+					onSelectSpan={selectSpan}
+					onOpenTraceView={openInTraceView}
 				/>
 			</TabsContent>
 		</Tabs>

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -81,6 +81,9 @@ interface SessionWaterfallProps {
 	onToggleTurn: (turnId: string) => void
 	/** The one span open in the popover (`?span=`). */
 	selectedSpanId: string | undefined
+	/** A span sent here from another view's inspection panel: its row is scrolled
+	 *  to and marked, with no panel over it. */
+	revealedSpanId: string | undefined
 	/** Raised with a span id to open it, `undefined` to close. */
 	onSelectSpan: (spanId: string | undefined) => void
 	/** The popover's tab, shared with the other views. */
@@ -99,6 +102,7 @@ export function SessionWaterfall({
 	collapsedTurns,
 	onToggleTurn,
 	selectedSpanId,
+	revealedSpanId,
 	onSelectSpan,
 	spanTab,
 	onSpanTabChange,
@@ -159,22 +163,24 @@ export function SessionWaterfall({
 		},
 	})
 
-	// A pasted `?span=` link lands on the exact span it names: the cursor starts
-	// there and the row is scrolled into view, so the row is waiting underneath
-	// when the reader closes the overlay. Once, on mount — after that the URL
-	// follows the reader rather than leading them.
+	// A pasted `?span=` link — or a span sent across from another view — lands on
+	// the exact row it names: the cursor starts there and the row is scrolled to
+	// the middle of the viewport, clear of both edges, so it reads with the rows
+	// around it rather than hard against the ruler or the fold. Once, on mount —
+	// after that the URL follows the reader rather than leading them.
+	const landingSpanId = revealedSpanId ?? selectedSpanId
 	const didInitialScroll = useRef(false)
 	useEffect(() => {
-		if (didInitialScroll.current || selectedSpanId === undefined) return
+		if (didInitialScroll.current || landingSpanId === undefined) return
 		// Not before the scroller exists: the list element attaches in a layout
 		// effect, so on the render that mounts this view there is nothing to
 		// scroll and the link would silently land at the top.
 		if (getScrollElement() === null) return
 		didInitialScroll.current = true
-		setFocusedId(selectedSpanId)
-		const index = spanRowIndexById.get(selectedSpanId)
+		setFocusedId(landingSpanId)
+		const index = spanRowIndexById.get(landingSpanId)
 		if (index !== undefined) virtualizer.scrollToIndex(index, { align: "center" })
-	}, [selectedSpanId, spanRowIndexById, setFocusedId, virtualizer, getScrollElement])
+	}, [landingSpanId, spanRowIndexById, setFocusedId, virtualizer, getScrollElement])
 
 	return (
 		<div className="@container flex grow flex-col">
@@ -258,6 +264,7 @@ export function SessionWaterfall({
 											axis={axis}
 											spansById={spansById}
 											selected={selected}
+											revealed={revealedSpanId === row.span.spanId}
 											focused={focusedId === row.span.spanId}
 											onClick={() => {
 												setFocusedId(row.span.spanId)
@@ -497,6 +504,7 @@ function SpanRow({
 	axis,
 	spansById,
 	selected,
+	revealed,
 	focused,
 	onClick,
 }: {
@@ -504,6 +512,8 @@ function SpanRow({
 	axis: SessionAxis
 	spansById: ReadonlyMap<string, AiSessionSpan>
 	selected: boolean
+	/** The row the reader was sent here to see: marked until they move on. */
+	revealed: boolean
 	/** Under the keyboard's span cursor — distinct from `selected`, which means open. */
 	focused: boolean
 	onClick: () => void
@@ -524,6 +534,9 @@ function SpanRow({
 			type="button"
 			onClick={onClick}
 			aria-current={selected || undefined}
+			// The mark is a background colour; this is how the page's tests — and
+			// anything else looking for it — find the row wearing it.
+			data-revealed={revealed || undefined}
 			aria-haspopup="dialog"
 			aria-expanded={selected}
 			className={cn(
@@ -531,6 +544,9 @@ function SpanRow({
 				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
 				errored && "bg-destructive/6",
 				focused && "bg-accent/60",
+				// Louder than the open row's mark on purpose: nothing is on screen
+				// saying which span the reader crossed views for except this row.
+				revealed && "border-l-2 border-l-primary bg-primary/12",
 				selected && "border-l-2 border-l-primary bg-primary/5",
 			)}
 		>


### PR DESCRIPTION
## What

In an agent session, **Open in Traces view** (the span inspection panel's door, in Overview and Flow — and the Transcript row's **Waterfall** button) crossed views with the overlay still up: the reader arrived in the waterfall looking at the same panel that had been covering the Flow canvas a moment earlier, and closing it dropped them wherever the list happened to be.

The door now:

1. **closes the panel** — seeing the span in its waterfall is the whole point of crossing;
2. **scrolls its row to the middle of the viewport**, clear of the ruler and the fold, so it reads with the rows around it;
3. **marks the row** (`border-l-2 border-l-primary bg-primary/12`, a step louder than the open row's `/5`, since nothing else on screen says which span the reader crossed for).

The mark comes off the moment the reader moves on themselves: opening any span, or picking a view by tab or hotkey.

## How

- `SessionViews` holds `revealedSpanId` — **component state, not `?span=`**: it is where the reader was just sent, not a place to link to. `openInTraceView()` stashes the selection there, clears `?span=` (which closes the overlay), and switches to Traces.
- `SessionWaterfall` takes it as a prop. It feeds the existing mount scroll (`scrollToIndex(…, { align: "center" })`) and seeds the keyboard cursor, so a pasted `?span=` link and a span sent across from another view now land the same way. The marked row also carries `data-revealed` as the test seam.

## Verification

- Browser, on the `/lab/agent-session` fixture: Flow → deep Turn-5 `run_tests` → panel → **Open in Traces view** → panel gone, Traces view, that row centred and marked. Same from the Transcript's **Waterfall**.
- `session-detail` 55/55, whole `agent-session` suite 291/291 (10 files), `apps/web` typecheck clean, oxlint shows only pre-existing warnings.

One test flipped meaning — `carries the open span and its tab through the panel's door` asserted the panel *stays* open. It is replaced by two: the panel closes and the row is marked, and the mark clears on the next selection. Tab-choice persistence stays covered by the neighbouring test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790703860&installation_model_id=427786&pr_number=691&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F691&signature=cf73013e27f736e4b872cc3fc1b370de911f5190f86ba6324f1d94014c93392d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->