### PR TITLE
feat(web): show a tool call's arguments and result together, on a spine

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
@@ -79,9 +79,8 @@ export function ViewSwitch({
 	)
 }
 
-/** One segment of a two-state switch; shared so a tool card's arguments ↔
- *  result selector reads exactly like the rendered ↔ raw one beside it. */
-export function ViewSegment({
+/** One segment of the two-state switch. */
+function ViewSegment({
 	active,
 	onSelect,
 	children,
@@ -106,4 +105,23 @@ export function ViewSegment({
 			{children}
 		</button>
 	)
+}
+
+/**
+ * Whether a keyed disclosure is open, given the default its section opens with.
+ * Presence in the set means "flipped away from the default", so a toolbar chip
+ * that changes the default still moves every row the reader has not touched.
+ *
+ * The set lives with the caller, never in the row: the transcript virtualizes,
+ * and local state would leave with the row when it scrolls out of view.
+ */
+export function disclosed(openRows: ReadonlySet<string>, key: string, byDefault: boolean): boolean {
+	return openRows.has(key) ? !byDefault : byDefault
+}
+
+/** The set with `id` flipped — the only write the disclosure set ever takes. */
+export function toggled(set: ReadonlySet<string>, id: string): ReadonlySet<string> {
+	const next = new Set(set)
+	if (!next.delete(id)) next.add(id)
+	return next
 }

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -710,6 +710,34 @@ describe("SessionWaterfall", () => {
 		expect(within(detail).queryByRole("button", { name: "arguments" })).toBeNull()
 	})
 
+	// A failed tool span condemns the call it EXECUTED. Without that, the Tool
+	// calls tab dressed a failed return in the success styling and dropped its
+	// error label — the tab said the call came back fine.
+	it("marks the executed call's return as the failure on the Tool calls tab", () => {
+		const { turns: toolTurns, summary: toolSummary } = sessionOf([
+			agentSpan({ spanId: "ft-agent", startMs: 0, durationMs: 4 * SECOND }),
+			toolSpan({
+				spanId: "ft-tool",
+				parentSpanId: "ft-agent",
+				startMs: SECOND,
+				durationMs: SECOND,
+				toolName: "run_tests",
+				statusCode: "Error",
+				statusMessage: "exit 1",
+				genAi: {
+					toolCallId: "call_11",
+					toolCallArguments: { suite: "webhooks" },
+					toolCallResult: "exit 1 · 2 failing",
+				},
+			}),
+		])
+		render(<Waterfall turns={toolTurns} summary={toolSummary} selectedSpanId="ft-tool" spanTab="tools" />)
+
+		const detail = spanPopover()
+		expect(detail.textContent).toContain("Returned · error")
+		expect(detail.textContent).toContain("span status Error")
+	})
+
 	// A half nobody recorded keeps its place: dropping it would leave a card that
 	// reads as a call which returned nothing.
 	it("keeps the returned half when no result was captured", () => {

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -677,10 +677,11 @@ describe("SessionWaterfall", () => {
 		expect(within(spanPopover()).getAllByText("grep_repo").length).toBeGreaterThan(0)
 	})
 
-	// A call and its result are one event: the panel shows them as one card
-	// whose selector flips between the halves, instead of two stacked cards the
-	// reader has to pair by eye.
-	it("groups a tool call and its result into one card behind a selector", () => {
+	// A call and its result are one event: the panel draws both halves of one
+	// card at once, joined by the direction gutter. The selector that used to
+	// show one at a time made a result nobody captured read exactly like a half
+	// nobody had clicked.
+	it("draws a tool call and its result as both halves of one card", () => {
 		const { turns: toolTurns, summary: toolSummary } = sessionOf([
 			agentSpan({ spanId: "tc-agent", startMs: 0, durationMs: 4 * SECOND }),
 			toolSpan({
@@ -698,14 +699,36 @@ describe("SessionWaterfall", () => {
 		])
 		render(<Waterfall turns={toolTurns} summary={toolSummary} selectedSpanId="tc-tool" spanTab="tools" />)
 
-		// Arguments first, pretty-printed; the result is a click away, not a scroll.
+		// Both halves, pretty-printed and named by direction — and nothing to click
+		// to see the other one.
 		const detail = spanPopover()
 		expect(detail.textContent).toContain('"sql"')
-		expect(detail.textContent).not.toContain('"rows"')
-
-		fireEvent.click(within(detail).getByRole("button", { name: "result" }))
 		expect(detail.textContent).toContain('"rows"')
-		expect(detail.textContent).not.toContain('"sql"')
+		expect(detail.textContent).toContain("Sent")
+		expect(detail.textContent).toContain("Returned")
+		expect(within(detail).queryByRole("button", { name: "result" })).toBeNull()
+		expect(within(detail).queryByRole("button", { name: "arguments" })).toBeNull()
+	})
+
+	// A half nobody recorded keeps its place: dropping it would leave a card that
+	// reads as a call which returned nothing.
+	it("keeps the returned half when no result was captured", () => {
+		const { turns: toolTurns, summary: toolSummary } = sessionOf([
+			agentSpan({ spanId: "nr-agent", startMs: 0, durationMs: 4 * SECOND }),
+			toolSpan({
+				spanId: "nr-tool",
+				parentSpanId: "nr-agent",
+				startMs: SECOND,
+				durationMs: SECOND,
+				toolName: "write_file",
+				genAi: { toolCallId: "call_10", toolCallArguments: { path: "a.ts" } },
+			}),
+		])
+		render(<Waterfall turns={toolTurns} summary={toolSummary} selectedSpanId="nr-tool" spanTab="tools" />)
+
+		const detail = spanPopover()
+		expect(detail.textContent).toContain("Returned")
+		expect(detail.textContent).toContain("whether the call succeeded is unknown")
 	})
 
 	// The panel is a dialog, so the page-level keys stand down while it is open:

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -40,8 +40,9 @@ import {
 import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
 import { formatClockInTimezone } from "@/lib/timezone-format"
 import { ClampedText, firstLine } from "./clamped-text"
-import { useJsonPayload, useMessageBody, ViewSwitch } from "./payload-view"
+import { disclosed, useJsonPayload, useMessageBody, ViewSwitch } from "./payload-view"
 import { Pill } from "./pill"
+import { ToolIo, ToolIoSummary } from "./tool-io"
 
 /**
  * The session as a conversation.
@@ -230,17 +231,6 @@ interface BlockProps {
 	selected: boolean
 	onSelectSpan: (spanId: string | undefined) => void
 	onOpenTraceView: () => void
-}
-
-/**
- * Is this disclosure open?
- *
- * The set holds the rows the reader has flipped AWAY from their default, so the
- * "Expand tool payloads" chip still moves every card they have not touched, and a card
- * they opened by hand stays open when the chip goes off.
- */
-function disclosed(openRows: ReadonlySet<string>, key: string, byDefault: boolean): boolean {
-	return openRows.has(key) ? !byDefault : byDefault
 }
 
 function TranscriptBlock(props: BlockProps) {
@@ -881,8 +871,10 @@ function ToolBlock({
 						<span className={cn(META, "shrink-0")}>
 							· {row.span.serviceName}
 							{!row.fromMessageOnly && ` · ${formatDuration(row.span.durationMs)}`}
-							{!open && payloadSummary(row)}
 						</span>
+						{/* Sizes in gutter order while the pair is shut, so the reader knows
+						    what opening it costs before they pay for it. */}
+						{!open && <ToolIoSummary args={row.args} result={row.result} />}
 					</button>
 					{row.failed && row.span.genAi.errorType !== undefined && (
 						<Pill tone="error" className={WIRE_PILL}>
@@ -893,66 +885,38 @@ function ToolBlock({
 						<span className={cn(META, "shrink-0")}>{row.callId}</span>
 					)}
 					{selected && <OpenInTraces span={row.span} onOpenTraceView={onOpenTraceView} />}
-				</div>
-
-				{open ? (
-					<>
-						{row.args !== undefined && (
-							<PayloadSection
-								label="Arguments"
-								payload={row.args}
-								openRows={openRows}
-								onToggleRow={onToggleRow}
-								textKey={`${row.key}:args-text`}
-							/>
-						)}
-						{row.result !== undefined ? (
-							<PayloadSection
-								label="Result"
-								payload={row.result}
-								meta={row.failed ? `span status ${row.span.statusCode}` : undefined}
-								tone={row.failed ? "text-destructive/90" : undefined}
-								bordered={row.args !== undefined}
-								openRows={openRows}
-								onToggleRow={onToggleRow}
-								textKey={`${row.key}:result-text`}
-							/>
-						) : (
-							<MissingResult fromMessageOnly={row.fromMessageOnly} />
-						)}
-						<button
-							type="button"
-							onClick={() => onToggleRow(payloadsKey)}
-							aria-expanded
-							className="flex cursor-pointer items-center gap-2 border-border/60 border-t px-3 py-1.5 text-chart-2 text-xs"
-						>
-							<ChevronDownIcon size={11} />
-							collapse payloads
-						</button>
-					</>
-				) : (
+					{/* The one control that opens the pair, in the header where the reader
+					    already is — not a footer they have to scroll the payloads to reach. */}
 					<button
 						type="button"
 						onClick={() => onToggleRow(payloadsKey)}
-						aria-expanded={false}
-						className="flex cursor-pointer items-center gap-2 border-border/60 border-t px-3 py-1.5 text-chart-2 text-xs"
+						aria-expanded={open}
+						aria-label={open ? "Collapse payloads" : "Expand payloads"}
+						className="-mr-1 shrink-0 cursor-pointer p-1 text-muted-foreground hover:text-foreground"
 					>
-						<ChevronRightIcon size={11} />
-						expand payloads
+						{open ? <ChevronDownIcon size={12} /> : <ChevronRightIcon size={12} />}
 					</button>
+				</div>
+
+				{open && (
+					<ToolIo
+						args={row.args}
+						result={row.result}
+						failed={row.failed}
+						resultMeta={row.failed ? `span status ${row.span.statusCode}` : undefined}
+						missingResultNote={
+							row.fromMessageOnly
+								? "not captured — this call is known only from the message that made it. Whether it ran is unknown."
+								: "not captured — the span carries no result attribute and no later message echoes this call id. Whether it succeeded is unknown."
+						}
+						keyPrefix={row.key}
+						openRows={openRows}
+						onToggleRow={onToggleRow}
+					/>
 				)}
 			</div>
 		</Row>
 	)
-}
-
-/** The one-line stand-in when payloads are collapsed — sizes, so the reader
- *  knows what expanding costs them. */
-function payloadSummary(row: Extract<TranscriptRow, { kind: "tool" }>): string {
-	const parts: string[] = []
-	if (row.args !== undefined) parts.push(`args ${formatBytes(row.args.byteLength)}`)
-	parts.push(row.result === undefined ? "no result" : `result ${formatBytes(row.result.byteLength)}`)
-	return ` · ${parts.join(" · ")}`
 }
 
 function PayloadSection({
@@ -1034,23 +998,6 @@ function PayloadSection({
 					Cut off here by the instrumentation, not by Maple — the tail was never recorded.
 				</p>
 			)}
-		</div>
-	)
-}
-
-/** A missing result is not a successful one, and this row refuses to imply it. */
-function MissingResult({ fromMessageOnly }: { fromMessageOnly: boolean }) {
-	return (
-		<div className="flex items-center gap-2.5 border-input border-t border-dashed bg-muted/20 px-3 py-2.5">
-			<CircleQuestionIcon size={13} className="shrink-0 text-muted-foreground" />
-			<span className="font-medium font-mono text-[10px] text-muted-foreground uppercase tracking-[0.1em]">
-				Result
-			</span>
-			<span className="min-w-0 text-muted-foreground text-xs">
-				{fromMessageOnly
-					? "not captured — this call is known only from the message that made it. Whether it ran is unknown."
-					: "not captured — the span carries no result attribute and no later message echoes this call id. Whether it succeeded is unknown."}
-			</span>
 		</div>
 	)
 }

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -18,6 +18,7 @@ import type { SessionSummary } from "@/lib/agent-sessions/session-summary"
 import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
 import { SessionFlow } from "./session-flow"
 import { SessionOverview } from "./session-overview"
+import { toggled } from "./payload-view"
 import { sessionToolResults } from "@/lib/agent-sessions/span-detail"
 import { SessionTranscript } from "./session-transcript"
 import { SessionWaterfall } from "./session-waterfall"
@@ -300,12 +301,6 @@ export function SessionViews({
 			</TabsContent>
 		</Tabs>
 	)
-}
-
-function toggled(set: ReadonlySet<string>, id: string): ReadonlySet<string> {
-	const next = new Set(set)
-	if (!next.delete(id)) next.add(id)
-	return next
 }
 
 interface ViewOption {

--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, type ReactNode } from "react"
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react"
 import { Link } from "@tanstack/react-router"
 import { Schema } from "effect"
 
@@ -43,9 +43,11 @@ import {
 } from "@/lib/agent-sessions/span-detail"
 import { classifyAiSpan, spanFailed, spanTtftMs } from "@/lib/agent-sessions/session-turns"
 import { callMetaLine, formatCost } from "@/lib/agent-sessions/session-summary"
+import { payload } from "@/lib/agent-sessions/session-transcript"
 import { ClampedText, firstLine } from "./clamped-text"
-import { useJsonPayload, useMessageBody, ViewSegment, ViewSwitch } from "./payload-view"
+import { toggled, useJsonPayload, useMessageBody, ViewSwitch } from "./payload-view"
 import { Pill } from "./pill"
+import { ToolIo } from "./tool-io"
 
 /**
  * The payload of one span. The chrome around it is the caller's — today that is
@@ -463,28 +465,51 @@ function ReasoningPart({ part }: { part: Extract<SpanMessagePart, { kind: "reaso
 /* -------------------------------------------------------------------------- */
 
 function ToolCallsSection({ toolCalls }: { toolCalls: readonly SpanToolCall[] }) {
+	// The expansion does not virtualize, so one disclosure set for every card on
+	// the tab lives here — the same shape the transcript hands its rows.
+	const [openRows, setOpenRows] = useState<ReadonlySet<string>>(() => new Set())
+	const onToggleRow = useCallback((key: string) => {
+		setOpenRows((previous) => toggled(previous, key))
+	}, [])
+
 	if (toolCalls.length === 0) {
 		return <EmptyNote>No tool calls were captured on this span.</EmptyNote>
 	}
 	return (
 		<div className="flex flex-col gap-3 pb-1">
 			{toolCalls.map((call, index) => (
-				<ToolCallCard key={index} call={call} />
+				<ToolCallCard
+					key={index}
+					call={call}
+					keyPrefix={`tool-call-${index}`}
+					openRows={openRows}
+					onToggleRow={onToggleRow}
+				/>
 			))}
 		</div>
 	)
 }
 
 /**
- * One invocation as one card: the call and its result belong to the same event,
- * and two stacked cards made the reader pair them by eye. A selector shows one
- * half at a time — the other stays a click away, never a scroll.
+ * One invocation as one card. The call and its result are the same event, and
+ * `ToolIo` draws both halves at once — the selector that used to show one at a
+ * time made a result nobody captured look exactly like one nobody had clicked.
  */
-function ToolCallCard({ call }: { call: SpanToolCall }) {
-	const [side, setSide] = useState<"arguments" | "result">(
-		call.argumentsText === undefined && call.resultText !== undefined ? "result" : "arguments",
-	)
-	const body = side === "arguments" ? call.argumentsText : call.resultText
+function ToolCallCard({
+	call,
+	keyPrefix,
+	openRows,
+	onToggleRow,
+}: {
+	call: SpanToolCall
+	keyPrefix: string
+	openRows: ReadonlySet<string>
+	onToggleRow: (key: string) => void
+}) {
+	// Same reading of the captured text the transcript gets, emitter truncation
+	// included — the expansion used to render the raw string and miss it.
+	const args = useMemo(() => payload(call.argumentsText), [call.argumentsText])
+	const result = useMemo(() => payload(call.resultText), [call.resultText])
 
 	return (
 		<div className="min-w-0 overflow-hidden rounded-md border border-border/70">
@@ -496,40 +521,28 @@ function ToolCallCard({ call }: { call: SpanToolCall }) {
 						{call.name}
 					</span>
 				)}
-				<span className="ml-auto flex shrink-0 items-center gap-2">
-					{call.id !== undefined && (
-						<span className="max-w-40 truncate font-mono text-[11px] text-muted-foreground/80" title={call.id}>
-							{call.id}
-						</span>
-					)}
+				{call.id !== undefined && (
 					<span
-						role="group"
-						aria-label="Tool payload"
-						className="flex shrink-0 items-center overflow-hidden rounded-sm border border-border"
+						className="ml-auto max-w-40 shrink-0 truncate font-mono text-[11px] text-muted-foreground/80"
+						title={call.id}
 					>
-						<ViewSegment active={side === "arguments"} onSelect={() => setSide("arguments")}>
-							arguments
-						</ViewSegment>
-						<ViewSegment active={side === "result"} onSelect={() => setSide("result")}>
-							result
-						</ViewSegment>
+						{call.id}
 					</span>
-				</span>
+				)}
 			</div>
 			{call.description !== undefined && (
 				<p className="border-border/60 border-t px-2.5 py-1.5 text-muted-foreground text-xs">
 					{call.description}
 				</p>
 			)}
-			{body === undefined ? (
-				<p className="border-border/60 border-t bg-background/50 px-2.5 py-2 text-muted-foreground text-xs italic">
-					{side === "arguments"
-						? "No arguments were captured for this call."
-						: "No result was captured — whether the call succeeded is unknown."}
-				</p>
-			) : (
-				<PayloadBody text={body} copyLabel={side} />
-			)}
+			<ToolIo
+				args={args}
+				result={result}
+				missingResultNote="not captured — whether the call succeeded is unknown."
+				keyPrefix={keyPrefix}
+				openRows={openRows}
+				onToggleRow={onToggleRow}
+			/>
 		</div>
 	)
 }

--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -139,7 +139,7 @@ export function SpanExpansion({
 
 				{active === "details" && <DetailsSection span={span} toolCalls={toolCalls} />}
 				{active === "messages" && <MessagesSection messages={messages} span={span} />}
-				{active === "tools" && <ToolCallsSection toolCalls={toolCalls} />}
+				{active === "tools" && <ToolCallsSection span={span} toolCalls={toolCalls} />}
 				{active === "logs" && <LogsSection span={span} />}
 			</div>
 		</div>
@@ -464,7 +464,13 @@ function ReasoningPart({ part }: { part: Extract<SpanMessagePart, { kind: "reaso
 /* Tool calls                                                                 */
 /* -------------------------------------------------------------------------- */
 
-function ToolCallsSection({ toolCalls }: { toolCalls: readonly SpanToolCall[] }) {
+function ToolCallsSection({
+	span,
+	toolCalls,
+}: {
+	span: AiSessionSpan
+	toolCalls: readonly SpanToolCall[]
+}) {
 	// The expansion does not virtualize, so one disclosure set for every card on
 	// the tab lives here — the same shape the transcript hands its rows.
 	const [openRows, setOpenRows] = useState<ReadonlySet<string>>(() => new Set())
@@ -475,12 +481,18 @@ function ToolCallsSection({ toolCalls }: { toolCalls: readonly SpanToolCall[] })
 	if (toolCalls.length === 0) {
 		return <EmptyNote>No tool calls were captured on this span.</EmptyNote>
 	}
+	// A failed span condemns the call it EXECUTED and no other: its output calls
+	// are the request it made, and a model call that died on its own error never
+	// learned whether they ran. `call.own` is the difference.
+	const failed = spanFailed(span)
 	return (
 		<div className="flex flex-col gap-3 pb-1">
 			{toolCalls.map((call, index) => (
 				<ToolCallCard
 					key={index}
 					call={call}
+					failed={failed && call.own}
+					statusCode={span.statusCode}
 					keyPrefix={`tool-call-${index}`}
 					openRows={openRows}
 					onToggleRow={onToggleRow}
@@ -497,11 +509,16 @@ function ToolCallsSection({ toolCalls }: { toolCalls: readonly SpanToolCall[] })
  */
 function ToolCallCard({
 	call,
+	failed,
+	statusCode,
 	keyPrefix,
 	openRows,
 	onToggleRow,
 }: {
 	call: SpanToolCall
+	/** This span executed this call, and it failed. */
+	failed: boolean
+	statusCode: string
 	keyPrefix: string
 	openRows: ReadonlySet<string>
 	onToggleRow: (key: string) => void
@@ -538,6 +555,8 @@ function ToolCallCard({
 			<ToolIo
 				args={args}
 				result={result}
+				failed={failed}
+				resultMeta={failed ? `span status ${statusCode}` : undefined}
 				missingResultNote="not captured — whether the call succeeded is unknown."
 				keyPrefix={keyPrefix}
 				openRows={openRows}
@@ -653,11 +672,12 @@ function DetailsSection({
 	const failed = spanFailed(span)
 	// A failed tool call's captured result is usually where the actual error
 	// text lives; surfacing it here saves the reader the trip to the Tool calls
-	// tab. Tool spans only — a model span's tool calls are its OUTPUT, and their
-	// results say nothing about why the model call itself failed. The own call
-	// is first in `spanToolCalls`' order.
+	// tab. The span's OWN call only — a model span's tool calls are its OUTPUT,
+	// and their results say nothing about why the model call itself failed.
 	const failedToolResult =
-		failed && classifyAiSpan(span) === "tool" ? toolCalls[0]?.resultText : undefined
+		failed && classifyAiSpan(span) === "tool"
+			? toolCalls.find((call) => call.own)?.resultText
+			: undefined
 
 	return (
 		<div className="flex flex-col gap-3 pb-1">

--- a/apps/web/src/components/agent-sessions/session-detail/tool-io.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/tool-io.tsx
@@ -1,0 +1,284 @@
+import { CopyButton } from "@maple/ui/components/ui/copy-button"
+import { formatBytes } from "@maple/ui/lib/format"
+import { cn } from "@maple/ui/lib/utils"
+
+import { ArrowDownIcon, ArrowUpIcon, CircleQuestionIcon } from "@/components/icons"
+import { ClampedText } from "./clamped-text"
+import { disclosed, useJsonPayload, ViewSwitch } from "./payload-view"
+import { Pill } from "./pill"
+
+/**
+ * One invocation, both halves, joined by a spine.
+ *
+ * A call and its return are one event. Stacking two identically dressed
+ * sections made the reader pair them by eye; putting them behind a selector —
+ * as the span expansion's Tools tab did — made a missing result read exactly
+ * like a tab nobody had opened. So both halves are always drawn, and the
+ * direction is carried three ways at once: a hollow ↓ marker for what went in
+ * and a solid ↑ marker for what came back, joined by a hairline in a fixed
+ * gutter; a recessed ground under the input; and the words themselves.
+ *
+ * None of it rests on hue alone — the two grounds and the two markers still
+ * separate in greyscale, and the failure tint lands on the RETURN only. The
+ * arguments are not at fault for what came back.
+ */
+
+/** What a half needs to render. Structurally `TranscriptPayload`, which the
+ *  transcript already builds; the span expansion builds it with `payload()`. */
+export interface ToolIoPayload {
+	readonly text: string
+	readonly byteLength: number
+	readonly lineCount: number
+	readonly truncatedByEmitter: boolean
+}
+
+/** Arguments are context and clamp shorter; the result is what the reader
+ *  opened the card for, and keeps the twelve-line body of every other payload. */
+const IN_CLAMP = "line-clamp-[8]"
+const OUT_CLAMP = "line-clamp-[14]"
+
+const LABEL = "font-medium font-mono text-[10px] uppercase tracking-[0.1em]"
+const META = "font-mono text-[10px] text-muted-foreground"
+/** Fixed, so the two markers and every body below them share one lane. */
+const GUTTER = "flex w-8 shrink-0 flex-col items-center gap-1.5 pt-2.5"
+
+export function ToolIo({
+	args,
+	result,
+	failed = false,
+	resultMeta,
+	missingResultNote,
+	keyPrefix,
+	openRows,
+	onToggleRow,
+}: {
+	args: ToolIoPayload | undefined
+	result: ToolIoPayload | undefined
+	/** Tints the return half and its marker. Never the arguments. */
+	failed?: boolean
+	/** One more fact about the return — the span status, where a call failed. */
+	resultMeta?: string
+	/** Why no result was captured. The wording differs by how the call was
+	 *  found, and only the caller knows which. */
+	missingResultNote: string
+	/** Namespaces this card's disclosure keys within the caller's set. */
+	keyPrefix: string
+	openRows: ReadonlySet<string>
+	onToggleRow: (key: string) => void
+}) {
+	// Most vendors capture neither half by default, so this is the common case
+	// and it gets one quiet line rather than two empty sections.
+	if (args === undefined && result === undefined) {
+		return (
+			<div className="flex items-center gap-2.5 border-input border-t border-dashed bg-muted/20 px-3 py-2.5">
+				<span aria-hidden className="flex shrink-0 items-center gap-0.5 text-muted-foreground/60">
+					<ArrowDownIcon size={10} />
+					<ArrowUpIcon size={10} />
+				</span>
+				<span className="min-w-0 text-muted-foreground text-xs">
+					Payloads not captured — this span records the call&apos;s timing and identity only.
+				</span>
+			</div>
+		)
+	}
+
+	return (
+		<>
+			{args === undefined ? (
+				<MissingHalf label="Sent" note="not captured — the span carries no arguments attribute." />
+			) : (
+				<IoHalf
+					direction="in"
+					label="Sent"
+					name="arguments"
+					payload={args}
+					clampClass={IN_CLAMP}
+					textKey={`${keyPrefix}:args-text`}
+					openRows={openRows}
+					onToggleRow={onToggleRow}
+				/>
+			)}
+			{result === undefined ? (
+				<MissingHalf label="Returned" note={missingResultNote} />
+			) : (
+				<IoHalf
+					direction="out"
+					label={failed ? "Returned · error" : "Returned"}
+					name="result"
+					payload={result}
+					meta={resultMeta}
+					failed={failed}
+					clampClass={OUT_CLAMP}
+					textKey={`${keyPrefix}:result-text`}
+					openRows={openRows}
+					onToggleRow={onToggleRow}
+				/>
+			)}
+		</>
+	)
+}
+
+/**
+ * The collapsed card's stand-in: both sizes on one line, in gutter order, so
+ * the reader knows what expanding costs before they pay for it.
+ */
+export function ToolIoSummary({
+	args,
+	result,
+}: {
+	args: ToolIoPayload | undefined
+	result: ToolIoPayload | undefined
+}) {
+	return (
+		<span className="flex shrink-0 items-center gap-1 font-mono text-[11px] text-muted-foreground">
+			<ArrowDownIcon size={10} aria-hidden className="text-muted-foreground/70" />
+			{args === undefined ? "not captured" : formatBytes(args.byteLength)}
+			<ArrowUpIcon size={10} aria-hidden className="ml-2 text-chart-4" />
+			{result === undefined ? "not captured" : sizeLine(result)}
+		</span>
+	)
+}
+
+function IoHalf({
+	direction,
+	label,
+	name,
+	payload,
+	meta,
+	failed = false,
+	clampClass,
+	textKey,
+	openRows,
+	onToggleRow,
+}: {
+	direction: "in" | "out"
+	label: string
+	/** The captured attribute this half came from, kept beside the direction so
+	 *  the reader can still name what they are looking at. */
+	name: string
+	payload: ToolIoPayload
+	meta?: string
+	failed?: boolean
+	clampClass: string
+	textKey: string
+	openRows: ReadonlySet<string>
+	onToggleRow: (key: string) => void
+}) {
+	const { formatted, highlighted } = useJsonPayload(payload.text)
+	const rawKey = `${textKey}:raw`
+	const raw = disclosed(openRows, rawKey, false)
+
+	return (
+		<div
+			className={cn(
+				"flex items-stretch",
+				// One step recessed under the input: the arguments are what the reader
+				// already knows, and the return is what they came for. A black tint
+				// rather than a ground token — light mode paints card and background
+				// the same white, so a token swap would recess nothing there.
+				direction === "in" ? "bg-black/[0.06]" : "border-border/60 border-t",
+				direction === "out" && failed && "bg-destructive/5",
+			)}
+		>
+			<div className={GUTTER}>
+				<Marker direction={direction} failed={failed} />
+				{/* Only the input half carries the spine — it ends at the marker it
+				    joins to, rather than trailing off past the last body. */}
+				{direction === "in" && <span aria-hidden className="w-px grow bg-input" />}
+			</div>
+			<div className="flex min-w-0 grow flex-col gap-2 pt-2.5 pr-3 pb-3">
+				<div className="flex flex-wrap items-center gap-2">
+					<span className={cn(LABEL, failed ? "text-destructive" : "text-foreground")}>
+						{label}
+					</span>
+					<span className={META}>
+						{[name, meta, sizeLine(payload)].filter(Boolean).join(" · ")}
+					</span>
+					{/* Emitter truncation, not the view's clamping — there is no "show
+					    full" that can recover what was never recorded. */}
+					{payload.truncatedByEmitter && (
+						<Pill tone="warn" className="rounded-sm font-mono normal-case tracking-normal">
+							truncated by the emitter
+						</Pill>
+					)}
+					{/* Copies what is displayed: the pretty-printed JSON, or the raw text.
+					    The switch only appears where the two differ. */}
+					{payload.text !== "" && (
+						<span className="-my-1 ml-auto flex items-center">
+							{highlighted !== undefined && (
+								<ViewSwitch
+									rendered="json"
+									raw={raw}
+									onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
+									className="mr-1"
+								/>
+							)}
+							<CopyButton value={raw ? payload.text : formatted} label={name} />
+						</span>
+					)}
+				</div>
+				{/* An emitter that recorded the truncation but kept no prefix leaves
+				    nothing to show; an empty body would read as an empty payload. */}
+				{payload.text !== "" && (
+					<ClampedText
+						text={raw ? payload.text : formatted}
+						html={raw ? undefined : highlighted}
+						mono
+						clampClass={clampClass}
+						toneClass={failed ? "text-destructive/90" : undefined}
+						expanded={disclosed(openRows, textKey, false)}
+						onToggleExpanded={() => onToggleRow(textKey)}
+					/>
+				)}
+				{payload.truncatedByEmitter && (
+					<p className="text-[11px] text-muted-foreground italic">
+						Cut off here by the instrumentation, not by Maple — the tail was never recorded.
+					</p>
+				)}
+			</div>
+		</div>
+	)
+}
+
+/** A half nobody recorded is still a half of this call, and it keeps its place
+ *  in the gutter: a card that drops it reads as a call that had none. */
+function MissingHalf({ label, note }: { label: string; note: string }) {
+	return (
+		<div className="flex items-center border-input border-t border-dashed bg-muted/20 py-2.5 pr-3">
+			<span className="flex w-8 shrink-0 justify-center">
+				<span className="flex size-4 items-center justify-center rounded-full border border-input border-dashed">
+					<CircleQuestionIcon size={9} className="text-muted-foreground" />
+				</span>
+			</span>
+			<span className={cn(LABEL, "shrink-0 pr-2.5 text-muted-foreground")}>{label}</span>
+			<span className="min-w-0 text-muted-foreground text-xs">{note}</span>
+		</div>
+	)
+}
+
+/** Hollow going in, solid coming back: the pair still separates in greyscale,
+ *  which colour alone would not. */
+function Marker({ direction, failed }: { direction: "in" | "out"; failed: boolean }) {
+	if (direction === "in") {
+		return (
+			<span className="flex size-4 shrink-0 items-center justify-center rounded-full border border-input">
+				<ArrowDownIcon size={9} aria-hidden className="text-muted-foreground" />
+			</span>
+		)
+	}
+	return (
+		<span
+			className={cn(
+				"flex size-4 shrink-0 items-center justify-center rounded-full",
+				failed ? "bg-destructive" : "bg-chart-4",
+			)}
+		>
+			<ArrowUpIcon size={9} aria-hidden className="text-background" />
+		</span>
+	)
+}
+
+function sizeLine(payload: ToolIoPayload): string {
+	const size = formatBytes(payload.byteLength)
+	return payload.lineCount > 1 ? `${size} · ${payload.lineCount} lines` : size
+}

--- a/apps/web/src/lib/agent-sessions/span-detail.test.ts
+++ b/apps/web/src/lib/agent-sessions/span-detail.test.ts
@@ -154,8 +154,38 @@ describe("spanToolCalls", () => {
 				description: undefined,
 				argumentsText: '{"path":"src/retry.ts"}',
 				resultText: "120 lines",
+				own: true,
 			},
 		])
+	})
+
+	// Only the call a span EXECUTED may be read against that span's status. A
+	// model call that died on its own error never learned whether the tools it
+	// asked for ran, so its output calls are not its own.
+	it("marks the span's own executed call, and only that one", () => {
+		const executed = toolSpan({
+			spanId: "t2",
+			startMs: 0,
+			durationMs: 1000,
+			toolName: "run_tests",
+			genAi: { toolCallId: "toolu_02", toolCallArguments: { suite: "webhooks" } },
+		})
+		expect(spanToolCalls(executed).map((call) => call.own)).toEqual([true])
+
+		const requested = llmSpan({
+			spanId: "l2",
+			startMs: 0,
+			durationMs: 1000,
+			genAi: {
+				outputMessages: [
+					{
+						role: "assistant",
+						parts: [{ type: "tool_call", id: "toolu_03", name: "run_tests", arguments: {} }],
+					},
+				],
+			},
+		})
+		expect(spanToolCalls(requested).map((call) => call.own)).toEqual([false])
 	})
 
 	it("reads the tool_call parts of the output this call produced, not the history", () => {

--- a/apps/web/src/lib/agent-sessions/span-detail.ts
+++ b/apps/web/src/lib/agent-sessions/span-detail.ts
@@ -54,6 +54,16 @@ export interface SpanToolCall {
 	readonly description: string | undefined
 	readonly argumentsText: string | undefined
 	readonly resultText: string | undefined
+	/**
+	 * This span EXECUTED this call, rather than merely making it: the call came
+	 * from the span's own `gen_ai.tool.*` attributes.
+	 *
+	 * It is the only call a reader may read the span's status against. A model
+	 * span's output calls are its request — a model call that failed on
+	 * `context_length_exceeded` says nothing about whether the tools it asked
+	 * for ever ran, and colouring them red would claim it did.
+	 */
+	readonly own: boolean
 }
 
 /**
@@ -89,6 +99,7 @@ export function spanToolCalls(
 						description: undefined,
 						argumentsText: part.argumentsText,
 						resultText: undefined,
+						own: false,
 					},
 					span,
 					results,
@@ -191,6 +202,7 @@ function ownToolCall(span: AiSessionSpan): SpanToolCall | undefined {
 		description: toolDescription,
 		argumentsText: toolCallArguments === undefined ? undefined : jsonText(toolCallArguments),
 		resultText: toolCallResult === undefined ? undefined : jsonText(toolCallResult),
+		own: true,
 	}
 }
 


### PR DESCRIPTION
A call and its return are one event, and neither view of them said so.

- **Transcript** stacked two identically dressed `PayloadSection`s (Arguments, Result) and left the reader to pair them by eye.
- **Span panel → Tool calls** put them behind an `arguments | result` selector, so a result nobody captured read exactly like a half nobody had clicked.

Both now render through one component, `session-detail/tool-io.tsx`.

## The card

Both halves, always, joined by a fixed 32px gutter that draws the direction: a hollow ↓ marker for what went in, a solid ↑ marker for what came back, and a hairline between them. Direction never rests on hue alone —

- the **input** half sits on a recessed ground and clamps at 8 lines, because arguments are context;
- the **output** half keeps the full 14, because the result is what the card was opened for;
- the words say `SENT` / `RETURNED`, with the captured attribute name (`arguments`, `result`) and its size in the mono meta beside them.

The recess is a black tint rather than a ground token: light mode paints `--card` and `--background` the same white, so a token swap would recess nothing there.

## States

- **Failed** tints the RETURN only. The arguments are not at fault for what came back.
- **No result captured** keeps its half — a hollow marker on a dashed edge, with the wording it had before. A card that drops it reads as a call that returned nothing.
- **Neither half captured** — the common case, since most vendors do not capture payloads by default — collapses to one quiet line instead of two empty sections.
- **Collapsed** carries both sizes in gutter order (`↓ 184 B  ↑ 6.1 KB · 148 lines`), so the reader knows what opening it costs. The chevron moves into the header; the footer expand/collapse button is gone.

## Incidental

The panel's tool cards now read their payloads through `payload()` from the transcript model, so they pick up emitter truncation (`{truncated, prefix}` envelopes, trailing `…[truncated]`) they used to render straight past. `disclosed`/`toggled` moved to `payload-view.tsx` as the shared disclosure helpers; `ViewSegment` is no longer exported, since nothing selects between halves any more.

Designed in Paper — page `Tool I/O 2026-08-30` in *Maple — Agent Sessions (Session Detail)*.

## Verification

- `turbo typecheck --filter=@maple/web` clean.
- `vitest run src/components/agent-sessions src/lib/agent-sessions` — 292 passed. The panel test that asserted the selector now asserts both halves and the absence of the selector; a new test covers the kept RETURNED half when no result was captured.
- Walked the `/lab/agent-session` fixture for all five states in both the Transcript and the span panel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790705816&installation_model_id=427786&pr_number=693&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F693&signature=b76ff822807a70b6b6e1928003572ea4d6dbc17dba28651412307e93d1225b16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->