### PR TITLE
feat(web): filter logs by trace ID

### DIFF
--- a/apps/web/src/api/warehouse/custom-charts.ts
+++ b/apps/web/src/api/warehouse/custom-charts.ts
@@ -26,6 +26,7 @@ import {
 	ServiceNamespace,
 	SpanName,
 } from "@maple/domain/http"
+import { TraceId } from "@maple/domain"
 import {
 	WarehouseDateTimeString,
 	decodeInput,
@@ -232,6 +233,8 @@ const SharedFiltersSchema = Schema.Struct({
 	excludedSeverities: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
 	excludedEnvironments: Schema.optional(Schema.mutable(Schema.Array(DeploymentEnvironment))),
 	excludedNamespaces: Schema.optional(Schema.mutable(Schema.Array(ServiceNamespace))),
+	// Logs-source only: the /logs volume chart scoped to one trace.
+	traceId: Schema.optional(TraceId),
 	metricName: Schema.optional(MetricName),
 	metricType: Schema.optional(Schema.Literals(QUERY_BUILDER_METRIC_TYPES)),
 	rootSpansOnly: Schema.optional(Schema.Boolean),
@@ -368,6 +371,7 @@ function buildTimeseriesQuerySpec(data: CustomChartTimeSeriesDecoded): QuerySpec
 				excludedNamespaces: data.filters?.excludedNamespaces,
 				environments: data.filters?.environments,
 				namespaces: data.filters?.namespaces,
+				traceId: data.filters?.traceId,
 			},
 			bucketSeconds: data.bucketSeconds,
 		}

--- a/apps/web/src/components/logs/logs-filter-sidebar.tsx
+++ b/apps/web/src/components/logs/logs-filter-sidebar.tsx
@@ -28,6 +28,14 @@ import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 
 const routeApi = getRouteApi("/logs/")
 
+const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/i
+const TRACEPARENT_PATTERN = /^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$/i
+
+function extractTraceId(value: string): string | undefined {
+	if (TRACE_ID_PATTERN.test(value)) return value.toLowerCase()
+	return TRACEPARENT_PATTERN.exec(value)?.[1]?.toLowerCase()
+}
+
 function LoadingState() {
 	return <FilterSidebarLoading sectionCount={3} />
 }
@@ -45,9 +53,19 @@ export function LogsFilterSidebar() {
 	const [searchText, setSearchText] = useState(search.search ?? "")
 
 	const debouncedNavigate = useDebouncedCallback((value: string) => {
-		const trimmed = value.trim() || undefined
+		const trimmed = value.trim()
+		// A pasted trace ID (or full W3C traceparent) becomes the trace filter —
+		// body search is ILIKE on the message text, where a 32-hex ID never matches.
+		const traceId = extractTraceId(trimmed)
+		if (traceId) {
+			setSearchText("")
+			navigate({
+				search: (prev) => ({ ...prev, search: undefined, traceId }),
+			})
+			return
+		}
 		navigate({
-			search: (prev) => ({ ...prev, search: trimmed }),
+			search: (prev) => ({ ...prev, search: trimmed || undefined }),
 		})
 	}, 300)
 
@@ -98,7 +116,8 @@ export function LogsFilterSidebar() {
 		(search.excludedSeverities?.length ?? 0) > 0 ||
 		(search.excludedDeploymentEnvs?.length ?? 0) > 0 ||
 		(search.excludedNamespaces?.length ?? 0) > 0 ||
-		!!search.search
+		!!search.search ||
+		!!search.traceId
 
 	return Result.builder(facetsResult)
 		.onInitial(() => <LoadingState />)
@@ -125,7 +144,7 @@ export function LogsFilterSidebar() {
 									size="sm"
 									value={searchText}
 									onChange={(e) => handleSearchChange(e.target.value)}
-									placeholder="Search log messages..."
+									placeholder="Search messages or trace ID..."
 									data-shortcut-focus="search"
 								/>
 								{!searchText && (

--- a/apps/web/src/components/logs/logs-volume-chart.tsx
+++ b/apps/web/src/components/logs/logs-volume-chart.tsx
@@ -277,6 +277,7 @@ export function LogsVolumeChart({ filters, onTimeRangeSelect }: LogsVolumeChartP
 						pinnedNamespace === null && filters?.excludedNamespaces
 							? [...filters.excludedNamespaces]
 							: undefined,
+					traceId: filters?.traceId,
 				},
 			},
 		}),

--- a/apps/web/src/components/traces/trace-logs-link.tsx
+++ b/apps/web/src/components/traces/trace-logs-link.tsx
@@ -1,0 +1,59 @@
+import { Link } from "@tanstack/react-router"
+import { formatWarehouseDateTime, parseWarehouseDateTime } from "@maple/query-engine"
+import { Result, useAtomValue } from "@/lib/effect-atom"
+import { getLogsCountResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
+import { FileIcon } from "@/components/icons"
+
+/** Clock skew between services can stamp a correlated log slightly outside the
+ *  trace's own span window; the margin also narrows the partition scan the same
+ *  way the trace page's `t` param does. */
+const WINDOW_MARGIN_MS = 5 * 60 * 1000
+
+/**
+ * Renders a "View Logs (N)" link into the trace-scoped /logs stream when any
+ * log carries this trace ID. Silent (renders nothing) while loading, on
+ * failure, and when no logs correlate — same contract as `TraceReplayLink`,
+ * so it can sit in the trace header unconditionally.
+ */
+export function TraceLogsLink({
+	traceId,
+	traceStartTime,
+	totalDurationMs,
+}: {
+	traceId: string
+	traceStartTime: string
+	totalDurationMs: number
+}) {
+	const traceStartMs = parseWarehouseDateTime(traceStartTime)
+	const window = Number.isNaN(traceStartMs)
+		? undefined
+		: {
+				startTime: formatWarehouseDateTime(traceStartMs - WINDOW_MARGIN_MS),
+				endTime: formatWarehouseDateTime(traceStartMs + totalDurationMs + WINDOW_MARGIN_MS),
+			}
+
+	const result = useAtomValue(
+		getLogsCountResultAtom({
+			data: { traceId, startTime: window?.startTime, endTime: window?.endTime },
+		}),
+	)
+
+	if (window === undefined) return null
+
+	return Result.builder(result)
+		.onSuccess((response) => {
+			const total = response.data[0]?.total ?? 0
+			if (total === 0) return null
+			return (
+				<Link
+					to="/logs"
+					search={{ traceId, startTime: window.startTime, endTime: window.endTime }}
+					className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium hover:bg-muted"
+				>
+					<FileIcon className="size-3.5" /> View Logs ({total})
+				</Link>
+			)
+		})
+		.onError(() => null)
+		.orElse(() => null)
+}

--- a/apps/web/src/hooks/use-infinite-logs.ts
+++ b/apps/web/src/hooks/use-infinite-logs.ts
@@ -47,6 +47,7 @@ function buildQueryParams(
 		excludedDeploymentEnvs: filters?.excludedDeploymentEnvs,
 		excludedNamespaces: pinned ? undefined : filters?.excludedNamespaces,
 		search: filters?.search,
+		traceId: filters?.traceId,
 	}
 }
 

--- a/apps/web/src/lib/logs/log-filter-chips.test.ts
+++ b/apps/web/src/lib/logs/log-filter-chips.test.ts
@@ -24,4 +24,15 @@ describe("logFilterChips", () => {
 	it("ignores params present but empty", () => {
 		expect(logFilterChips({ services: [], excludedServices: [] })).toEqual([])
 	})
+
+	it("puts the trace scope ahead of everything, exclusions included", () => {
+		const traceId = "0af7651916cd43dd8448eb211c80319c"
+		const chips = logFilterChips({ traceId, excludedSeverities: ["DEBUG"], services: ["api"] })
+		expect(chips.map((c) => [c.label, c.negated])).toEqual([
+			["Trace", false],
+			["Severity", true],
+			["Service", false],
+		])
+		expect(chips[0]).toEqual({ param: "traceId", label: "Trace", values: [traceId], negated: false })
+	})
 })

--- a/apps/web/src/lib/logs/log-filter-chips.ts
+++ b/apps/web/src/lib/logs/log-filter-chips.ts
@@ -21,9 +21,14 @@ export interface LogFilterChipDescriptor {
 
 /** The applied facet filters, exclusions first — see `traceFilterChips` for why they lead. */
 export function logFilterChips(
-	search: Pick<LogsSearchParams, (typeof FACETS)[number]["include" | "exclude"]>,
+	search: Pick<LogsSearchParams, (typeof FACETS)[number]["include" | "exclude"] | "traceId">,
 ): LogFilterChipDescriptor[] {
 	const chips: LogFilterChipDescriptor[] = []
+	// The trace scope leads even the exclusions: it redefines what the page shows
+	// (one trace's logs) rather than trimming it, and it has no sidebar section.
+	if (search.traceId) {
+		chips.push({ param: "traceId", label: "Trace", values: [search.traceId], negated: false })
+	}
 	for (const facet of FACETS) {
 		const excluded = search[facet.exclude]
 		if (excluded?.length) {

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -18,6 +18,7 @@ import { getErrorsByType, getErrorsFacets, getErrorsSpark, getErrorsSummary } fr
 import {
 	getLog,
 	getLogAttributeKeys,
+	getLogsCount,
 	getLogsFacetValues,
 	getLogsFacets,
 	listLogs,
@@ -422,6 +423,11 @@ export const listLogsResultAtom = makeQueryAtomFamily(listLogs, {
 
 export const getLogResultAtom = makeQueryAtomFamily(getLog, {
 	staleTime: 60_000,
+})
+
+export const getLogsCountResultAtom = makeQueryAtomFamily(getLogsCount, {
+	staleTime: 60_000,
+	globalNamespace: "top",
 })
 
 export const getLogsFacetsResultAtom = makeQueryAtomFamily(getLogsFacets, {

--- a/apps/web/src/routes/logs/index.tsx
+++ b/apps/web/src/routes/logs/index.tsx
@@ -27,6 +27,9 @@ const logsSearchSchema = Schema.Struct({
 	// Attribute keys pinned as columns in the logs stream. Shareable via URL.
 	columns: OptionalStringArrayParam,
 	search: Schema.optional(Schema.String),
+	// Scopes the stream to one trace. Set by pasting a trace ID into the search
+	// box or following "View Logs" from a trace; cleared via its chip.
+	traceId: Schema.optional(Schema.String),
 	...TimeRangeSearchFields,
 })
 
@@ -69,6 +72,9 @@ function LogsPage() {
 			label: chip.label,
 			values: chip.values,
 			negated: chip.negated,
+			// The chip's tooltip still carries the full ID; the trace page itself
+			// abbreviates to the same 8 characters.
+			getValueLabel: chip.param === "traceId" ? (value: string) => value.slice(0, 8) : undefined,
 			onRemove: () => navigate({ search: (prev) => ({ ...prev, [chip.param]: undefined }) }),
 		}))
 

--- a/apps/web/src/routes/traces/$traceId.tsx
+++ b/apps/web/src/routes/traces/$traceId.tsx
@@ -8,6 +8,7 @@ import { TraceId } from "@maple/domain"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { useAppHotkey } from "@/hooks/use-app-hotkey"
 import { TraceReplayLink } from "@/components/replays/trace-replay-link"
+import { TraceLogsLink } from "@/components/traces/trace-logs-link"
 import { QueryErrorState } from "@/components/common/query-error-state"
 import { TraceViewTabs } from "@maple/ui/components/traces/trace-view-tabs"
 import { SpanDetailPanel } from "@/components/traces/span-detail-panel"
@@ -313,6 +314,11 @@ function TraceDetailContent({
 							}
 						>
 							<div className="flex items-center gap-2">
+								<TraceLogsLink
+									traceId={traceId}
+									traceStartTime={traceStartTime}
+									totalDurationMs={data.totalDurationMs}
+								/>
 								<TraceReplayLink traceId={traceId} />
 							</div>
 						</DashboardLayout.Header>


### PR DESCRIPTION
A customer asked to filter logs by trace ID. Every layer beneath the web app already supported it — the ClickHouse logs queries, the internal `ListLogsRequest`, the public v2 `LogFilters.trace_id`, and the MCP `search_logs` tool all accept a trace ID — but the Logs page never exposed it. Worse, pasting a trace ID into the search box silently ran a `Body ILIKE` that could never match, since free-text search only covers the log message.

This lights up the existing plumbing end to end:

### Deep links
`/logs?traceId=<id>` is now a real, shareable URL. The route's search schema carries `traceId`, and both the log stream and the volume histogram scope to it. The rollup planner already forces the raw table for trace-scoped queries, so no warehouse changes were needed.

### Paste-to-filter
The sidebar search box detects a pasted 32-hex trace ID — or a full W3C `traceparent` header (`00-<trace>-<span>-01`), which is what people actually copy out of their own logs — and converts it into the trace filter instead of a doomed body search. The input clears and the filter appears as a chip. Placeholder now reads "Search messages or trace ID...".

### A visible, clearable chip
`logFilterChips` emits a `Trace is 0af76519` chip (abbreviated to 8 chars like the trace page breadcrumb, full ID in the tooltip), placed ahead of even the exclusions since it redefines what the page shows rather than trimming it. Removal and "Clear all" work through the existing chip machinery.

### Trace → logs
The trace detail header gains **View Logs (N)** next to View Session Replay, on the same contract: it probes the log count over the trace's own window (span ± 5 min, which also keeps the partition scan narrow) and renders nothing when no logs correlate, so it never links into an empty page. Log → trace already existed; this closes the loop.

### Notes
- No new UI patterns: the chip reuses `ActiveFilterChips`, the header link mirrors `TraceReplayLink`'s markup and silent-on-empty behavior, and the icon is the nav's own `FileIcon` for Logs.
- The only near-backend edit is `SharedFiltersSchema` in the web custom-charts client so the volume chart can pass `traceId` through; the domain `LogsFilters` already accepted it.
- With the org-global namespace pin active, the count probe and the destination page are pinned consistently, so the link never promises logs the page won't show.
- Tested: chip ordering unit test added (11/11 passing), `turbo typecheck --filter=@maple/web` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790781506&installation_model_id=427786&pr_number=705&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F705&signature=7bab48c65418ae1329cea7d1311f2f2e58c3c6d204a86b532c9fb4654cc51bab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->