### PR TITLE
fix(ci): make a skipped deploy fail its run

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -144,3 +144,24 @@ jobs:
               run: |
                   echo "::error::alchemy deploy failed and the certificate-validation retry did not recover it (retry outcome: ${{ steps.retry.outcome }})"
                   exit 1
+
+    # A skipped job does not fail its run, so with CI red this workflow reported
+    # SUCCESS while nothing deployed — which is how a broken `main` looked like a
+    # string of clean deploys for several commits, and why an Electric deploy
+    # nobody had noticed was never running took an hour to spot. This job always
+    # runs, so the run's conclusion says what actually happened.
+    deployment-gate:
+        needs: deploy-prd
+        if: ${{ always() }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Report whether the deploy ran
+              run: |
+                  result="${{ needs.deploy-prd.result }}"
+                  if [ "$result" = "skipped" ]; then
+                      echo "::error::Nothing was deployed: CI did not pass for ${{ github.event.workflow_run.head_sha || github.sha }}. Fix main, then re-run."
+                      exit 1
+                  fi
+                  # A genuine deploy failure already fails its own job and reddens
+                  # the run; there is nothing to add here.
+                  echo "deploy-prd: $result"

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -134,3 +134,24 @@ jobs:
               run: |
                   echo "::error::alchemy deploy failed and the certificate-validation retry did not recover it (retry outcome: ${{ steps.retry.outcome }})"
                   exit 1
+
+    # A skipped job does not fail its run, so with CI red this workflow reported
+    # SUCCESS while nothing deployed — which is how a broken `main` looked like a
+    # string of clean deploys for several commits, and why an Electric deploy
+    # nobody had noticed was never running took an hour to spot. This job always
+    # runs, so the run's conclusion says what actually happened.
+    deployment-gate:
+        needs: deploy-stg
+        if: ${{ always() }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Report whether the deploy ran
+              run: |
+                  result="${{ needs.deploy-stg.result }}"
+                  if [ "$result" = "skipped" ]; then
+                      echo "::error::Nothing was deployed: CI did not pass for ${{ github.event.workflow_run.head_sha || github.sha }}. Fix main, then re-run."
+                      exit 1
+                  fi
+                  # A genuine deploy failure already fails its own job and reddens
+                  # the run; there is nothing to add here.
+                  echo "deploy-stg: $result"


### PR DESCRIPTION
## The problem

`deploy-prd` and `deploy-stg` gate their deploy job on CI having passed:

```yaml
if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
```

A **skipped job does not fail its run**. So while `main` was red, both workflows reported **success** with nothing deployed — a green checkmark on a deploy that never happened.

That is not hypothetical. It hid a broken `main` for several commits: the self-hosted Electric stack sat undeployed behind a failing test in an unrelated file (`Llm.test.ts` asserting the old default model's context window), and the deploy history looked like a clean run of successes throughout.

## The fix

A `deployment-gate` job that always runs and fails when the deploy was skipped, so the run's conclusion reflects reality.

A genuine deploy *failure* already reddens the run through its own job, so the gate stays quiet in that case rather than reporting the same failure twice. It only speaks up for the one state that was previously invisible.

## Effect on the signal

- CI passed, deploy succeeded → green, unchanged
- CI passed, deploy failed → red, unchanged
- **CI red, deploy skipped → now red, was green**

The last line is the point. It does mean a red `main` produces a red deploy run in addition to the red CI run — deliberate, since "we were supposed to deploy `main` and didn't" is worth seeing on the deploy workflow, which is where you look to answer "is production current?"

## Testing

Both files parse as valid YAML with the expected three jobs (`ingest-binary`, `deploy-*`, `deployment-gate`) and the gate wired to `needs: deploy-*` with `if: always()`. The behaviour itself only exercises on a real red-CI push, which is not something to manufacture on `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790726655&installation_model_id=427786&pr_number=700&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F700&signature=43f4eb3e77b4da78c74f6770ff5609bfe3fa7672c6f24112607161044d07e95e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->