### PR TITLE
fix(scrape-targets): admin-gate mutations and unbind credentials from a changed origin

### DIFF
--- a/apps/api/src/routes/v2/config-resources.http.test.ts
+++ b/apps/api/src/routes/v2/config-resources.http.test.ts
@@ -428,6 +428,48 @@ describe("v2 scrape_targets over HTTP", () => {
 		await harness.dispose()
 	})
 
+	it("refuses scrape-target writes from a non-admin member", async () => {
+		const harness = makeHarness()
+		const adminKey = await harness.bootstrapKey()
+		const memberKey = await harness.bootstrapMemberKey()
+
+		const created = await harness.request("POST", "/v2/scrape_targets", {
+			token: adminKey.secret,
+			body: {
+				name: "payments prometheus",
+				url: "https://example.com:1/metrics",
+				target_type: "prometheus",
+			},
+		})
+		expect(created.status).toBe(200)
+
+		// A member keeps the reads — the credential itself is never returned.
+		const listed = await harness.request("GET", "/v2/scrape_targets", { token: memberKey.secret })
+		expect(listed.status).toBe(200)
+
+		for (const [method, path, body] of [
+			["POST", "/v2/scrape_targets", { name: "member target", url: "https://example.com:1/m" }],
+			["PATCH", `/v2/scrape_targets/${created.body.id}`, { url: "https://evil.example.com/m" }],
+			["POST", `/v2/scrape_targets/${created.body.id}/probe`, undefined],
+			["DELETE", `/v2/scrape_targets/${created.body.id}`, undefined],
+		] as const) {
+			const denied = await harness.request(method, path, {
+				token: memberKey.secret,
+				...(body !== undefined ? { body } : undefined),
+			})
+			expect(denied.status).toBe(403)
+			expect(denied.body.error.type).toBe("permission_error")
+		}
+
+		// Still there, still untouched.
+		const after = await harness.request("GET", `/v2/scrape_targets/${created.body.id}`, {
+			token: adminKey.secret,
+		})
+		expect(after.status).toBe(200)
+		expect(after.body.url).toBe("https://example.com:1/metrics")
+		await harness.dispose()
+	})
+
 	it("paginates scrape checks beyond the former 200-row window", async () => {
 		const harness = makeHarness()
 		const key = await harness.bootstrapKey()

--- a/apps/api/src/routes/v2/scrape-targets.http.ts
+++ b/apps/api/src/routes/v2/scrape-targets.http.ts
@@ -1,10 +1,24 @@
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import type { ScrapeTargetResponse } from "@maple/domain/http"
 import { CreateScrapeTargetRequest, CurrentTenant, UpdateScrapeTargetRequest } from "@maple/domain/http"
-import { MapleApiV2, paginateArray, paginateOffsetQuery, timestamp } from "@maple/domain/http/v2"
+import {
+	MapleApiV2,
+	paginateArray,
+	paginateOffsetQuery,
+	timestamp,
+	V2InsufficientPermissions,
+} from "@maple/domain/http/v2"
 import type { V2ScrapeTarget, V2ScrapeTargetCheck } from "@maple/domain/http/v2"
 import { Effect } from "effect"
 import { ScrapeTargetsService } from "@/services/integrations/ScrapeTargetsService"
+import { requireAdmin } from "@/services/auth/auth"
+
+// Every write is admin-gated: a scrape target stores credentials and makes
+// Maple's infrastructure fetch an operator-chosen URL, so `probe` (which sends
+// the stored credential on demand) is a write, not a read. Reads stay on the
+// `scrape_targets:read` scope — they never expose the credential itself.
+const adminOnly = (action: string) => () =>
+	V2InsufficientPermissions.make(`Only org admins can ${action} scrape targets`)
 
 const toV2ScrapeTarget = (target: ScrapeTargetResponse): V2ScrapeTarget => ({
 	id: target.id,
@@ -52,6 +66,7 @@ export const HttpV2ScrapeTargetsLive = HttpApiBuilder.group(MapleApiV2, "scrapeT
 			.handle("create", ({ payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(tenant.roles, adminOnly("create"))
 					const created = yield* service.create(
 						tenant.orgId,
 						new CreateScrapeTargetRequest({
@@ -102,6 +117,7 @@ export const HttpV2ScrapeTargetsLive = HttpApiBuilder.group(MapleApiV2, "scrapeT
 			.handle("update", ({ params, payload }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(tenant.roles, adminOnly("update"))
 					const updated = yield* service.update(
 						tenant.orgId,
 						params.id,
@@ -150,6 +166,7 @@ export const HttpV2ScrapeTargetsLive = HttpApiBuilder.group(MapleApiV2, "scrapeT
 			.handle("delete", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(tenant.roles, adminOnly("delete"))
 					const deleted = yield* service.delete(tenant.orgId, params.id)
 
 					return { id: deleted.id, object: "scrape_target" as const, deleted: true as const }
@@ -158,6 +175,7 @@ export const HttpV2ScrapeTargetsLive = HttpApiBuilder.group(MapleApiV2, "scrapeT
 			.handle("probe", ({ params }) =>
 				Effect.gen(function* () {
 					const tenant = yield* CurrentTenant.Context
+					yield* requireAdmin(tenant.roles, adminOnly("probe"))
 					const result = yield* service.probe(tenant.orgId, params.id)
 
 					return {

--- a/apps/api/src/services/integrations/PlanetScaleConnectionService.ts
+++ b/apps/api/src/services/integrations/PlanetScaleConnectionService.ts
@@ -488,20 +488,27 @@ export class PlanetScaleConnectionService extends Context.Service<
 					// enabled only if the bearer probe passed.
 					const keepsToken =
 						adoptable.authType === "token" && adoptable.authCredentialsCiphertext !== null
-					yield* scrapeTargetsService.update(orgId, adoptable.id, {
-						...(!keepsToken ? { authType: "planetscale_oauth" } : undefined),
-						...(request.includeBranches !== undefined
-							? {
-									includeBranches: request.includeBranches,
-								}
-							: undefined),
-						...(request.excludeBranches !== undefined
-							? {
-									excludeBranches: request.excludeBranches,
-								}
-							: undefined),
-						enabled: keepsToken || permissions.readMetricsEndpoints,
-					})
+					yield* scrapeTargetsService.update(
+						orgId,
+						adoptable.id,
+						{
+							...(!keepsToken ? { authType: "planetscale_oauth" } : undefined),
+							...(request.includeBranches !== undefined
+								? {
+										includeBranches: request.includeBranches,
+									}
+								: undefined),
+							...(request.excludeBranches !== undefined
+								? {
+										excludeBranches: request.excludeBranches,
+									}
+								: undefined),
+							enabled: keepsToken || permissions.readMetricsEndpoints,
+						},
+						// The integration owns this row, so it writes past the
+						// managed-row guard the generic scrape API is held to.
+						{ allowManaged: true },
+					)
 					scrapeTargetId = adoptable.id
 				} else {
 					const created = yield* scrapeTargetsService.create(orgId, {
@@ -618,23 +625,25 @@ export class PlanetScaleConnectionService extends Context.Service<
 						Effect.mapError(toPersistenceError),
 						Effect.tapError(() =>
 							createdTarget
-								? scrapeTargetsService.delete(orgId, scrapeTargetId).pipe(
-										Effect.catchTag(
-											"@maple/http/errors/ScrapeTargetNotFoundError",
-											() => Effect.void,
-										),
-										Effect.catch((error) =>
-											Effect.logWarning(
-												"Failed to compensate newly created PlanetScale target after binding failure",
-											).pipe(
-												Effect.annotateLogs({
-													orgId,
-													scrapeTargetId,
-													error: String(error),
-												}),
+								? scrapeTargetsService
+										.delete(orgId, scrapeTargetId, { allowManaged: true })
+										.pipe(
+											Effect.catchTag(
+												"@maple/http/errors/ScrapeTargetNotFoundError",
+												() => Effect.void,
 											),
-										),
-									)
+											Effect.catch((error) =>
+												Effect.logWarning(
+													"Failed to compensate newly created PlanetScale target after binding failure",
+												).pipe(
+													Effect.annotateLogs({
+														orgId,
+														scrapeTargetId,
+														error: String(error),
+													}),
+												),
+											),
+										)
 								: Effect.void,
 						),
 					)
@@ -700,11 +709,16 @@ export class PlanetScaleConnectionService extends Context.Service<
 					}),
 				)
 			}
-			yield* scrapeTargetsService.update(orgId, target.id, {
-				authType: "token",
-				authCredentials: JSON.stringify({ tokenId, tokenSecret: request.tokenSecret }),
-				enabled: true,
-			})
+			yield* scrapeTargetsService.update(
+				orgId,
+				target.id,
+				{
+					authType: "token",
+					authCredentials: JSON.stringify({ tokenId, tokenSecret: request.tokenSecret }),
+					enabled: true,
+				},
+				{ allowManaged: true },
+			)
 
 			return yield* getStatus(orgId)
 		})
@@ -718,16 +732,16 @@ export class PlanetScaleConnectionService extends Context.Service<
 				// owns it (a user-created row adopted by a *different* connection stays).
 				const target = yield* selectManagedTarget(connection)
 				if (target !== null && target.managedBy === managedByForConnection(connection.id)) {
-					yield* scrapeTargetsService
-						.delete(orgId, target.id)
-						.pipe(
-							Effect.catchTag("@maple/http/errors/ScrapeTargetNotFoundError", () =>
-								Effect.annotateCurrentSpan(
-									"maple.planetscale.disconnect_target_missing",
-									true,
-								),
-							),
-						)
+					yield* scrapeTargetsService.delete(orgId, target.id, { allowManaged: true }).pipe(
+						Effect.catchTag("@maple/http/errors/ScrapeTargetNotFoundError", () =>
+							Effect.annotateCurrentSpan("maple.planetscale.disconnect_target_missing", true),
+						),
+						// `allowManaged` is the only thing delete validates, so this
+						// branch is unreachable — a reachable one is a bug, not a 400.
+						Effect.catchTag("@maple/http/errors/ScrapeTargetValidationError", (error) =>
+							Effect.die(error),
+						),
+					)
 				}
 
 				yield* database

--- a/apps/api/src/services/integrations/ScrapeTargetsService.test.ts
+++ b/apps/api/src/services/integrations/ScrapeTargetsService.test.ts
@@ -736,6 +736,112 @@ describe("ScrapeTargetsService", () => {
 		}).pipe(Effect.provide(makeLayer(testDb)))
 	})
 
+	it.effect("refuses to carry stored credentials to a new origin", () => {
+		const testDb = createTestDb(trackedDbs)
+		return Effect.gen(function* () {
+			const service = yield* ScrapeTargetsService
+			const orgId = asOrgId("org_1")
+			const target = yield* service.create(
+				orgId,
+				new CreateScrapeTargetRequest({
+					name: "Node Exporter",
+					url: "https://metrics.example.com/metrics",
+					authType: "bearer",
+					authCredentials: JSON.stringify({ token: "stored-token" }),
+				}),
+			)
+			assert.isTrue(target.hasCredentials)
+
+			// Repointing at an attacker-controlled host without re-supplying the
+			// credential is exactly the exfiltration path: it must not persist.
+			const error = yield* service
+				.update(
+					orgId,
+					target.id,
+					new UpdateScrapeTargetRequest({ url: "https://attacker.example.com/metrics" }),
+				)
+				.pipe(Effect.flip)
+			assert.strictEqual(error._tag, "@maple/http/errors/ScrapeTargetValidationError")
+			assert.include(error.message, "re-supplying authCredentials")
+
+			const unchanged = yield* service.get(orgId, target.id)
+			assert.strictEqual(unchanged.url, "https://metrics.example.com/metrics")
+			assert.isTrue(unchanged.hasCredentials)
+
+			// A port change is an origin change too.
+			const portError = yield* service
+				.update(
+					orgId,
+					target.id,
+					new UpdateScrapeTargetRequest({ url: "https://metrics.example.com:8443/metrics" }),
+				)
+				.pipe(Effect.flip)
+			assert.strictEqual(portError._tag, "@maple/http/errors/ScrapeTargetValidationError")
+
+			// Same origin, different path: nothing moves, so the credential stays.
+			const samePath = yield* service.update(
+				orgId,
+				target.id,
+				new UpdateScrapeTargetRequest({ url: "https://metrics.example.com/other" }),
+			)
+			assert.strictEqual(samePath.url, "https://metrics.example.com/other")
+			assert.isTrue(samePath.hasCredentials)
+
+			// Re-supplying the credential in the same request is the way across.
+			const moved = yield* service.update(
+				orgId,
+				target.id,
+				new UpdateScrapeTargetRequest({
+					url: "https://other.example.com/metrics",
+					authCredentials: JSON.stringify({ token: "fresh-token" }),
+				}),
+			)
+			assert.strictEqual(moved.url, "https://other.example.com/metrics")
+			assert.isTrue(moved.hasCredentials)
+		}).pipe(Effect.provide(makeLayer(testDb)))
+	})
+
+	it.effect("refuses generic update/delete against an integration-managed target", () => {
+		const testDb = createTestDb(trackedDbs)
+		return Effect.gen(function* () {
+			const service = yield* ScrapeTargetsService
+			const orgId = asOrgId("org_1")
+			const target = yield* service.create(
+				orgId,
+				new CreateScrapeTargetRequest({
+					name: "Managed target",
+					url: "https://metrics.example.com/metrics",
+				}),
+			)
+			yield* Effect.promise(() =>
+				executeSql(testDb, "UPDATE scrape_targets SET managed_by = $1 WHERE id = $2", [
+					"planetscale:conn_1",
+					target.id,
+				]),
+			)
+
+			const updateError = yield* service
+				.update(orgId, target.id, new UpdateScrapeTargetRequest({ enabled: false }))
+				.pipe(Effect.flip)
+			assert.strictEqual(updateError._tag, "@maple/http/errors/ScrapeTargetValidationError")
+			assert.include(updateError.message, "managed by an integration")
+
+			const deleteError = yield* service.delete(orgId, target.id).pipe(Effect.flip)
+			assert.strictEqual(deleteError._tag, "@maple/http/errors/ScrapeTargetValidationError")
+
+			// The owning integration still writes through.
+			const disabled = yield* service.update(
+				orgId,
+				target.id,
+				new UpdateScrapeTargetRequest({ enabled: false }),
+				{ allowManaged: true },
+			)
+			assert.isFalse(disabled.enabled)
+			const deleted = yield* service.delete(orgId, target.id, { allowManaged: true })
+			assert.strictEqual(deleted.id, target.id)
+		}).pipe(Effect.provide(makeLayer(testDb)))
+	})
+
 	it.effect("prometheus targets reject the planetscale_oauth auth type", () => {
 		const testDb = createTestDb(trackedDbs)
 		return Effect.gen(function* () {

--- a/apps/api/src/services/integrations/ScrapeTargetsService.ts
+++ b/apps/api/src/services/integrations/ScrapeTargetsService.ts
@@ -76,6 +76,16 @@ const parseRetryAfterSeconds = (value: string | null): number | null => {
 	return Number.isFinite(seconds) && seconds >= 0 ? seconds : null
 }
 
+/**
+ * Mutation options for the scrape-target write paths. Integration-owned rows
+ * (`managedBy` set) are refused by default so a generic `scrape_targets:write`
+ * caller cannot delete, disable, or re-credential a row an integration owns;
+ * the owning integration passes `allowManaged` for its own writes.
+ */
+export interface ScrapeTargetMutationOptions {
+	readonly allowManaged?: boolean
+}
+
 export interface ScrapeTargetsServiceApi {
 	readonly list: (
 		orgId: OrgId,
@@ -101,6 +111,7 @@ export interface ScrapeTargetsServiceApi {
 		orgId: OrgId,
 		targetId: ScrapeTargetId,
 		request: UpdateScrapeTargetRequest,
+		options?: ScrapeTargetMutationOptions,
 	) => Effect.Effect<
 		ScrapeTargetResponse,
 		| ScrapeTargetNotFoundError
@@ -112,7 +123,11 @@ export interface ScrapeTargetsServiceApi {
 	readonly delete: (
 		orgId: OrgId,
 		targetId: ScrapeTargetId,
-	) => Effect.Effect<ScrapeTargetDeleteResponse, ScrapeTargetNotFoundError | ScrapeTargetPersistenceError>
+		options?: ScrapeTargetMutationOptions,
+	) => Effect.Effect<
+		ScrapeTargetDeleteResponse,
+		ScrapeTargetNotFoundError | ScrapeTargetValidationError | ScrapeTargetPersistenceError
+	>
 	readonly listAllEnabled: (
 		interval?: ScrapeIntervalSeconds,
 	) => Effect.Effect<ReadonlyArray<ScrapeTargetRow>, ScrapeTargetPersistenceError>
@@ -407,6 +422,37 @@ const validateUrl = (url: string) => {
 		),
 	)
 }
+
+/**
+ * Scheme + host + port equality over parsed URLs (a string compare would miss
+ * normalization and default ports). An unparseable side counts as a change:
+ * failing closed keeps a stored credential from following an unknown origin.
+ */
+const isSameOrigin = (left: string, right: string): boolean => {
+	const parse = Option.liftThrowable((value: string) => new URL(value))
+	const a = parse(left)
+	const b = parse(right)
+	if (Option.isNone(a) || Option.isNone(b)) return false
+	return (
+		a.value.protocol === b.value.protocol &&
+		a.value.hostname === b.value.hostname &&
+		a.value.port === b.value.port
+	)
+}
+
+/** Integration-owned rows are edited through the owning integration, not the generic API. */
+const rejectManaged = (
+	row: ScrapeTargetRow,
+	options: ScrapeTargetMutationOptions | undefined,
+	verb: string,
+) =>
+	options?.allowManaged !== true && row.managedBy !== null
+		? Effect.fail(
+				new ScrapeTargetValidationError({
+					message: `This scrape target is managed by an integration (${row.managedBy}); ${verb} it through that integration instead`,
+				}),
+			)
+		: Effect.void
 
 const validateInterval = (seconds: number | undefined) => {
 	if (seconds === undefined) return Effect.void
@@ -797,9 +843,11 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 				orgId: OrgId,
 				targetId: ScrapeTargetId,
 				request: UpdateScrapeTargetRequest,
+				options?: ScrapeTargetMutationOptions,
 			) {
 				yield* Effect.annotateCurrentSpan({ orgId, scrapeTargetId: targetId })
 				const existing = yield* requireTarget(orgId, targetId)
+				yield* rejectManaged(existing, options, "edit")
 				const isPlanetScale = existing.targetType === "planetscale"
 
 				if (isPlanetScale && request.url !== undefined) {
@@ -860,8 +908,15 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 					unknown
 				>
 
+				// Tracked separately from `updates` so the origin check below reads a
+				// typed value rather than digging back out of the untyped patch.
+				let nextUrl: string | null = null
+
 				if (request.name !== undefined) updates.name = request.name.trim()
-				if (request.url !== undefined && request.url !== null) updates.url = request.url.trim()
+				if (request.url !== undefined && request.url !== null) {
+					nextUrl = request.url.trim()
+					updates.url = nextUrl
+				}
 
 				if (
 					isPlanetScale &&
@@ -895,7 +950,8 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 						request.excludeBranches !== undefined
 							? yield* validateBranchPatterns(request.excludeBranches, "excludeBranches")
 							: (existingConfig?.excludeBranches ?? [])
-					updates.url = planetScaleDiscoveryUrl(organization)
+					nextUrl = planetScaleDiscoveryUrl(organization)
+					updates.url = nextUrl
 					updates.discoveryConfigJson = buildDiscoveryConfig(
 						organization,
 						includeBranches,
@@ -935,6 +991,24 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 					}
 				}
 
+				// A stored credential is bound to the origin it was issued for. Carrying
+				// it across a scheme/host/port change would hand the secret to whoever
+				// controls the new host on the very next scrape or probe.
+				const credentialsRewritten = "authCredentialsCiphertext" in updates
+				if (
+					nextUrl !== null &&
+					existing.authCredentialsCiphertext !== null &&
+					!credentialsRewritten &&
+					!isSameOrigin(existing.url, nextUrl)
+				) {
+					return yield* Effect.fail(
+						new ScrapeTargetValidationError({
+							message:
+								"Changing a scrape target's scheme, host, or port requires re-supplying authCredentials — stored credentials are never carried to a new origin",
+						}),
+					)
+				}
+
 				yield* database
 					.execute((db) =>
 						db
@@ -966,8 +1040,10 @@ export class ScrapeTargetsService extends Context.Service<ScrapeTargetsService, 
 			const remove = Effect.fn("ScrapeTargetsService.delete")(function* (
 				orgId: OrgId,
 				targetId: ScrapeTargetId,
+				options?: ScrapeTargetMutationOptions,
 			) {
 				yield* Effect.annotateCurrentSpan({ orgId, scrapeTargetId: targetId })
+				yield* rejectManaged(yield* requireTarget(orgId, targetId), options, "remove")
 				const rows = yield* database
 					.execute((db) =>
 						db

--- a/packages/domain/src/http/v2/scrape-targets.ts
+++ b/packages/domain/src/http/v2/scrape-targets.ts
@@ -18,7 +18,7 @@ import {
 } from "../scrape-targets"
 import { AuthorizationV2 } from "./auth"
 import { wireExample, ListOf, ListQuery, Timestamp } from "./envelopes"
-import { V2ParameterInvalid } from "./errors"
+import { V2InsufficientPermissions, V2ParameterInvalid } from "./errors"
 import { publicErrors } from "./public-error"
 import { PublicId, PublicIdPrefixes } from "./public-id"
 
@@ -393,13 +393,13 @@ export class V2ScrapeTargetsApiGroup extends HttpApiGroup.make("scrapeTargets")
 		HttpApiEndpoint.post("create", "/", {
 			payload: V2ScrapeTargetCreateParams,
 			success: V2ScrapeTarget,
-			error: [scrapeValidation, scrapePersistence, scrapeEncryption],
+			error: [V2InsufficientPermissions.schema, scrapeValidation, scrapePersistence, scrapeEncryption],
 		}).annotateMerge(
 			OpenApi.annotations({
 				identifier: "createScrapeTarget",
 				summary: "Create a scrape target",
 				description:
-					"Creates a scrape target. `prometheus` targets need a `url`; `planetscale` targets need an `organization` (the URL is derived). Requires the `scrape_targets:write` scope.",
+					"Creates a scrape target. `prometheus` targets need a `url`; `planetscale` targets need an `organization` (the URL is derived). Requires the `scrape_targets:write` scope and an org-admin caller.",
 			}),
 		),
 	)
@@ -423,6 +423,7 @@ export class V2ScrapeTargetsApiGroup extends HttpApiGroup.make("scrapeTargets")
 			payload: V2ScrapeTargetUpdateParams,
 			success: V2ScrapeTarget,
 			error: [
+				V2InsufficientPermissions.schema,
 				scrapeNotFound,
 				scrapeValidation,
 				scrapePersistence,
@@ -434,7 +435,7 @@ export class V2ScrapeTargetsApiGroup extends HttpApiGroup.make("scrapeTargets")
 				identifier: "updateScrapeTarget",
 				summary: "Update a scrape target",
 				description:
-					"Updates a target's configuration; omitted fields are unchanged. Requires the `scrape_targets:write` scope.",
+					"Updates a target's configuration; omitted fields are unchanged. Changing the scheme, host, or port of a target that stores credentials requires re-supplying `auth_credentials` in the same request — stored credentials are never carried to a new origin. Targets owned by an integration (`managed_by` set) are edited through that integration. Requires the `scrape_targets:write` scope and an org-admin caller.",
 			}),
 		),
 	)
@@ -442,13 +443,13 @@ export class V2ScrapeTargetsApiGroup extends HttpApiGroup.make("scrapeTargets")
 		HttpApiEndpoint.delete("delete", "/:id", {
 			params: { id: ScrapeTargetPublicId },
 			success: V2ScrapeTargetDeleteResponse,
-			error: [scrapeNotFound, scrapePersistence],
+			error: [V2InsufficientPermissions.schema, scrapeNotFound, scrapeValidation, scrapePersistence],
 		}).annotateMerge(
 			OpenApi.annotations({
 				identifier: "deleteScrapeTarget",
 				summary: "Delete a scrape target",
 				description:
-					"Permanently deletes a scrape target and stops scraping it. Already-ingested metrics are unaffected. Requires the `scrape_targets:write` scope.",
+					"Permanently deletes a scrape target and stops scraping it. Already-ingested metrics are unaffected. Targets owned by an integration (`managed_by` set) are removed through that integration. Requires the `scrape_targets:write` scope and an org-admin caller.",
 			}),
 		),
 	)
@@ -456,13 +457,19 @@ export class V2ScrapeTargetsApiGroup extends HttpApiGroup.make("scrapeTargets")
 		HttpApiEndpoint.post("probe", "/:id/probe", {
 			params: { id: ScrapeTargetPublicId },
 			success: V2ScrapeTargetProbeResult,
-			error: [scrapeNotFound, scrapePersistence, scrapeEncryption, ...planetScaleAccessTokenErrors],
+			error: [
+				V2InsufficientPermissions.schema,
+				scrapeNotFound,
+				scrapePersistence,
+				scrapeEncryption,
+				...planetScaleAccessTokenErrors,
+			],
 		}).annotateMerge(
 			OpenApi.annotations({
 				identifier: "probeScrapeTarget",
 				summary: "Probe a scrape target",
 				description:
-					"Runs an on-demand scrape against the target and reports the outcome without waiting for the schedule. Requires the `scrape_targets:write` scope.",
+					"Runs an on-demand scrape against the target and reports the outcome without waiting for the schedule. Requires the `scrape_targets:write` scope and an org-admin caller.",
 			}),
 		),
 	)


### PR DESCRIPTION
Scrape targets hold credentials and cause outbound requests from Maple's
infrastructure, but create, update, delete and probe were reachable by any
member. All four are now admin-only. Probe is included deliberately: it reads
like a read, but it decrypts the stored credential and sends it to an
operator-chosen URL, which is update's blast radius. The three real reads stay
open — they never expose the ciphertext, and closing them would break dashboards
for no gain.

Updating only the URL left the encrypted credential in place, bound to an origin
the target no longer points at. An update that changes scheme, host or port now
requires the credential to be re-supplied in the same request. Refusing is
better than silently clearing, which would leave the target scraping
unauthenticated and reporting 401s.

The generic API could also delete or re-credential integration-owned rows.
Mutations against a row with `managed_by` set are refused; the PlanetScale
integration passes an explicit opt-in at its own call sites.
---

### Stack

Part of a 9-PR security stack off `main`. Each PR is based on the one above it, so **review and merge in order**; each commit typechecks standalone.

1. `sec/01-ci-supply-chain` — supply chain: pinned downloads and installers
2. `sec/02-v2-scope-enforcement` — v2 API key scope enforcement
3. `sec/03-admin-role-gates` — missing org-admin checks
4. `sec/04-oauth-return-to` — OAuth `returnTo` validation
5. `sec/05-canonical-api-origin` — discovery documents from configured origin
6. `sec/06-session-replay-privacy` — replay block markers
7. `sec/07-outbound-request-hardening` — outbound credentials and redirects
8. `sec/08-scrape-target-authz` — scrape target authorization and credentials
9. `sec/09-membership-revocation` — revocation on member/org removal

Findings came from a `deepsec` scan triaged down to the real defects; each was verified against `HEAD` before being fixed, and each fix was reviewed adversarially afterwards. Reproduction detail is deliberately kept out of these descriptions until the fixes are deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849843&installation_model_id=427786&pr_number=718&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F718&signature=c678846a0d94f0b9441260cd71ed97788d51727dd8342e1701b98da0a9ad8266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->