### PR TITLE
fix: stop forwarding credentials and following redirects on outbound paths

### DIFF
--- a/apps/api/src/http/url-validator.test.ts
+++ b/apps/api/src/http/url-validator.test.ts
@@ -183,6 +183,54 @@ describe("safeFetch", () => {
 		expect(calls).toBe(2)
 	})
 
+	it("drops credential headers on a cross-origin redirect", async () => {
+		const seen: Array<string | null> = []
+		const fakeFetch: typeof fetch = async (_url, init) => {
+			seen.push(new Headers(init?.headers).get("authorization"))
+			return seen.length === 1
+				? new Response(null, { status: 302, headers: { location: "https://attacker.example/steal" } })
+				: new Response("ok", { status: 200 })
+		}
+		const response = await safeFetch("https://api.example.com/metrics", {
+			fetchFn: fakeFetch,
+			headers: { Authorization: "Bearer scrape-secret", Accept: "text/plain" },
+		})
+		expect(response.status).toBe(200)
+		expect(seen).toEqual(["Bearer scrape-secret", null])
+	})
+
+	it("keeps credential headers on a same-origin redirect", async () => {
+		const seen: Array<string | null> = []
+		const fakeFetch: typeof fetch = async (_url, init) => {
+			seen.push(new Headers(init?.headers).get("authorization"))
+			return seen.length === 1
+				? new Response(null, { status: 302, headers: { location: "/metrics/v2" } })
+				: new Response("ok", { status: 200 })
+		}
+		await safeFetch("https://api.example.com/metrics", {
+			fetchFn: fakeFetch,
+			headers: { Authorization: "Bearer scrape-secret" },
+		})
+		expect(seen).toEqual(["Bearer scrape-secret", "Bearer scrape-secret"])
+	})
+
+	it("does not restore credentials when a redirect bounces back to the original origin", async () => {
+		const seen: Array<string | null> = []
+		const hops = ["https://attacker.example/a", "https://api.example.com/back"]
+		const fakeFetch: typeof fetch = async (_url, init) => {
+			seen.push(new Headers(init?.headers).get("authorization"))
+			const location = hops[seen.length - 1]
+			return location === undefined
+				? new Response("ok", { status: 200 })
+				: new Response(null, { status: 302, headers: { location } })
+		}
+		await safeFetch("https://api.example.com/metrics", {
+			fetchFn: fakeFetch,
+			headers: { Authorization: "Bearer scrape-secret" },
+		})
+		expect(seen).toEqual(["Bearer scrape-secret", null, null])
+	})
+
 	it("caps redirect chains", async () => {
 		let calls = 0
 		const fakeFetch: typeof fetch = async () => {

--- a/apps/api/src/http/url-validator.ts
+++ b/apps/api/src/http/url-validator.ts
@@ -189,6 +189,20 @@ export const validateExternalUrl = (raw: string): Effect.Effect<URL, UrlValidati
 
 const MAX_REDIRECTS = 5
 
+/**
+ * Headers that authenticate the caller to a specific origin. Validating a
+ * redirect's destination says it is not internal; it says nothing about whether
+ * it should be handed the credential meant for the origin we started at.
+ */
+const CREDENTIAL_HEADERS = ["authorization", "cookie", "proxy-authorization"] as const
+
+/** Strip credential headers, whatever shape `RequestInit.headers` arrived in. */
+const withoutCredentialHeaders = (headers: HeadersInit | undefined): Headers => {
+	const next = new Headers(headers)
+	for (const name of CREDENTIAL_HEADERS) next.delete(name)
+	return next
+}
+
 export interface SafeFetchOptions extends RequestInit {
 	readonly fetchFn?: typeof fetch
 }
@@ -196,9 +210,18 @@ export interface SafeFetchOptions extends RequestInit {
 export const safeFetch = async (initialUrl: string, init: SafeFetchOptions = {}): Promise<Response> => {
 	const fetchFn = init.fetchFn ?? fetch
 	let currentUrl = initialUrl
+	let headers = init.headers
+	let previousOrigin: string | null = null
 	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
 		const validated = validateExternalUrlSync(currentUrl)
-		const response = await fetchFn(validated.toString(), { ...init, redirect: "manual" })
+		// A cross-origin hop drops the credentials for good: restoring them on a
+		// bounce back to the original origin would make the strip trivially
+		// bypassable by redirecting away and back again.
+		if (previousOrigin !== null && validated.origin !== previousOrigin) {
+			headers = withoutCredentialHeaders(headers)
+		}
+		previousOrigin = validated.origin
+		const response = await fetchFn(validated.toString(), { ...init, headers, redirect: "manual" })
 		if (response.status < 300 || response.status >= 400) return response
 		const location = response.headers.get("location")
 		if (!location) return response

--- a/apps/api/src/services/warehouse/WarehouseQueryService.test.ts
+++ b/apps/api/src/services/warehouse/WarehouseQueryService.test.ts
@@ -20,7 +20,7 @@ import { rawCompiledQuery } from "@maple/query-engine/ch"
 import { parseStatement, type ClickHouseStatement } from "@maple-dev/clickhouse-builder/sql"
 import { EdgeCacheService, MemoryCacheBackendLive } from "@maple/cache"
 import { makeWarehouseExecutor, type ResolvedWarehouseConfig } from "@maple/query-engine/execution"
-import { __testables, WarehouseQueryService } from "./WarehouseQueryService"
+import { __testables, WarehouseQueryService, WarehouseRedirectRefusedError } from "./WarehouseQueryService"
 import {
 	OrgClickHouseSettingsService,
 	type OrgClickHouseSettingsServiceApi,
@@ -966,5 +966,50 @@ describe("isEmptyJsonBodyError (empty Tinybird body ⇒ zero rows)", () => {
 		assert.isFalse(__testables.isEmptyJsonBodyError(new Error("Unexpected end of JSON input")))
 		assert.isFalse(__testables.isEmptyJsonBodyError("Unexpected end of JSON input"))
 		assert.isFalse(__testables.isEmptyJsonBodyError(null))
+	})
+})
+
+describe("BYO ClickHouse redirect refusal", () => {
+	// A BYO endpoint is validated when saved, not when used, so a target that
+	// passed validation and then answers a query with a 307 must not be followed
+	// into the internal network.
+	const chConfig = {
+		kind: "clickhouse" as const,
+		url: "https://ch.example.com",
+		username: "u",
+		password: "p",
+		database: "default",
+	}
+
+	it("refuses a 3xx from the query endpoint and never follows the Location", async () => {
+		const seen: RequestInit[] = []
+		const requestFetch = (async (_input: unknown, init: RequestInit) => {
+			seen.push(init)
+			return new Response("", { status: 307, headers: { location: "http://169.254.169.254/" } })
+		}) as unknown as typeof fetch
+
+		const client = __testables.createClickHouseSqlClient(chConfig, requestFetch)
+		let thrown: unknown
+		try {
+			await client.sql(parseStatement("SELECT 1"), undefined)
+		} catch (error) {
+			thrown = error
+		}
+
+		assert.instanceOf(thrown, WarehouseRedirectRefusedError)
+		assert.match((thrown as Error).message, /redirect responses are not allowed \(307\)/)
+		// The Location is kept as context, so a refusal is diagnosable without
+		// being confusable with an ordinary 4xx from the cluster.
+		assert.strictEqual((thrown as WarehouseRedirectRefusedError).location, "http://169.254.169.254/")
+		// Exactly one request, and it opted out of automatic redirect following.
+		assert.strictEqual(seen.length, 1)
+		assert.strictEqual(seen[0]?.redirect, "manual")
+	})
+
+	it("passes an ordinary 2xx response through untouched", async () => {
+		const requestFetch = (async () =>
+			new Response('{"n":1}\n', { status: 200 })) as unknown as typeof fetch
+		const response = await __testables.redirectRefusingFetch(requestFetch)("https://ch.example.com")
+		assert.strictEqual(response.status, 200)
 	})
 })

--- a/apps/api/src/services/warehouse/WarehouseQueryService.ts
+++ b/apps/api/src/services/warehouse/WarehouseQueryService.ts
@@ -1,6 +1,6 @@
 import { createClient as createClickHouseClient } from "@clickhouse/client-web"
 import { Tinybird } from "@tinybirdco/sdk"
-import { Context, Effect, Layer, Option, Redacted } from "effect"
+import { Context, Effect, Layer, Option, Redacted, Schema } from "effect"
 import { WarehouseConfigError, type WarehouseQueryRequest } from "@maple/domain/http"
 import {
 	BackendDialect,
@@ -38,12 +38,50 @@ import { TinybirdOrgTokenService } from "@/services/integrations/TinybirdOrgToke
 // Re-export the executor types so existing import sites stay stable.
 export type { WarehouseQueryServiceApi, SqlQueryOptions }
 
-const createClickHouseSqlClient = (config: ClickHouseProtocolBackendConfig): WarehouseSqlClient => {
+/**
+ * A ClickHouse-protocol endpoint answering a query with a redirect is never
+ * legitimate, and a BYO cluster's URL is org-configured and validated when
+ * saved, not when used — so a target that passed validation can still answer a
+ * query with a 307 into the internal network. Refused here, and named so it is
+ * distinguishable from an ordinary 4xx (same reasoning as the ingest exporter's
+ * `redirect_refused` drop, which keeps redirects for Tinybird and R2).
+ */
+export class WarehouseRedirectRefusedError extends Schema.TaggedError<WarehouseRedirectRefusedError>()(
+	"@maple/api/warehouse/WarehouseRedirectRefusedError",
+	{
+		status: Schema.Number,
+		location: Schema.optionalKey(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+const redirectRefusingFetch =
+	(requestFetch: typeof fetch = fetch): typeof fetch =>
+	async (input, init) => {
+		const response = await requestFetch(input, { ...init, redirect: "manual" })
+		// `redirect: "manual"` surfaces the 3xx itself on Workers/undici, and an
+		// `opaqueredirect` response (status 0) in browser-shaped runtimes.
+		if ((response.status >= 300 && response.status < 400) || response.type === "opaqueredirect") {
+			const location = response.headers.get("location")
+			throw new WarehouseRedirectRefusedError({
+				status: response.status,
+				...(location === null ? undefined : { location }),
+				message: `ClickHouse redirect responses are not allowed (${response.status})`,
+			})
+		}
+		return response
+	}
+
+const createClickHouseSqlClient = (
+	config: ClickHouseProtocolBackendConfig,
+	requestFetch: typeof fetch = fetch,
+): WarehouseSqlClient => {
 	const client = createClickHouseClient({
 		url: config.url,
 		username: config.username,
 		password: config.password,
 		database: config.database,
+		fetch: redirectRefusingFetch(requestFetch),
 	})
 	// Wire-format parity with the Tinybird SDK: without this, JSONEachRow quotes
 	// 64-bit ints ("count":"42") and every schema-less query leaks strings into
@@ -514,5 +552,6 @@ export const __testables = {
 	createClickHouseSqlClient,
 	createTinybirdSdkSqlClient,
 	boundedResponseFetch,
+	redirectRefusingFetch,
 	isEmptyJsonBodyError,
 }

--- a/apps/electric-sync/src/electric/ElectricClient.test.ts
+++ b/apps/electric-sync/src/electric/ElectricClient.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Duration, Effect, Fiber, Layer, Option, Redacted } from "effect"
+import { Duration, Effect, Fiber, Layer, Option, Redacted, Tracer } from "effect"
 import { TestClock } from "effect/testing"
 import { FetchHttpClient } from "effect/unstable/http"
 import { type RecordedRequest, stubFetch, syncConfigLayer } from "../test-support"
@@ -10,6 +10,7 @@ import {
 	describeUpstreamFailure,
 	ElectricClient,
 	isElectricConfigCoherent,
+	sanitizedUpstreamAttributes,
 } from "./ElectricClient"
 
 const parse = (raw: string) => {
@@ -493,4 +494,108 @@ describe("ElectricClient.fetchShape", () => {
 			assert.strictEqual(response.status, 200)
 		}).pipe(Effect.provide(clientLayer())),
 	)
+})
+
+describe("Electric upstream span never carries the secret", () => {
+	const clientLayer = (config: Parameters<typeof syncConfigLayer>[0] = {}) =>
+		ElectricClient.layer.pipe(
+			Layer.provide(Layer.mergeAll(FetchHttpClient.layer, syncConfigLayer(config))),
+		)
+
+	// Electric has no header for `secret`, so it must stay in the query string —
+	// which makes the traced HTTP client's automatic `url.full` / `url.query` a
+	// telemetry sink for the credential. Maple traces itself, so a leak here is a
+	// leak into a queryable warehouse.
+	const secretLayer = clientLayer({ ELECTRIC_SECRET: Option.some(Redacted.make("sh_secret")) })
+
+	it.effect("records no url.full / url.query on any span of the request", () =>
+		Effect.gen(function* () {
+			const spans: Array<Tracer.NativeSpan> = []
+			const tracer = Tracer.make({
+				span(options) {
+					const span = new Tracer.NativeSpan(options)
+					spans.push(span)
+					return span
+				},
+			})
+			const recorded: Array<RecordedRequest> = []
+
+			const response = yield* (yield* ElectricClient)
+				.fetchShape(syncRequest("dashboards", { query: "offset=-1" }), "org_live")
+				.pipe(
+					Effect.provideService(
+						FetchHttpClient.Fetch,
+						stubFetch(recorded, () => Response.json([])),
+					),
+					Effect.provideService(Tracer.Tracer, tracer),
+				)
+
+			assert.strictEqual(response.status, 200)
+			// The secret really was sent — the span is what must not carry it.
+			assert.include(recorded[0]?.url ?? "", "secret=sh_secret")
+			assert.isAbove(spans.length, 0)
+			for (const span of spans) {
+				assert.isUndefined(span.attributes.get("url.full"))
+				assert.isUndefined(span.attributes.get("url.query"))
+				for (const value of span.attributes.values()) {
+					assert.notInclude(String(value), "sh_secret")
+				}
+			}
+			const client = spans.find((span) => span.name === "http.client GET")
+			assert.isDefined(client)
+			assert.strictEqual(client?.attributes.get("url.path"), "/v1/shape")
+			assert.strictEqual(client?.attributes.get("peer.service"), "electric")
+			assert.strictEqual(client?.attributes.get("http.response.status_code"), 200)
+		}).pipe(Effect.provide(secretLayer)),
+	)
+
+	it.effect("keeps the secret out of the span when the upstream is unreachable", () =>
+		Effect.gen(function* () {
+			const spans: Array<Tracer.NativeSpan> = []
+			const tracer = Tracer.make({
+				span(options) {
+					const span = new Tracer.NativeSpan(options)
+					spans.push(span)
+					return span
+				},
+			})
+
+			const error = yield* (yield* ElectricClient)
+				.fetchShape(syncRequest("dashboards"), "org_live")
+				.pipe(
+					Effect.provideService(FetchHttpClient.Fetch, () => {
+						throw new Error("ECONNREFUSED")
+					}),
+					Effect.provideService(Tracer.Tracer, tracer),
+					Effect.flip,
+				)
+
+			assert.notInclude(error.message, "sh_secret")
+			for (const span of spans) {
+				for (const value of span.attributes.values()) {
+					assert.notInclude(String(value), "sh_secret")
+				}
+				// The recorded exit is a sink too: an HttpClientError's own text is
+				// "Transport error (GET <full url>)".
+				assert.notInclude(
+					JSON.stringify(span.status, (_key, value) =>
+						typeof value === "bigint" ? value.toString() : value,
+					),
+					"sh_secret",
+				)
+			}
+		}).pipe(Effect.provide(secretLayer)),
+	)
+
+	it("omits the url.full / url.query attributes entirely", () => {
+		const attributes = sanitizedUpstreamAttributes(
+			"http://electric:3000/v1/shape?secret=sh_secret&table=dashboards",
+			"dashboards",
+		)
+		assert.isUndefined(attributes["url.full"])
+		assert.isUndefined(attributes["url.query"])
+		assert.strictEqual(attributes["url.path"], "/v1/shape")
+		assert.strictEqual(attributes["server.address"], "electric:3000")
+		for (const value of Object.values(attributes)) assert.notInclude(value, "sh_secret")
+	})
 })

--- a/apps/electric-sync/src/electric/ElectricClient.ts
+++ b/apps/electric-sync/src/electric/ElectricClient.ts
@@ -60,6 +60,26 @@ export const describeUpstreamFailure = (error: unknown): string => {
 	return redactSecrets(cause === undefined ? text : `${text}: ${cause}`)
 }
 
+/**
+ * The client span's attributes, with the query string structurally absent
+ * rather than scrubbed — `secret` cannot leak through an attribute that is
+ * never written. `url.full` and `url.query` are deliberately NOT among them;
+ * everything a trace needs to identify the hop (target, path, shape) is.
+ *
+ * Exported so the omission is asserted directly, not inferred from a span.
+ */
+export const sanitizedUpstreamAttributes = (upstreamUrl: string, shape: string): Record<string, string> => {
+	const url = new URL(upstreamUrl)
+	return {
+		"http.request.method": "GET",
+		"server.address": url.host,
+		"url.path": url.pathname,
+		"url.scheme": url.protocol.slice(0, -1),
+		"peer.service": "electric",
+		"maple.electric.shape": shape,
+	}
+}
+
 const isLiveRequest = (clientParams: URLSearchParams): boolean => {
 	const live = clientParams.get("live")
 	return live !== null && live !== "false"
@@ -241,7 +261,12 @@ export class ElectricClient extends Context.Service<ElectricClient, ElectricClie
 				// (not an open SSE stream), and control-plane shapes are small, so we
 				// buffer the body rather than manage a scoped pass-through stream.
 				const fetched = client.get(url).pipe(
-					Effect.annotateSpans("peer.service", "electric"),
+					// Electric authenticates a shape request with `secret` in the query
+					// string and offers no header equivalent, so the HTTP client's own
+					// span — which records `url.full` and `url.query` verbatim — would
+					// write the credential into Maple's warehouse. Its span is suppressed
+					// and replaced by the sanitized one below, which never sees a query.
+					Effect.provideService(HttpClient.TracerDisabledWhen, () => true),
 					Effect.flatMap((response) =>
 						response.text.pipe(Effect.map((body) => ({ response, body }))),
 					),
@@ -254,13 +279,22 @@ export class ElectricClient extends Context.Service<ElectricClient, ElectricClie
 				).pipe(
 					// One mapping for transport failures and timeouts alike: the cause
 					// travels in the message instead of the mutable closure variable this
-					// replaces, so the span can say what actually went wrong.
+					// replaces, so the span can say what actually went wrong. Mapped
+					// INSIDE the span below: an `HttpClientError`'s raw text is
+					// "Transport error (GET <full url>)", secret included.
 					Effect.mapError(
 						(error) =>
 							new ElectricUpstreamUnreachable({
 								message: `Electric upstream unreachable (${request.shape}): ${describeUpstreamFailure(error)}`,
 							}),
 					),
+					Effect.tap(({ response }) =>
+						Effect.annotateCurrentSpan("http.response.status_code", response.status),
+					),
+					Effect.withSpan("http.client GET", {
+						kind: "client",
+						attributes: sanitizedUpstreamAttributes(url, request.shape),
+					}),
 					Effect.tapError((error) =>
 						Effect.logWarning("Electric shape upstream request failed").pipe(
 							Effect.annotateLogs({ shape: request.shape, error: error.message }),

--- a/apps/ingest/src/main.rs
+++ b/apps/ingest/src/main.rs
@@ -2610,6 +2610,17 @@ async fn accept_grpc_decoded(
     resolved: &ResolvedIngestKey,
     decoded_bytes: usize,
 ) -> Result<(), tonic::Status> {
+    // The sentinel token is a PUBLIC constant, so anything it carries is
+    // attacker-authored and must never be stored. Discarded here for the same
+    // reasons and with the same shape as `handle_signal_inner`'s HTTP
+    // short-circuit: success to the client, nothing resolved, nothing forwarded.
+    if resolved.org_id == SENTINEL_ORG_ID {
+        metrics::sentinel(signal.path());
+        Span::current().record("maple.ingest.key_type", "sentinel");
+        debug!("Sentinel token; skipping forward");
+        return Ok(());
+    }
+
     let _org_inflight_permit = state
         .org_inflight_limiter
         .try_acquire(&resolved.org_id)
@@ -8426,6 +8437,97 @@ mod tests {
                 error.kind()
             );
         }
+    }
+
+    /// `MAPLE_TEST` is a PUBLIC constant, so a sentinel export is
+    /// attacker-authored: it must look successful and store nothing. The HTTP
+    /// path discards in `handle_signal_inner`; this pins the gRPC twin, which
+    /// used to run `process_decoded_payload` unconditionally.
+    #[tokio::test]
+    async fn sentinel_grpc_export_writes_nothing() {
+        let (forward_tx, mut forward_rx) = tokio::sync::mpsc::unbounded_channel();
+        let forward_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let forward_addr = forward_listener.local_addr().unwrap();
+        let forward_app = Router::new()
+            .route("/v1/logs", post(fake_forward_collector))
+            .with_state(forward_tx);
+        tokio::spawn(async move {
+            axum::serve(forward_listener, forward_app).await.unwrap();
+        });
+
+        let queue_dir = unique_main_test_dir("grpc-sentinel");
+        let store = Arc::new(FakeKeyStore::default());
+        let raw_key = "maple_sk_test_grpc_sentinel";
+        store.insert_private(
+            raw_key,
+            KeyRow {
+                org_id: "org_grpc_sentinel".to_owned(),
+                self_managed: false,
+                clickhouse_ready: false,
+            },
+        );
+        let state = test_app_state(
+            Arc::clone(&store),
+            queue_dir.clone(),
+            format!("http://{forward_addr}"),
+            Duration::from_millis(5),
+        )
+        .await;
+
+        let mut metadata = tonic::metadata::MetadataMap::new();
+        metadata.insert("authorization", "Bearer MAPLE_TEST".parse().unwrap());
+        let sentinel = resolve_grpc_ingest_key(&state, &metadata)
+            .await
+            .expect("the sentinel token authenticates");
+        assert_eq!(sentinel.org_id, SENTINEL_ORG_ID);
+
+        let payload = test_log_request("sentinel over grpc");
+        let decoded_bytes = payload.encoded_len();
+        accept_grpc_decoded(
+            &state,
+            Signal::Logs,
+            DecodedPayload::Logs(payload),
+            &sentinel,
+            decoded_bytes,
+        )
+        .await
+        .expect("a sentinel export must look successful to the client");
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), forward_rx.recv())
+                .await
+                .is_err(),
+            "the sentinel org must not write telemetry"
+        );
+
+        // The same harness with a real key, so the assertion above cannot pass
+        // because nothing was ever wired up.
+        let resolved = state
+            .resolver
+            .resolve_ingest_key(raw_key)
+            .await
+            .expect("resolution should not fail")
+            .expect("the test key resolves");
+        let real = test_log_request("real key over grpc");
+        let real_bytes = real.encoded_len();
+        accept_grpc_decoded(
+            &state,
+            Signal::Logs,
+            DecodedPayload::Logs(real),
+            &resolved,
+            real_bytes,
+        )
+        .await
+        .expect("a real export is accepted");
+        let forwarded = tokio::time::timeout(Duration::from_secs(2), forward_rx.recv())
+            .await
+            .expect("a real key forwards")
+            .expect("forward channel should stay open");
+        assert!(forwarded.body_len > 0);
+
+        drop(std::fs::remove_dir_all(&queue_dir));
     }
 
     #[tokio::test]


### PR DESCRIPTION
`safeFetch` re-validated every redirect destination but spread the caller's
headers into each hop unchanged. Validating where a redirect points says nothing
about whether it should be handed the credential meant for the origin we started
at. Credential headers are now dropped on any cross-origin hop, and dropped for
good — restoring them when a redirect returns to the original origin would make
the strip bypassable.

That strip is a deny-list, which holds only because no caller sets a custom
header today; a webhook config that gains arbitrary headers would need an
allow-list instead.

The BYO ClickHouse client followed redirects for the same reason the Rust
exporter used to: the endpoint is validated when saved, not when used. #709
fixed the exporter; this does the TypeScript path, refusing 3xx with a
distinguishable error. The Tinybird SDK path keeps its policy, since Tinybird
and R2 legitimately redirect.

Electric authenticates with its secret in the query string and offers no header
form, so the fix is to stop recording it: the HTTP client's automatic span is
disabled for those requests and replaced with one carrying no query string, with
the error redaction now running inside it. ELECTRIC_SECRET should be rotated —
it may already sit in stored telemetry.

The public sentinel ingest token was discarded on the HTTP path but not on gRPC.
It now short-circuits before the in-flight permit, matching the HTTP discard.
---

### Stack

Part of a 9-PR security stack off `main`. Each PR is based on the one above it, so **review and merge in order**; each commit typechecks standalone.

1. `sec/01-ci-supply-chain` — supply chain: pinned downloads and installers
2. `sec/02-v2-scope-enforcement` — v2 API key scope enforcement
3. `sec/03-admin-role-gates` — missing org-admin checks
4. `sec/04-oauth-return-to` — OAuth `returnTo` validation
5. `sec/05-canonical-api-origin` — discovery documents from configured origin
6. `sec/06-session-replay-privacy` — replay block markers
7. `sec/07-outbound-request-hardening` — outbound credentials and redirects
8. `sec/08-scrape-target-authz` — scrape target authorization and credentials
9. `sec/09-membership-revocation` — revocation on member/org removal

Findings came from a `deepsec` scan triaged down to the real defects; each was verified against `HEAD` before being fixed, and each fix was reviewed adversarially afterwards. Reproduction detail is deliberately kept out of these descriptions until the fixes are deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849840&installation_model_id=427786&pr_number=717&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F717&signature=e17548355eea9e6390dee3f3f21672b4b0979123d2221c9ebed060c755f3077c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->