### PR TITLE
fix(web): clamp every transcript body, not most of them

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/clamped-text.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/clamped-text.tsx
@@ -47,12 +47,17 @@ export function ClampedText({
 	const expanded = controlledExpanded ?? localExpanded
 	const [clamped, setClamped] = useState(false)
 	const bodyRef = useRef<HTMLDivElement>(null)
+	/** Which of the three bodies is mounted. Same text laid out as markdown and
+	 *  as pre-wrapped raw are different heights, so a view switch has to
+	 *  re-measure — and `body` itself is a fresh node every render, so naming
+	 *  the CHOICE is what keeps the effect from running forever. */
+	const rendering = body !== undefined ? "body" : html !== undefined ? "html" : "text"
 
 	useLayoutEffect(() => {
-		const body = bodyRef.current
-		if (body === null || expanded) return
-		setClamped(body.scrollHeight > body.clientHeight + 1)
-	}, [text, expanded])
+		const measured = bodyRef.current
+		if (measured === null || expanded) return
+		setClamped(measured.scrollHeight > measured.clientHeight + 1)
+	}, [text, rendering, expanded])
 
 	return (
 		<div className="min-w-0">

--- a/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
@@ -2,8 +2,10 @@ import { useMemo } from "react"
 
 import { cn } from "@maple/ui/lib/utils"
 
+import { MessageResponse } from "@/components/ai-elements/message-response"
 import { tryParseJson } from "@/components/attributes"
 import { highlightCode } from "@/lib/sugar-high"
+import { ClampedText } from "./clamped-text"
 
 /**
  * The rendered ↔ raw affordances every captured body shares, wherever it is
@@ -124,4 +126,46 @@ export function toggled(set: ReadonlySet<string>, id: string): ReadonlySet<strin
 	const next = new Set(set)
 	if (!next.delete(id)) next.add(id)
 	return next
+}
+
+/**
+ * A captured message body, in whichever reading is selected, clamped with a
+ * "Show full" control. Every message the transcript shows goes through here:
+ * an uncapped body — one 900-line reply, one pasted file — pushes every row
+ * after it off the page, and the list stops being a list.
+ */
+export function MessageBody({
+	text,
+	body,
+	raw,
+	clampClass,
+	proseClassName = "text-foreground text-sm leading-relaxed",
+	expanded,
+	onToggleExpanded,
+}: {
+	text: string
+	/** The reading chosen by `useMessageBody`, hoisted so the caller's ViewSwitch
+	 *  can label the segment it selects. */
+	body: { rendered: "md" | "json"; formatted: string; highlighted: string | undefined }
+	raw: boolean
+	clampClass?: string
+	proseClassName?: string
+	expanded: boolean
+	onToggleExpanded: () => void
+}) {
+	return (
+		<ClampedText
+			text={raw ? text : body.formatted}
+			html={raw ? undefined : body.highlighted}
+			mono={!raw && body.rendered === "json"}
+			clampClass={clampClass}
+			body={
+				raw || body.rendered === "json" ? undefined : (
+					<MessageResponse className={proseClassName}>{text}</MessageResponse>
+				)
+			}
+			expanded={expanded}
+			onToggleExpanded={onToggleExpanded}
+		/>
+	)
 }

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -8,7 +8,6 @@ import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { formatBytes, formatDuration, formatNumber } from "@maple/ui/lib/format"
 import { cn } from "@maple/ui/lib/utils"
 
-import { MessageResponse } from "@/components/ai-elements/message-response"
 import {
 	AlertWarningIcon,
 	BranchForkIcon,
@@ -40,7 +39,7 @@ import {
 import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
 import { formatClockInTimezone } from "@/lib/timezone-format"
 import { ClampedText, firstLine } from "./clamped-text"
-import { disclosed, useJsonPayload, useMessageBody, ViewSwitch } from "./payload-view"
+import { disclosed, MessageBody, useJsonPayload, useMessageBody, ViewSwitch } from "./payload-view"
 import { Pill } from "./pill"
 import { ToolIo, ToolIoSummary } from "./tool-io"
 
@@ -473,17 +472,10 @@ function UserBlock({
 				</div>
 				{/* Clamped like every other long body: a pasted 400-line prompt is one
 				    block of a conversation, not the page. "Show full" opens it. */}
-				<ClampedText
-					text={raw ? row.text : body.formatted}
-					html={raw ? undefined : body.highlighted}
-					mono={!raw && body.rendered === "json"}
-					body={
-						raw || body.rendered === "json" ? undefined : (
-							<MessageResponse className="text-foreground text-sm leading-relaxed">
-								{row.text}
-							</MessageResponse>
-						)
-					}
+				<MessageBody
+					text={row.text}
+					body={body}
+					raw={raw}
 					expanded={disclosed(openRows, textKey, false)}
 					onToggleExpanded={() => onToggleRow(textKey)}
 				/>
@@ -566,15 +558,11 @@ function SystemBlock({
 			{open && (
 				<div className="flex items-start gap-1.5 pb-2 pl-6">
 					<div className="min-w-0 grow">
-						<ClampedText
-							text={raw ? row.text : body.formatted}
-							html={raw ? undefined : body.highlighted}
-							mono={!raw && body.rendered === "json"}
-							body={
-								raw || body.rendered === "json" ? undefined : (
-									<MessageResponse className="text-sm">{row.text}</MessageResponse>
-								)
-							}
+						<MessageBody
+							text={row.text}
+							body={body}
+							raw={raw}
+							proseClassName="text-sm"
 							expanded={disclosed(openRows, textKey, false)}
 							onToggleExpanded={() => onToggleRow(textKey)}
 						/>
@@ -608,6 +596,7 @@ function AssistantBlock({
 	// payload. Empty where the call succeeded, and the hook is cheap on "".
 	const error = useJsonPayload(row.failed ? row.span.statusMessage : "")
 	const body = useMessageBody(row.text ?? "")
+	const textKey = `${row.key}:text`
 	const rawKey = `${row.key}:raw`
 	const raw = disclosed(openRows, rawKey, false)
 	const errorRawKey = `${row.key}:error-raw`
@@ -649,21 +638,17 @@ function AssistantBlock({
 				)}
 				{selected && <OpenInTraces span={row.span} onOpenTraceView={onOpenTraceView} />}
 			</div>
-			{row.text !== undefined &&
-				(raw ? (
-					<p className="whitespace-pre-wrap break-words pt-2.5 text-foreground text-sm leading-relaxed">
-						{row.text}
-					</p>
-				) : body.highlighted !== undefined ? (
-					<div
-						className="min-w-0 whitespace-pre-wrap break-words pt-2.5 font-mono text-muted-foreground text-xs leading-relaxed"
-						dangerouslySetInnerHTML={{ __html: body.highlighted }}
+			{row.text !== undefined && (
+				<div className="pt-2.5">
+					<MessageBody
+						text={row.text}
+						body={body}
+						raw={raw}
+						expanded={disclosed(openRows, textKey, false)}
+						onToggleExpanded={() => onToggleRow(textKey)}
 					/>
-				) : (
-					<MessageResponse className="pt-2.5 text-foreground text-sm leading-relaxed">
-						{row.text}
-					</MessageResponse>
-				))}
+				</div>
+			)}
 			{row.failed && (
 				<div className="flex flex-col gap-1.5 pt-2.5">
 					{row.span.statusMessage !== "" && (
@@ -719,6 +704,7 @@ function PromptBlock({
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "prompt" }> }) {
 	const rawKey = `${row.key}:raw`
 	const raw = disclosed(openRows, rawKey, false)
+	const textKey = `${row.key}:text`
 	const body = useMessageBody(row.text)
 
 	return (
@@ -736,20 +722,13 @@ function PromptBlock({
 						onRawChange={(next) => next !== raw && onToggleRow(rawKey)}
 					/>
 				</div>
-				{raw ? (
-					<p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
-						{row.text}
-					</p>
-				) : body.highlighted !== undefined ? (
-					<div
-						className="min-w-0 whitespace-pre-wrap break-words font-mono text-muted-foreground text-xs leading-relaxed"
-						dangerouslySetInnerHTML={{ __html: body.highlighted }}
-					/>
-				) : (
-					<MessageResponse className="text-foreground text-sm leading-relaxed">
-						{row.text}
-					</MessageResponse>
-				)}
+				<MessageBody
+					text={row.text}
+					body={body}
+					raw={raw}
+					expanded={disclosed(openRows, textKey, false)}
+					onToggleExpanded={() => onToggleRow(textKey)}
+				/>
 				<InlineNote>
 					The reply isn't captured. This emitter records{" "}
 					<span className="font-mono">gen_ai.input.messages</span> but not{" "}


### PR DESCRIPTION
An assistant reply and a captured prompt rendered their text straight into the row — no clamp, no "Show full". One long reply pushed every row after it off the page, which is the whole list. The user, system, tool-payload and reasoning bodies were already clamped; these two were the holes.

- New `MessageBody` in `payload-view.tsx` wraps `ClampedText` with the raw / json / markdown reading choice the four message blocks were each spelling out.
- User, system, assistant and prompt blocks all route through it, so every body clamps at 12 lines with a "Show full" toggle.
- Expansion stays keyed (`<row>:text`) in the caller's `openRows` set — the transcript virtualizes, so local state would leave with a row scrolled out of view.

`bun run typecheck` and `vitest run src/components/agent-sessions` (62 tests) both clean in `apps/web`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790759778&installation_model_id=427786&pr_number=702&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F702&signature=ad6ec8607bca465961bb5e493db89fb623f6ec393564f21ebfef93164127d265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->