### PR TITLE
ci: verify the libchdb download and keep installers out of secret scope

### DIFF
--- a/.github/workflows/build-ingest-binary.yml
+++ b/.github/workflows/build-ingest-binary.yml
@@ -78,7 +78,7 @@ jobs:
                       -v "$PWD/apps/ingest:/app" \
                       -v "$RUNNER_TEMP/ingest-target:/target" \
                       -w /app \
-                      rust:1.94-bookworm \
+                      rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55 \
                       cargo build --release --target-dir /target
                   cp "$RUNNER_TEMP/ingest-target/release/maple-ingest" apps/ingest/dist/maple-ingest
                   file apps/ingest/dist/maple-ingest

--- a/.github/workflows/cleanup-preview-orphans.yml
+++ b/.github/workflows/cleanup-preview-orphans.yml
@@ -81,6 +81,22 @@ jobs:
             - name: Setup mise (toolchain)
               uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
+            # The single-file installer used by deploy-pr-preview.yml — branch
+            # commands live in the real `tb` CLI, not `bunx tinybird`. Runs BEFORE
+            # secrets are loaded so a compromised installer never sees the job's
+            # exported Infisical secrets. Unconditional (unlike the sweep step
+            # below) since the gate on TINYBIRD_TOKEN can't be evaluated yet.
+            #
+            # `continue-on-error` because this step is now FIRST: a tinybird.co
+            # outage would otherwise fail it, skip the `success()`-gated secrets
+            # step, blank every `env.X != ''` guard below, and silently skip ALL
+            # sweeps while orphaned previews keep billing. Only the Tinybird sweep
+            # needs `tb`, so only it is gated on this step's outcome.
+            - name: Install Tinybird CLI
+              id: install-tinybird-cli
+              continue-on-error: true
+              run: curl https://tinybird.co | sh
+
             - name: Load deployment secrets from Infisical
               uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
               with:
@@ -96,7 +112,7 @@ jobs:
 
             - name: Install PlanetScale CLI
               if: ${{ env.PLANETSCALE_SERVICE_TOKEN != '' }}
-              uses: planetscale/setup-pscale-action@v1
+              uses: planetscale/setup-pscale-action@b6a50ee45b4b24944e1d8de6e57b3a5f6476a1af # v1
 
             # Residual net: previews no longer create `pr-<n>` branches, so this
             # should find nothing. Gated on the service token, so it SKIPs cleanly
@@ -117,14 +133,8 @@ jobs:
                   GITHUB_TOKEN: ${{ github.token }}
               run: bun scripts/electric-pr-branch.ts sweep
 
-            # The single-file installer used by deploy-pr-preview.yml — branch
-            # commands live in the real `tb` CLI, not `bunx tinybird`.
-            - name: Install Tinybird CLI
-              if: ${{ !cancelled() && env.TINYBIRD_TOKEN != '' }}
-              run: curl https://tinybird.co | sh
-
             - name: Sweep orphaned Tinybird PR branches
-              if: ${{ !cancelled() && env.TINYBIRD_TOKEN != '' }}
+              if: ${{ !cancelled() && env.TINYBIRD_TOKEN != '' && steps.install-tinybird-cli.outcome == 'success' }}
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: bun scripts/tinybird-pr-branch.ts sweep

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -107,6 +107,13 @@ jobs:
             - name: Setup mise (toolchain)
               uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
+            # Needed for both branch create (deploy) and rm (close). `tb` is the
+            # real Tinybird CLI (branch commands live there, not in `bunx tinybird`).
+            # Runs BEFORE secrets are loaded so a compromised installer never sees
+            # the job's exported Infisical secrets.
+            - name: Install Tinybird CLI
+              run: curl https://tinybird.co | sh
+
             - name: Load deployment secrets from Infisical
               uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
               with:
@@ -166,11 +173,6 @@ jobs:
             - name: Build Tinybird TypeScript workspace dependencies
               if: ${{ env.TEARDOWN != 'true' }}
               run: bun turbo build --filter=@maple-dev/clickhouse-builder
-
-            # Needed for both branch create (deploy) and rm (close). `tb` is the
-            # real Tinybird CLI (branch commands live there, not in `bunx tinybird`).
-            - name: Install Tinybird CLI
-              run: curl https://tinybird.co | sh
 
             # Create/refresh an ephemeral Tinybird branch `pr_<n>` seeded with the
             # latest prod partition, deploy this PR's schema into it, and override

--- a/.github/workflows/tinybird-ci.yml
+++ b/.github/workflows/tinybird-ci.yml
@@ -17,7 +17,7 @@ jobs:
                 working-directory: "."
         services:
             tinybird:
-                image: tinybirdco/tinybird-local:latest
+                image: tinybirdco/tinybird-local@sha256:de47f2863c43bfec24024ea20db8a82cfe26511e69daf021d668e3be389a8a39 # latest
                 ports:
                     - 7181:7181
         steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,16 +109,17 @@ Workers via the Hyperdrive binding `MAPLE_DB`.
   dial is bounded so a stall lands as `error.type = CONNECT_TIMEOUT` instead of hanging.
 - Migrations: `bun run --cwd packages/db db:generate`; CI applies them against the branch's DIRECT
   port 5432 (never a pooler) before `alchemy deploy`. PGlite applies them at layer build.
-- **PR preview deploys are disabled** (2026-08, cost). `deploy-pr-preview.yml` triggers on the
-  `closed` event only, so it tears down pre-cutover stacks and never deploys a new one; restore
-  `types: [opened, synchronize, reopened, closed]` to re-enable.
-- **PR previews have no application database** either (PS-DEV branches billed continuously and
-  ate the Hyperdrive config cap) — this is the state previews return to when re-enabled.
-  `resolveDatabaseMode` in
-  `packages/infra/src/cloudflare/stage.ts` returns `"none"` for `pr`, so no `MAPLE_DB` is bound
-  and `DatabasePgLive` fails every query with a `DatabaseError` — DB-backed routes 500, the rest
-  of the preview works. To restore: return `"managed"` for `pr` and re-add the PlanetScale +
-  Electric steps to `.github/workflows/deploy-pr-preview.yml` (the scripts are kept, dormant).
+- **PR preview deploys are label-gated** (2026-08, cost — re-enabled by `fd00bcd412`). A PR gets a
+  preview only while it carries the `preview` label; `deploy-pr-preview.yml` triggers on
+  `opened, reopened, synchronize, labeled, unlabeled, closed` and tears the stack down the moment
+  the label is removed or the PR closes. `cleanup-preview-orphans.yml` is the backstop for PRs that
+  close without a teardown run.
+- **PR previews still have no application database** (PS-DEV branches billed continuously and ate
+  the Hyperdrive config cap). `resolveDatabaseMode` in `packages/infra/src/cloudflare/stage.ts`
+  returns `"none"` for `pr`, so no `MAPLE_DB` is bound and `DatabasePgLive` fails every query with a
+  `DatabaseError` — DB-backed routes 500, the rest of the preview works. To restore: return
+  `"managed"` for `pr` and re-add the PlanetScale + Electric steps to
+  `.github/workflows/deploy-pr-preview.yml` (the scripts are kept, dormant).
 - The ingest gateway resolves ingest keys from the same Postgres via PSBouncer (6432, no Hyperdrive).
 
 ## Conventions

--- a/scripts/build-local-binary.sh
+++ b/scripts/build-local-binary.sh
@@ -62,9 +62,33 @@ case "$(uname -s)-$(uname -m)" in
 	Darwin-arm64)        ASSET="macos-arm64-libchdb.tar.gz" ;;
 	*) echo "ERROR: unsupported platform $(uname -s)-$(uname -m)" >&2; exit 1 ;;
 esac
+# Expected sha256 per platform asset, pinned to LIBCHDB_VERSION: release assets
+# are mutable even for a fixed tag, so this is verified before extraction.
+# Bumping LIBCHDB_VERSION means re-hashing each asset here. A `case` rather than
+# an associative array because macOS still ships bash 3.2.
+case "$ASSET" in
+	linux-x86_64-libchdb.tar.gz)  EXPECTED_SHA256="3f192cb85cbdb6153622db8ad6f6a25d7163bbda57f283e5ba8fd22cadd0da81" ;;
+	linux-aarch64-libchdb.tar.gz) EXPECTED_SHA256="08ee80488822dfa04776841bb5a4b7ddce35e161ef579b5615b80a88b177428d" ;;
+	macos-x86_64-libchdb.tar.gz)  EXPECTED_SHA256="425db8a197288e1826b60958b3e233d0a7a5b4b46b8065c8bb7489366dbaf47f" ;;
+	macos-arm64-libchdb.tar.gz)   EXPECTED_SHA256="78cfd42203cd33cb0304952f4a6c39921fd9a583c614c2eef96ef6060e9677eb" ;;
+	*) echo "ERROR: no pinned sha256 for $ASSET (LIBCHDB_VERSION=$LIBCHDB_VERSION)" >&2; exit 1 ;;
+esac
+
 URL="https://github.com/chdb-io/chdb-core/releases/download/$LIBCHDB_VERSION/$ASSET"
 TMP="$(mktemp -d)"
 curl -fsSL "$URL" -o "$TMP/libchdb.tar.gz"
+
+# Verify BEFORE extracting: release assets are mutable even for a fixed tag,
+# so this authenticates the download rather than whatever happened to arrive.
+ACTUAL_SHA256="$(if command -v sha256sum >/dev/null 2>&1; then sha256sum "$TMP/libchdb.tar.gz"; else shasum -a 256 "$TMP/libchdb.tar.gz"; fi | awk '{print $1}')"
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+	echo "ERROR: libchdb checksum mismatch for $ASSET" >&2
+	echo "  expected: $EXPECTED_SHA256" >&2
+	echo "  actual:   $ACTUAL_SHA256" >&2
+	rm -rf "$TMP"
+	exit 1
+fi
+
 tar -xzf "$TMP/libchdb.tar.gz" -C "$TMP"
 LIB="$(find "$TMP" -name 'libchdb.so' -o -name 'libchdb.dylib' | head -1)"
 [ -n "$LIB" ] || { echo "ERROR: libchdb not found in $ASSET" >&2; exit 1; }


### PR DESCRIPTION
libchdb is fetched from a mutable GitHub release asset and dlopen'd via bun:ffi
on end users' machines. The build now checks it against a committed per-platform
sha256 before extraction, failing closed. A `case` rather than an associative
array because macOS still ships bash 3.2, where `declare -A` silently collapses
every entry onto index 0.

Pins the last mutable action ref and the two mutable container images, and moves
the `curl | sh` installer ahead of the secret export in both workflows that load
it, so it no longer runs with deployment secrets in scope.

Running it first made an upstream outage fatal to the whole orphan sweep, which
is the failure that workflow exists to prevent — so there it is
`continue-on-error` and only the Tinybird sweep checks its outcome. The preview
deploy keeps failing loudly: it needs `tb` on both the deploy and teardown
paths, and half-configuring a preview is worse than a red, re-runnable job.

Also corrects the CLAUDE.md claim that PR previews are disabled — they were
re-enabled behind a `preview` label in fd00bcd412, and the stale note misled a
review of exactly this workflow.
---

### Stack

Part of a 9-PR security stack off `main`. Each PR is based on the one above it, so **review and merge in order**; each commit typechecks standalone.

1. `sec/01-ci-supply-chain` — supply chain: pinned downloads and installers
2. `sec/02-v2-scope-enforcement` — v2 API key scope enforcement
3. `sec/03-admin-role-gates` — missing org-admin checks
4. `sec/04-oauth-return-to` — OAuth `returnTo` validation
5. `sec/05-canonical-api-origin` — discovery documents from configured origin
6. `sec/06-session-replay-privacy` — replay block markers
7. `sec/07-outbound-request-hardening` — outbound credentials and redirects
8. `sec/08-scrape-target-authz` — scrape target authorization and credentials
9. `sec/09-membership-revocation` — revocation on member/org removal

Findings came from a `deepsec` scan triaged down to the real defects; each was verified against `HEAD` before being fixed, and each fix was reviewed adversarially afterwards. Reproduction detail is deliberately kept out of these descriptions until the fixes are deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849824&installation_model_id=427786&pr_number=711&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F711&signature=2537b511f9eca297a0727ecabe01a44a1e86c5b7a3eaaadd7810baa826574731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->