### PR TITLE
fix(replay): make the documented block markers work, and use them on secrets

### DIFF
--- a/apps/web/src/components/account/two-factor-section.test.tsx
+++ b/apps/web/src/components/account/two-factor-section.test.tsx
@@ -4,6 +4,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
+import { REPLAY_BLOCK_CLASS } from "@/components/common/replay-privacy"
+
 const BACKUP_CODES = ["11112222", "33334444", "55556666"]
 
 async function mount(user: Record<string, unknown>) {
@@ -50,6 +52,43 @@ describe("TwoFactorSection", () => {
 		await screen.findByText("Save your backup codes")
 		for (const code of BACKUP_CODES) {
 			expect(screen.getByText(code)).toBeTruthy()
+		}
+	}, 30_000)
+
+	it("blocks the enrollment dialog from session replay", async () => {
+		const secret = "JBSWY3DPEHPK3PXP"
+		const user = {
+			id: "user_1",
+			totpEnabled: false,
+			backupCodeEnabled: false,
+			createTOTP: vi.fn().mockResolvedValue({
+				uri: `otpauth://totp/Maple:ada@example.com?secret=${secret}&issuer=Maple`,
+				secret,
+			}),
+			verifyTOTP: vi.fn().mockResolvedValue({ verified: true, backupCodes: BACKUP_CODES }),
+		}
+		await mount(user)
+
+		fireEvent.click(screen.getByRole("button", { name: /Set up authenticator/ }))
+		await screen.findByText("Scan this code")
+
+		// rrweb blocks an `rr-block` element together with its whole subtree, so asserting
+		// each secret sits under one is what keeps it out of the replay stream.
+		const blocked = document.querySelector(`.${REPLAY_BLOCK_CLASS}`)
+		expect(blocked).not.toBeNull()
+		expect(blocked?.contains(screen.getByDisplayValue(secret))).toBe(true)
+		expect(blocked?.contains(screen.getByRole("img", { name: "Two-factor setup QR code" }))).toBe(true)
+
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }))
+		await screen.findByText("Enter the code")
+		const inputs = screen.getAllByLabelText(/Digit \d of 6/)
+		fireEvent.change(inputs[0] as HTMLInputElement, { target: { value: "123456" } })
+
+		await screen.findByText("Save your backup codes")
+		for (const code of BACKUP_CODES) {
+			expect(document.querySelector(`.${REPLAY_BLOCK_CLASS}`)?.contains(screen.getByText(code))).toBe(
+				true,
+			)
 		}
 	}, 30_000)
 

--- a/apps/web/src/components/account/two-factor-section.tsx
+++ b/apps/web/src/components/account/two-factor-section.tsx
@@ -32,6 +32,7 @@ import { toastAccountError } from "@/components/account/account-errors"
 import { AccountSectionSkeleton } from "@/components/account/account-section-skeleton"
 import { CodeField } from "@/components/account/code-field"
 import { QrCode } from "@/components/account/qr-code"
+import { REPLAY_BLOCK_CLASS } from "@/components/common/replay-privacy"
 
 /**
  * Enrollment is a three-step dialog. `uri`/`secret` come back from `createTOTP()` and are only
@@ -205,7 +206,9 @@ export function TwoFactorSection() {
 					if (!open) setEnroll({ step: "closed" })
 				}}
 			>
-				<DialogContent>
+				{/* Every step of enrollment shows a secret in plain text (QR, setup key, backup
+				    codes), and the dashboard records itself with rrweb — block the whole dialog. */}
+				<DialogContent className={REPLAY_BLOCK_CLASS}>
 					{enroll.step === "scan" && (
 						<>
 							<DialogHeader>

--- a/apps/web/src/components/common/replay-privacy.ts
+++ b/apps/web/src/components/common/replay-privacy.ts
@@ -1,0 +1,15 @@
+/**
+ * Session-replay privacy convention for the dashboard, which records itself with
+ * rrweb (`otel-layer.ts`) at `maskAllInputs: true` / `maskAllText: false` — so any
+ * secret rendered as plain text, not into an `<input>`, is serialized verbatim into
+ * the replay stream.
+ *
+ * rrweb's default `blockClass` is `rr-block` and `startRecording`
+ * (`packages/browser-session/src/replay/record.ts`) never overrides it. Blocking is
+ * ancestor-checked: the element and its whole subtree are replaced by a sized
+ * placeholder at serialization time, so the values never leave the browser.
+ *
+ * Put this on the smallest container that encloses a revealed secret — TOTP setup
+ * keys and QR codes, backup/recovery codes, freshly minted API and ingest keys.
+ */
+export const REPLAY_BLOCK_CLASS = "rr-block"

--- a/apps/web/src/components/ingest/guided-setup.test.tsx
+++ b/apps/web/src/components/ingest/guided-setup.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { REPLAY_BLOCK_CLASS } from "@/components/common/replay-privacy"
+import { ConnectInstructions } from "./guided-setup"
+
+const API_KEY = "mpl_ingest_supersecretkey123"
+
+describe("ConnectInstructions", () => {
+	afterEach(cleanup)
+
+	it("keeps the ingest key out of session replay", () => {
+		const { container } = render(
+			<ConnectInstructions framework="nodejs" apiKey={API_KEY} showCredentials />,
+		)
+
+		fireEvent.click(screen.getByRole("tab", { name: "Instrument" }))
+		fireEvent.click(screen.getByRole("tab", { name: "Claude Code" }))
+
+		// rrweb blocks an `rr-block` element with its whole subtree, so every plain-text
+		// rendering of the key must sit under one. The credentials column renders into a
+		// readonly <input>, which `maskAllInputs: true` already masks.
+		const blocked = [...container.querySelectorAll(`.${REPLAY_BLOCK_CLASS}`)]
+		expect(blocked.length).toBeGreaterThan(0)
+		for (const el of container.querySelectorAll("pre")) {
+			if (!el.textContent?.includes(API_KEY)) continue
+			expect(blocked.some((b) => b.contains(el))).toBe(true)
+		}
+		const leaked = [...container.querySelectorAll("*")].filter(
+			(el) =>
+				el.children.length === 0 &&
+				el.textContent?.includes(API_KEY) &&
+				!blocked.some((b) => b.contains(el)),
+		)
+		expect(leaked).toEqual([])
+	})
+})

--- a/apps/web/src/components/ingest/guided-setup.tsx
+++ b/apps/web/src/components/ingest/guided-setup.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "@clerk/clerk-react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@maple/ui/components/ui/tabs"
 import { cn } from "@maple/ui/lib/utils"
 import { CodeBlock } from "@/components/quick-start/code-block"
+import { REPLAY_BLOCK_CLASS } from "@/components/common/replay-privacy"
 import { PackageManagerCodeBlock } from "@/components/quick-start/package-manager-code-block"
 import {
 	EffectIcon,
@@ -168,9 +169,12 @@ export function ConnectInstructions({
 				</TabsContent>
 
 				<TabsContent value="instrument" className={cn("overflow-auto mt-0", contentPadding)}>
+					{/* The snippet carries the org's ingest key in plain text and the dashboard
+					    records itself with rrweb — block the block, not just the key. */}
 					<CodeBlock
 						code={interpolate(snippet.instrument)}
 						language={snippet.label.toLowerCase()}
+						className={REPLAY_BLOCK_CLASS}
 					/>
 				</TabsContent>
 
@@ -187,6 +191,7 @@ export function ConnectInstructions({
 					<CodeBlock
 						code={`Install Maple in this repo using the maple-onboard skill.\nMy ingest key is ${apiKey || "<your-api-key>"}.`}
 						language="shell"
+						className={REPLAY_BLOCK_CLASS}
 					/>
 				</TabsContent>
 			</Tabs>

--- a/packages/browser-session/src/capture/baseline.test.ts
+++ b/packages/browser-session/src/capture/baseline.test.ts
@@ -43,6 +43,54 @@ describe("startBaselineCapture", () => {
 		expect(events[0]?.targetText).toBeUndefined()
 	})
 
+	it("omits click target text inside an rrweb-blocked subtree", () => {
+		start()
+		// A backup code the user clicks to select: rrweb never serializes it, and this
+		// separate click path must not either.
+		const blocked = document.createElement("div")
+		blocked.className = "rr-block"
+		const code = document.createElement("span")
+		code.textContent = "11112222"
+		blocked.appendChild(code)
+		document.body.appendChild(blocked)
+		code.click()
+
+		expect(events).toHaveLength(1)
+		expect(events[0]?.type).toBe("click")
+		expect(events[0]?.targetSelector).toBe("span")
+		expect(events[0]?.targetText).toBeUndefined()
+		expect(JSON.stringify(events[0])).not.toContain("11112222")
+	})
+
+	// `data-rr-block` is advertised beside `.rr-block` in the README and docs, so
+	// it has to hide a subtree from this path too — not only from rrweb's.
+	it("omits click target text inside a data-rr-block subtree", () => {
+		start()
+		const blocked = document.createElement("div")
+		blocked.setAttribute("data-rr-block", "")
+		const code = document.createElement("span")
+		code.textContent = "33334444"
+		blocked.appendChild(code)
+		document.body.appendChild(blocked)
+		code.click()
+
+		expect(events[0]?.targetText).toBeUndefined()
+		expect(JSON.stringify(events[0])).not.toContain("33334444")
+	})
+
+	it("still captures click target text outside a blocked subtree", () => {
+		start()
+		const blocked = document.createElement("div")
+		blocked.className = "rr-block"
+		document.body.appendChild(blocked)
+		const button = document.createElement("button")
+		button.textContent = "Save changes"
+		document.body.appendChild(button)
+		button.click()
+
+		expect(events[0]?.targetText).toBe("Save changes")
+	})
+
 	it("captures uncaught errors as error-level events", () => {
 		start()
 		window.dispatchEvent(new ErrorEvent("error", { message: "boom" }))

--- a/packages/browser-session/src/capture/interactions.ts
+++ b/packages/browser-session/src/capture/interactions.ts
@@ -1,3 +1,4 @@
+import { isBlocked } from "../privacy-markers"
 import { type Emit, safeEmit } from "./shared"
 
 const MAX_TEXT = 120
@@ -6,7 +7,8 @@ const MAX_TEXT = 120
  * Capture clicks and input events as session events. Listens in the capture
  * phase so it sees interactions even when the host app calls
  * `stopPropagation()`. Input *values* are never recorded; only the target
- * element. Click target text is omitted when `maskAllText` is set.
+ * element. Click target text is omitted when `maskAllText` is set, and when the
+ * target sits inside a blocked (`.rr-block` / `data-rr-block`) subtree.
  */
 export function installInteractionCapture(emit: Emit, maskAllText: boolean): () => void {
 	const onClick = (event: Event): void => {
@@ -15,7 +17,7 @@ export function installInteractionCapture(emit: Emit, maskAllText: boolean): () 
 		safeEmit(emit, {
 			type: "click",
 			targetSelector: selectorOf(target),
-			targetText: maskAllText ? undefined : textOf(target),
+			targetText: maskAllText || isBlocked(target) ? undefined : textOf(target),
 		})
 	}
 

--- a/packages/browser-session/src/privacy-markers.ts
+++ b/packages/browser-session/src/privacy-markers.ts
@@ -1,0 +1,32 @@
+/**
+ * The markup hooks that exclude an element and its subtree from capture.
+ *
+ * Both are documented to customers (`packages/browser/README.md`,
+ * `docs/browser-sdk.md`), so both have to work everywhere capture reads the DOM
+ * — rrweb's replay stream and the distilled interaction stream alike. They live
+ * here rather than in either capture module because a marker honoured by only
+ * one of them is worse than no marker: the page looks redacted and is not.
+ */
+
+/** rrweb's default block class. Declared, not assumed, so it stays in step. */
+export const BLOCK_CLASS = "rr-block"
+
+/** rrweb leaves `blockSelector` null by default, so this must be passed explicitly. */
+export const BLOCK_ATTRIBUTE = "data-rr-block"
+
+export const BLOCK_SELECTOR = `[${BLOCK_ATTRIBUTE}]`
+
+/**
+ * Whether `el` sits inside a blocked subtree. Mirrors rrweb's own ancestor
+ * check so the two capture paths agree on what is hidden.
+ *
+ * Walks parents rather than using `closest()`: no string reaches a selector
+ * parser, so a malformed marker cannot throw into the host app's event handler.
+ */
+export const isBlocked = (el: Element | null): boolean => {
+	for (let node: Element | null = el; node !== null; node = node.parentElement) {
+		if (node.classList?.contains(BLOCK_CLASS)) return true
+		if (node.hasAttribute?.(BLOCK_ATTRIBUTE)) return true
+	}
+	return false
+}

--- a/packages/browser-session/src/replay/record.ts
+++ b/packages/browser-session/src/replay/record.ts
@@ -1,4 +1,5 @@
 import { record } from "rrweb"
+import { BLOCK_SELECTOR } from "../privacy-markers"
 import { markActivity, nextChunkSeq } from "../session/session"
 import type { IngestConfig } from "../platform/transport"
 import { gzip, postSessionBlob, warnDropped, type ChunkMeta } from "../platform/transport"
@@ -175,6 +176,11 @@ export function startRecording(config: IngestConfig, sessionId: string): Recorde
 			if (bufferBytes >= FLUSH_BYTES) void flush()
 		},
 		maskAllInputs: config.maskAllInputs,
+		// The README and docs advertise `data-rr-block` alongside `.rr-block`, but
+		// rrweb defaults `blockSelector` to null — the attribute silently did
+		// nothing, so anyone who marked up sensitive elements from the docs was
+		// still being recorded. Declaring it makes the documented hook real.
+		blockSelector: BLOCK_SELECTOR,
 		// rrweb has no `maskAllText` flag; selecting all elements masks every text node.
 		...(config.maskAllText ? { maskTextSelector: "*" } : undefined),
 		checkoutEveryNms: CHECKOUT_EVERY_MS,


### PR DESCRIPTION
`data-rr-block` is advertised beside `.rr-block` in the browser SDK's README and
docs, but the recorder never set rrweb's `blockSelector`, which defaults to
null — so the attribute did nothing, and anyone who marked up sensitive elements
from the documentation was still having them recorded. Declaring it makes the
documented hook real.

The distilled click stream is a second capture path that never honoured either
marker: it records up to 120 characters of the target's text, and the dashboard
runs with `maskAllText` false. Both markers now hide a subtree from it as well.
They live in one module because a marker honoured by only one path is worse than
no marker — the page looks redacted and is not.

Two places in the dashboard relied on that: two-factor enrollment renders the QR
and the backup codes as text (the setup key is a readonly input, which
`maskAllInputs` already covered), and guided setup interpolates the org's ingest
key into a snippet. Both now carry the block class. Marking the enrollment
dialog rather than each field covers the regenerate-codes flow, which reuses it.

The event shape is unchanged and a page using no marker records exactly as
before, but this is customer-visible behaviour in a published SDK and wants a
release note.
---

### Stack

Part of a 9-PR security stack off `main`. Each PR is based on the one above it, so **review and merge in order**; each commit typechecks standalone.

1. `sec/01-ci-supply-chain` — supply chain: pinned downloads and installers
2. `sec/02-v2-scope-enforcement` — v2 API key scope enforcement
3. `sec/03-admin-role-gates` — missing org-admin checks
4. `sec/04-oauth-return-to` — OAuth `returnTo` validation
5. `sec/05-canonical-api-origin` — discovery documents from configured origin
6. `sec/06-session-replay-privacy` — replay block markers
7. `sec/07-outbound-request-hardening` — outbound credentials and redirects
8. `sec/08-scrape-target-authz` — scrape target authorization and credentials
9. `sec/09-membership-revocation` — revocation on member/org removal

Findings came from a `deepsec` scan triaged down to the real defects; each was verified against `HEAD` before being fixed, and each fix was reviewed adversarially afterwards. Reproduction detail is deliberately kept out of these descriptions until the fixes are deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849838&installation_model_id=427786&pr_number=716&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F716&signature=bd1d39d9e58b13fe09039bbf707cdb1c842009db9ab3248f9cb2c76c1264943d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->