### PR TITLE
Close a cross-tenant SQL injection and harden outbound request paths

### DIFF
--- a/apps/api/src/http/url-validator.test.ts
+++ b/apps/api/src/http/url-validator.test.ts
@@ -43,8 +43,61 @@ describe("validateExternalUrlSync", () => {
 		"http://[::ffff:10.0.0.1]/",
 		"http://[::ffff:192.168.1.1]/",
 		"http://[::ffff:172.20.0.1]/",
+		// A trailing dot is the same name fully qualified, but the URL parser keeps
+		// it, so a blocklist keyed on the bare name used to miss it entirely.
+		"http://localhost./",
+		"http://metadata.google.internal./computeMetadata/v1/",
+		// Link-local is fe80::/10, not fe80::/16 — everything up to febf: is in range.
+		"http://[fe9f::1]/",
+		"http://[fea0::1]/",
+		"http://[febf::1]/",
+		// Deprecated site-local, still routed on plenty of internal networks.
+		"http://[fec0::1]/",
+		// Transition mechanisms delivering to an embedded IPv4 address.
+		"http://[2002:7f00:1::]/",
+		"http://[64:ff9b::7f00:1]/",
+		"http://[64:ff9b::169.254.169.254]/",
+		// Oracle Cloud metadata, documentation ranges, multicast and reserved.
+		"http://192.0.0.192/opc/v1/instance/",
+		"http://192.0.2.1/",
+		"http://198.51.100.1/",
+		"http://203.0.113.1/",
+		"http://224.0.0.1/",
+		"http://239.255.255.250/",
+		"http://240.0.0.1/",
 	])("rejects private/loopback host: %s", (raw) => {
 		expect(() => validateExternalUrlSync(raw)).toThrow(UrlValidationError)
+	})
+
+	// The parser's host here is `internal`, not `real.example.com` — the credentials
+	// hide the real destination from anyone eyeballing the stored URL.
+	it.each(["https://real.example.com@localhost/", "https://user:pw@api.example.com/"])(
+		"rejects embedded credentials: %s",
+		(raw) => {
+			expect(() => validateExternalUrlSync(raw)).toThrow(UrlValidationError)
+		},
+	)
+
+	// Public addresses that merely sit near a blocked range must still pass, or
+	// the widened patterns would start rejecting legitimate destinations.
+	it.each([
+		"https://api.example.com./webhook",
+		"http://100.63.255.255/",
+		"http://100.128.0.1/",
+		"http://192.0.1.1/",
+		"http://192.1.0.1/",
+		"http://198.20.0.1/",
+		"http://223.255.255.255/",
+		"http://[2001:db8::1]/",
+		"http://[2002::1]/",
+		// Hostnames that merely start like a blocked range. The IPv4 patterns are
+		// prefix matches, so they are only applied to actual address literals.
+		"https://10.example.com/hook",
+		"https://240.example.com/hook",
+		"https://127.acme.io/hook",
+		"https://192.168.example.com/hook",
+	])("accepts public host: %s", (raw) => {
+		expect(() => validateExternalUrlSync(raw)).not.toThrow()
 	})
 
 	it("rejects empty string", () => {

--- a/apps/api/src/http/url-validator.ts
+++ b/apps/api/src/http/url-validator.ts
@@ -14,7 +14,9 @@ const BLOCKED_HOSTNAMES = new Set([
 	"ip6-localhost",
 	"ip6-loopback",
 	"broadcasthost",
+	"metadata",
 	"metadata.google.internal",
+	"metadata.goog",
 	"metadata.azure.com",
 ])
 
@@ -28,6 +30,15 @@ const PRIVATE_IPV4_PATTERNS: ReadonlyArray<RegExp> = [
 	/^100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./,
 	/^198\.(?:1[8-9])\./,
 	/^255\.255\.255\.255$/,
+	// IETF protocol assignments — `192.0.0.192` is Oracle Cloud's metadata address.
+	/^192\.0\.0\./,
+	// Documentation ranges: never routable, so a request to one is a probe.
+	/^192\.0\.2\./,
+	/^198\.51\.100\./,
+	/^203\.0\.113\./,
+	// Multicast (224/4) and reserved (240/4).
+	/^(?:22[4-9]|23\d)\./,
+	/^(?:24\d|25[0-5])\./,
 ]
 
 const PRIVATE_IPV6_PATTERNS: ReadonlyArray<RegExp> = [
@@ -35,8 +46,19 @@ const PRIVATE_IPV6_PATTERNS: ReadonlyArray<RegExp> = [
 	/^::$/,
 	/^fc[0-9a-f]{2}:/i,
 	/^fd[0-9a-f]{2}:/i,
-	/^fe80:/i,
+	// Link-local is `fe80::/10` — `fe80:` alone is `/16`, which let `fe9f::1`,
+	// `fea0::1` and everything up to `febf:…` through.
+	/^fe[89ab][0-9a-f]:/i,
+	// Site-local: deprecated, still routed on plenty of internal networks.
+	/^fe[cdef][0-9a-f]:/i,
 ]
+
+// Transition mechanisms that carry an IPv4 destination inside an IPv6 address:
+// the packet ends up at the embedded address, so it has to face the IPv4 rules.
+// `2002:7f00:0001::` is 6to4 for 127.0.0.1; `64:ff9b::7f00:1` is NAT64.
+const SIX_TO_FOUR_RE = /^2002:([0-9a-f]{1,4}):([0-9a-f]{1,4}):/i
+const NAT64_RE = /^64:ff9b(?::0)*::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i
+const NAT64_DOTTED_RE = /^64:ff9b(?::0)*::(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i
 
 // IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) are canonicalised by most URL
 // parsers to the hex form `::ffff:HHHH:HHHH`, with leading zeros stripped from
@@ -56,18 +78,59 @@ const decodeIPv4MappedIPv6 = (inner: string): string | null => {
 	return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
 }
 
-const isPrivateIPv4 = (host: string): boolean => PRIVATE_IPV4_PATTERNS.some((re) => re.test(host))
+/**
+ * The patterns above are prefix matches, which is only sound against something
+ * already known to be an IPv4 literal: `/^10\./` says yes to the perfectly
+ * ordinary hostname `10.example.com`, and the widened multicast and reserved
+ * ranges would do the same to `240.example.com`. A URL parser normalises every
+ * accepted IPv4 form — decimal, octal, hex — to a dotted quad, so anything that
+ * is an address at all reaches here looking like one.
+ */
+const IPV4_LITERAL_RE = /^\d{1,3}(?:\.\d{1,3}){3}$/
+
+const isPrivateIPv4 = (host: string): boolean =>
+	IPV4_LITERAL_RE.test(host) && PRIVATE_IPV4_PATTERNS.some((re) => re.test(host))
+
+const hexPairToDotted = (hi: string, lo: string): string | null => {
+	const high = Number.parseInt(hi, 16)
+	const low = Number.parseInt(lo, 16)
+	if (!Number.isFinite(high) || !Number.isFinite(low) || high > 0xffff || low > 0xffff) return null
+	return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`
+}
+
+/** The IPv4 address an IPv6 literal ultimately delivers to, if it embeds one. */
+const embeddedIPv4 = (inner: string): string | null => {
+	const mapped = decodeIPv4MappedIPv6(inner)
+	if (mapped) return mapped
+	const nat64Dotted = NAT64_DOTTED_RE.exec(inner)
+	if (nat64Dotted) return nat64Dotted[1]
+	const nat64 = NAT64_RE.exec(inner)
+	if (nat64) return hexPairToDotted(nat64[1], nat64[2])
+	const sixToFour = SIX_TO_FOUR_RE.exec(inner)
+	if (sixToFour) return hexPairToDotted(sixToFour[1], sixToFour[2])
+	return null
+}
 
 const isPrivateIPv6 = (host: string): boolean => {
 	const inner = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host
 	if (PRIVATE_IPV6_PATTERNS.some((re) => re.test(inner))) return true
-	const mappedDotted = decodeIPv4MappedIPv6(inner)
-	if (mappedDotted && isPrivateIPv4(mappedDotted)) return true
+	const embedded = embeddedIPv4(inner)
+	if (embedded && isPrivateIPv4(embedded)) return true
 	return false
 }
 
-const isPrivateHost = (hostname: string): boolean => {
+/**
+ * A trailing dot makes a name fully qualified — `localhost.` and `localhost`
+ * resolve identically — but it is kept verbatim by the URL parser, so a blocklist
+ * keyed on the bare name never matched it. Strip it before every name comparison.
+ */
+const canonicalHostname = (hostname: string): string => {
 	const lower = hostname.toLowerCase()
+	return lower.endsWith(".") ? lower.slice(0, -1) : lower
+}
+
+const isPrivateHost = (hostname: string): boolean => {
+	const lower = canonicalHostname(hostname)
 	if (BLOCKED_HOSTNAMES.has(lower)) return true
 	if (isPrivateIPv4(lower)) return true
 	if (isPrivateIPv6(lower)) return true
@@ -93,6 +156,15 @@ export const validateExternalUrlSync = (raw: string): URL => {
 	}
 	if (parsed.hostname.length === 0) {
 		throw new UrlValidationError({ message: "URL must include a hostname", url: trimmed })
+	}
+	// Credentials in the URL are both a way to smuggle a second host past a
+	// reader (`https://real.example.com@internal/`, where the parser's host is
+	// `internal`) and a way to have Maple replay them at the destination.
+	if (parsed.username !== "" || parsed.password !== "") {
+		throw new UrlValidationError({
+			message: "URL must not embed credentials",
+			url: trimmed,
+		})
 	}
 	if (isPrivateHost(parsed.hostname)) {
 		throw new UrlValidationError({

--- a/apps/ingest/src/telemetry.rs
+++ b/apps/ingest/src/telemetry.rs
@@ -28,7 +28,6 @@ use opentelemetry_proto::tonic::metrics::v1::{
     metric, number_data_point, Exemplar, NumberDataPoint,
 };
 use opentelemetry_proto::tonic::trace::v1::{span, status, Span};
-#[cfg(test)]
 use reqwest::Client;
 
 /// The shared outbound HTTP client type: plain `reqwest::Client` in normal
@@ -833,6 +832,23 @@ impl TelemetryPipeline {
         segment_store: Option<Arc<WalSegmentStore>>,
     ) -> Result<Self, String> {
         let http: HttpClient = http.into();
+        // A second client, for tenant-controlled destinations only.
+        //
+        // The shared one carries reqwest's default redirect policy, which is
+        // right for Tinybird and R2 but not for a BYO-ClickHouse endpoint: that
+        // URL is org-configured, and the API validates it when it is saved, not
+        // when it is used. A target that passes validation and then answers an
+        // export with `307 Location: http://169.254.169.254/` had the whole
+        // batch — and the request — follow it into the internal network.
+        // Refusing redirects outright is the fix; a ClickHouse endpoint has no
+        // legitimate reason to bounce an INSERT somewhere else.
+        let clickhouse_http: HttpClient = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .pool_max_idle_per_host(64)
+            .pool_idle_timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|error| format!("ClickHouse export HTTP client init: {error}"))?
+            .into();
         cfg.validate_for_pipeline(require_tinybird_credentials)?;
         std::fs::create_dir_all(&cfg.queue_dir)
             .map_err(|error| format!("create ingest WAL dir: {error}"))?;
@@ -883,6 +899,7 @@ impl TelemetryPipeline {
                     clickhouse_breakers: Arc::clone(&clickhouse_breakers),
                     clickhouse_targets: clickhouse_targets.clone(),
                     http: http.clone(),
+                    clickhouse_http: clickhouse_http.clone(),
                     receiver,
                 };
                 tokio::spawn(worker.run());
@@ -2662,6 +2679,9 @@ struct ExportWorker {
     clickhouse_breakers: Arc<ClickHouseBreakerRegistry>,
     clickhouse_targets: Option<Arc<dyn ClickHouseTargetProvider>>,
     http: HttpClient,
+    /// Redirect-refusing client, used only for org-configured ClickHouse
+    /// endpoints. See `new_with_object_store` for why it is separate.
+    clickhouse_http: HttpClient,
     receiver: mpsc::Receiver<QueuedFrame>,
 }
 
@@ -3181,7 +3201,7 @@ impl ExportWorker {
                     .append_pair("query", sql.as_str());
             }
             let mut request = self
-                .http
+                .clickhouse_http
                 .post(request_url)
                 .timeout(self.cfg.clickhouse_export_timeout)
                 .header("X-ClickHouse-User", target.user.as_str())
@@ -3212,8 +3232,33 @@ impl ExportWorker {
                     let status = response.status();
                     let status_code = status.as_u16();
                     let bucket = status_bucket(status_code);
+                    let response_location = response
+                        .headers()
+                        .get(reqwest::header::LOCATION)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or("")
+                        .to_owned();
                     let body = response.text().await.unwrap_or_default();
                     span.record("http.response.status_code", status_code);
+                    if status.is_redirection() {
+                        // The client refuses to follow these, so a redirect is a
+                        // drop either way — named separately because it is the
+                        // signature of a target trying to bounce the export
+                        // somewhere it could not have configured directly, and
+                        // "non_retryable 4xx" would bury that.
+                        span.record("maple.ingest.outcome", "dropped");
+                        record_stage_error(&span, "redirect_refused", &body, true);
+                        metrics::clickhouse_export_dropped(datasource, "redirect_refused", rows as u64);
+                        warn!(
+                            org_id,
+                            datasource,
+                            status = status_code,
+                            location = %response_location,
+                            rows,
+                            "Dropping ClickHouse batch: target answered with a redirect"
+                        );
+                        return Ok(ClickHouseExportOutcome::Dropped);
+                    }
                     if !is_retryable_clickhouse_status(status_code) {
                         // Non-retryable (4xx) is the batch's fault, not the
                         // target's health — drop it without tripping the breaker.
@@ -5086,6 +5131,88 @@ mod tests {
         assert!(
             tb_rx.try_recv().is_err(),
             "ClickHouse-routed frames should not fall back to Tinybird"
+        );
+
+        drop(std::fs::remove_dir_all(queue_dir));
+    }
+
+    /// A target that answers every export with a redirect to somewhere else —
+    /// the shape a tenant uses to bounce an export at an address the API's
+    /// save-time URL validation would have rejected outright.
+    /// The Location is relative so it resolves back onto this same test server,
+    /// where a second route records the hop. In production it is an absolute URL
+    /// at an address like `169.254.169.254` — unreachable from a test, and the
+    /// point is the following, not the destination.
+    async fn redirecting_clickhouse_handler(_body: Bytes) -> impl axum::response::IntoResponse {
+        (
+            StatusCode::TEMPORARY_REDIRECT,
+            [(axum::http::header::LOCATION, "/latest/")],
+        )
+    }
+
+    #[tokio::test]
+    async fn clickhouse_export_refuses_to_follow_a_redirect() {
+        // The BYO-ClickHouse endpoint is org-configured and validated when it is
+        // saved, not when it is used, so a target that passes validation and then
+        // 307s the export was an SSRF primitive: the shared client carried
+        // reqwest's default redirect policy and followed it. The export client
+        // now refuses redirects, so the batch is dropped at the first hop.
+        let (redirected_tx, mut redirected_rx) = mpsc::unbounded_channel();
+        let ch_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let ch_addr = ch_listener.local_addr().unwrap();
+        let ch_app = Router::new()
+            .route("/", post(redirecting_clickhouse_handler))
+            // Where the redirect points, so a followed hop is observable rather
+            // than inferred from the absence of one.
+            .route("/latest/", post(fake_clickhouse_import))
+            .with_state(redirected_tx);
+        tokio::spawn(async move {
+            axum::serve(ch_listener, ch_app).await.unwrap();
+        });
+
+        let queue_dir = unique_test_dir("fake-clickhouse-redirect");
+        let mut cfg = test_cfg();
+        cfg.queue_dir = queue_dir.clone();
+        cfg.wal_shards = 1;
+        cfg.batch_max_wait = Duration::from_millis(1);
+        cfg.export_max_attempts = 1;
+
+        let provider = Arc::new(StaticClickHouseTargetProvider {
+            target: ClickHouseTarget {
+                endpoint: format!("http://{ch_addr}"),
+                user: "ingest".to_owned(),
+                // Empty, so the https-when-passworded rule does not short-circuit
+                // the send and the redirect is what actually stops it.
+                password: String::new(),
+                database: "maple".to_owned(),
+            },
+        });
+        let pipeline = TelemetryPipeline::new_with_clickhouse(
+            cfg,
+            Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .unwrap(),
+            Some(provider),
+        )
+        .await
+        .unwrap();
+
+        pipeline
+            .accept_logs_to(
+                "org_ready",
+                &populated_log_request(),
+                ExportDestination::ClickHouse,
+            )
+            .await
+            .unwrap();
+
+        wait_for_export_drain(queue_dir.clone(), 0, ExportDestination::ClickHouse).await;
+        assert!(
+            redirected_rx.try_recv().is_err(),
+            "export must not follow a redirect from a tenant-configured target"
         );
 
         drop(std::fs::remove_dir_all(queue_dir));

--- a/lib/clickhouse-builder/src/ch/compile.test.ts
+++ b/lib/clickhouse-builder/src/ch/compile.test.ts
@@ -755,3 +755,50 @@ describe("handwritten SQL", () => {
 		expect(built.rawSql).toBeUndefined()
 	})
 })
+
+// Params are resolved by rewriting `__PARAM_<kind>_<name>__` across the finished
+// SQL, so a *literal* whose text spells a placeholder used to be rewritten too —
+// and the replacement's own quotes closed the literal it sat in, letting a second
+// user-controlled param continue as SQL past the tenant predicate. The escaper
+// now hex-escapes the marker out of every value; these pin that shut.
+describe("param placeholders inside user literals", () => {
+	const table = CH.table(
+		"metrics",
+		{ OrgId: CH.string, ServiceName: CH.string, Host: CH.string },
+		{ tenantColumn: "OrgId" },
+	)
+
+	const compileWith = (host: string, serviceName: string) =>
+		compileCHUnsafe(
+			CH.from(table)
+				.select(($) => ({ host: $.Host }))
+				.where(($) => [
+					$.OrgId.eq(CH.param.string("orgId")),
+					$.ServiceName.eq(CH.param.string("serviceName")),
+					CH.inList($.Host, [host]),
+				]),
+			{ orgId: "org_victim", serviceName },
+		)
+
+	it("keeps a placeholder-shaped literal as one escaped string", () => {
+		const { sql } = compileWith("__PARAM_string_serviceName__", "svc")
+		expect(sql).toContain("Host IN ('\\x5F_PARAM_string_serviceName__')")
+		expect(sql).toContain("ServiceName = 'svc'")
+	})
+
+	// The payload needs no quotes of its own: the breakout quotes used to come
+	// from the substituted literal's own delimiters. It used to compile to
+	// `Host IN ('') OR 1=1 --'')`, which OR-ed the whole WHERE — OrgId included —
+	// into a tautology while `tenantScope` still read "single-tenant".
+	it("cannot break out of the literal to bypass the tenant predicate", () => {
+		const { sql, tenantScope } = compileWith("__PARAM_string_serviceName__", ") OR 1=1 --")
+
+		// The payload stays inside the param's own literal, and the host predicate
+		// stays one closed literal: no bare `OR` joins them at WHERE level.
+		expect(sql).toContain("ServiceName = ') OR 1=1 --'")
+		expect(sql).toContain("Host IN ('\\x5F_PARAM_string_serviceName__')")
+		expect(sql).not.toMatch(/IN \('[^']*'\)[^\n]*\bOR\b/)
+		expect(sql).toContain("OrgId = 'org_victim'")
+		expect(tenantScope).toBe("single-tenant")
+	})
+})

--- a/lib/clickhouse-builder/src/ch/compile.ts
+++ b/lib/clickhouse-builder/src/ch/compile.ts
@@ -15,7 +15,7 @@ import { aliased } from "./expr"
 import { raw, ident, escapeClickHouseString, compile as compileSqlFragment } from "../sql/sql-fragment"
 import { splitTerminalClauses } from "../sql/terminal-clauses"
 import { compileQuery, type SqlQuery } from "../sql/sql-query"
-import { PARAM_PLACEHOLDER_PATTERN, paramSchema, type ParamKind } from "./param"
+import { PARAM_MARKER_PREFIX, PARAM_PLACEHOLDER_PATTERN, paramSchema, type ParamKind } from "./param"
 import { encodeLiteral } from "./literal"
 import { Effect, Option, Schema } from "effect"
 import { QueryBuilderDefect, QueryBuilderError } from "./errors"
@@ -967,6 +967,17 @@ function resolveParams(sql: string, params: Record<string, unknown>): string {
 			message: `compile: no value given for param${missing.length > 1 ? "s" : ""} ${missing
 				.map((n) => `'${n}'`)
 				.join(", ")}`,
+		})
+	}
+
+	// Nothing placeholder-shaped may survive a resolved compile. The loop above
+	// only reports the names it recognised, so a marker naming a kind the pattern
+	// matches but `paramSchema` cannot resolve — or one a value smuggled past the
+	// escaper — would otherwise reach the warehouse as query text.
+	if (resolved.includes(PARAM_MARKER_PREFIX)) {
+		throw new QueryBuilderError({
+			code: "UnresolvedParam",
+			message: "compile: unresolved param placeholder remains in the compiled SQL",
 		})
 	}
 

--- a/lib/clickhouse-builder/src/ch/param.ts
+++ b/lib/clickhouse-builder/src/ch/param.ts
@@ -33,8 +33,16 @@ export type ParamKind = string
  */
 export const paramPlaceholder = (kind: ParamKind, name: string): string => {
 	assertValidParamName(name)
-	return `__PARAM_${kind}_${name}__`
+	return `${PARAM_MARKER_PREFIX}${kind}_${name}__`
 }
+
+/**
+ * The text every placeholder starts with — the one substring that must never
+ * appear in rendered SQL except as a real marker. `escapeClickHouseString`
+ * hex-escapes it out of user values for exactly that reason, and `compile`
+ * checks for it as a post-condition once params are resolved.
+ */
+export const PARAM_MARKER_PREFIX = "__PARAM_"
 
 export const PARAM_PLACEHOLDER_PATTERN = /__PARAM_([A-Za-z][A-Za-z0-9]*)_(.+?)__/g
 

--- a/lib/clickhouse-builder/src/sql/sql-fragment.test.ts
+++ b/lib/clickhouse-builder/src/sql/sql-fragment.test.ts
@@ -43,6 +43,16 @@ describe("compile", () => {
 		it("hex-escapes semicolons so gateway statement splitters never see the raw byte", () => {
 			expect(compile(str("bot;"))).toBe("'bot\\x3B'")
 		})
+
+		it("hex-escapes the param marker so a value can never spell a placeholder", () => {
+			expect(compile(str("__PARAM_string_serviceName__"))).toBe("'\\x5F_PARAM_string_serviceName__'")
+		})
+
+		it("neutralises the marker in overlapping runs of underscores", () => {
+			for (const value of ["___PARAM_x__", "____PARAM_x__", "a__PARAM_b__PARAM_c"]) {
+				expect(compile(str(value))).not.toContain("__PARAM_")
+			}
+		})
 	})
 
 	describe("Int", () => {

--- a/lib/clickhouse-builder/src/sql/sql-fragment.ts
+++ b/lib/clickhouse-builder/src/sql/sql-fragment.ts
@@ -6,8 +6,25 @@ import { Data } from "effect"
 // split statements on the raw byte even inside string literals, truncating the
 // query mid-literal. The server unescapes `\x3B` back to `;`, so results are
 // byte-identical.
+//
+// `__PARAM_` gets the same treatment, for the same reason one layer up: params
+// are resolved by rewriting `__PARAM_<kind>_<name>__` across the *finished* SQL
+// (see `resolveParams`), which cannot tell an executable placeholder from one
+// that happens to sit inside an already-escaped literal. A value of
+// `__PARAM_string_serviceName__` used to be replaced with that param's rendered
+// literal — quotes included — and those quotes closed the literal it landed in,
+// letting a second user-controlled param continue as SQL. Escaping one `_` here
+// means no user value can ever spell a placeholder, so the rewrite can only
+// ever see the real ones. `\x5F` unescapes to `_`, so values stay byte-identical.
+//
+// Order matters: this runs after the backslash escape, or the `\` it introduces
+// would itself be escaped.
 export function escapeClickHouseString(value: string): string {
-	return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/;/g, "\\x3B")
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/'/g, "\\'")
+		.replace(/;/g, "\\x3B")
+		.replace(/__PARAM_/g, "\\x5F_PARAM_")
 }
 
 // SQL Fragment AST

--- a/packages/domain/src/http/query-engine.ts
+++ b/packages/domain/src/http/query-engine.ts
@@ -2098,6 +2098,7 @@ export class RawSqlValidationError extends Schema.TaggedError<RawSqlValidationEr
 			"MissingOrgFilter",
 			"InvalidMacro",
 			"DisallowedStatement",
+			"DisallowedFunction",
 			"MultipleStatements",
 			"UnresolvedMacro",
 			"ResourceLimit",

--- a/packages/domain/src/raw-sql.test.ts
+++ b/packages/domain/src/raw-sql.test.ts
@@ -50,6 +50,45 @@ describe("rawSqlIssue", () => {
 		}
 	})
 
+	// `$__orgFilter` used to be checked with a raw `includes`, so a mention in a
+	// comment satisfied the requirement while expanding to nothing — the tenant
+	// predicate became opt-out for anyone who noticed.
+	it.each([
+		"SELECT 1 FROM traces WHERE 1=1 -- $__orgFilter",
+		"SELECT 1 FROM traces /* $__orgFilter */ WHERE 1=1",
+		"SELECT '$__orgFilter' AS x FROM traces",
+	])("rejects $__orgFilter hidden from the query: %s", (sql) => {
+		expect(rawSqlIssue(sql)?.code).toBe("MissingOrgFilter")
+	})
+
+	// Statement-shape checks say nothing about where a SELECT reads from, and a
+	// table function makes the *server* fetch — per-org credentials never see it.
+	it.each([
+		"SELECT * FROM url('http://169.254.169.254/', JSONEachRow) WHERE $__orgFilter",
+		"SELECT * FROM remote('10.0.0.1:9000', default.traces) WHERE $__orgFilter",
+		"SELECT * FROM s3('https://x/y.parquet') WHERE $__orgFilter",
+		"SELECT * FROM mysql('h:3306','d','t','u','p') WHERE $__orgFilter",
+		"SELECT * FROM postgresql('h:5432','d','t','u','p') WHERE $__orgFilter",
+		"SELECT * FROM file('/etc/passwd', LineAsString) WHERE $__orgFilter",
+		// A subquery is the documented way past the org-filter requirement: the
+		// outer query supplies OrgId while the inner one does the fetching.
+		"SELECT OrgId FROM traces WHERE $__orgFilter AND SpanId IN (SELECT * FROM url('http://internal/'))",
+		// Case and whitespace are not a bypass.
+		"SELECT * FROM URL ('http://internal/') WHERE $__orgFilter",
+	])("rejects network and filesystem table functions: %s", (sql) => {
+		expect(rawSqlIssue(sql)?.code).toBe("DisallowedFunction")
+	})
+
+	// The check is anchored on the call form, so ordinary names survive.
+	it.each([
+		"SELECT urlHash(Url) AS h FROM traces WHERE $__orgFilter",
+		"SELECT file FROM traces WHERE $__orgFilter",
+		"SELECT domain(Url) AS d FROM traces WHERE $__orgFilter",
+		"SELECT 'url(' AS literal FROM traces WHERE $__orgFilter",
+	])("does not mistake a column or unrelated function for a table function: %s", (sql) => {
+		expect(rawSqlIssue(sql)).toBeNull()
+	})
+
 	it("rejects INTO OUTFILE", () => {
 		expect(rawSqlIssue("SELECT 1 WHERE $__orgFilter INTO OUTFILE '/tmp/x'")?.message).toContain(
 			"INTO OUTFILE",

--- a/packages/domain/src/raw-sql.test.ts
+++ b/packages/domain/src/raw-sql.test.ts
@@ -14,6 +14,16 @@ describe("rawSqlIssue", () => {
 		expect(rawSqlIssue("SELECT 1 FROM logs")?.code).toBe("MissingOrgFilter")
 	})
 
+	// Same masking bug the org filter had: a macro in a comment expands to nothing,
+	// so the alert would rescan all of history on every evaluation.
+	it.each([
+		"SELECT count() AS v FROM traces WHERE $__orgFilter -- $__timeFilter(Timestamp)",
+		"SELECT count() AS v FROM traces WHERE $__orgFilter /* $__timeFilter(Timestamp) */",
+		"SELECT count() AS v, '$__timeFilter(Timestamp)' AS x FROM traces WHERE $__orgFilter",
+	])("rejects an alert whose $__timeFilter is not executable: %s", (sql) => {
+		expect(rawSqlIssue(sql, { workload: "alert" })?.code).toBe("InvalidMacro")
+	})
+
 	it("requires $__timeFilter for alerts only", () => {
 		const sql = "SELECT count() FROM logs WHERE $__orgFilter"
 		expect(rawSqlIssue(sql)).toBeNull()
@@ -75,6 +85,15 @@ describe("rawSqlIssue", () => {
 		"SELECT OrgId FROM traces WHERE $__orgFilter AND SpanId IN (SELECT * FROM url('http://internal/'))",
 		// Case and whitespace are not a bypass.
 		"SELECT * FROM URL ('http://internal/') WHERE $__orgFilter",
+		// Suffixed variants: an exact-name list matched `iceberg` but not
+		// `icebergS3`, so every lake-format reader walked straight through.
+		"SELECT * FROM icebergS3('https://x/y', 'k', 's') WHERE $__orgFilter",
+		"SELECT * FROM icebergAzure('https://x/y') WHERE $__orgFilter",
+		"SELECT * FROM deltaLakeS3('https://x/y') WHERE $__orgFilter",
+		"SELECT * FROM deltaLakeAzure('https://x/y') WHERE $__orgFilter",
+		"SELECT * FROM icebergS3Cluster('c', 'https://x/y') WHERE $__orgFilter",
+		"SELECT * FROM s3Cluster('c', 'https://x/y.parquet') WHERE $__orgFilter",
+		"SELECT * FROM executablePool('script', TSV, 'x UInt32') WHERE $__orgFilter",
 	])("rejects network and filesystem table functions: %s", (sql) => {
 		expect(rawSqlIssue(sql)?.code).toBe("DisallowedFunction")
 	})
@@ -85,6 +104,12 @@ describe("rawSqlIssue", () => {
 		"SELECT file FROM traces WHERE $__orgFilter",
 		"SELECT domain(Url) AS d FROM traces WHERE $__orgFilter",
 		"SELECT 'url(' AS literal FROM traces WHERE $__orgFilter",
+		// Scalar functions sharing a prefix with a blocked name. These are why
+		// `url`, `file` and `hive` are matched exactly rather than as prefixes.
+		"SELECT URLHash(Url) AS h FROM traces WHERE $__orgFilter",
+		"SELECT URLPathHierarchy(Url) AS p FROM traces WHERE $__orgFilter",
+		"SELECT filesystemAvailable() AS free FROM traces WHERE $__orgFilter",
+		"SELECT hiveHash(SpanName) AS h FROM traces WHERE $__orgFilter",
 	])("does not mistake a column or unrelated function for a table function: %s", (sql) => {
 		expect(rawSqlIssue(sql)).toBeNull()
 	})

--- a/packages/domain/src/raw-sql.ts
+++ b/packages/domain/src/raw-sql.ts
@@ -73,18 +73,24 @@ const INTO_OUTFILE_RE = /\bINTO\s+OUTFILE\b/i
  * touch it. On BYO and self-hosted clusters that is a working SSRF primitive
  * with the response handed back as rows.
  *
- * A deny list is the wrong shape long-term — ClickHouse keeps adding table
- * functions, and only an allow list of Maple's own tables closes the class. It
- * is what fits behind the existing text checks today; replacing all of this with
- * a parser is the real fix.
+ * A deny list is the wrong shape long-term — only an allow list of Maple's own
+ * tables closes the class, which needs a parser. Until then the shape that
+ * matters is *prefix* matching, below: ClickHouse suffixes these families freely
+ * (`iceberg`, `icebergS3`, `icebergAzure`, `icebergS3Cluster`, `deltaLakeAzure`,
+ * `s3Cluster`), so an exact-name list goes stale the moment a variant lands —
+ * and goes stale silently, because the check keeps passing. No ClickHouse scalar
+ * function begins with any of these, which is what makes the prefix safe.
  */
-const DISALLOWED_FUNCTIONS = [
-	"url",
-	"urlCluster",
+const DISALLOWED_FUNCTION_PREFIXES = [
+	"iceberg",
+	"deltaLake",
+	"hudi",
+	"s3",
+	"gcs",
+	"azureBlobStorage",
+	"hdfs",
 	"remote",
-	"remoteSecure",
 	"cluster",
-	"clusterAllReplicas",
 	"mysql",
 	"postgresql",
 	"mongodb",
@@ -92,26 +98,35 @@ const DISALLOWED_FUNCTIONS = [
 	"sqlite",
 	"odbc",
 	"jdbc",
-	"hdfs",
-	"hdfsCluster",
-	"s3",
-	"s3Cluster",
-	"gcs",
-	"azureBlobStorage",
-	"azureBlobStorageCluster",
-	"deltaLake",
-	"hudi",
-	"iceberg",
+	"executable",
+	"arrowFlight",
+	"ytsaurus",
+] as const
+
+/**
+ * Names that must match *exactly*, because each is a prefix of a legitimate
+ * scalar function: `url` would take `URLHash` and `URLPathHierarchy`, `file`
+ * would take `filesystemAvailable`, `hive` would take `hiveHash`, `dictionary`
+ * would take nothing today but sits beside the whole `dict*` family.
+ */
+const DISALLOWED_FUNCTION_NAMES = [
+	"url",
+	"urlCluster",
 	"file",
 	"fileCluster",
 	"input",
-	"executable",
 	"dictionary",
+	"hive",
 ] as const
 
-// Anchored on the opening paren so a *column* named `file` or a function like
-// `urlHash` is untouched — only the call form is a table function.
-const DISALLOWED_FUNCTION_RE = new RegExp(`\\b(${DISALLOWED_FUNCTIONS.join("|")})\\s*\\(`, "i")
+// Anchored on the opening paren so a *column* named `file`, or a scalar function
+// like `urlHash`, is untouched — only the call form is a table function. The
+// leading `\b` is what keeps the exact names exact: there is no word boundary
+// inside `urlHash`, so its `url` prefix is never a match start.
+const DISALLOWED_FUNCTION_RE = new RegExp(
+	`\\b(${DISALLOWED_FUNCTION_PREFIXES.join("|")})[A-Za-z0-9_]*\\s*\\(|\\b(${DISALLOWED_FUNCTION_NAMES.join("|")})\\s*\\(`,
+	"i",
+)
 
 /** Macros the engine expands. Anything else `$__`-shaped is a typo. */
 export const RAW_SQL_MACROS = [
@@ -164,8 +179,17 @@ export const rawSqlIssue = (
 				: "SQL must reference $__orgFilter so the query is scoped to your org.",
 		)
 	}
-	if (options.workload === "alert" && !sql.includes("$__timeFilter(")) {
-		return issue("InvalidMacro", "Raw SQL alerts must reference $__timeFilter(...) to bound alert reads.")
+	// Masked, for the same reason as the org filter: an alert whose only
+	// `$__timeFilter(` sits in a comment expands to nothing and then rescans all
+	// of history on every evaluation, which is the cost the requirement exists to
+	// prevent.
+	if (options.workload === "alert" && !maskedSql.includes("$__timeFilter(")) {
+		return issue(
+			"InvalidMacro",
+			sql.includes("$__timeFilter(")
+				? "$__timeFilter(...) must appear in the query itself, not inside a comment or string literal."
+				: "Raw SQL alerts must reference $__timeFilter(...) to bound alert reads.",
+		)
 	}
 
 	for (const macro of ["$__timeFilter", "$__timeGroup"] as const) {

--- a/packages/domain/src/raw-sql.ts
+++ b/packages/domain/src/raw-sql.ts
@@ -24,6 +24,7 @@ export type RawSqlIssueCode =
 	| "MissingOrgFilter"
 	| "InvalidMacro"
 	| "DisallowedStatement"
+	| "DisallowedFunction"
 	| "MultipleStatements"
 	| "UnresolvedMacro"
 	| "ResourceLimit"
@@ -62,6 +63,56 @@ const DENY_LIST_RE = new RegExp(`\\b(${DENY_LIST.join("|")})\\b`, "i")
  */
 const INTO_OUTFILE_RE = /\bINTO\s+OUTFILE\b/i
 
+/**
+ * ClickHouse table functions that read from somewhere other than this warehouse.
+ *
+ * Everything above this line polices what *kind of statement* a query is; none
+ * of it constrains where a SELECT reads from. `SELECT * FROM url('http://…')`
+ * is a perfectly well-formed single SELECT, and it makes the ClickHouse server —
+ * not the API — issue the request, so per-org credentials and the row cap do not
+ * touch it. On BYO and self-hosted clusters that is a working SSRF primitive
+ * with the response handed back as rows.
+ *
+ * A deny list is the wrong shape long-term — ClickHouse keeps adding table
+ * functions, and only an allow list of Maple's own tables closes the class. It
+ * is what fits behind the existing text checks today; replacing all of this with
+ * a parser is the real fix.
+ */
+const DISALLOWED_FUNCTIONS = [
+	"url",
+	"urlCluster",
+	"remote",
+	"remoteSecure",
+	"cluster",
+	"clusterAllReplicas",
+	"mysql",
+	"postgresql",
+	"mongodb",
+	"redis",
+	"sqlite",
+	"odbc",
+	"jdbc",
+	"hdfs",
+	"hdfsCluster",
+	"s3",
+	"s3Cluster",
+	"gcs",
+	"azureBlobStorage",
+	"azureBlobStorageCluster",
+	"deltaLake",
+	"hudi",
+	"iceberg",
+	"file",
+	"fileCluster",
+	"input",
+	"executable",
+	"dictionary",
+] as const
+
+// Anchored on the opening paren so a *column* named `file` or a function like
+// `urlHash` is untouched — only the call form is a table function.
+const DISALLOWED_FUNCTION_RE = new RegExp(`\\b(${DISALLOWED_FUNCTIONS.join("|")})\\s*\\(`, "i")
+
 /** Macros the engine expands. Anything else `$__`-shaped is a typo. */
 export const RAW_SQL_MACROS = [
 	"$__orgFilter",
@@ -93,10 +144,24 @@ export const rawSqlIssue = (
 	if (sql.length === 0 || sql.length > MAX_RAW_SQL_LENGTH) {
 		return issue("ResourceLimit", `Raw SQL must contain between 1 and ${MAX_RAW_SQL_LENGTH} characters`)
 	}
-	if (!sql.includes("$__orgFilter")) {
+
+	// Masking is offset-preserving, so it is safe to compute once here and share
+	// with the structural checks further down.
+	//
+	// The org filter is checked against the *masked* text on purpose: expansion is
+	// textual, so a `$__orgFilter` written inside a comment expands to a predicate
+	// that is still inside the comment — inert — while a raw `includes` reported
+	// the requirement as met. That turned the mandatory tenant predicate into an
+	// opt-out. The macro checks below stay on the raw text, which is the stricter
+	// input: `prepareRawSql` expands macros wherever they appear, literals
+	// included, so a macro hidden in a string still has to be a legal one.
+	const maskedSql = maskLiteralsAndComments(sql)
+	if (!maskedSql.includes("$__orgFilter")) {
 		return issue(
 			"MissingOrgFilter",
-			"SQL must reference $__orgFilter so the query is scoped to your org.",
+			sql.includes("$__orgFilter")
+				? "$__orgFilter must appear in the query itself, not inside a comment or string literal."
+				: "SQL must reference $__orgFilter so the query is scoped to your org.",
 		)
 	}
 	if (options.workload === "alert" && !sql.includes("$__timeFilter(")) {
@@ -125,7 +190,7 @@ export const rawSqlIssue = (
 
 	// A single trailing terminator is one statement, not several — rejecting it as
 	// "multiple statements" is a false error on the most common way to end a query.
-	let masked = maskLiteralsAndComments(sql)
+	let masked = maskedSql
 	const terminatorMatch = masked.match(/;\s*$/)
 	if (terminatorMatch?.index !== undefined) masked = masked.slice(0, terminatorMatch.index)
 	if (masked.includes(";")) {
@@ -149,6 +214,13 @@ export const rawSqlIssue = (
 		return issue(
 			"DisallowedStatement",
 			"Raw SQL must be a SELECT query (WITH common table expressions are supported).",
+		)
+	}
+	const functionMatch = masked.match(DISALLOWED_FUNCTION_RE)
+	if (functionMatch) {
+		return issue(
+			"DisallowedFunction",
+			`Table function '${functionMatch[1]}' is not allowed in raw SQL — queries may only read Maple's own tables.`,
 		)
 	}
 	// The row cap nests the query, and `SETTINGS` is a statement terminator, so an


### PR DESCRIPTION
A security scan surfaced 18 critical findings. This closes four of the five clusters. DNS rebinding is deliberately left open — see the end.

Every fix has a regression test, and each one was verified to fail without the fix.

## Cross-tenant SQL injection — the one that matters

`resolveParams` substitutes `__PARAM_<kind>_<name>__` by rewriting the **finished** SQL, so it cannot distinguish an executable placeholder from one sitting inside an already-escaped literal. A literal whose text spelled a placeholder was rewritten too — and the replacement carries its own delimiting quotes, which closed the literal it landed in.

`cloudflareInfraZoneDetail` has both halves attacker-controlled: `hosts[]` is inlined via `CH.inList`, `serviceName` is a `param.string`. With `hosts: ["__PARAM_string_serviceName__"]` and `serviceName: ") OR 1=1 --"` it compiled to:

```sql
WHERE OrgId = 'org_victim'
  AND ServiceName = ') OR 1=1 --'
  ...
  AND if(...) IN ('') OR 1=1 --'')
```

The `OR 1=1` lands at WHERE top level and `--` eats the rest, so the tenant predicate is bypassed and the query returns every org's rows. The payload needs no quotes of its own — the escaper never sees them, because the breakout quotes come from the substitution. `tenantScope` is derived from the AST *before* substitution, so it still reported `single-tenant` and `validateTenantScope` waved it through.

**Fix:** `escapeClickHouseString` hex-escapes the marker, exactly as it already does for `;` to defeat gateway statement splitters. `\x5F` unescapes to `_`, so values stay byte-identical, but no user value can spell a placeholder. `resolveParams` additionally fails if anything placeholder-shaped survives a resolved compile.

The structural alternative — params as AST nodes — is not available: `paramPlaceholder` is a documented export and `rollup-splice.ts` builds placeholder text by hand into raw SQL, so placeholders have to survive as text.

I swept every `raw` / `ident` / `rawExpr` / `dynamicColumn` call site for user-controlled input. All take module constants or developer-declared column defs, so `Str` was the only way in.

## Outbound URL validation

Two of these needed no DNS trickery at all:

- **Trailing dot.** `http://localhost./` → `hostname === "localhost."`, and the blocklist holds `"localhost"`. Same for `metadata.google.internal.`
- **IPv6 link-local was `/16`, not `/10`.** The check was `/^fe80:/i`; the range is `fe80::/10`, so `fe9f::1` … `febf::1` all passed.

Also added: embedded-credential rejection, 6to4 and NAT64 decoding back to the IPv4 they deliver to, deprecated site-local, and the missing IPv4 ranges (Oracle's `192.0.0.192`, documentation ranges, multicast, reserved).

One note for the reviewer: the IPv4 patterns are **prefix** matches, which is only sound against something already known to be an address — `/^10\./` matches the perfectly ordinary hostname `10.example.com`. Widening the list would have made that worse, so they are now gated on an actual IPv4 literal. That also fixes the pre-existing entries, not just the new ones.

## Raw SQL

Statement-shape checks say nothing about *where* a SELECT reads from, and a table function makes the warehouse server issue the request — so per-org credentials and the row cap never see it. Now rejects 28 network/filesystem table functions (`url`, `remote`, `s3`, `mysql`, `file`, …), anchored on the call form so `urlHash` and a column named `file` are untouched.

Separately: `$__orgFilter` was checked against raw text, so a mention inside a comment satisfied the requirement while expanding to nothing — turning the mandatory tenant predicate into an opt-out for anyone who noticed. It now runs against the masked text.

This adds a `DisallowedFunction` code to `RawSqlValidationError`, which is a wire enum — the one-line change in `query-engine.ts`.

## Ingest export

The BYO-ClickHouse endpoint is org-configured and validated when it is *saved*, not when it is *used*, and the exporter shared a client carrying reqwest's default redirect policy. A target that passed validation and then answered an export with `307 Location: http://169.254.169.254/` had the whole batch follow it inside.

Now uses a second, redirect-refusing client for that path only — the shared client keeps its policy for Tinybird and R2, which legitimately redirect. A 3xx drops as `redirect_refused` rather than a generic `non_retryable`, since it is the signature of a target trying to reach somewhere it could not have configured directly.

## Deliberately not in this PR

- **DNS rebinding.** Nothing resolves and pins, so a public hostname can still point or rebind to a private address. Workers `fetch` cannot pin at all; the ingest side could via a custom `dns::Resolve`. Both really want an egress proxy — that is a design decision, not a patch.
- **Requiring HTTPS for all BYO-ClickHouse targets.** Currently enforced only when a password is set. Forcing it everywhere would break self-hosted deployments running ClickHouse over plaintext internally — a product call.
- **Suppressing the 500-byte upstream body in webhook delivery errors.** It is a response oracle, but only reachable via rebinding, and suppressing it removes genuinely useful debugging for customers whose own webhook is failing. Worth revisiting alongside the egress proxy.

## Verification

- `lib/clickhouse-builder` 248, `packages/domain` 641, `packages/query-engine` 1366, `packages/query-engine-integrations` 314, `apps/api` (http/mcp/alerts/integrations) 1176, `apps/ingest` 142 — all passing
- No SQL-baseline drift
- typecheck, `bun run lint`, and `oxfmt --check` clean
- The ingest redirect test was confirmed to fail when pointed back at the shared client

(The two failures in `packages/domain/src/tinybird/product-event-attributes.test.ts` on my machine are from unrelated in-progress work in the same tree; those files are untracked and not part of this branch.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790810391&installation_model_id=427786&pr_number=709&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F709&signature=b6196082eae4002211ed58eca5ad444805badc1dca246a484b57b4bb45f683bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->