### PR TITLE
fix(auth): gate billing, error policy and attribute mappings on org admin

### DIFF
--- a/apps/api/src/mcp/tools/update-error-notification-policy.ts
+++ b/apps/api/src/mcp/tools/update-error-notification-policy.ts
@@ -111,9 +111,17 @@ export function registerUpdateErrorNotificationPolicyTool(server: McpToolRegistr
 			)
 
 			const policy = yield* policies
-				.upsertNotificationPolicy(tenant.orgId, tenant.userId, decodedPatch)
+				.upsertNotificationPolicy(tenant.orgId, tenant.userId, tenant.roles, decodedPatch)
 				.pipe(
 					Effect.catchTags({
+						"@maple/http/errors/ErrorForbiddenError": (error) =>
+							Effect.fail(
+								new McpQueryError({
+									message: `${error._tag}: ${error.message}`,
+									pipeName: "update_error_notification_policy",
+									cause: error,
+								}),
+							),
 						"@maple/http/errors/ErrorPersistenceError": (error) =>
 							Effect.fail(
 								new McpQueryError({

--- a/apps/api/src/routes/internal/billing.http.test.ts
+++ b/apps/api/src/routes/internal/billing.http.test.ts
@@ -1,7 +1,13 @@
 import { assert, describe, it } from "@effect/vitest"
-import { ConfigProvider, Effect, Layer, Schema } from "effect"
-import { FetchHttpClient } from "effect/unstable/http"
-import { type EdgeCacheBackend, makeEdgeCacheService, makeMemoryBackend } from "@maple/cache"
+import { ConfigProvider, Context, Effect, Layer, Schema } from "effect"
+import { FetchHttpClient, HttpRouter } from "effect/unstable/http"
+import { HttpApi, HttpApiBuilder } from "effect/unstable/httpapi"
+import {
+	EdgeCacheService,
+	type EdgeCacheBackend,
+	makeEdgeCacheService,
+	makeMemoryBackend,
+} from "@maple/cache"
 import { Env } from "@/platform/Env"
 import {
 	CUSTOMER_CACHE_BUCKET,
@@ -16,13 +22,21 @@ import {
 } from "@/services/billing/autumn-client"
 import { AutumnClient, type AutumnResult } from "@/services/billing/autumn-http"
 import {
+	BillingApiGroup,
 	BillingConflictError,
 	BillingCustomer,
+	CurrentTenant,
+	V1SchemaErrors,
+	V1UnexpectedErrors,
 	UpdateBillingControlsRequest,
 	UpdateBillingSpendLimit,
 	UpdateBillingUsageAlert,
 } from "@maple/domain/http"
-import { decodeInvoices, resolveCycleWindow } from "./billing.http"
+import { DailySpendService } from "@/services/billing/DailySpendService"
+import { ProductEventsService } from "@/services/product-events/ProductEventsService"
+import { StripeClient } from "@/services/billing/stripe-http"
+import { decodeInvoices, HttpBillingLive, resolveCycleWindow } from "./billing.http"
+import { V1ErrorBoundaryLive } from "../v1/error-boundary"
 
 const ORG = "org_test_123"
 
@@ -507,5 +521,86 @@ describe("resolveAttachConflict", () => {
 			resolveAttachConflict(customerRead(trialing), "startup", conflict),
 		)
 		assert.deepStrictEqual(result, {})
+	})
+})
+
+// Changing the subscription and opening the Stripe portal are org-wide spend
+// decisions, gated like every other billing write in the group.
+describe("billing writes over HTTP", () => {
+	class BillingOnlyApi extends HttpApi.make("MapleInternalApi")
+		.add(BillingApiGroup)
+		.middleware(V1SchemaErrors)
+		.middleware(V1UnexpectedErrors) {}
+
+	const decodeTenant = Schema.decodeUnknownSync(CurrentTenant.TenantSchema)
+	const tenantWithRoles = (roles: ReadonlyArray<string>) =>
+		decodeTenant({ orgId: ORG, userId: "user_billing_test", roles, authMode: "self_hosted" })
+
+	const die = () => Effect.die(new Error("not reachable once the admin gate rejects"))
+
+	const makeHarness = (roles: ReadonlyArray<string>) => {
+		const routes = HttpApiBuilder.layer(BillingOnlyApi).pipe(
+			Layer.provide(HttpBillingLive),
+			Layer.provide(V1ErrorBoundaryLive),
+			Layer.provideMerge(
+				Layer.succeed(
+					CurrentTenant.SessionAuthorization,
+					CurrentTenant.SessionAuthorization.of({
+						bearer: (httpEffect) =>
+							Effect.provideService(httpEffect, CurrentTenant.Context, tenantWithRoles(roles)),
+					}),
+				),
+			),
+			Layer.provideMerge(Layer.succeed(EdgeCacheService, makeCache())),
+			Layer.provideMerge(Layer.succeed(DailySpendService, { get: die })),
+			Layer.provideMerge(Layer.succeed(ProductEventsService, { track: die, trackMany: die })),
+			Layer.provideMerge(Layer.succeed(StripeClient, { request: die })),
+			Layer.provideMerge(
+				Layer.succeed(AutumnClient, {
+					attach: die,
+					openCustomerPortal: die,
+				} as never),
+			),
+		)
+		const { handler, dispose } = HttpRouter.toWebHandler(routes as never, { disableLogger: true })
+
+		const post = async (path: string, body: unknown) => {
+			const response = await handler(
+				new Request(`http://maple.test${path}`, {
+					method: "POST",
+					headers: { authorization: "Bearer test-token", "content-type": "application/json" },
+					body: JSON.stringify(body),
+				}),
+				Context.empty() as never,
+			)
+			const text = await response.text()
+			return { status: response.status, body: text.length === 0 ? null : JSON.parse(text) }
+		}
+
+		return { post, dispose }
+	}
+
+	it("refuses attach from a non-admin member", async () => {
+		const harness = makeHarness(["org:member"])
+		try {
+			const response = await harness.post("/internal/billing/attach", { planId: "startup" })
+			assert.strictEqual(response.status, 403)
+			assert.strictEqual(response.body._tag, "@maple/http/errors/BillingForbiddenError")
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("refuses the Stripe customer portal from a non-admin member", async () => {
+		const harness = makeHarness(["org:member"])
+		try {
+			const response = await harness.post("/internal/billing/portal", {
+				returnUrl: "https://maple.test/settings/billing",
+			})
+			assert.strictEqual(response.status, 403)
+			assert.strictEqual(response.body._tag, "@maple/http/errors/BillingForbiddenError")
+		} finally {
+			await harness.dispose()
+		}
 	})
 })

--- a/apps/api/src/routes/internal/billing.http.ts
+++ b/apps/api/src/routes/internal/billing.http.ts
@@ -222,6 +222,15 @@ export const HttpBillingLive = HttpApiBuilder.group(MapleInternalApi, "billing",
 				.handle("attach", ({ payload }) =>
 					Effect.gen(function* () {
 						const tenant = yield* CurrentTenant.Context
+						// Starting or changing a plan is an org-wide spend decision, so
+						// it is gated like every other billing write in this group.
+						yield* requireAdmin(
+							tenant.roles,
+							() =>
+								new BillingForbiddenError({
+									message: "Only org admins can change the subscription",
+								}),
+						)
 						// No buyer identity rides along: `/v1/billing.attach` carries no
 						// identity fields in Autumn 2.3.0, and the `customerData` we used to
 						// hand `autumnHandler` here was silently discarded by it. Seeding
@@ -299,6 +308,16 @@ export const HttpBillingLive = HttpApiBuilder.group(MapleInternalApi, "billing",
 				.handle("openCustomerPortal", ({ payload }) =>
 					Effect.gen(function* () {
 						const tenant = yield* CurrentTenant.Context
+						// The Stripe portal can cancel the subscription and exposes the
+						// payment methods and invoice history — admin-only, like the
+						// billing-details writes it overlaps with.
+						yield* requireAdmin(
+							tenant.roles,
+							() =>
+								new BillingForbiddenError({
+									message: "Only org admins can open the billing portal",
+								}),
+						)
 						const result = yield* autumn.openCustomerPortal(tenant.orgId, {
 							returnUrl: payload.returnUrl,
 						})

--- a/apps/api/src/routes/v1/errors.http.ts
+++ b/apps/api/src/routes/v1/errors.http.ts
@@ -299,14 +299,14 @@ export const HttpErrorsLive = HttpApiBuilder.group(MapleApi, "errors", (handlers
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
 					yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
-					yield* requireAdmin(
+					// The gate itself lives in the service (the MCP tool and chat apply
+					// reach the same mutation); this keeps the failure adjacent to the route.
+					return yield* policies.upsertNotificationPolicy(
+						tenant.orgId,
+						tenant.userId,
 						tenant.roles,
-						() =>
-							new ErrorForbiddenError({
-								message: "Only org admins can manage error notification policy",
-							}),
+						payload,
 					)
-					return yield* policies.upsertNotificationPolicy(tenant.orgId, tenant.userId, payload)
 				}).pipe(Effect.withSpan("HttpErrors.upsertNotificationPolicy")),
 			)
 			.handle("getEscalationPolicy", () =>

--- a/apps/api/src/routes/v2/attribute-mappings.http.ts
+++ b/apps/api/src/routes/v2/attribute-mappings.http.ts
@@ -3,12 +3,14 @@ import type { IngestAttributeMapping, IngestAttributeMappingId, OrgId } from "@m
 import {
 	CreateIngestAttributeMappingRequest,
 	CurrentTenant,
+	IngestAttributeMappingForbiddenError,
 	IngestAttributeMappingNotFoundError,
 	UpdateIngestAttributeMappingRequest,
 } from "@maple/domain/http"
 import { MapleApiV2, paginateArray } from "@maple/domain/http/v2"
 import type { V2AttributeMapping } from "@maple/domain/http/v2"
 import { Array as Arr, Effect, Option } from "effect"
+import { requireAdmin } from "@/services/auth/auth"
 import { IngestAttributeMappingService } from "@/services/org/IngestAttributeMappingService"
 
 const toV2AttributeMapping = (mapping: IngestAttributeMapping): V2AttributeMapping => ({
@@ -27,6 +29,18 @@ const toV2AttributeMapping = (mapping: IngestAttributeMapping): V2AttributeMappi
 export const HttpV2AttributeMappingsLive = HttpApiBuilder.group(MapleApiV2, "attributeMappings", (handlers) =>
 	Effect.gen(function* () {
 		const service = yield* IngestAttributeMappingService
+
+		// A mapping rewrites every ingested span for the whole org, so the writes
+		// are admin-only; the reads stay open to any member.
+		const requireMappingAdmin = (tenant: CurrentTenant.TenantSchema, action: string) =>
+			requireAdmin(
+				tenant.roles,
+				() =>
+					new IngestAttributeMappingForbiddenError({
+						message: `Only org admins can ${action} attribute mappings`,
+						...(tenant.roles.length > 0 ? { roles: [...tenant.roles] } : undefined),
+					}),
+			)
 
 		const listMappings = (orgId: OrgId) => service.list(orgId)
 
@@ -68,6 +82,7 @@ export const HttpV2AttributeMappingsLive = HttpApiBuilder.group(MapleApiV2, "att
 			.handle("create", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireMappingAdmin(tenant, "create")
 					const created = yield* service.create(
 						tenant.orgId,
 						new CreateIngestAttributeMappingRequest({
@@ -86,6 +101,7 @@ export const HttpV2AttributeMappingsLive = HttpApiBuilder.group(MapleApiV2, "att
 			.handle("update", ({ params, payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireMappingAdmin(tenant, "update")
 					const updated = yield* service.update(
 						tenant.orgId,
 						params.id,
@@ -115,6 +131,7 @@ export const HttpV2AttributeMappingsLive = HttpApiBuilder.group(MapleApiV2, "att
 			.handle("delete", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireMappingAdmin(tenant, "delete")
 					const deleted = yield* service.delete(tenant.orgId, params.id)
 
 					return { id: deleted.id, object: "attribute_mapping" as const, deleted: true as const }

--- a/apps/api/src/routes/v2/config-resources.http.test.ts
+++ b/apps/api/src/routes/v2/config-resources.http.test.ts
@@ -156,6 +156,17 @@ const makeHarness = () => {
 				return yield* service.create(ORG, USER, { name: "config-test", scopes })
 			}),
 		)
+	/** A key whose pinned roles make it a plain member rather than `root`. */
+	const bootstrapMemberKey = () =>
+		runtime.runPromise(
+			Effect.gen(function* () {
+				const service = yield* ApiKeysService
+				return yield* service.create(ORG, USER, {
+					name: "config-test-member",
+					metadataJson: { source: "maple_cli", roles: ["org:member"], deviceName: "laptop" },
+				})
+			}),
+		)
 	const seedScrapeChecks = (publicId: string, count: number) => {
 		const internalId = decodePublicId("scrp", publicId)
 		if (internalId === null) throw new Error(`Invalid scrape target public ID: ${publicId}`)
@@ -188,6 +199,7 @@ const makeHarness = () => {
 	return {
 		request,
 		bootstrapKey,
+		bootstrapMemberKey,
 		seedScrapeChecks,
 		corruptScrapeDiscoveryConfig,
 		dispose: async () => {
@@ -272,6 +284,54 @@ describe("v2 attribute_mappings over HTTP", () => {
 		expect(missing.status).toBe(404)
 		expect(missing.body.error.type).toBe("not_found_error")
 		expect(missing.body.error.code).toBe("attribute_mapping_not_found")
+		await harness.dispose()
+	})
+	// Mappings rewrite every ingested span org-wide, so the writes are admin-only.
+	it("refuses attribute_mapping writes from a non-admin member", async () => {
+		const harness = makeHarness()
+		const admin = await harness.bootstrapKey()
+		const member = await harness.bootstrapMemberKey()
+
+		const created = await harness.request("POST", "/v2/attribute_mappings", {
+			token: admin.secret,
+			body: {
+				name: "Promote team label",
+				source_context: "resource",
+				source_key: "labels.team",
+				target_key: "team",
+				operation: "copy",
+			},
+		})
+		expect(created.status).toBe(200)
+
+		const denied = await harness.request("POST", "/v2/attribute_mappings", {
+			token: member.secret,
+			body: {
+				name: "Member mapping",
+				source_context: "resource",
+				source_key: "labels.other",
+				target_key: "other",
+				operation: "copy",
+			},
+		})
+		expect(denied.status).toBe(403)
+		expect(denied.body.error.code).toBe("attribute_mapping_forbidden")
+
+		const patched = await harness.request("PATCH", `/v2/attribute_mappings/${created.body.id}`, {
+			token: member.secret,
+			body: { enabled: false },
+		})
+		expect(patched.status).toBe(403)
+
+		const deleted = await harness.request("DELETE", `/v2/attribute_mappings/${created.body.id}`, {
+			token: member.secret,
+		})
+		expect(deleted.status).toBe(403)
+
+		// Reads stay open to any member.
+		const list = await harness.request("GET", "/v2/attribute_mappings", { token: member.secret })
+		expect(list.status).toBe(200)
+		expect(list.body.data).toHaveLength(1)
 		await harness.dispose()
 	})
 })

--- a/apps/api/src/services/errors/ErrorPolicyService.test.ts
+++ b/apps/api/src/services/errors/ErrorPolicyService.test.ts
@@ -6,6 +6,7 @@ import {
 	IssueEscalationPolicyRule,
 	IssueEscalationPolicyUpsertRequest,
 	OrgId,
+	RoleName,
 	UserId,
 } from "@maple/domain/http"
 import { AlertDestinationId, ErrorIssueId, IssueEscalationId } from "@maple/domain/primitives"
@@ -25,6 +26,9 @@ const asUserId = Schema.decodeUnknownSync(UserId)
 const asDestinationId = Schema.decodeUnknownSync(AlertDestinationId)
 const asIssueId = Schema.decodeUnknownSync(ErrorIssueId)
 const asEscalationId = Schema.decodeUnknownSync(IssueEscalationId)
+const asRoleName = Schema.decodeUnknownSync(RoleName)
+const ADMIN_ROLES = [asRoleName("org:admin")]
+const MEMBER_ROLES = [asRoleName("org:member")]
 
 const ORG = asOrgId("org_error_policy_service_test")
 const OTHER_ORG = asOrgId("org_error_policy_service_other")
@@ -80,6 +84,7 @@ describe("ErrorPolicyService", () => {
 			const updated = yield* policies.upsertNotificationPolicy(
 				ORG,
 				USER,
+				ADMIN_ROLES,
 				new ErrorNotificationPolicyUpsertRequest({
 					destinationIds: [destinationId],
 					notifyOnResolve: true,
@@ -98,6 +103,27 @@ describe("ErrorPolicyService", () => {
 			assert.deepStrictEqual(policies.parseNotificationDestinationIds(row?.destinationIdsJson), [
 				destinationId,
 			])
+		}).pipe(Effect.provide(makeLayer())),
+	)
+
+	// The gate lives here rather than on the v1 route because the MCP tool and
+	// the chat apply path reach the same mutation.
+	it.effect("refuses a notification policy write from a non-admin", () =>
+		Effect.gen(function* () {
+			const policies = yield* ErrorPolicyService
+
+			const failure = yield* Effect.flip(
+				policies.upsertNotificationPolicy(
+					ORG,
+					USER,
+					MEMBER_ROLES,
+					new ErrorNotificationPolicyUpsertRequest({ enabled: false }),
+				),
+			)
+
+			assert.strictEqual(failure._tag, "@maple/http/errors/ErrorForbiddenError")
+			// And nothing was written.
+			assert.isNull(yield* policies.loadNotificationPolicyRow(ORG))
 		}).pipe(Effect.provide(makeLayer())),
 	)
 

--- a/apps/api/src/services/errors/ErrorPolicyService.ts
+++ b/apps/api/src/services/errors/ErrorPolicyService.ts
@@ -3,6 +3,7 @@ import {
 	type AlertDestinationId,
 	ErrorNotificationPolicyDocument,
 	type ErrorNotificationPolicyUpsertRequest,
+	ErrorForbiddenError,
 	ErrorPersistenceError,
 	ErrorValidationError,
 	EscalationDestinationOutcome,
@@ -16,6 +17,7 @@ import {
 	type IssueEscalationPolicyUpsertRequest,
 	type ErrorIssueId,
 	type OrgId,
+	type RoleName,
 	type UserId,
 	UserId as UserIdSchema,
 } from "@maple/domain/http"
@@ -31,6 +33,7 @@ import {
 import { and, desc, eq, inArray } from "drizzle-orm"
 import { Array as Arr, Clock, Context, Effect, HashSet, Layer, Option, Schema } from "effect"
 import { Database } from "@/platform/DatabaseLive"
+import { requireAdmin } from "@/services/auth/auth"
 import { msToDate } from "@/platform/time"
 import { evaluateEscalationPolicy as evaluateRoutingPolicy } from "@/services/alerts/escalation-policy"
 import { makeErrorDatabaseExecute } from "./error-persistence"
@@ -55,11 +58,19 @@ export interface ErrorPolicyPublicApi {
 	readonly getNotificationPolicy: (
 		orgId: OrgId,
 	) => Effect.Effect<ErrorNotificationPolicyDocument, ErrorPersistenceError>
+	/**
+	 * Roles live on the service, not the route: the same mutation is reachable
+	 * from the v1 route, the MCP tool and the chat apply path.
+	 */
 	readonly upsertNotificationPolicy: (
 		orgId: OrgId,
 		userId: UserId,
+		roles: ReadonlyArray<RoleName>,
 		request: ErrorNotificationPolicyUpsertRequest,
-	) => Effect.Effect<ErrorNotificationPolicyDocument, ErrorPersistenceError | ErrorValidationError>
+	) => Effect.Effect<
+		ErrorNotificationPolicyDocument,
+		ErrorForbiddenError | ErrorPersistenceError | ErrorValidationError
+	>
 	readonly getEscalationPolicy: (
 		orgId: OrgId,
 	) => Effect.Effect<IssueEscalationPolicyDocument, ErrorPersistenceError>
@@ -169,8 +180,15 @@ const make: Effect.Effect<ErrorPolicyServiceApi, never, Database> = Effect.gen(f
 
 	const upsertNotificationPolicy: ErrorPolicyServiceApi["upsertNotificationPolicy"] = Effect.fn(
 		"ErrorsService.upsertNotificationPolicy",
-	)(function* (orgId, userId, request) {
+	)(function* (orgId, userId, roles, request) {
 		yield* Effect.annotateCurrentSpan({ orgId })
+		yield* requireAdmin(
+			roles,
+			() =>
+				new ErrorForbiddenError({
+					message: "Only org admins can manage error notification policy",
+				}),
+		)
 		const existing = yield* loadNotificationPolicyRow(orgId)
 		const timestamp = yield* Clock.currentTimeMillis
 		const base = existing ?? defaultNotificationPolicy(orgId, timestamp)

--- a/packages/auth/src/auth.test.ts
+++ b/packages/auth/src/auth.test.ts
@@ -1186,7 +1186,63 @@ describe(`${ORG_SELECTION_HEADER} (organization selection)`, () => {
 			)
 
 			assertDenied(exit)
-			assert.strictEqual(membership.calls(), 0)
+		}),
+	)
+
+	// The pin replaces the organization, so it must replace the role too.
+	it.effect("MAPLE_ORG_ID_OVERRIDE takes its role from the pinned org's membership", () =>
+		Effect.gen(function* () {
+			const membership = verifier([{ orgId: "org_pinned", role: "org:member" }])
+			const resolveTenant = makeResolveTenant(
+				{ ...clerkEnv, MAPLE_ORG_ID_OVERRIDE: Option.some("org_pinned") },
+				// The session is an `org:admin` of org_123, a different organization.
+				clerkAuth(),
+				undefined,
+				membership.verify,
+			)
+
+			const tenant = yield* resolveTenant({ authorization: "Bearer test-token" })
+
+			assert.deepStrictEqual(tenant, {
+				orgId: asOrgId("org_pinned"),
+				roles: [asRoleName("org:member")],
+				userId: asUserId("user_123"),
+				authMode: "clerk",
+			})
+		}),
+	)
+
+	it.effect("MAPLE_ORG_ID_OVERRIDE refuses an org the user is not a member of", () =>
+		Effect.gen(function* () {
+			const membership = verifier([])
+			const resolveTenant = makeResolveTenant(
+				{ ...clerkEnv, MAPLE_ORG_ID_OVERRIDE: Option.some("org_pinned") },
+				clerkAuth(),
+				undefined,
+				membership.verify,
+			)
+
+			assertDenied(yield* Effect.exit(resolveTenant({ authorization: "Bearer test-token" })))
+		}),
+	)
+
+	// No membership directory wired (MCP, electric-sync): the pin still selects
+	// the organization, but it can prove nothing, so it confers no role.
+	it.effect("MAPLE_ORG_ID_OVERRIDE confers no role without a verifier", () =>
+		Effect.gen(function* () {
+			const resolveTenant = makeResolveTenant(
+				{ ...clerkEnv, MAPLE_ORG_ID_OVERRIDE: Option.some("org_pinned") },
+				clerkAuth(),
+			)
+
+			const tenant = yield* resolveTenant({ authorization: "Bearer test-token" })
+
+			assert.deepStrictEqual(tenant, {
+				orgId: asOrgId("org_pinned"),
+				roles: [],
+				userId: asUserId("user_123"),
+				authMode: "clerk",
+			})
 		}),
 	)
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -687,7 +687,48 @@ export const makeResolveTenant = (
 					? verifyOrgMembership
 					: undefined
 
-			if (!auth.orgId && !orgIdOverride) {
+			const sessionRoles: ReadonlyArray<RoleName> =
+				typeof auth.orgRole === "string"
+					? yield* Effect.map(
+							decodeRoleName(auth.orgRole, "Invalid role in Clerk session token"),
+							(role) => [role],
+						)
+					: []
+
+			if (orgIdOverride !== undefined) {
+				const pinnedOrgId = yield* decodeOrgId(orgIdOverride, "Invalid MAPLE_ORG_ID_OVERRIDE value")
+				// The pin replaces the organization, so it must replace the role with
+				// it — same invariant as `applyRequestedOrg`. Carrying `auth.orgRole`
+				// across made an admin of their own organization an admin of the
+				// pinned one. Naming your own organization is still free; anything
+				// else takes its role from a verified membership, and where there is
+				// no membership directory to ask, the pin grants no role at all.
+				if (auth.orgId === pinnedOrgId) {
+					return yield* applyRequestedOrg(
+						{ orgId: pinnedOrgId, userId, roles: sessionRoles, authMode: "clerk" },
+						headers,
+						selectable,
+					)
+				}
+				if (verifyOrgMembership) {
+					const membership = yield* verifyOrgMembership(userId, pinnedOrgId)
+					if (Option.isNone(membership)) {
+						return yield* Effect.fail(organizationAccessDenied(pinnedOrgId))
+					}
+					return yield* applyRequestedOrg(
+						{ orgId: pinnedOrgId, userId, roles: [membership.value.role], authMode: "clerk" },
+						headers,
+						selectable,
+					)
+				}
+				return yield* applyRequestedOrg(
+					{ orgId: pinnedOrgId, userId, roles: [], authMode: "clerk" },
+					headers,
+					selectable,
+				)
+			}
+
+			if (!auth.orgId) {
 				// No active organization in the session. A request that names one it
 				// can prove membership of is still serviceable — this is the widget
 				// publishing path, whose whole point is not to disturb whatever the
@@ -705,18 +746,9 @@ export const makeResolveTenant = (
 			}
 
 			const clerkTenant: TenantContext = {
-				orgId: yield* decodeOrgId(
-					orgIdOverride ?? auth.orgId!,
-					"Invalid organization in Clerk session token",
-				),
+				orgId: yield* decodeOrgId(auth.orgId, "Invalid organization in Clerk session token"),
 				userId,
-				roles:
-					typeof auth.orgRole === "string"
-						? yield* Effect.map(
-								decodeRoleName(auth.orgRole, "Invalid role in Clerk session token"),
-								(role) => [role],
-							)
-						: [],
+				roles: sessionRoles,
 				authMode: "clerk",
 			}
 

--- a/packages/domain/src/http/billing.ts
+++ b/packages/domain/src/http/billing.ts
@@ -624,7 +624,7 @@ export class BillingApiGroup extends HttpApiGroup.make("billing")
 		HttpApiEndpoint.post("attach", "/attach", {
 			payload: AttachRequest,
 			success: AttachResult,
-			error: [...billingRequestErrors],
+			error: [BillingForbiddenError, ...billingRequestErrors],
 		}),
 	)
 	.add(
@@ -638,7 +638,7 @@ export class BillingApiGroup extends HttpApiGroup.make("billing")
 		HttpApiEndpoint.post("openCustomerPortal", "/portal", {
 			payload: CustomerPortalRequest,
 			success: CustomerPortalResult,
-			error: [...billingTransportErrors],
+			error: [BillingForbiddenError, ...billingTransportErrors],
 		}),
 	)
 	// Billing details live on the Stripe customer, read through Stripe directly.

--- a/packages/domain/src/http/ingest-attribute-mappings.ts
+++ b/packages/domain/src/http/ingest-attribute-mappings.ts
@@ -4,6 +4,7 @@ import {
 	IngestMappingOperation,
 	IngestMappingSourceContext,
 	IsoDateTimeString,
+	RoleName,
 } from "../primitives"
 import { HttpTaggedError } from "./error-policy"
 
@@ -83,6 +84,27 @@ export class IngestAttributeMappingNotFoundError extends HttpTaggedError<IngestA
 		param: "id",
 		retry: "never",
 		recovery: "none",
+		exposure: "redacted",
+	},
+) {}
+
+/**
+ * Mappings rewrite every ingested span for the whole organization, so the
+ * write endpoints are admin-only.
+ */
+export class IngestAttributeMappingForbiddenError extends HttpTaggedError<IngestAttributeMappingForbiddenError>()(
+	"@maple/http/errors/IngestAttributeMappingForbiddenError",
+	{
+		message: Schema.String,
+		roles: Schema.optionalKey(Schema.Array(RoleName)),
+	},
+	{
+		status: 403,
+		code: "attribute_mapping_forbidden",
+		title: "Permission required",
+		message: "Only org admins can manage attribute mappings.",
+		retry: "never",
+		recovery: "request_access",
 		exposure: "redacted",
 	},
 ) {}

--- a/packages/domain/src/http/v2/attribute-mappings.ts
+++ b/packages/domain/src/http/v2/attribute-mappings.ts
@@ -1,6 +1,7 @@
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { Schema } from "effect"
 import {
+	IngestAttributeMappingForbiddenError,
 	IngestAttributeMappingNotFoundError,
 	IngestAttributeMappingPersistenceError,
 	IngestAttributeMappingValidationError,
@@ -154,10 +155,11 @@ export const V2AttributeMappingDeleteResponse = Schema.Struct({
 })
 export type V2AttributeMappingDeleteResponse = Schema.Schema.Type<typeof V2AttributeMappingDeleteResponse>
 
-const [mappingNotFound, mappingValidation, mappingPersistence] = publicErrors(
+const [mappingNotFound, mappingValidation, mappingPersistence, mappingForbidden] = publicErrors(
 	IngestAttributeMappingNotFoundError,
 	IngestAttributeMappingValidationError,
 	IngestAttributeMappingPersistenceError,
+	IngestAttributeMappingForbiddenError,
 )
 
 const AttributeMappingList = ListOf(V2AttributeMapping).annotate({
@@ -185,7 +187,7 @@ export class V2AttributeMappingsApiGroup extends HttpApiGroup.make("attributeMap
 		HttpApiEndpoint.post("create", "/", {
 			payload: V2AttributeMappingCreateParams,
 			success: V2AttributeMapping,
-			error: [mappingValidation, mappingPersistence],
+			error: [mappingForbidden, mappingValidation, mappingPersistence],
 		}).annotateMerge(
 			OpenApi.annotations({
 				identifier: "createAttributeMapping",
@@ -214,7 +216,7 @@ export class V2AttributeMappingsApiGroup extends HttpApiGroup.make("attributeMap
 			params: { id: AttributeMappingPublicId },
 			payload: V2AttributeMappingUpdateParams,
 			success: V2AttributeMapping,
-			error: [mappingNotFound, mappingValidation, mappingPersistence],
+			error: [mappingForbidden, mappingNotFound, mappingValidation, mappingPersistence],
 		}).annotateMerge(
 			OpenApi.annotations({
 				identifier: "updateAttributeMapping",
@@ -228,7 +230,7 @@ export class V2AttributeMappingsApiGroup extends HttpApiGroup.make("attributeMap
 		HttpApiEndpoint.delete("delete", "/:id", {
 			params: { id: AttributeMappingPublicId },
 			success: V2AttributeMappingDeleteResponse,
-			error: [mappingNotFound, mappingPersistence],
+			error: [mappingForbidden, mappingNotFound, mappingPersistence],
 		}).annotateMerge(
 			OpenApi.annotations({
 				identifier: "deleteAttributeMapping",


### PR DESCRIPTION
Three org-wide surfaces did not check the caller's role: billing subscription
and portal handlers, v2 attribute-mapping writes (mappings rewrite every
ingested span for the org), and the error notification policy, which was gated
on its v1 route while other entry points reached the service directly.

The notification-policy gate moves into `ErrorPolicyService`, matching how
`AlertRulesService` does it: that closes the class rather than the callers we
happened to find, and the chat path needed no change because it already forwards
the member's real roles. The v1 route's error shape is unchanged.

`MAPLE_ORG_ID_OVERRIDE` under Clerk pinned the org but still took roles from the
user's own active organization. Roles now come from the pinned org's membership
when a verifier is wired, and from nothing when one is not. The override is left
working for the documented single-tenant and local-Clerk setups.

Note for follow-up: where no verifier is wired — which includes the session
layer, the busiest path — a non-member still resolves into the pinned org with
no roles at all. That is a read exposure rather than the escalation this closes,
and failing closed there deserves its own change.
---

### Stack

Part of a 9-PR security stack off `main`. Each PR is based on the one above it, so **review and merge in order**; each commit typechecks standalone.

1. `sec/01-ci-supply-chain` — supply chain: pinned downloads and installers
2. `sec/02-v2-scope-enforcement` — v2 API key scope enforcement
3. `sec/03-admin-role-gates` — missing org-admin checks
4. `sec/04-oauth-return-to` — OAuth `returnTo` validation
5. `sec/05-canonical-api-origin` — discovery documents from configured origin
6. `sec/06-session-replay-privacy` — replay block markers
7. `sec/07-outbound-request-hardening` — outbound credentials and redirects
8. `sec/08-scrape-target-authz` — scrape target authorization and credentials
9. `sec/09-membership-revocation` — revocation on member/org removal

Findings came from a `deepsec` scan triaged down to the real defects; each was verified against `HEAD` before being fixed, and each fix was reviewed adversarially afterwards. Reproduction detail is deliberately kept out of these descriptions until the fixes are deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849831&installation_model_id=427786&pr_number=713&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F713&signature=606f31434c23d8693a01a9971c64e908a87fe05952be72ee38f31a4376afc26f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->