### PR TITLE
feat(cli): publish an Intel macOS bundle

### DIFF
--- a/.github/workflows/local-binary-release.yml
+++ b/.github/workflows/local-binary-release.yml
@@ -44,13 +44,21 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # No x86_64-apple-darwin: GitHub retired the macos-13 Intel image
-                # (Dec 2025), so that job sat queued forever. The next Intel label
-                # would be macos-15-intel, but Intel macOS is EOL on GitHub in Fall
-                # 2027 — not worth carrying. Intel-Mac users build from source.
+                # x86_64-apple-darwin builds on macos-15-intel. The previous Intel
+                # label (macos-13) was retired in Dec 2025 and its job sat queued
+                # forever, which is why the target was dropped; macos-15-intel is the
+                # supported replacement and is available now. Intel macOS is EOL on
+                # GitHub in Fall 2027 — drop this entry then, not before.
+                #
+                # Intel runners are the scarcest capacity in the pool, so this job can
+                # sit queued far longer than the others. Publishing is per-job (see the
+                # header), so a slow Intel build delays only its own tarball.
                 include:
                     - target: aarch64-apple-darwin
                       runner: macos-14
+                      os: macos
+                    - target: x86_64-apple-darwin
+                      runner: macos-15-intel
                       os: macos
                     - target: x86_64-unknown-linux-gnu
                       runner: ubuntu-22.04

--- a/apps/landing/src/pages/local.astro
+++ b/apps/landing/src/pages/local.astro
@@ -226,7 +226,7 @@ const valueProps = [
                     <li class="flex items-baseline justify-between gap-4 px-5 py-3.5">
                         <span class="text-[10px] uppercase tracking-wider text-fg-muted">Platforms</span>
                         <span class="font-mono text-xs text-fg text-right"
-                            >macOS (Apple Silicon)<br />Linux (x86_64 &amp; arm64)</span
+                            >macOS (Apple Silicon &amp; Intel)<br />Linux (x86_64 &amp; arm64)</span
                         >
                     </li>
                     <li class="flex items-baseline justify-between gap-4 px-5 py-3.5">

--- a/docs/local-mode.md
+++ b/docs/local-mode.md
@@ -18,9 +18,10 @@ brew install Makisuo/tap/maple
 
 Homebrew downloads the matching release bundle, verifies its checksum, installs
 `maple` and `libchdb.so` together in the Homebrew Cellar, and links `maple` onto
-your PATH. macOS Apple Silicon and Linux (x86_64 & arm64) are supported. If
-Homebrew asks you to trust the third-party tap, run `brew trust Makisuo/tap`
-once and retry the install.
+your PATH. If Homebrew asks you to trust the third-party tap, run
+`brew trust Makisuo/tap` once and retry the install. The tap lives in
+`Makisuo/homebrew-tap`, not this repo, so its platform coverage is set there —
+Intel macOS currently installs via the manual installer below.
 
 Manual installer:
 
@@ -35,7 +36,16 @@ curl -fsSL https://maple.dev/cli/install | sh
 The manual installer detects your OS/arch, downloads the matching bundle from
 the latest GitHub release, verifies its checksum, installs the two files into
 `~/.maple/bin`, clears the macOS Gatekeeper quarantine, and symlinks `maple`
-onto your PATH. Then:
+onto your PATH.
+
+Released targets: macOS (Apple Silicon & Intel) and Linux (x86_64 & arm64).
+Intel macOS builds on GitHub's `macos-15-intel` runner, which is the scarcest
+capacity in the pool — its tarball can land minutes after the others on a
+release. Each build job publishes independently, so the rest of the release is
+never held up. GitHub retires Intel macOS in Fall 2027; the target goes away
+with it.
+
+Then:
 
 ```bash
 maple start            # OTLP ingest + embedded ClickHouse on :4318; UI from local.maple.dev


### PR DESCRIPTION
As discussed [here](https://x.com/makisuo/status/2094373130441523636), this PR adds support for Intel based Macs for the next year before they are retired.

Thanks a lot,

Jamie

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790765750&installation_model_id=427786&pr_number=703&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F703&signature=764ce6195e7cf7c84bf9ec2d591cec172521de08ad98c445dde26a96d69305ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->