### PR TITLE
feat(web): split a tool's failed calls out of its usage bar, and send a shape cell to its turn

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -300,6 +300,7 @@ function Waterfall(props: {
 	onToggleTurn?: (turnId: string) => void
 	selectedSpanId?: string
 	revealedSpanId?: string
+	revealedTurnId?: string
 	onSelectSpan?: (spanId: string | undefined) => void
 	spanTab?: SpanDetailTab
 }) {
@@ -314,6 +315,7 @@ function Waterfall(props: {
 			onToggleTurn={props.onToggleTurn ?? noop}
 			selectedSpanId={props.selectedSpanId}
 			revealedSpanId={props.revealedSpanId}
+			revealedTurnId={props.revealedTurnId}
 			onSelectSpan={props.onSelectSpan ?? noop}
 			spanTab={props.spanTab}
 			onSpanTabChange={noop}
@@ -379,6 +381,7 @@ describe("SessionOverview", () => {
 		initialSpanId?: string
 		onSelectSpan?: (spanId: string | undefined) => void
 		onOpenTraceView?: () => void
+		onOpenTurnInTraceView?: (turnId: string) => void
 	}) {
 		const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>(props.initialSpanId)
 		return (
@@ -393,6 +396,7 @@ describe("SessionOverview", () => {
 				spanTab={undefined}
 				onSpanTabChange={noop}
 				onOpenTraceView={props.onOpenTraceView ?? noop}
+				onOpenTurnInTraceView={props.onOpenTurnInTraceView ?? noop}
 			/>
 		)
 	}
@@ -480,14 +484,29 @@ describe("SessionOverview", () => {
 	})
 
 	// The shape strip replaces the turn digest: one cell per turn, colored by
-	// what the findings attribute to it, each opening the turn's anchor span.
-	it("draws one cell per turn and opens the turn's anchor from a click", () => {
+	// what the findings attribute to it. A cell is a whole turn, so it crosses to
+	// Traces and lands on that turn — opening its root span in the overlay
+	// answered a question nobody asked of a strip of turns.
+	it("draws one cell per turn and sends a click to that turn in Traces", () => {
 		const onSelectSpan = vi.fn()
-		render(<Overview onSelectSpan={onSelectSpan} />)
+		const onOpenTurnInTraceView = vi.fn()
+		render(<Overview onSelectSpan={onSelectSpan} onOpenTurnInTraceView={onOpenTurnInTraceView} />)
 
-		const cellTwo = screen.getByRole("button", { name: "2" })
-		fireEvent.click(cellTwo)
-		expect(onSelectSpan).toHaveBeenCalledWith("agent-2")
+		fireEvent.click(screen.getByRole("button", { name: "2" }))
+		expect(onOpenTurnInTraceView).toHaveBeenCalledWith(turns[1]!.id)
+		expect(onSelectSpan).not.toHaveBeenCalled()
+	})
+
+	// A tool called ten times and failing every time reads nothing like one that
+	// never failed; the rail used to draw both as the same bar.
+	it("separates a tool's failed calls from its successful ones", () => {
+		render(<Overview />)
+
+		// run_tests: one call, and it errored.
+		expect(screen.getByTitle("1 failed")).toBeTruthy()
+		expect(screen.getByTitle("0 ok · 1 errored")).toBeTruthy()
+		// read_file and grep_repo ran clean, and say so by having nothing to say.
+		expect(screen.getAllByTitle("1 ok · 0 errored").length).toBe(2)
 	})
 
 	it("says no cost was reported rather than pricing tokens itself", () => {
@@ -543,6 +562,16 @@ describe("SessionOverview", () => {
 })
 
 describe("SessionWaterfall", () => {
+	// The Overview's session shape sends the reader here by turn, not by span:
+	// the header is what they were sent to, so it wears the mark.
+	it("marks the turn header the reader was sent to", () => {
+		render(<Waterfall revealedTurnId={turns[1]!.id} />)
+
+		const marked = document.querySelectorAll("[data-revealed]")
+		expect(marked.length).toBe(1)
+		expect(marked[0]!.textContent).toContain("Turn 2")
+	})
+
 	it("groups spans under their turn and marks the idle between them", () => {
 		render(<Waterfall />)
 

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type ReactNode } from "react"
 
-import { ArrowRightIcon, ChevronRightIcon } from "@/components/icons"
+import { ArrowRightIcon, ChevronRightIcon, CircleXmarkIcon } from "@/components/icons"
 import { Button } from "@maple/ui/components/ui/button"
 import { formatNumber, formatPercent } from "@maple/ui/lib/format"
 import { formatSessionDuration } from "@maple/ui/lib/replay-format"
@@ -59,6 +59,7 @@ export function SessionOverview({
 	onSpanTabChange,
 	toolResults,
 	onOpenTraceView,
+	onOpenTurnInTraceView,
 }: {
 	turns: readonly SessionTurn[]
 	summary: SessionSummary
@@ -73,6 +74,8 @@ export function SessionOverview({
 	toolResults?: SessionToolResults
 	/** The popover's "Open in Traces view": same span, sibling view. */
 	onOpenTraceView: () => void
+	/** A session-shape cell: cross to Traces and land on that whole turn. */
+	onOpenTurnInTraceView: (turnId: string) => void
 }) {
 	const report = useMemo(() => buildSessionFindings(turns, summary), [turns, summary])
 	const spansById = useMemo(
@@ -97,7 +100,7 @@ export function SessionOverview({
 						turns={turns}
 						health={report.turnHealth}
 						summary={summary}
-						onOpenSpan={openSpan}
+						onOpenTurn={onOpenTurnInTraceView}
 					/>
 					<TimeComposition summary={summary} turns={turns} />
 				</div>
@@ -291,12 +294,14 @@ function TurnHealthStrip({
 	turns,
 	health,
 	summary,
-	onOpenSpan,
+	onOpenTurn,
 }: {
 	turns: readonly SessionTurn[]
 	health: readonly TurnHealth[]
 	summary: SessionSummary
-	onOpenSpan: OpenSpan
+	/** A cell is a whole turn, so it opens the turn in Traces rather than one
+	 *  span in the overlay: the reader asking about turn 7 wants what it did. */
+	onOpenTurn: (turnId: string) => void
 }) {
 	// "with errors", not "failed": a red cell marks a turn something went wrong
 	// INSIDE — the turn itself may have closed cleanly, and calling it failed
@@ -326,11 +331,10 @@ function TurnHealthStrip({
 					<button
 						key={turn.id}
 						type="button"
-						aria-haspopup="dialog"
-						onClick={() => onOpenSpan(turn.anchor.spanId)}
-						title={`${turnOrdinal(turn)}${turn.label === undefined ? "" : ` — ${turn.label}`}`}
+						onClick={() => onOpenTurn(turn.id)}
+						title={`${turnOrdinal(turn)}${turn.label === undefined ? "" : ` — ${turn.label}`} — open in Traces`}
 						className={cn(
-							"flex size-8 items-center justify-center rounded-sm border font-mono text-[11px] tabular-nums",
+							"flex size-8 cursor-pointer items-center justify-center rounded-sm border font-mono text-[11px] tabular-nums",
 							HEALTH_CELL[health[index] ?? "clean"],
 						)}
 					>
@@ -586,11 +590,39 @@ function ToolUsageRow({ tool, topToolCalls }: { tool: SessionToolUsage; topToolC
 					{tool.name}
 				</span>
 			</span>
-			<span className="h-1 min-w-0 flex-1 overflow-hidden rounded-xs bg-muted">
-				<span
-					className="block h-full bg-chart-4"
-					style={{ width: `${sharePercent(tool.calls, topToolCalls)}%` }}
-				/>
+			{/* One bar, two parts: the length is how often the tool was reached
+			    for, the red head how much of that failed. A tool called twenty
+			    times and failing every time reads nothing like one that never
+			    failed, and the bar is where that difference belongs. */}
+			<span
+				className="h-1 min-w-0 flex-1 overflow-hidden rounded-xs bg-muted"
+				title={`${tool.calls - tool.failed} ok · ${tool.failed} errored`}
+			>
+				<span className="flex h-full" style={{ width: `${sharePercent(tool.calls, topToolCalls)}%` }}>
+					<span
+						className="h-full bg-chart-4"
+						style={{ width: `${sharePercent(tool.calls - tool.failed, tool.calls)}%` }}
+					/>
+					<span
+						className="h-full bg-destructive"
+						style={{ width: `${sharePercent(tool.failed, tool.calls)}%` }}
+					/>
+				</span>
+			</span>
+			{/* A fixed slot, empty on a tool that never failed: a count only some
+			    rows carry would shorten their bars, and bar lengths across the
+			    rail are the whole reason the bars are there. */}
+			<span
+				className="flex w-8 shrink-0 items-center justify-end gap-0.5 font-mono text-destructive text-[11px] tabular-nums"
+				title={tool.failed > 0 ? `${tool.failed} failed` : undefined}
+			>
+				{tool.failed > 0 && (
+					<>
+						<CircleXmarkIcon aria-hidden size={10} className="shrink-0" />
+						{tool.failed}
+						<span className="sr-only"> failed</span>
+					</>
+				)}
 			</span>
 			<span className="w-6 shrink-0 text-right font-mono text-muted-foreground text-xs tabular-nums">
 				{tool.calls}

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -93,21 +93,45 @@ export function SessionViews({
 	// reader lands at the top of six hundred of them. Component state rather
 	// than the URL: it is where the reader was just sent, not a place to link to.
 	const [revealedSpanId, setRevealedSpanId] = useState<string | undefined>(undefined)
+	// The same door, one level up: a cell of the Overview's session shape is a
+	// whole turn, so what the reader is sent to is the turn's header row rather
+	// than any one span inside it.
+	const [revealedTurnId, setRevealedTurnId] = useState<string | undefined>(undefined)
 
 	// Opening the panel on any span — or picking another view by hand — is the
 	// reader moving on, and the mark comes off the row they were sent to.
-	const selectSpan = (spanId: string | undefined) => {
+	const clearRevealed = () => {
 		setRevealedSpanId(undefined)
+		setRevealedTurnId(undefined)
+	}
+	const selectSpan = (spanId: string | undefined) => {
+		clearRevealed()
 		onSelectSpan(spanId)
 	}
 	const changeView = (next: SessionView) => {
-		setRevealedSpanId(undefined)
+		clearRevealed()
 		onViewChange(next)
 	}
 
 	/** The panel's "Open in Traces view": close it, cross, and land on the row. */
 	const openInTraceView = () => {
+		clearRevealed()
 		setRevealedSpanId(selectedSpanId)
+		onSelectSpan(undefined)
+		onViewChange("trace")
+	}
+
+	/** A session-shape cell: cross to Traces and land on that turn, expanded —
+	 *  a turn folded shut would put the reader on a header with nothing under it. */
+	const openTurnInTraceView = (turnId: string) => {
+		clearRevealed()
+		setRevealedTurnId(turnId)
+		setCollapsedTurns((previous) => {
+			if (!previous.has(turnId)) return previous
+			const next = new Set(previous)
+			next.delete(turnId)
+			return next
+		})
 		onSelectSpan(undefined)
 		onViewChange("trace")
 	}
@@ -247,6 +271,7 @@ export function SessionViews({
 					onSpanTabChange={setSpanTab}
 					toolResults={toolResults}
 					onOpenTraceView={openInTraceView}
+					onOpenTurnInTraceView={openTurnInTraceView}
 				/>
 			</TabsContent>
 			<TabsContent value="trace" className="flex flex-[1_1_auto] flex-col pb-4">
@@ -260,6 +285,7 @@ export function SessionViews({
 					onToggleTurn={(turnId) => setCollapsedTurns((previous) => toggled(previous, turnId))}
 					selectedSpanId={view === "trace" ? selectedSpanId : undefined}
 					revealedSpanId={revealedSpanId}
+					revealedTurnId={revealedTurnId}
 					onSelectSpan={selectSpan}
 					spanTab={spanTab}
 					onSpanTabChange={setSpanTab}

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -84,6 +84,9 @@ interface SessionWaterfallProps {
 	/** A span sent here from another view's inspection panel: its row is scrolled
 	 *  to and marked, with no panel over it. */
 	revealedSpanId: string | undefined
+	/** A turn sent here from the Overview's session shape: its header row is
+	 *  scrolled to and marked, and the spans under it read as its content. */
+	revealedTurnId: string | undefined
 	/** Raised with a span id to open it, `undefined` to close. */
 	onSelectSpan: (spanId: string | undefined) => void
 	/** The popover's tab, shared with the other views. */
@@ -103,6 +106,7 @@ export function SessionWaterfall({
 	onToggleTurn,
 	selectedSpanId,
 	revealedSpanId,
+	revealedTurnId,
 	onSelectSpan,
 	spanTab,
 	onSpanTabChange,
@@ -171,16 +175,34 @@ export function SessionWaterfall({
 	const landingSpanId = revealedSpanId ?? selectedSpanId
 	const didInitialScroll = useRef(false)
 	useEffect(() => {
-		if (didInitialScroll.current || landingSpanId === undefined) return
+		if (didInitialScroll.current) return
 		// Not before the scroller exists: the list element attaches in a layout
 		// effect, so on the render that mounts this view there is nothing to
 		// scroll and the link would silently land at the top.
 		if (getScrollElement() === null) return
+		// A revealed turn wins over a revealed span: it is the later of the two
+		// gestures, and its header is what the reader was sent to see.
+		if (revealedTurnId !== undefined) {
+			const index = rows.findIndex((row) => row.kind === "turn" && row.turn.id === revealedTurnId)
+			if (index === -1) return
+			didInitialScroll.current = true
+			virtualizer.scrollToIndex(index, { align: "center" })
+			return
+		}
+		if (landingSpanId === undefined) return
 		didInitialScroll.current = true
 		setFocusedId(landingSpanId)
 		const index = spanRowIndexById.get(landingSpanId)
 		if (index !== undefined) virtualizer.scrollToIndex(index, { align: "center" })
-	}, [landingSpanId, spanRowIndexById, setFocusedId, virtualizer, getScrollElement])
+	}, [
+		landingSpanId,
+		revealedTurnId,
+		rows,
+		spanRowIndexById,
+		setFocusedId,
+		virtualizer,
+		getScrollElement,
+	])
 
 	return (
 		<div className="@container flex grow flex-col">
@@ -255,6 +277,7 @@ export function SessionWaterfall({
 											turns={turns}
 											axis={axis}
 											collapsed={collapsedTurns.has(row.turn.id)}
+											revealed={revealedTurnId === row.turn.id}
 											onToggle={() => onToggleTurn(row.turn.id)}
 										/>
 									)}
@@ -400,6 +423,7 @@ function TurnHeader({
 	turns,
 	axis,
 	collapsed,
+	revealed,
 	onToggle,
 }: {
 	row: Extract<WaterfallRow, { kind: "turn" }>
@@ -407,6 +431,8 @@ function TurnHeader({
 	turns: readonly SessionTurn[]
 	axis: SessionAxis
 	collapsed: boolean
+	/** The turn the reader was sent here to see: marked until they move on. */
+	revealed: boolean
 	onToggle: () => void
 }) {
 	const { turn } = row
@@ -423,7 +449,15 @@ function TurnHeader({
 	const traceId = turn.traceIds[0]
 
 	return (
-		<div className="flex h-full w-full items-center rounded-md bg-card px-2.5 text-left text-xs hover:bg-accent/40">
+		<div
+			// The mark is a background colour; this is how the page's tests — and
+			// anything else looking for it — find the turn wearing it.
+			data-revealed={revealed || undefined}
+			className={cn(
+				"flex h-full w-full items-center rounded-md bg-card px-2.5 text-left text-xs hover:bg-accent/40",
+				revealed && "border-l-2 border-l-primary bg-primary/12",
+			)}
+		>
 			<span className={COL_SPAN}>
 				<button
 					type="button"

--- a/apps/web/src/lib/agent-sessions/session-summary.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-summary.test.ts
@@ -898,8 +898,38 @@ describe("per-model cost, tools and failure groups", () => {
 		])
 
 		expect(summary.tools).toEqual([
-			{ name: "read_file", calls: 2 },
-			{ name: "run_tests", calls: 1 },
+			{ name: "read_file", calls: 2, failed: 0 },
+			{ name: "run_tests", calls: 1, failed: 0 },
+		])
+	})
+
+	// The rail draws the failed share inside the tool's bar, so the count has to
+	// be per tool — a session-wide error count cannot say which tool broke.
+	it("counts the failed calls of each tool alongside its total", () => {
+		const summary = summarize([
+			agentSpan({ spanId: "a1", startMs: 0, durationMs: 10 * SECOND }),
+			toolSpan({ spanId: "t1", parentSpanId: "a1", startMs: 0, durationMs: 100 }),
+			toolSpan({
+				spanId: "t2",
+				parentSpanId: "a1",
+				startMs: 200,
+				durationMs: 100,
+				statusCode: "Error",
+			}),
+			// A tool the framework recorded as failed by attribute, on an Ok span.
+			toolSpan({
+				spanId: "t3",
+				parentSpanId: "a1",
+				startMs: 400,
+				durationMs: 100,
+				toolName: "run_tests",
+				genAi: { errorType: "timeout" },
+			}),
+		])
+
+		expect(summary.tools).toEqual([
+			{ name: "read_file", calls: 2, failed: 1 },
+			{ name: "run_tests", calls: 1, failed: 1 },
 		])
 	})
 
@@ -918,7 +948,7 @@ describe("per-model cost, tools and failure groups", () => {
 		])
 
 		expect(summary.tools).toEqual([
-			{ name: "read_file", calls: 2, description: "Read a file from the repository." },
+			{ name: "read_file", calls: 2, failed: 0, description: "Read a file from the repository." },
 		])
 	})
 

--- a/apps/web/src/lib/agent-sessions/session-summary.ts
+++ b/apps/web/src/lib/agent-sessions/session-summary.ts
@@ -98,6 +98,8 @@ export interface SessionModelUsage {
 export interface SessionToolUsage {
 	readonly name: string
 	readonly calls: number
+	/** Of those calls, the ones whose span reported a failure. */
+	readonly failed: number
 	/** `gen_ai.tool.description`, from the first span that stamped one. */
 	readonly description: string | undefined
 }
@@ -742,19 +744,25 @@ function modelUsage(
  * disappearing from a column whose total says 63.
  */
 function toolUsage(spans: readonly AiSessionSpan[]): readonly SessionToolUsage[] {
-	const calls = new Map<string, { count: number; description: string | undefined }>()
+	const calls = new Map<string, { count: number; failed: number; description: string | undefined }>()
 	for (const span of spans) {
 		if (classifyAiSpan(span) !== "tool") continue
 		const name = span.genAi.toolName ?? span.spanName
-		const entry = calls.get(name) ?? { count: 0, description: undefined }
+		const entry = calls.get(name) ?? { count: 0, failed: 0, description: undefined }
 		entry.count += 1
+		if (spanFailed(span)) entry.failed += 1
 		// The first stamped description speaks for the tool: emitters send the
 		// same definition on every call, so later ones only repeat it.
 		entry.description ??= span.genAi.toolDescription
 		calls.set(name, entry)
 	}
 	return [...calls]
-		.map(([name, entry]) => ({ name, calls: entry.count, description: entry.description }))
+		.map(([name, entry]) => ({
+			name,
+			calls: entry.count,
+			failed: entry.failed,
+			description: entry.description,
+		}))
 		.sort((a, b) => b.calls - a.calls || a.name.localeCompare(b.name))
 }
 


### PR DESCRIPTION
Two readings of the agent-session Overview that were saying less than they knew.

## Tools rail: errored vs successful calls

The rail drew one bar per tool, sized by call count — so a tool called ten times read identically whether it worked every time or failed every time.

- `SessionToolUsage` gains `failed`, counted with the same `spanFailed` the rest of the page uses, so a framework that records a failed tool as a *value* on an `Ok` span still counts.
- The bar keeps its length (how often the tool was reached for) and carries the failed share as a red tail.
- The count sits in a fixed-width slot — fixed because a label only some rows carry would shorten their bars, and comparing lengths down the rail is the reason the bars are there. Hovering a bar reads `9 ok · 1 errored`.

## Session shape: a cell opens its turn in Traces

Clicking a cell opened the turn's root span in the inspection overlay, which answered a question nobody asks of a strip of turns: the reader clicking turn 14 wants to see what turn 14 *did*.

- The cell crosses to Traces and lands on that turn's header, marked the way a revealed span row is.
- The turn is expanded on the way over — a turn folded shut would put the reader on a header with nothing under it.
- Reuses the door the panel's "Open in Traces view" already opened for a single span (`revealedTurnId` beside `revealedSpanId`); the mark comes off on any span selection or a manual view switch.

## Verification

- `apps/web` vitest, `src/lib/agent-sessions` + `src/components/agent-sessions`: 297 passed. Three new: per-tool failed counts (including the attribute-only failure), the cell raising the turn door rather than a span selection, and the waterfall marking the revealed turn header.
- `bun run --cwd apps/web typecheck` clean; oxlint clean.
- Driven end to end in `/lab/agent-session`: clicked turn 14's cell, landed on its header in Traces, centered and marked.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790716222&installation_model_id=427786&pr_number=697&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F697&signature=f1a58586383892ca2d6d1b16fd575b38fbc52086cfe9c0ce0342912ac6b5efc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->