### PR TITLE
fix(api): build discovery documents from the configured origin, not the request

### DIFF
--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -22,6 +22,7 @@ import {
 	appUrlsEnv,
 	authEnv,
 	cloudflareOAuthEnv,
+	derived,
 	ingestKeyCryptoEnv,
 	merge,
 	optionalPlain,
@@ -145,7 +146,7 @@ export const createReplayBlobStore = ({ stage }: { stage: MapleStage }) =>
  * reports all of them at once, and so `.env` / `--env-file` reach it — see
  * `@maple/infra/env`.
  */
-const apiConfiguredEnv = (stage: MapleStage) =>
+const apiConfiguredEnv = (stage: MapleStage, domains: MapleDomains) =>
 	merge(
 		tinybirdEnv,
 		// ClickHouse (BYO warehouse); `tinybird` unless an org config overrides it.
@@ -158,6 +159,13 @@ const apiConfiguredEnv = (stage: MapleStage) =>
 		ingestKeyCryptoEnv,
 		requireSecretEntry("MAPLE_SHARE_TOKEN_HMAC_KEY"),
 		appUrlsEnv,
+		// The worker's own canonical origin — everything it publishes about itself
+		// (MCP `server.json`, the discovery index) is built from this rather than
+		// from client-controlled forwarded headers. Stages with a real domain
+		// derive it; the rest fall back to production, overridable per deploy.
+		domains.api
+			? derived("MAPLE_API_BASE_URL", `https://${domains.api}`)
+			: plainWithDefault("MAPLE_API_BASE_URL", "https://api.maple.dev"),
 		// Bucket-cache knobs: on by default in deployed stages. Override via
 		// deploy-time env (e.g. `QE_BUCKET_CACHE_ENABLED=false`) if needed.
 		plainWithDefault("QE_BUCKET_CACHE_ENABLED", "true"),
@@ -274,7 +282,7 @@ export const createMapleApi = ({ stage, domains, replayBlobs }: CreateMapleApiOp
 
 		// Resolved before any resource is created, so a misconfigured deploy fails
 		// with the full list of missing vars rather than part-way through applying.
-		const configuredEnv = yield* apiConfiguredEnv(stage)
+		const configuredEnv = yield* apiConfiguredEnv(stage, domains)
 
 		const mcpSessions = yield* Cloudflare.KV.Namespace("MCP_SESSIONS", {
 			title: resolveWorkerName("mcp-sessions", stage),

--- a/apps/api/src/platform/Env.ts
+++ b/apps/api/src/platform/Env.ts
@@ -36,6 +36,13 @@ export interface EnvConfig {
 	readonly MAPLE_SHARE_TOKEN_HMAC_KEY: Option.Option<Redacted.Redacted<string>>
 	readonly MAPLE_INGEST_PUBLIC_URL: string
 	readonly MAPLE_APP_BASE_URL: string
+	/**
+	 * This worker's own canonical public origin, e.g. `https://api.maple.dev`.
+	 * Anything the API publishes about itself — the MCP `server.json` remote URL,
+	 * the discovery index — must be built from this, never from the request's
+	 * `Host`/`X-Forwarded-*` headers, which a client controls.
+	 */
+	readonly MAPLE_API_BASE_URL: string
 	/** Deployment environment (`production`, `staging`, `pr-<n>`, `development`) — set by alchemy from the stage. */
 	readonly MAPLE_ENVIRONMENT: string
 	/** Escape hatch: allow real email sends outside production (e.g. a dedicated stg test run). */
@@ -156,6 +163,7 @@ const envConfig = Config.all({
 	MAPLE_SHARE_TOKEN_HMAC_KEY: optionalRedacted("MAPLE_SHARE_TOKEN_HMAC_KEY"),
 	MAPLE_INGEST_PUBLIC_URL: stringWithDefault("MAPLE_INGEST_PUBLIC_URL", "http://127.0.0.1:3474"),
 	MAPLE_APP_BASE_URL: stringWithDefault("MAPLE_APP_BASE_URL", "http://127.0.0.1:3471"),
+	MAPLE_API_BASE_URL: stringWithDefault("MAPLE_API_BASE_URL", "http://127.0.0.1:3472"),
 	MAPLE_ENVIRONMENT: stringWithDefault("MAPLE_ENVIRONMENT", "development"),
 	MAPLE_EMAIL_ALLOW_NONPROD: stringWithDefault("MAPLE_EMAIL_ALLOW_NONPROD", "false"),
 	CLERK_SECRET_KEY: optionalRedacted("CLERK_SECRET_KEY"),

--- a/apps/api/src/routes/discovery.http.test.ts
+++ b/apps/api/src/routes/discovery.http.test.ts
@@ -1,8 +1,28 @@
 import { afterAll, describe, expect, it } from "@effect/vitest"
 import { MAPLE_MCP_SERVER_NAME } from "@maple/domain/mcp-manifest"
-import { Effect, Layer } from "effect"
+import { ConfigProvider, Effect, Layer } from "effect"
 import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
+import { Env } from "@/platform/Env"
 import { DiscoveryRouter, NotFoundRouter } from "./discovery.http"
+
+const API_ORIGIN = "https://api.maple.test"
+
+const envLive = Env.layer.pipe(
+	Layer.provide(
+		ConfigProvider.layer(
+			ConfigProvider.fromUnknown({
+				TINYBIRD_HOST: "https://api.tinybird.co",
+				TINYBIRD_TOKEN: "test-token",
+				MAPLE_AUTH_MODE: "self_hosted",
+				MAPLE_ROOT_PASSWORD: "test-root-password",
+				MAPLE_DEFAULT_ORG_ID: "default",
+				MAPLE_API_BASE_URL: `${API_ORIGIN}/`,
+				MAPLE_INGEST_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 4).toString("base64"),
+				MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "maple-test-lookup-secret",
+			}),
+		),
+	),
+)
 
 // A registered route that must keep winning over the catch-all.
 const ProbeRouter = HttpRouter.use((router) =>
@@ -13,7 +33,7 @@ const ProbeRouter = HttpRouter.use((router) =>
 )
 
 const { handler, dispose } = HttpRouter.toWebHandler(
-	Layer.mergeAll(DiscoveryRouter, NotFoundRouter, ProbeRouter),
+	Layer.mergeAll(DiscoveryRouter, NotFoundRouter, ProbeRouter).pipe(Layer.provide(envLive)),
 	{ disableLogger: true },
 )
 afterAll(() => dispose())
@@ -55,17 +75,34 @@ describe("DiscoveryRouter", () => {
 			const manifest = await response.json()
 			expect(manifest.name).toBe(MAPLE_MCP_SERVER_NAME)
 			expect(manifest.remotes).toEqual([
-				expect.objectContaining({ type: "streamable-http", url: "https://api.example.com/mcp" }),
+				expect.objectContaining({ type: "streamable-http", url: `${API_ORIGIN}/mcp` }),
 			])
 		}
+	})
+
+	// The manifest tells clients where to send a Maple bearer token and is served
+	// publicly cacheable, so it must never be built from headers a client sets.
+	it("ignores forged forwarded headers when building the MCP manifest", async () => {
+		const response = await handler(
+			new Request("https://api.example.com/.well-known/mcp.json", {
+				headers: {
+					host: "attacker.example",
+					"x-forwarded-host": "attacker.example",
+					"x-forwarded-proto": "https",
+				},
+			}),
+		)
+		const manifest = await response.json()
+		expect(JSON.stringify(manifest)).not.toContain("attacker.example")
+		expect(manifest.remotes[0].url).toBe(`${API_ORIGIN}/mcp`)
 	})
 
 	it("answers the bare origin with a JSON index", async () => {
 		const response = await get("/")
 		expect(response.status).toBe(200)
 		const index = await response.json()
-		expect(index.openapi).toBe("https://api.example.com/openapi.json")
-		expect(index.mcp.endpoint).toBe("https://api.example.com/mcp")
+		expect(index.openapi).toBe(`${API_ORIGIN}/openapi.json`)
+		expect(index.mcp.endpoint).toBe(`${API_ORIGIN}/mcp`)
 	})
 })
 

--- a/apps/api/src/routes/discovery.http.ts
+++ b/apps/api/src/routes/discovery.http.ts
@@ -3,7 +3,7 @@ import { mapleMcpServerManifest } from "@maple/domain/mcp-manifest"
 import { Effect } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { OpenApi } from "effect/unstable/httpapi"
-import { requestOrigin } from "@/routes/v1/oauth-discovery.http"
+import { Env } from "@/platform/Env"
 
 /**
  * Machine discovery for agents and tooling.
@@ -16,10 +16,27 @@ import { requestOrigin } from "@/routes/v1/oauth-discovery.http"
  * - `GET /` — a JSON index pointing at all of the above, so the bare origin
  *   is self-describing instead of an empty 404.
  *
- * Everything here is public, unauthenticated, and cacheable.
+ * Everything here is public, unauthenticated, and cacheable — which is exactly
+ * why the self-describing URLs come from the configured `MAPLE_API_BASE_URL` and
+ * not from the request. `Host`/`X-Forwarded-*` are client-controlled, so a forged
+ * header would otherwise publish (and let an intermediary cache) a manifest that
+ * tells MCP clients to send their Maple bearer token to an attacker's origin.
  */
 
 const PUBLIC_CACHE = { "cache-control": "public, max-age=300" }
+
+/**
+ * Origin as the CALLER sees it, from headers the caller controls. Deliberately
+ * private and used only for the doc links echoed into an uncached 404 body —
+ * anything published, cached, or credential-bearing must use the configured
+ * `MAPLE_API_BASE_URL` instead.
+ */
+const untrustedRequestOrigin = (request: HttpServerRequest.HttpServerRequest) => {
+	const forwarded = (value: string | undefined) => value?.split(",")[0]?.trim()
+	const proto = forwarded(request.headers["x-forwarded-proto"]) ?? "https"
+	const host = forwarded(request.headers["x-forwarded-host"]) ?? request.headers.host
+	return host ? `${proto}://${host}` : ""
+}
 
 let openApiDocument: string | undefined
 const openApiJson = Effect.sync(() => {
@@ -49,22 +66,20 @@ export const DiscoveryRouter = HttpRouter.use((router) =>
 		yield* router.add("GET", "/openapi.json", serveOpenApi)
 		yield* router.add("GET", "/v2/openapi.json", serveOpenApi)
 
-		const serveManifest = (request: HttpServerRequest.HttpServerRequest) =>
-			Effect.succeed(
-				HttpServerResponse.jsonUnsafe(
-					mapleMcpServerManifest({ apiBaseUrl: requestOrigin(request) }),
-					{
-						headers: PUBLIC_CACHE,
-					},
-				),
-			)
+		const env = yield* Env
+		const origin = env.MAPLE_API_BASE_URL.replace(/\/+$/, "")
+
+		const manifest = HttpServerResponse.jsonUnsafe(mapleMcpServerManifest({ apiBaseUrl: origin }), {
+			headers: PUBLIC_CACHE,
+		})
+		const serveManifest = Effect.succeed(manifest)
 		yield* router.add("GET", "/.well-known/mcp.json", serveManifest)
 		yield* router.add("GET", "/.well-known/mcp/server.json", serveManifest)
 
-		yield* router.add("GET", "/", (request) =>
-			Effect.succeed(
-				HttpServerResponse.jsonUnsafe(apiIndex(requestOrigin(request)), { headers: PUBLIC_CACHE }),
-			),
+		yield* router.add(
+			"GET",
+			"/",
+			Effect.succeed(HttpServerResponse.jsonUnsafe(apiIndex(origin), { headers: PUBLIC_CACHE })),
 		)
 	}),
 )
@@ -77,7 +92,7 @@ export const DiscoveryRouter = HttpRouter.use((router) =>
  */
 export const NotFoundRouter = HttpRouter.use((router) =>
 	router.add("*", "/*", (request) => {
-		const origin = requestOrigin(request)
+		const origin = untrustedRequestOrigin(request)
 		const path = request.url.split("?")[0] ?? request.url
 		return Effect.succeed(
 			HttpServerResponse.jsonUnsafe(

--- a/apps/api/src/routes/v1/oauth-discovery.http.test.ts
+++ b/apps/api/src/routes/v1/oauth-discovery.http.test.ts
@@ -20,6 +20,8 @@ const testConfig = () =>
 			MAPLE_ROOT_PASSWORD: "test-root-password",
 			MAPLE_DEFAULT_ORG_ID: "default",
 			MAPLE_APP_BASE_URL: "https://app.example.com",
+			// Trailing slash on purpose: the router must normalize it away.
+			MAPLE_API_BASE_URL: "https://api.example.com/",
 			MAPLE_INGEST_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 4).toString("base64"),
 			MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "maple-test-lookup-secret",
 		}),
@@ -28,7 +30,9 @@ const testConfig = () =>
 const makeHarness = () => {
 	const db = createTestDb(createdDbs)
 	const base = Layer.mergeAll(db.layer, Env.layer.pipe(Layer.provide(testConfig())))
-	const service = McpOAuthService.layer.pipe(Layer.provide(base))
+	// `provideMerge`, so the router can read the same `Env` the service was built
+	// with — its canonical origin now comes from configuration.
+	const service = McpOAuthService.layer.pipe(Layer.provideMerge(base))
 	const routes = OAuthDiscoveryRouter.pipe(Layer.provideMerge(service))
 	const { handler, dispose } = HttpRouter.toWebHandler(routes, { disableLogger: true })
 	const runtime = ManagedRuntime.make(service)
@@ -87,6 +91,93 @@ describe("MCP OAuth HTTP routes", () => {
 				authorization_servers: ["https://api.example.com"],
 				scopes_supported: ["mcp:tools"],
 			})
+		} finally {
+			await harness.dispose()
+			await harness.runtime.dispose()
+		}
+	})
+
+	// These documents are publicly cacheable and tell clients where to send a Maple
+	// bearer token, so a forged forwarded host must never reach them.
+	it("builds issuer, endpoints and resource from config, not forwarded headers", async () => {
+		const harness = makeHarness()
+		const forged = {
+			host: "attacker.example",
+			"x-forwarded-host": "attacker.example",
+			"x-forwarded-proto": "https",
+		}
+		try {
+			const authorization = await harness.handler(
+				new Request("https://api.example.com/.well-known/oauth-authorization-server/mcp", {
+					headers: forged,
+				}),
+				Context.empty() as never,
+			)
+			const metadata = await authorization.json()
+			expect(JSON.stringify(metadata)).not.toContain("attacker.example")
+			expect(metadata).toMatchObject({
+				issuer: "https://api.example.com",
+				authorization_endpoint: "https://api.example.com/oauth/authorize",
+				token_endpoint: "https://api.example.com/oauth/token",
+				registration_endpoint: "https://api.example.com/register",
+				revocation_endpoint: "https://api.example.com/oauth/revoke",
+			})
+
+			const resource = await harness.handler(
+				new Request("https://api.example.com/.well-known/oauth-protected-resource", {
+					headers: forged,
+				}),
+				Context.empty() as never,
+			)
+			const resourceMetadata = await resource.json()
+			expect(JSON.stringify(resourceMetadata)).not.toContain("attacker.example")
+			expect(resourceMetadata).toMatchObject({
+				resource: "https://api.example.com/mcp",
+				authorization_servers: ["https://api.example.com"],
+			})
+		} finally {
+			await harness.dispose()
+			await harness.runtime.dispose()
+		}
+	})
+
+	// The resource indicator the token is bound to must be Maple's own identity,
+	// so a forged host cannot make `/oauth/authorize` validate against itself.
+	it("rejects an authorize whose resource follows a forged forwarded host", async () => {
+		const harness = makeHarness()
+		try {
+			const registered = await harness.handler(
+				postJson("https://api.example.com/register", {
+					client_name: "Forged Host Client",
+					redirect_uris: ["http://127.0.0.1:49876/callback"],
+				}),
+				Context.empty() as never,
+			)
+			const client = (await registered.json()) as { client_id: string }
+			const verifier = "http-route-pkce-verifier-with-more-than-forty-three-characters"
+			const authorizeUrl = new URL("https://api.example.com/oauth/authorize")
+			authorizeUrl.search = new URLSearchParams({
+				client_id: client.client_id,
+				redirect_uri: "http://127.0.0.1:49876/callback",
+				response_type: "code",
+				code_challenge: createHash("sha256").update(verifier).digest("base64url"),
+				code_challenge_method: "S256",
+				resource: "https://attacker.example/mcp",
+				scope: "mcp:tools",
+			}).toString()
+			const authorize = await harness.handler(
+				new Request(authorizeUrl, {
+					headers: {
+						host: "attacker.example",
+						"x-forwarded-host": "attacker.example",
+						"x-forwarded-proto": "https",
+					},
+				}),
+				Context.empty() as never,
+			)
+			expect(authorize.status).toBe(302)
+			const location = new URL(authorize.headers.get("location")!)
+			expect(location.searchParams.get("error")).toBe("invalid_target")
 		} finally {
 			await harness.dispose()
 			await harness.runtime.dispose()

--- a/apps/api/src/routes/v1/oauth-discovery.http.ts
+++ b/apps/api/src/routes/v1/oauth-discovery.http.ts
@@ -1,5 +1,6 @@
 import { Effect, Schema } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { Env } from "@/platform/Env"
 import {
 	MCP_OAUTH_SCOPE,
 	McpOAuthProtocolError,
@@ -19,12 +20,6 @@ const RegistrationRequest = Schema.Struct({
 const decodeRegistrationRequest = Schema.decodeUnknownEffect(RegistrationRequest)
 
 const forwardedValue = (value: string | undefined) => value?.split(",")[0]?.trim()
-
-export const requestOrigin = (request: HttpServerRequest.HttpServerRequest) => {
-	const proto = forwardedValue(request.headers["x-forwarded-proto"]) ?? "https"
-	const host = forwardedValue(request.headers["x-forwarded-host"]) ?? request.headers.host
-	return host ? `${proto}://${host}` : ""
-}
 
 const requesterKey = (request: HttpServerRequest.HttpServerRequest) =>
 	request.headers["cf-connecting-ip"] ?? forwardedValue(request.headers["x-forwarded-for"]) ?? "unknown"
@@ -120,20 +115,21 @@ const rateLimitResponse = (error: McpOAuthRateLimitError) =>
 export const OAuthDiscoveryRouter = HttpRouter.use((router) =>
 	Effect.gen(function* () {
 		const oauth = yield* McpOAuthService
+		// This server's identity — issuer, endpoints, and the resource indicator
+		// callers are held to — comes from configuration, never from the request:
+		// `Host`/`X-Forwarded-*` are client-controlled, and these documents are
+		// served publicly cacheable and tell clients where to send credentials.
+		const env = yield* Env
+		const origin = env.MAPLE_API_BASE_URL.replace(/\/+$/, "")
 
-		const authorizationServerMetadata = (request: HttpServerRequest.HttpServerRequest) =>
-			Effect.succeed(
-				HttpServerResponse.jsonUnsafe(metadata(requestOrigin(request)), {
-					headers: { "cache-control": "public, max-age=300" },
-				}),
-			)
+		const publicCache = { "cache-control": "public, max-age=300" }
+		const authorizationServerMetadata = Effect.succeed(
+			HttpServerResponse.jsonUnsafe(metadata(origin), { headers: publicCache }),
+		)
 
-		const protectedResource = (request: HttpServerRequest.HttpServerRequest) =>
-			Effect.succeed(
-				HttpServerResponse.jsonUnsafe(protectedResourceMetadata(requestOrigin(request)), {
-					headers: { "cache-control": "public, max-age=300" },
-				}),
-			)
+		const protectedResource = Effect.succeed(
+			HttpServerResponse.jsonUnsafe(protectedResourceMetadata(origin), { headers: publicCache }),
+		)
 
 		const register = (request: HttpServerRequest.HttpServerRequest) =>
 			Effect.gen(function* () {
@@ -205,7 +201,11 @@ export const OAuthDiscoveryRouter = HttpRouter.use((router) =>
 						...(url.searchParams.get("scope")
 							? { scope: url.searchParams.get("scope")! }
 							: undefined),
-						expectedResource: `${requestOrigin(request)}/mcp`,
+						// RFC 8707 audience binding: the token minted from this grant is
+						// bound to `resource`, so it must be Maple's canonical server
+						// identity — the same value `/.well-known/oauth-protected-resource`
+						// advertises — not a host the caller chose.
+						expectedResource: `${origin}/mcp`,
 					},
 					requesterKey(request),
 				)

--- a/packages/domain/src/mcp-manifest.ts
+++ b/packages/domain/src/mcp-manifest.ts
@@ -25,7 +25,15 @@ export const MAPLE_MCP_SERVER_DESCRIPTION =
 	"Query Maple traces, logs, metrics, errors, dashboards, and alerts over the Model Context Protocol."
 
 export interface MapleMcpManifestOptions {
-	/** Origin of the API worker that serves `/mcp`, e.g. `https://api.maple.dev`. */
+	/**
+	 * Origin of the API worker that serves `/mcp`, e.g. `https://api.maple.dev`.
+	 *
+	 * Must come from configuration (`MAPLE_API_BASE_URL`, or the landing site's
+	 * build-time `API_ORIGIN`) — NEVER from the request's `Host`/`X-Forwarded-*`
+	 * headers. The manifest tells clients to send a Maple bearer token to this
+	 * origin, and it is served publicly cacheable, so a request-derived value is
+	 * a credential-redirection primitive for anyone who can forge a header.
+	 */
 	readonly apiBaseUrl: string
 	/** Origin of the marketing/docs site. Defaults to production. */
 	readonly siteUrl?: string


### PR DESCRIPTION
The MCP manifest and the OAuth authorization-server and protected-resource
metadata derived their origin from request headers, and were served
`public, max-age=300` with no `Vary`. `GET /oauth/authorize` derived its
RFC 8707 resource indicator the same way — the one place the resource is
anchored to an external identity, since everything downstream only re-checks
self-consistency.

The API worker had no canonical origin of its own; `MAPLE_APP_BASE_URL` is the
dashboard's. `MAPLE_API_BASE_URL` is derived from the stage domain and all three
sinks read it. The metadata responses no longer vary by request, which is what
makes their public caching correct rather than dangerous. Already-issued tokens
are unaffected: the resource indicator gates grant creation, not validation.

The request-derived helper had no callers left afterwards. It is now private to
the 404 handler and named for what it is, so it is not reached for again in a
credential-bearing context. Token *validation* in `resolve-tenant` still derives
its expected resource from the request; that can only cause a rejection, but
anchoring both ends to config is worth a follow-up.
---

### Stack

Part of a 9-PR security stack off `main`. Each PR is based on the one above it, so **review and merge in order**; each commit typechecks standalone.

1. `sec/01-ci-supply-chain` — supply chain: pinned downloads and installers
2. `sec/02-v2-scope-enforcement` — v2 API key scope enforcement
3. `sec/03-admin-role-gates` — missing org-admin checks
4. `sec/04-oauth-return-to` — OAuth `returnTo` validation
5. `sec/05-canonical-api-origin` — discovery documents from configured origin
6. `sec/06-session-replay-privacy` — replay block markers
7. `sec/07-outbound-request-hardening` — outbound credentials and redirects
8. `sec/08-scrape-target-authz` — scrape target authorization and credentials
9. `sec/09-membership-revocation` — revocation on member/org removal

Findings came from a `deepsec` scan triaged down to the real defects; each was verified against `HEAD` before being fixed, and each fix was reviewed adversarially afterwards. Reproduction detail is deliberately kept out of these descriptions until the fixes are deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849834&installation_model_id=427786&pr_number=715&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F715&signature=77f68ad96563b67d1efcc8a249326e113d646f8dbb77a42b94fa4da52a38ac99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->