### PR TITLE
fix(web): a view the reader left stops standing in the page

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -9,7 +9,7 @@
 // `spanPopover()` below rather than the render's own container.
 
 import { useState, type ReactNode } from "react"
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react"
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
 
 vi.mock("@tanstack/react-router", () => ({
@@ -1146,6 +1146,44 @@ describe("SessionViews", () => {
 
 		fireEvent.click(screen.getAllByText("read_file")[0]!)
 		expect(document.querySelector("[data-revealed]")).toBeNull()
+	})
+
+	// The mark alone is not the landing: the row has to be brought on screen, and
+	// the aim the virtualizer makes on mount is made against a page that is still
+	// settling into the switch. The row corrects it a frame later, from where it
+	// actually is — which is also the only part of the landing jsdom can observe.
+	it("brings the row it sent the reader to on screen, from the row's own position", async () => {
+		const scrollIntoView = vi.fn()
+		const original = Element.prototype.scrollIntoView
+		Element.prototype.scrollIntoView = scrollIntoView
+		try {
+			render(<Views view="flow" />)
+
+			fireEvent.click(screen.getByText("grep_repo"))
+			fireEvent.click(within(spanPopover()).getByRole("button", { name: "Open in Traces view" }))
+
+			await act(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())))
+
+			expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" })
+			// On the marked row itself, not on whatever happened to be first.
+			expect((scrollIntoView.mock.instances[0] as HTMLElement).dataset.revealed).toBe("true")
+		} finally {
+			Element.prototype.scrollIntoView = original
+		}
+	})
+
+	// A view left behind is not just invisible, it is out of the page: the
+	// waterfall measures its own offset inside the page scroller as it mounts,
+	// and a view still standing above it moves that measurement by its whole
+	// height — which is what sent "Open in Traces view" nowhere near its row.
+	it("takes the view being left out of the page, not just out of sight", () => {
+		render(<Views view="overview" />)
+		expect(screen.getByText(/Completed, with/)).toBeTruthy()
+
+		fireEvent.click(screen.getByRole("tab", { name: /Traces/ }))
+
+		expect(screen.getByText("Model / target")).toBeTruthy()
+		expect(screen.queryByText(/Completed, with/)).toBeNull()
 	})
 
 	// The tab choice lives beside the other cross-view state in SessionViews:

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -233,71 +233,89 @@ export function SessionViews({
 
 			{/* Overview, Trace and Transcript carry the bottom padding the page
 			    scroller gave up (`pb-0`, so the Flow floor can pin flush — see the
-			    route); the Flow view stays unpadded for the same reason. Only the
-			    active view sees the span selection: an outgoing panel stays
-			    mounted until its exit transition completes, and two views holding
-			    the inspection overlay open would stack two scrims. */}
+			    route); the Flow view stays unpadded for the same reason.
+
+			    Each panel renders its view only while that view is the active one.
+			    The panel ELEMENTS outlive the switch — a Tabs panel unmounts only
+			    once its exit transition reports complete, an animation frame or
+			    more after the tab changed — and a view left standing that long is
+			    not free. The waterfall measures its own offset inside the page
+			    scroller as it mounts, so the Overview still in the page above it
+			    moved that measurement by the Overview's whole height, and "Open in
+			    Traces view" scrolled to a row a screenful and more from where the
+			    row actually was. It also means a list the reader had scrolled
+			    comes back as a fresh mount rather than waking up mid-session with
+			    a stale scroll — and, as before, that only one view holds the
+			    inspection overlay, so no switch can stack two scrims. */}
 			<TabsContent value="overview" className="flex flex-[1_1_auto] flex-col pb-4">
-				<SessionOverview
-					turns={turns}
-					summary={summary}
-					selectedSpanId={view === "overview" ? selectedSpanId : undefined}
-					onSelectSpan={selectSpan}
-					spanTab={spanTab}
-					onSpanTabChange={setSpanTab}
-					toolResults={toolResults}
-					onOpenTraceView={openInTraceView}
-				/>
+				{view === "overview" && (
+					<SessionOverview
+						turns={turns}
+						summary={summary}
+						selectedSpanId={selectedSpanId}
+						onSelectSpan={selectSpan}
+						spanTab={spanTab}
+						onSpanTabChange={setSpanTab}
+						toolResults={toolResults}
+						onOpenTraceView={openInTraceView}
+					/>
+				)}
 			</TabsContent>
 			<TabsContent value="trace" className="flex flex-[1_1_auto] flex-col pb-4">
-				<SessionWaterfall
-					turns={turns}
-					summary={summary}
-					query={query}
-					agentSpansOnly={agentSpansOnly}
-					collapseIdle={collapseIdle}
-					collapsedTurns={collapsedTurns}
-					onToggleTurn={(turnId) => setCollapsedTurns((previous) => toggled(previous, turnId))}
-					selectedSpanId={view === "trace" ? selectedSpanId : undefined}
-					revealedSpanId={revealedSpanId}
-					onSelectSpan={selectSpan}
-					spanTab={spanTab}
-					onSpanTabChange={setSpanTab}
-					toolResults={toolResults}
-				/>
+				{view === "trace" && (
+					<SessionWaterfall
+						turns={turns}
+						summary={summary}
+						query={query}
+						agentSpansOnly={agentSpansOnly}
+						collapseIdle={collapseIdle}
+						collapsedTurns={collapsedTurns}
+						onToggleTurn={(turnId) => setCollapsedTurns((previous) => toggled(previous, turnId))}
+						selectedSpanId={selectedSpanId}
+						revealedSpanId={revealedSpanId}
+						onSelectSpan={selectSpan}
+						spanTab={spanTab}
+						onSpanTabChange={setSpanTab}
+						toolResults={toolResults}
+					/>
+				)}
 			</TabsContent>
 			<TabsContent value="flow" className="flex flex-[1_1_auto] flex-col">
-				<SessionFlow
-					turns={turns}
-					mergeRepeats={mergeRepeats}
-					query={query}
-					agentSpansOnly={agentSpansOnly}
-					zoom={zoom}
-					onZoomChange={setZoom}
-					selectedSpanId={view === "flow" ? selectedSpanId : undefined}
-					onSelectSpan={selectSpan}
-					spanTab={spanTab}
-					onSpanTabChange={setSpanTab}
-					toolResults={toolResults}
-					onOpenTraceView={openInTraceView}
-				/>
+				{view === "flow" && (
+					<SessionFlow
+						turns={turns}
+						mergeRepeats={mergeRepeats}
+						query={query}
+						agentSpansOnly={agentSpansOnly}
+						zoom={zoom}
+						onZoomChange={setZoom}
+						selectedSpanId={selectedSpanId}
+						onSelectSpan={selectSpan}
+						spanTab={spanTab}
+						onSpanTabChange={setSpanTab}
+						toolResults={toolResults}
+						onOpenTraceView={openInTraceView}
+					/>
+				)}
 			</TabsContent>
 			<TabsContent value="transcript" className="flex flex-[1_1_auto] flex-col pb-4">
-				<SessionTranscript
-					turns={turns}
-					toolResults={toolResults}
-					query={query}
-					showThinking={showThinking}
-					showPayloads={showPayloads}
-					truncated={truncated}
-					collapsedTurns={collapsedTurns}
-					onToggleTurn={(turnId) => setCollapsedTurns((previous) => toggled(previous, turnId))}
-					openRows={openRows}
-					onToggleRow={(key) => setOpenRows((previous) => toggled(previous, key))}
-					selectedSpanId={selectedSpanId}
-					onSelectSpan={selectSpan}
-					onOpenTraceView={openInTraceView}
-				/>
+				{view === "transcript" && (
+					<SessionTranscript
+						turns={turns}
+						toolResults={toolResults}
+						query={query}
+						showThinking={showThinking}
+						showPayloads={showPayloads}
+						truncated={truncated}
+						collapsedTurns={collapsedTurns}
+						onToggleTurn={(turnId) => setCollapsedTurns((previous) => toggled(previous, turnId))}
+						openRows={openRows}
+						onToggleRow={(key) => setOpenRows((previous) => toggled(previous, key))}
+						selectedSpanId={selectedSpanId}
+						onSelectSpan={selectSpan}
+						onOpenTraceView={openInTraceView}
+					/>
+				)}
 			</TabsContent>
 		</Tabs>
 	)

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -168,19 +168,50 @@ export function SessionWaterfall({
 	// the middle of the viewport, clear of both edges, so it reads with the rows
 	// around it rather than hard against the ruler or the fold. Once, on mount —
 	// after that the URL follows the reader rather than leading them.
+	//
+	// It aims twice. The first aim is the virtualizer's, and it is made against a
+	// number — this list's offset inside the page scroller — measured while the
+	// page was still settling into the view switch that brought the reader here.
+	// The second is the row's own: a frame later the row exists in the DOM, and
+	// an element can be asked where it is without anything having to have been
+	// measured correctly first.
 	const landingSpanId = revealedSpanId ?? selectedSpanId
 	const didInitialScroll = useRef(false)
+	// The correcting frame is held here and cancelled only on unmount: the effect
+	// below re-runs on every render (`getScrollElement` is a fresh closure each
+	// time), and a cleanup that cancelled per run would cancel the correction
+	// before the frame it is waiting for ever arrived.
+	const correctionFrame = useRef<number>(undefined)
+	useEffect(
+		() => () => {
+			if (correctionFrame.current !== undefined) cancelAnimationFrame(correctionFrame.current)
+		},
+		[],
+	)
 	useEffect(() => {
 		if (didInitialScroll.current || landingSpanId === undefined) return
 		// Not before the scroller exists: the list element attaches in a layout
 		// effect, so on the render that mounts this view there is nothing to
 		// scroll and the link would silently land at the top.
 		if (getScrollElement() === null) return
+		// Nor before the row is in the list: a span the filter is hiding, or one
+		// inside a collapsed turn, has nowhere to land yet — leaving the landing
+		// unspent means it still happens if the reader clears the filter.
+		const index = spanRowIndexById.get(landingSpanId)
+		if (index === undefined) return
 		didInitialScroll.current = true
 		setFocusedId(landingSpanId)
-		const index = spanRowIndexById.get(landingSpanId)
-		if (index !== undefined) virtualizer.scrollToIndex(index, { align: "center" })
+		virtualizer.scrollToIndex(index, { align: "center" })
+		correctionFrame.current = requestAnimationFrame(() => {
+			// Read off the drawn rows rather than through a selector: a span id is
+			// warehouse data, not something to interpolate into one.
+			const row = [...document.querySelectorAll("[data-span-row]")].find(
+				(candidate) => candidate.getAttribute("data-span-row") === landingSpanId,
+			)
+			row?.scrollIntoView({ block: "center" })
+		})
 	}, [landingSpanId, spanRowIndexById, setFocusedId, virtualizer, getScrollElement])
+
 
 	return (
 		<div className="@container flex grow flex-col">
@@ -534,6 +565,9 @@ function SpanRow({
 			type="button"
 			onClick={onClick}
 			aria-current={selected || undefined}
+			// How the landing above finds this row once it has been drawn, to
+			// correct its own aim against where the row actually is.
+			data-span-row={span.spanId}
 			// The mark is a background colour; this is how the page's tests — and
 			// anything else looking for it — find the row wearing it.
 			data-revealed={revealed || undefined}


### PR DESCRIPTION
Follow-up to #691, which added the landing: **Open in Traces view** did not reliably scroll to its row — most often for a reader who had already been to the Traces view once.

## Root cause

A Tabs panel does not leave when its tab does. Base UI unmounts it only once its exit reports complete (`useOpenChangeComplete` → `useAnimationsFinished` → an animation frame, then a `getAnimations()` promise), so the view being left is still in the page — at full height — for at least a frame. Measured in the browser on `/lab/agent-session`, mid-switch:

```
[{ idx: 0,  h: 1270, ending: true, inert: true },   // the Overview, still standing
 { idx: -1, h: 4284 }]                              // the waterfall that just mounted under it
```

Two failures came out of that:

1. **The landing aimed at a stale measurement.** The waterfall measures its own offset inside the page scroller as it mounts (`usePageScrollMargin`). With the Overview still above it, that offset was ~1270px too large, so `scrollToIndex` scrolled to a row a screenful and more away. The frame after the door, the list rendered **empty** — the virtualizer believed nothing was in range.
2. **The landing never fired at all.** After Overview → Traces → Overview, the Traces panel may not have finished leaving; going back re-activated *that same instance*, and the landing is a mount effect. Nothing scrolled. This is the "especially when switching between the overview and trace view before clicking" case.

## Fix

- **Each panel renders its view only while that view is the active one** — which is what the file already claimed ("The views unmount when the view changes"). A left view is now out of the page, not merely out of sight, and coming back is always a fresh mount. This also retires the `view === "trace" ? selectedSpanId : undefined` guards that existed to stop two mounted views stacking two scrims.
- **The landing aims twice.** First the virtualizer's aim, against the measurement; then, a frame later, the row's own `scrollIntoView({ block: "center" })` once it is drawn — an element can say where it is without anything having been measured correctly first. The frame is held in a ref and cancelled on unmount only: the effect re-runs on every render (`getScrollElement` is a fresh closure each time), and a per-run cleanup cancelled the correction before its frame ever arrived.
- **The landing is no longer spent on a row that is not in the list** (hidden by the filter, or inside a collapsed turn), so clearing the filter still lands it.

## Verification

Browser, `/lab/agent-session`, measuring the marked row's distance from the middle of the scrollport:

| sequence | before | after |
| --- | --- | --- |
| Overview → Traces → Overview → finding → door | first frame renders an **empty** waterfall | row centred (−14px), first frame |
| Traces → Flow → Overview → finding → door | — | row centred (−14px) |
| door twice in a row, different spans | — | centred both times, one panel with children |
| Transcript row → **Waterfall** | — | row marked, clamped at the top of the list (a 6th row cannot be centred) |

`session-detail` 59/59 (two new: the landing brings the row on screen from the row's own position; leaving a view takes it out of the page), whole `agent-session` suite 296/296, `apps/web` typecheck clean, oxlint unchanged (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790714526&installation_model_id=427786&pr_number=696&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F696&signature=62ca551ca37cdd945ba53dd07eac1d086edc4ccd8401c36b5d27b7984802b080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->