### PR TITLE
fix(auth): key v2 scope enforcement off the matched route, and fail closed

### DIFF
--- a/apps/api/src/routes/v2/api-keys.http.test.ts
+++ b/apps/api/src/routes/v2/api-keys.http.test.ts
@@ -48,9 +48,7 @@ const testConfig = () =>
 		}),
 	)
 
-const makeHarness = (
-	checkRateLimit: RateLimiterApi["check"] = () => Effect.succeed("allowed" as const),
-) => {
+const makeHarness = (checkRateLimit: RateLimiterApi["check"] = () => Effect.succeed("allowed" as const)) => {
 	const testDb = createTestDb(createdDbs)
 	const envLive = Env.layer.pipe(Layer.provide(testConfig()))
 	const servicesLive = Layer.mergeAll(
@@ -403,6 +401,43 @@ describe("v2 api_keys over HTTP", () => {
 		const writeKey = await harness.bootstrapKey(["api_keys:write"])
 		const listViaWrite = await harness.request("GET", "/v2/api_keys", { token: writeKey.secret })
 		expect(listViaWrite.status).toBe(200)
+		await harness.dispose()
+	})
+
+	// The scope check reads the router's matched route template, so a path the
+	// router normalizes (case, percent-encoding, duplicate slashes, path
+	// parameters) can no longer route to a handler while dodging the check.
+	it.each([
+		["/V2/api_keys", "uppercase segment"],
+		["/v2/%61pi_keys", "percent-encoded segment"],
+		["/v2//api_keys", "duplicate slash"],
+		["/v2/api_keys;x", "path parameter suffix"],
+		["/v2/api_keys/", "trailing slash"],
+	])("rejects %s (%s) for a read-only key", async (path) => {
+		const harness = makeHarness()
+		const readOnly = await harness.bootstrapKey(["api_keys:read"])
+
+		const created = await harness.request("POST", path, {
+			token: readOnly.secret,
+			body: { name: "nope" },
+		})
+		expect(created.status).toBe(403)
+		expect(created.body.error.code).toBe("insufficient_scope")
+		await harness.dispose()
+	})
+
+	// The mirror of the case above: a key that *does* hold the scope still
+	// reaches the handler through a normalized path, so the fix denies on scope
+	// rather than on the path shape.
+	it("still serves a normalized path to a key that holds the scope", async () => {
+		const harness = makeHarness()
+		const writeKey = await harness.bootstrapKey(["api_keys:write"])
+
+		const created = await harness.request("POST", "/V2//api_keys", {
+			token: writeKey.secret,
+			body: { name: "normalized" },
+		})
+		expect(created.status).toBe(200)
 		await harness.dispose()
 	})
 

--- a/apps/api/src/routes/v2/widget-credentials.http.ts
+++ b/apps/api/src/routes/v2/widget-credentials.http.ts
@@ -19,7 +19,7 @@ import { ApiKeysService } from "@/services/org/ApiKeysService"
  */
 const WIDGET_CREDENTIAL_TTL_SECONDS = 60 * 60 * 24 * 30
 /**
- * The fence. `requiredScopeForRequest` derives an API key's required scope from
+ * The fence. `requiredScopeForRoute` derives an API key's required scope from
  * the first path segment, so this reaches `/v2/widget_summary` and nothing
  * else. Composed from the endpoints that summary is built out of, the same
  * credential would need `error_issues:read` + `services:read` + `traces:read` —

--- a/apps/api/src/services/auth/ApiAuthorizationV2Layer.ts
+++ b/apps/api/src/services/auth/ApiAuthorizationV2Layer.ts
@@ -1,8 +1,8 @@
-import { HttpServerRequest } from "effect/unstable/http"
+import { HttpRouter, HttpServerRequest } from "effect/unstable/http"
 import { CurrentTenant, RoleName } from "@maple/domain/http"
 import {
 	AuthorizationV2,
-	requiredScopeForRequest,
+	requiredScopeForRoute,
 	scopeAllows,
 	V2InsufficientScope,
 	V2InvalidCredentials,
@@ -39,16 +39,26 @@ const getBearerToken = (headers: Record<string, string | undefined>): string | u
 const getOrgSelectionHeader = (headers: Record<string, string | undefined>): string | undefined =>
 	headers[ORG_SELECTION_HEADER]
 
-const requestPath = (url: string): string => {
-	const queryStart = url.indexOf("?")
-	return queryStart === -1 ? url : url.slice(0, queryStart)
-}
+/**
+ * A protected v2 route the scope derivation cannot classify. Every group behind
+ * `AuthorizationV2` is prefixed `/v2/<family>`, so this is unreachable by
+ * construction — it is a defect (500), never a silently unscoped request.
+ */
+class V2UnclassifiableRoute extends Schema.TaggedError<V2UnclassifiableRoute>()(
+	"@maple/api/auth/V2UnclassifiableRoute",
+	{
+		message: Schema.String,
+		method: Schema.String,
+		routePath: Schema.String,
+	},
+) {}
 
 /**
  * v2 flavor of `ApiAuthorizationLayer`: same credential resolution (API key
  * first, then Clerk/self-hosted session token), but errors use the v2
  * envelope and restricted API keys are scope-checked mechanically from the
- * request (family = first path segment under /v2, GET/HEAD → read else write).
+ * matched route template (family = first path segment under /v2, GET/HEAD →
+ * read else write).
  * Session tokens and legacy null-scope keys bypass scope checks.
  */
 export const ApiAuthorizationV2Layer = Layer.effect(
@@ -128,8 +138,22 @@ export const ApiAuthorizationV2Layer = Layer.effect(
 							)
 						}
 
-						const required = requiredScopeForRequest(request.method, requestPath(request.url))
-						if (required !== null && !scopeAllows(resolved.scopes, required)) {
+						// The route *template* the router matched, not `request.url`: the
+						// router lowercases, percent-decodes, collapses `//` and strips
+						// `;`-suffixes before matching, so a raw URL that reaches this
+						// handler need not look like the path the scope check expects.
+						const { route } = yield* HttpRouter.RouteContext
+						const required = requiredScopeForRoute(request.method, route.path)
+						if (required === null) {
+							return yield* Effect.die(
+								new V2UnclassifiableRoute({
+									message: "Cannot derive a scope family for a scope-protected v2 route.",
+									method: request.method,
+									routePath: route.path,
+								}),
+							)
+						}
+						if (!scopeAllows(resolved.scopes, required)) {
 							return yield* Effect.fail(
 								V2InsufficientScope.make(
 									`This API key does not have the "${required.family}:${required.access}" scope required for this request.`,

--- a/docs/http-api-migration.md
+++ b/docs/http-api-migration.md
@@ -70,7 +70,7 @@ The following v1 groups are dashboard workflows or protocol surfaces. Do not por
 
 Three consequences, all deliberate:
 
-- **No scope.** `requiredScopeForRequest` would derive the family `share` from the path, but it is only called by `ApiAuthorizationV2Layer`, which these routes never run. There is no `share:read` scope and nothing issues one.
+- **No scope.** `requiredScopeForRoute` would derive the family `share` from the path, but it is only called by `ApiAuthorizationV2Layer`, which these routes never run. There is no `share:read` scope and nothing issues one.
 - **`security: []` and no `401`** in the OpenAPI spec. `openapi.test.ts` exempts the two operations by operationId through `PUBLIC_OPERATION_IDS` — an allowlist, so a third public operation cannot appear without someone editing it. Every other operation guarantee still applies to them.
 - **The v2 rate limiter never runs.** These routes carry their own per-token and per-IP limiter in the handler; it is the only one on the path, not a supplement.
 

--- a/packages/domain/src/http/v2/auth.ts
+++ b/packages/domain/src/http/v2/auth.ts
@@ -117,13 +117,20 @@ const isReadOnlyPost = (path: string): boolean =>
 /**
  * Mechanical scope derivation: the resource family is the first path segment
  * after `/v2/`. GET/HEAD and explicitly registered read-only POST queries require
- * read access; mutation methods require write access. Returns null for non-/v2 paths.
+ * read access; mutation methods require write access.
+ *
+ * `routePath` must be the router's **matched route template** (`/v2/api_keys`,
+ * `/v2/api_keys/:keyId`), never the raw request URL. The router matches
+ * case-insensitively, decodes percent-escapes, collapses duplicate slashes and
+ * strips `;`-suffixes, so a raw URL that reaches an endpoint (`/V2/api_keys`,
+ * `/v2/%61pi_keys`) can miss this pattern while the handler still runs. Null
+ * means "unclassifiable" and callers must fail closed, not skip the check.
  */
-export const requiredScopeForRequest = (method: string, path: string): RequiredScope | null => {
-	const match = /^\/v2\/([a-z][a-z0-9_]*)(?:\/|$)/.exec(path)
+export const requiredScopeForRoute = (method: string, routePath: string): RequiredScope | null => {
+	const match = /^\/v2\/([a-z][a-z0-9_]*)(?:\/|$)/.exec(routePath)
 	if (match === null) return null
 	const access =
-		method === "GET" || method === "HEAD" || (method === "POST" && isReadOnlyPost(path))
+		method === "GET" || method === "HEAD" || (method === "POST" && isReadOnlyPost(routePath))
 			? "read"
 			: "write"
 	return { family: match[1]!, access }

--- a/packages/domain/src/http/v2/share.ts
+++ b/packages/domain/src/http/v2/share.ts
@@ -10,7 +10,7 @@
  *
  * Consequences worth knowing before adding to this group:
  *
- *   - `requiredScopeForRequest` would derive the family `share` from the path,
+ *   - `requiredScopeForRoute` would derive the family `share` from the path,
  *     but it is only ever called by `ApiAuthorizationV2Layer`, which these
  *     routes do not run. There is no `share:read` scope and nothing issues one.
  *   - The operations publish `security: []`. That is derived from the absent

--- a/packages/domain/src/http/v2/v2-contract.test.ts
+++ b/packages/domain/src/http/v2/v2-contract.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "@effect/vitest"
-import { Effect, Result, Schema } from "effect"
+import { Effect, Predicate, Result, Schema } from "effect"
+import { MapleApiV2 } from "./api"
 import { V2AlertDestinationCreateParams } from "./alert-destinations"
 import { V2AlertIncident } from "./alert-incidents"
 import { V2AlertRule, V2AlertRuleMutationResponse } from "./alert-rules"
 import { V2ApiKey, V2ApiKeyMutationResponse, V2ApiKeyWithSecret } from "./api-keys"
 import { V2DashboardMutation } from "./dashboards"
 import { V2ErrorIssue, V2ErrorIssueDetail } from "./error-issues"
-import { requiredScopeForRequest, scopeAllows, V2Scope } from "./auth"
+import { AuthorizationV2, requiredScopeForRoute, scopeAllows, V2Scope } from "./auth"
 import {
 	V2PlanetScaleIntegration,
 	V2PlanetScaleMetricsTokenRequest,
@@ -564,36 +565,36 @@ describe("scopes", () => {
 	})
 
 	it("derives the required scope from method + path", () => {
-		expect(requiredScopeForRequest("GET", "/v2/api_keys")).toEqual({
+		expect(requiredScopeForRoute("GET", "/v2/api_keys")).toEqual({
 			family: "api_keys",
 			access: "read",
 		})
-		expect(requiredScopeForRequest("GET", "/v2/api_keys/key_abc")).toEqual({
+		expect(requiredScopeForRoute("GET", "/v2/api_keys/key_abc")).toEqual({
 			family: "api_keys",
 			access: "read",
 		})
-		expect(requiredScopeForRequest("POST", "/v2/api_keys/key_abc/roll")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/api_keys/key_abc/roll")).toEqual({
 			family: "api_keys",
 			access: "write",
 		})
-		expect(requiredScopeForRequest("DELETE", "/v2/api_keys/key_abc")).toEqual({
+		expect(requiredScopeForRoute("DELETE", "/v2/api_keys/key_abc")).toEqual({
 			family: "api_keys",
 			access: "write",
 		})
 		// Namespaced groups share one family: the first path segment under /v2.
-		expect(requiredScopeForRequest("GET", "/v2/alerts/rules")).toEqual({
+		expect(requiredScopeForRoute("GET", "/v2/alerts/rules")).toEqual({
 			family: "alerts",
 			access: "read",
 		})
-		expect(requiredScopeForRequest("POST", "/v2/alerts/destinations/dest_abc/test")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/alerts/destinations/dest_abc/test")).toEqual({
 			family: "alerts",
 			access: "write",
 		})
-		expect(requiredScopeForRequest("POST", "/v2/session_replays/search")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/session_replays/search")).toEqual({
 			family: "session_replays",
 			access: "read",
 		})
-		expect(requiredScopeForRequest("POST", "/v2/session_replays/for_trace")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/session_replays/for_trace")).toEqual({
 			family: "session_replays",
 			access: "read",
 		})
@@ -607,19 +608,19 @@ describe("scopes", () => {
 			["/v2/metrics/timeseries", "metrics"],
 			["/v2/metrics/breakdown", "metrics"],
 		] as const) {
-			expect(requiredScopeForRequest("POST", path)).toEqual({ family, access: "read" })
+			expect(requiredScopeForRoute("POST", path)).toEqual({ family, access: "read" })
 		}
 		// Every /v2/integrations/<provider> group shares one family, and the two
 		// PlanetScale proxies are POSTs only because their filters need a body.
-		expect(requiredScopeForRequest("GET", "/v2/integrations/planetscale")).toEqual({
+		expect(requiredScopeForRoute("GET", "/v2/integrations/planetscale")).toEqual({
 			family: "integrations",
 			access: "read",
 		})
-		expect(requiredScopeForRequest("POST", "/v2/integrations/planetscale/metrics_token")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/integrations/planetscale/metrics_token")).toEqual({
 			family: "integrations",
 			access: "write",
 		})
-		expect(requiredScopeForRequest("DELETE", "/v2/integrations/planetscale")).toEqual({
+		expect(requiredScopeForRoute("DELETE", "/v2/integrations/planetscale")).toEqual({
 			family: "integrations",
 			access: "write",
 		})
@@ -627,12 +628,69 @@ describe("scopes", () => {
 			"/v2/integrations/planetscale/query_insights",
 			"/v2/integrations/planetscale/events",
 		]) {
-			expect(requiredScopeForRequest("POST", path)).toEqual({
+			expect(requiredScopeForRoute("POST", path)).toEqual({
 				family: "integrations",
 				access: "read",
 			})
 		}
-		expect(requiredScopeForRequest("GET", "/api/api-keys")).toBeNull()
+		expect(requiredScopeForRoute("GET", "/api/api-keys")).toBeNull()
+	})
+
+	// The derivation only ever sees the router's matched route template, and it
+	// classifies path parameters exactly like a concrete id.
+	it("derives the scope from a route template with path parameters", () => {
+		expect(requiredScopeForRoute("GET", "/v2/api_keys/:keyId")).toEqual({
+			family: "api_keys",
+			access: "read",
+		})
+		expect(requiredScopeForRoute("POST", "/v2/api_keys/:keyId/roll")).toEqual({
+			family: "api_keys",
+			access: "write",
+		})
+		expect(requiredScopeForRoute("POST", "/v2/dashboards/templates/:templateId/preview")).toEqual({
+			family: "dashboards",
+			access: "read",
+		})
+	})
+
+	// The fail-closed half of the contract: a scope-protected route the
+	// derivation cannot classify is a 500, so every declared one must classify.
+	it("classifies every scope-protected v2 route template", () => {
+		let checked = 0
+		for (const group of Object.values(MapleApiV2.groups)) {
+			for (const endpoint of Object.values(group.endpoints)) {
+				const scoped = Array.from(endpoint.middlewares).some(
+					(middleware) =>
+						Predicate.hasProperty(middleware, "key") &&
+						Predicate.isString(middleware.key) &&
+						middleware.key === AuthorizationV2.key,
+				)
+				if (!scoped) continue
+				checked += 1
+				expect(
+					requiredScopeForRoute(endpoint.method, endpoint.path),
+					`${endpoint.method} ${endpoint.path}`,
+				).not.toBeNull()
+			}
+		}
+		expect(checked).toBeGreaterThan(50)
+	})
+
+	// These are the shapes the router normalizes away before matching. They must
+	// stay unclassifiable so the caller fails closed instead of skipping the
+	// check — see the enforcement test in apps/api/src/routes/v2.
+	it("refuses to classify non-canonical paths", () => {
+		for (const path of [
+			"/V2/api_keys",
+			"/v2/API_KEYS",
+			"/v2/%61pi_keys",
+			"/v2//api_keys",
+			"/v2/api_keys;x",
+			"/v2/",
+			"/v2",
+		]) {
+			expect(requiredScopeForRoute("POST", path)).toBeNull()
+		}
 	})
 
 	it("enforces the scope matrix", () => {
@@ -651,11 +709,11 @@ describe("scopes", () => {
 	})
 
 	it("treats alert preview as a read-only POST", () => {
-		expect(requiredScopeForRequest("POST", "/v2/alerts/rules/preview")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/alerts/rules/preview")).toEqual({
 			family: "alerts",
 			access: "read",
 		})
-		expect(requiredScopeForRequest("POST", "/v2/alerts/rules/test")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/alerts/rules/test")).toEqual({
 			family: "alerts",
 			access: "write",
 		})
@@ -664,16 +722,16 @@ describe("scopes", () => {
 	// Template preview builds the dashboard without saving it, so a read key
 	// must reach it; instantiate right next to it must not.
 	it("treats template preview as a read-only POST but instantiate as a write", () => {
-		expect(requiredScopeForRequest("POST", "/v2/dashboards/templates/dtpl_abc/preview")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/dashboards/templates/dtpl_abc/preview")).toEqual({
 			family: "dashboards",
 			access: "read",
 		})
-		expect(requiredScopeForRequest("POST", "/v2/dashboards/templates/dtpl_abc/instantiate")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/dashboards/templates/dtpl_abc/instantiate")).toEqual({
 			family: "dashboards",
 			access: "write",
 		})
 		// The pattern must not open up nested or lookalike paths.
-		expect(requiredScopeForRequest("POST", "/v2/dashboards/templates/dtpl_abc/preview/apply")).toEqual({
+		expect(requiredScopeForRoute("POST", "/v2/dashboards/templates/dtpl_abc/preview/apply")).toEqual({
 			family: "dashboards",
 			access: "write",
 		})

--- a/packages/domain/src/http/v2/widget-summary.ts
+++ b/packages/domain/src/http/v2/widget-summary.ts
@@ -15,7 +15,7 @@ import { ErrorIssuePublicId } from "./resource-ids"
  * + `/v2/services` + `/v2/traces/timeseries`, for two reasons that are not
  * "three requests is more than one":
  *
- * 1. **It is the credential's fence.** `requiredScopeForRequest` derives an API
+ * 1. **It is the credential's fence.** `requiredScopeForRoute` derives an API
  *    key's required scope from the first path segment, so a key scoped
  *    `widget_summary:read` can reach exactly this endpoint and nothing else.
  *    Composed from the generic endpoints, the same widget would need


### PR DESCRIPTION
API-key scope enforcement derived a request's route family from the raw
`request.url`, while the router matched on a normalised form of the same path
and never rewrites the URL. The two could disagree, and the derivation treated
"cannot classify" as "no scope required" — so a disagreement meant the check was
skipped rather than applied.

Enforcement now reads the route template the router actually matched, via
`HttpRouter.RouteContext`. That value is canonical by construction — it is the
same string stamped as `http.route` on the span — so there is no second
normalisation to disagree with. The URL-slicing helper is deleted rather than
left available.

An unclassifiable protected route is now a defect rather than a skipped check.
Every group behind `AuthorizationV2` is prefixed `/v2/<family>`, so this is
unreachable by construction; a contract test walks every scope-protected
endpoint and asserts each one classifies, which is what keeps it unreachable.
---

### Stack

Part of a 9-PR security stack off `main`. Each PR is based on the one above it, so **review and merge in order**; each commit typechecks standalone.

1. `sec/01-ci-supply-chain` — supply chain: pinned downloads and installers
2. `sec/02-v2-scope-enforcement` — v2 API key scope enforcement
3. `sec/03-admin-role-gates` — missing org-admin checks
4. `sec/04-oauth-return-to` — OAuth `returnTo` validation
5. `sec/05-canonical-api-origin` — discovery documents from configured origin
6. `sec/06-session-replay-privacy` — replay block markers
7. `sec/07-outbound-request-hardening` — outbound credentials and redirects
8. `sec/08-scrape-target-authz` — scrape target authorization and credentials
9. `sec/09-membership-revocation` — revocation on member/org removal

Findings came from a `deepsec` scan triaged down to the real defects; each was verified against `HEAD` before being fixed, and each fix was reviewed adversarially afterwards. Reproduction detail is deliberately kept out of these descriptions until the fixes are deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849827&installation_model_id=427786&pr_number=712&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F712&signature=b1b3bd465799372e9d4bd5daa9f84c410de242ce948e118c40502df0d785d93b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->