### PR TITLE
fix(billing): meter every investigation turn, not just the first diagnosis

### DIFF
--- a/apps/api/src/chat/investigation-metering.test.ts
+++ b/apps/api/src/chat/investigation-metering.test.ts
@@ -130,6 +130,17 @@ describe("meterInvestigationTurn", () => {
 		assert.deepEqual(tracked, [])
 	})
 
+	it("gives up on a tracker that never answers, rather than holding the turn slot", async () => {
+		// `endTurn` waits on this finalizer, and a wedged slot is only reclaimed after 15 minutes.
+		globalThis.fetch = () => new Promise<Response>(() => {})
+
+		const started = Date.now()
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "msg-1", 1000, 100)
+
+		assert.isBelow(Date.now() - started, 30_000, "metering did not give up")
+		assert.deepEqual(tracked, [])
+	})
+
 	it("charges nothing for an `inv-` tab whose id is not an investigation id", async () => {
 		// Same guard `submit_diagnosis` applies: the set of sessions that bill is exactly the set
 		// that gets the tool.

--- a/apps/api/src/chat/investigation-metering.test.ts
+++ b/apps/api/src/chat/investigation-metering.test.ts
@@ -1,0 +1,140 @@
+/**
+ * What an investigation turn charges, and under which idempotency key.
+ *
+ * The key is the whole subject. Metering used to hang off `submit_diagnosis` keyed on the bare
+ * investigation id, so an investigation was billed once no matter how many turns it went on to
+ * cost — and a turn that failed before reaching the tool was billed nothing at all. Every
+ * assertion here is about a charge that used to be silently deduplicated away.
+ */
+import { Effect } from "effect"
+import { afterEach, assert, beforeEach, describe, it } from "vitest"
+import { meterInvestigationTurn } from "./turn-runner"
+
+const ORG = "org_test"
+const INVESTIGATION = "0199a4d1-9f3c-7c8e-b2a1-3f5e7d9c1b40"
+
+const tenant = { orgId: ORG }
+
+const env = { AUTUMN_SECRET_KEY: "sk_test" }
+
+const turn = (sessionId: string, messageId: string) => ({ sessionId, messageId, env })
+
+interface Tracked {
+	readonly featureId: string
+	readonly value: number
+	readonly key: string
+}
+
+/** The track body the tracker builds; read back field by field rather than asserted into shape. */
+const trackedFrom = (body: unknown): Tracked => {
+	const fields = body as Record<string, unknown>
+	return {
+		featureId: String(fields["feature_id"]),
+		value: Number(fields["value"]),
+		key: String(fields["idempotency_key"]),
+	}
+}
+
+let tracked: Array<Tracked>
+let realFetch: typeof globalThis.fetch
+
+beforeEach(() => {
+	tracked = []
+	realFetch = globalThis.fetch
+	globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+		tracked.push(trackedFrom(JSON.parse(typeof init?.body === "string" ? init.body : "{}")))
+		return new Response("{}", { status: 200 })
+	}
+})
+
+afterEach(() => {
+	globalThis.fetch = realFetch
+})
+
+const meter = (sessionId: string, messageId: string, input: number, output: number) =>
+	Effect.runPromise(meterInvestigationTurn(turn(sessionId, messageId), tenant, { input, output }))
+
+const keysFor = (featureId: string) => tracked.filter((t) => t.featureId === featureId).map((t) => t.key)
+
+describe("meterInvestigationTurn", () => {
+	it("charges input and output under a key that carries the turn", async () => {
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "msg-1", 1200, 340)
+
+		assert.deepEqual(
+			tracked.map((t) => ({ featureId: t.featureId, value: t.value })),
+			[
+				{ featureId: "ai_input_tokens", value: 1200 },
+				{ featureId: "ai_output_tokens", value: 340 },
+			],
+		)
+		assert.deepEqual(keysFor("ai_input_tokens"), [`${INVESTIGATION}:turn-msg-1:triage:input`])
+		assert.deepEqual(keysFor("ai_output_tokens"), [`${INVESTIGATION}:turn-msg-1:triage:output`])
+	})
+
+	it("bills every turn of an investigation, not just the first", async () => {
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "msg-1", 1000, 100)
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "msg-2", 2000, 200)
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "msg-3", 3000, 300)
+
+		// The regression this guards: one shared key collapsed all three follow-ups into one charge.
+		assert.deepEqual(keysFor("ai_input_tokens"), [
+			`${INVESTIGATION}:turn-msg-1:triage:input`,
+			`${INVESTIGATION}:turn-msg-2:triage:input`,
+			`${INVESTIGATION}:turn-msg-3:triage:input`,
+		])
+		assert.strictEqual(
+			tracked.filter((t) => t.featureId === "ai_input_tokens").reduce((sum, t) => sum + t.value, 0),
+			6000,
+		)
+	})
+
+	it("reuses one key across retries of the same turn", async () => {
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "msg-1", 1000, 100)
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "msg-1", 1000, 100)
+
+		assert.deepEqual(keysFor("ai_input_tokens"), [
+			`${INVESTIGATION}:turn-msg-1:triage:input`,
+			`${INVESTIGATION}:turn-msg-1:triage:input`,
+		])
+	})
+
+	it("keeps its keys disjoint from the fan-out's attempt keys", async () => {
+		// The fan-out meters the same investigation as `<id>:<attempt>`. A turn id that happens to
+		// be "1" must not land on the key attempt 1 already used, or one of the two goes unbilled.
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "1", 500, 50)
+
+		assert.deepEqual(keysFor("ai_input_tokens"), [`${INVESTIGATION}:turn-1:triage:input`])
+		assert.notInclude(keysFor("ai_input_tokens"), `${INVESTIGATION}:1:triage:input`)
+	})
+
+	it("charges a turn that spent only input", async () => {
+		// A turn that died mid-step still burned its prompt. It used to bill nothing at all.
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "msg-1", 900, 0)
+
+		assert.deepEqual(
+			tracked.map((t) => t.featureId),
+			["ai_input_tokens"],
+		)
+	})
+
+	it("charges nothing for a turn that spent nothing", async () => {
+		await meter(`${ORG}:inv-${INVESTIGATION}`, "msg-1", 0, 0)
+
+		assert.deepEqual(tracked, [])
+	})
+
+	it("charges nothing for a session that is not an investigation", async () => {
+		await meter(`${ORG}:default`, "msg-1", 1000, 100)
+		await meter(`${ORG}:alert-abc`, "msg-1", 1000, 100)
+
+		assert.deepEqual(tracked, [])
+	})
+
+	it("charges nothing for an `inv-` tab whose id is not an investigation id", async () => {
+		// Same guard `submit_diagnosis` applies: the set of sessions that bill is exactly the set
+		// that gets the tool.
+		await meter(`${ORG}:inv-not-a-uuid`, "msg-1", 1000, 100)
+
+		assert.deepEqual(tracked, [])
+	})
+})

--- a/apps/api/src/chat/loop/index.ts
+++ b/apps/api/src/chat/loop/index.ts
@@ -21,6 +21,7 @@
  */
 export { runChatTurn } from "./turn"
 export {
+	addUsage,
 	makeTurnObservability,
 	makeTurnUsage,
 	type ChatTurnEvent,
@@ -31,10 +32,5 @@ export {
 } from "./types"
 export { MAX_STEPS, SUBAGENT_MAX_STEPS } from "./budgets"
 export { dropOldestToolStep, isNearContextLimit } from "./context"
-export {
-	annotateModelResponse,
-	modelCallAttributes,
-	modelCallSpanName,
-	type GenAiIdentity,
-} from "./genai"
+export { annotateModelResponse, modelCallAttributes, modelCallSpanName, type GenAiIdentity } from "./genai"
 export { isRetryableStepFailure, stepRetryDelayMs } from "./retry"

--- a/apps/api/src/chat/loop/types.ts
+++ b/apps/api/src/chat/loop/types.ts
@@ -180,11 +180,11 @@ export interface StepState {
 /**
  * Running token total for one turn, accumulated across its steps.
  *
- * Mutable and shared rather than returned, because the one consumer — `submit_diagnosis` — is a
- * *tool* invoked mid-turn, so there is no "after the turn" moment at which to hand it a total.
- * In practice the diagnosis call is the last thing an investigation does, so this is the whole turn
- * bar the final assistant message. Before this, `SubmitDiagnosisRequest` was built with no usage at
- * all, so `InvestigationService`'s `if (env && (inputTokens || outputTokens))` was always false:
+ * Mutable and shared rather than returned, because one of its consumers — `submit_diagnosis` — is a
+ * *tool* invoked mid-turn, so there is no "after the turn" moment at which to hand it a total. It
+ * records what the investigation cost onto the row; the billing charge is raised separately, from
+ * the finalizer in `turn-runner.ts`, which reads the same record once the turn has ended however it
+ * ended. Before this record existed, `SubmitDiagnosisRequest` was built with no usage at all, so
  * `investigations.model` stayed null and Autumn was never metered for autonomous investigations,
  * which the pre-`@opencode-ai/ai` workflow path did meter.
  */

--- a/apps/api/src/chat/turn-runner.ts
+++ b/apps/api/src/chat/turn-runner.ts
@@ -237,6 +237,20 @@ const decodeInvestigationIdOption = Schema.decodeUnknownOption(InvestigationId)
 /** Compaction is housekeeping; it must not hold the turn slot open. */
 const COMPACTION_TIMEOUT = "20 seconds"
 
+/**
+ * So is metering, and it runs even later — after the answer, on the way out of the turn.
+ *
+ * `endTurn` sits in the `finally` of `ChatSession.runTurn`, so whatever the metering finalizer
+ * waits on holds the session's turn slot, and the stale-claim reclaim is 15 minutes out
+ * (`TURN_STALE_MS` in `ChatSession.ts`). Unbounded, a POST to Autumn that never answers is a way
+ * for a third party's outage to wedge a conversation — the exact hazard `COMPACTION_TIMEOUT`
+ * exists for, one step later in the same tail.
+ *
+ * On timeout the request is abandoned rather than aborted: it may still land, and if it does not,
+ * one turn goes unbilled. That is the trade the tracker already makes for a failed request.
+ */
+const METERING_TIMEOUT = "5 seconds"
+
 /** Stable copy for the durable/browser event; detailed causes stay server-side. */
 const CHAT_TURN_FAILED = "Maple couldn't complete this response."
 
@@ -280,7 +294,7 @@ export const meterInvestigationTurn = (
 			idempotencyKey: `${investigationId}:turn-${input.messageId}`,
 			source: "triage",
 		}).catch(() => undefined),
-	)
+	).pipe(Effect.timeout(METERING_TIMEOUT), Effect.ignore)
 }
 
 /**

--- a/apps/api/src/chat/turn-runner.ts
+++ b/apps/api/src/chat/turn-runner.ts
@@ -23,15 +23,19 @@ import { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
 import { MCP_ANTICIPATED_ERROR_IDENTIFIERS } from "@/mcp/expected-failures"
 import {
 	decodeChatTurnTenant,
+	investigationIdFromChatSessionId,
 	type ChatMessage,
 	type ChatTurnTenantEncoded,
 } from "@maple/domain/chat-session"
 import { layerFromEnvRecord, WorkerConfigProviderLayer } from "@maple/effect-cloudflare"
 import { LLM, Message, type LanguageModel, type LLMClientService } from "@opencode-ai/ai"
-import { Cause, Effect, Layer, ManagedRuntime, Stream } from "effect"
+import { Cause, Effect, Layer, ManagedRuntime, Option, Schema, Stream } from "effect"
 import type { ChatSession } from "./ChatSession"
 import type { TenantContext } from "@/services/auth/tenant-context"
 import { summarizeCause } from "@/platform/describe-cause"
+import { trackTokenUsage } from "@/services/billing/autumn-tracker"
+import { InvestigationId } from "@maple/domain/primitives"
+import type { TurnUsage } from "./loop"
 
 const telemetry = MapleCloudflareSDK.make({
 	serviceName: "maple-api",
@@ -145,12 +149,17 @@ export const toLlmMessages = (
 const compactIfNeeded = (
 	input: RunChatSessionTurnInput,
 	model: LanguageModel,
-	usage: { readonly input: number },
+	usage: TurnUsage,
 ): Effect.Effect<void, never, LLMClientService> =>
 	Effect.gen(function* () {
 		const { contextLimitOf, outputLimitOf } = yield* Effect.promise(() => import("../platform/Llm"))
-		const { isNearContextLimit, annotateModelResponse, modelCallAttributes, modelCallSpanName } =
-			yield* Effect.promise(() => import("./loop"))
+		const {
+			addUsage,
+			isNearContextLimit,
+			annotateModelResponse,
+			modelCallAttributes,
+			modelCallSpanName,
+		} = yield* Effect.promise(() => import("./loop"))
 		if (
 			!isNearContextLimit(usage.input, {
 				context: contextLimitOf(model),
@@ -194,6 +203,11 @@ const compactIfNeeded = (
 				},
 			}),
 		)
+		// Housekeeping is still spend. The compaction call is billed to the same turn as the answer
+		// it follows — it is charged to us either way, and a turn that hides it under-reports what
+		// the conversation cost.
+		addUsage(usage, response.usage)
+
 		const summary = response.text.trim()
 		if (summary === "") return
 		input.session.append({ type: "compaction", messageId: input.messageId, summary, throughSeq })
@@ -218,11 +232,56 @@ const compactIfNeeded = (
 		),
 	)
 
+const decodeInvestigationIdOption = Schema.decodeUnknownOption(InvestigationId)
+
 /** Compaction is housekeeping; it must not hold the turn slot open. */
 const COMPACTION_TIMEOUT = "20 seconds"
 
 /** Stable copy for the durable/browser event; detailed causes stay server-side. */
 const CHAT_TURN_FAILED = "Maple couldn't complete this response."
+
+/**
+ * Meter one investigation turn's token spend into Autumn.
+ *
+ * **Per turn, not per diagnosis.** This used to hang off `submit_diagnosis`, keyed on the bare
+ * investigation id, which billed an investigation exactly once however much it went on to cost:
+ * every follow-up turn the user asked for was free, and so was any turn that errored or ran out of
+ * steps before reaching the tool. The key carries the turn (`messageId`), so each turn bills once
+ * and a retried turn does not double-bill — the same reason the fan-out workflow keys on its
+ * attempt rather than on the investigation.
+ *
+ * `turn-` keeps this key space disjoint from the fan-out's `<id>:<attempt>`. Both meter the same
+ * investigation under the same `triage` source, so an unprefixed turn id could collide with an
+ * attempt number and silently deduplicate a real charge.
+ *
+ * Investigations only: a plain chat session has no investigation id and stays unmetered here.
+ */
+export const meterInvestigationTurn = (
+	input: Pick<RunChatSessionTurnInput, "sessionId" | "messageId" | "env">,
+	tenant: Pick<TenantContext, "orgId">,
+	usage: { readonly input: number; readonly output: number },
+): Effect.Effect<void> => {
+	const rawId = investigationIdFromChatSessionId(input.sessionId)
+	if (rawId === undefined) return Effect.void
+	// The same guard `buildDiagnosisCompletion` uses, so the set of sessions that bill is exactly
+	// the set that gets a `submit_diagnosis` tool: an `inv-` suffix that is not a UUID is not an
+	// investigation, and must not be charged as one.
+	const decoded = decodeInvestigationIdOption(rawId)
+	if (Option.isNone(decoded)) return Effect.void
+	const investigationId = decoded.value
+	if (usage.input <= 0 && usage.output <= 0) return Effect.void
+	// Bookkeeping must never fail a delivered answer. `trackTokenUsage` already swallows its own
+	// transport errors; the `catch` covers the rest so this can be an infallible Effect.
+	return Effect.promise(() =>
+		trackTokenUsage(input.env, {
+			orgId: tenant.orgId,
+			inputTokens: usage.input,
+			outputTokens: usage.output,
+			idempotencyKey: `${investigationId}:turn-${input.messageId}`,
+			source: "triage",
+		}).catch(() => undefined),
+	)
+}
 
 /**
  * Drive one turn to completion.
@@ -261,6 +320,9 @@ export const runChatSessionTurn = async (input: RunChatSessionTurnInput): Promis
 
 	const tenant = toTenantContext(input.tenant)
 	const observability = loop.makeTurnObservability()
+	// Hoisted out of the program: `submit_diagnosis` reads it mid-turn, and the metering finalizer
+	// reads it after the turn has ended — including when it ended by failing.
+	const usage = loop.makeTurnUsage()
 	let recordedTerminal = false
 	const annotateTurn = () =>
 		Effect.annotateCurrentSpan({
@@ -288,9 +350,6 @@ export const runChatSessionTurn = async (input: RunChatSessionTurnInput): Promis
 			orgId: tenant.orgId,
 			sessionId: input.sessionId,
 		})
-		// Shared with the turn so `submit_diagnosis` can report what the investigation cost. See
-		// `TurnUsage` — the tool is invoked mid-turn, so there is no later moment to hand it a total.
-		const usage = loop.makeTurnUsage()
 		// One value: the tool *and* whether this turn's answer is a call to it. Passing the tool alone
 		// is what left an autonomous investigation with no way to file its report once it ran out of
 		// steps — see `buildDiagnosisCompletion`.
@@ -343,6 +402,9 @@ export const runChatSessionTurn = async (input: RunChatSessionTurnInput): Promis
 		yield* annotateTurn()
 		yield* compactIfNeeded(input, model, usage)
 	}).pipe(
+		// `ensuring`, not a trailing statement: a turn that failed, was aborted, or ran out of steps
+		// still burned the tokens it burned, and the pre-`ensuring` shape billed none of them.
+		Effect.ensuring(Effect.suspend(() => meterInvestigationTurn(input, tenant, usage))),
 		Effect.tapCause((cause) => {
 			observability.outcome = "error"
 			observability.failureReason ??= "UnhandledTurnFailure"

--- a/apps/api/src/services/errors/InvestigationService.ts
+++ b/apps/api/src/services/errors/InvestigationService.ts
@@ -37,7 +37,6 @@ import {
 import { WorkerEnvironment } from "@maple/effect-cloudflare/worker-environment"
 import { and, desc, eq, inArray, isNull, lt, sql } from "drizzle-orm"
 import { Clock, Context, Duration, Effect, Exit, Layer, Option, Redacted, Schema } from "effect"
-import { trackTokenUsage } from "@/services/billing/autumn-tracker"
 import { applyDiagnosisWrites, subjectTypeOf } from "@/services/errors/apply-diagnosis"
 import { AUTONOMOUS_KICKOFF_LEAD, buildIncidentContextMessage } from "@/workflows/incident-context"
 import { routeInvestigation, type InvestigationRoute } from "@/services/errors/investigation-route"
@@ -1011,33 +1010,14 @@ export class InvestigationService extends Context.Service<InvestigationService, 
 					// A human follow-up that re-diagnoses a ranked fan-out orphans the lens
 					// verdicts: they explain a cause that is no longer on screen.
 					...(row.fanoutState === "ranked" ? { fanoutState: "superseded" as const } : undefined),
-				}).pipe(
-					Effect.mapError(makePersistenceError),
-					Effect.provideService(Database, database),
-				)
+				}).pipe(Effect.mapError(makePersistenceError), Effect.provideService(Database, database))
 
-				const env = Option.getOrUndefined(workerEnv)
-				if (env && (request.inputTokens || request.outputTokens)) {
-					// Keyed on the investigation id (one diagnosis per investigation): a
-					// re-diagnosis updates the report but is intentionally NOT re-billed,
-					// matching the once-per-investigation timeline event above. A tracking
-					// failure must not fail the diagnosis write, but is surfaced as a log.
-					yield* Effect.tryPromise(() =>
-						trackTokenUsage(env, {
-							orgId,
-							inputTokens: request.inputTokens ?? 0,
-							outputTokens: request.outputTokens ?? 0,
-							idempotencyKey: id,
-							source: "triage",
-						}),
-					).pipe(
-						Effect.catchCause((cause) =>
-							Effect.logWarning("token usage tracking failed").pipe(
-								Effect.annotateLogs({ investigationId: id, cause: summarizeCause(cause) }),
-							),
-						),
-					)
-				}
+				// Deliberately does NOT meter. `request.inputTokens`/`outputTokens` are persisted onto
+				// the row above for display, but the charge is raised per *turn* in
+				// `chat/turn-runner.ts` — see `meterInvestigationTurn`. Metering here billed an
+				// investigation once, on its first diagnosis, and every follow-up turn (and every turn
+				// that failed before reaching this tool) was free. This path also carries no usage at
+				// all when reached over internal RPC, which never populates those fields.
 
 				const updated = yield* loadRow(orgId, id)
 				return yield* documentFor(orgId, updated ?? row)


### PR DESCRIPTION
Investigation token spend is now metered per turn. It was metered once per investigation, on the first `submit_diagnosis`, which left most of a long investigation's cost uncharged.

## What was wrong

`InvestigationService.submitDiagnosis` called `trackTokenUsage` with the bare investigation id as the idempotency key. Consequences, all of them silent:

- Every follow-up turn in an investigation — "why?", "check payments too" — ran a full agent loop with tools and billed nothing, because its charge deduplicated against the first one.
- A turn that errored, was aborted, or ran out of steps before reaching `submit_diagnosis` billed nothing at all, having spent its tokens.
- The compaction pass (`compactIfNeeded`) is a real model call and was invisible to both the meter and the row.

`InvestigationFanoutWorkflow` already hit the retry half of this and fixed it by keying on `<id>:<attempt>`; the chat path never got the same treatment.

## The fix

The charge now comes from the turn, in `chat/turn-runner.ts`:

- `meterInvestigationTurn` keys on `<investigationId>:turn-<messageId>` — each turn bills once, a retried turn does not double-bill.
- The `turn-` prefix keeps this key space disjoint from the fan-out's `<id>:<attempt>`. Both meter the same investigation under the same `triage` source, so an unprefixed turn id could collide with an attempt number and drop one of the two charges.
- It runs from `Effect.ensuring`, so a failed or aborted turn still bills what it burned. `TurnUsage` is hoisted out of the turn program so the finalizer can read the running total.
- `compactIfNeeded` now folds its response into `TurnUsage`, so compaction is charged to the turn it follows and shows up on the row.
- Same investigation-id decode guard as `buildDiagnosisCompletion`: the set of sessions that bill is exactly the set that gets the tool.

`submitDiagnosis` still persists `model` / `inputTokens` / `outputTokens` onto the row for display, and no longer meters. That path carries no usage at all when reached over internal RPC (`submitDiagnosisRpc` constructs the request without those fields), so it was never a viable billing seam.

Scope: investigations only. Plain chat and MCP stay unmetered — separate work.

On cache reads: `TurnUsage.cacheRead` is deliberately not passed to the tracker, and that is not an under-bill. `AI.Usage` is an inclusive contract — `inputTokens` already includes cached input, and every protocol mapper normalizes to it (OpenAI-shaped providers derive `nonCachedInputTokens` by subtraction; Anthropic sums its non-cached native count back up). Adding `cacheRead` on top would double-count. The open question is the opposite one, and it is pricing rather than correctness: providers discount cache reads to roughly 0.1-0.5x, and this meter counts them at par. It bills nothing today (`ai_input_tokens` has no plan item), so it is latent until a rate is set.

## Hardening (second commit)

`endTurn` is in the `finally` of `ChatSession.runTurn`, so the metering finalizer holds the session's turn slot while it waits, and a wedged slot is only reclaimed after `TURN_STALE_MS` — 15 minutes. `trackTokenUsage` posts with a bare `fetch`: no timeout, no abort signal. An Autumn outage that hangs rather than fails could make an investigation's chat unusable for a quarter of an hour, for bookkeeping. Bounded at 5s inside `meterInvestigationTurn` (not at the call site, so it cannot be forgotten by a future caller) — the same guard `COMPACTION_TIMEOUT` already applies one step earlier in the same tail.

## Tests

- New `chat/investigation-metering.test.ts`, 8 cases: per-turn keys, three follow-ups billing three times, one key across retries of a turn, disjointness from a numeric fan-out attempt, input-only turns, zero-spend turns, non-investigation sessions, and an `inv-` tab whose id is not a UUID.
- Reverted the key to the old scheme locally to confirm 4 of the 8 fail against it, so they are not vacuous.
- `apps/api` typecheck clean; `oxlint -c .oxlintrc.effect.json` and `oxfmt` clean on the touched files.
- `src/chat` + `src/services/errors`: 378/379. The one failure is `loop/turn.test.ts:622` (`flushedBefore.length >= 24`), which passes in isolation and sits on a path this PR does not touch — a load-sensitive threshold, flagged rather than assumed harmless.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790711529&installation_model_id=427786&pr_number=695&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F695&signature=a8cb279e52aca32d6871a7eca9bddc6a5f7876d1eafd1c98be04aefa2f9283fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

