### PR TITLE
feat(agent-sessions): load older sessions continuously, like the replays list

### DIFF
--- a/apps/api/src/routes/internal/ai-sessions.http.ts
+++ b/apps/api/src/routes/internal/ai-sessions.http.ts
@@ -37,6 +37,7 @@ export const HttpAiSessionsInternalLive = HttpApiBuilder.group(
 						const compiled = CH.compile(
 							Integrations.aiSessionListQuery({
 								limit: payload.limit,
+								offset: payload.offset,
 								vendorIds: payload.vendorIds,
 								serviceNames: payload.serviceNames,
 							}),

--- a/apps/web/src/api/warehouse/ai-sessions.ts
+++ b/apps/web/src/api/warehouse/ai-sessions.ts
@@ -13,6 +13,7 @@ const ListAiSessionsInput = Schema.Struct({
 	startTime: Schema.optional(WarehouseDateTimeString),
 	endTime: Schema.optional(WarehouseDateTimeString),
 	limit: Schema.optional(Schema.Number),
+	offset: Schema.optional(Schema.Number),
 	vendorIds: Schema.optional(Schema.Array(Schema.String)),
 	serviceNames: Schema.optional(Schema.Array(Schema.String)),
 })
@@ -40,6 +41,7 @@ export const listAiSessions = Effect.fn("AiSessions.listAiSessions")(function* (
 					startTime: input.startTime ?? fallback.startTime,
 					endTime: input.endTime ?? fallback.endTime,
 					limit: input.limit,
+					offset: input.offset,
 					vendorIds: input.vendorIds,
 					serviceNames: input.serviceNames,
 				}),

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.test.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+// TEST-SEAM: This focused test replaces process-global modules that have no instance-level injection seam.
+
+import { cleanup, render } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { AgentSessionsList, type AgentSessionRow } from "./agent-sessions-list"
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+		<a {...(props as Record<string, string>)}>{children}</a>
+	),
+}))
+
+const session: AgentSessionRow = {
+	sessionId: "wrun_01M0CSAEW96BH2W9185XZPRPKH",
+	vendorId: "eve",
+	vendorVersion: "1",
+	traceCount: 2,
+	spanCount: 12,
+	errorSpanCount: 0,
+	serviceNames: ["maple-slack-agent"],
+	startTime: "2026-08-19 10:33:25.825000000",
+	endTime: "2026-08-19 10:34:25.825000000",
+	durationMs: 60_000,
+}
+
+class MockIntersectionObserver {
+	static instances: MockIntersectionObserver[] = []
+	readonly observe = vi.fn()
+	readonly disconnect = vi.fn()
+
+	constructor(readonly callback: IntersectionObserverCallback) {
+		MockIntersectionObserver.instances.push(this)
+	}
+}
+
+describe("AgentSessionsList pagination observer", () => {
+	beforeEach(() => {
+		MockIntersectionObserver.instances = []
+		vi.stubGlobal("IntersectionObserver", MockIntersectionObserver)
+	})
+
+	afterEach(() => {
+		cleanup()
+		vi.unstubAllGlobals()
+	})
+
+	it("asks for the next page when the sentinel comes into view, but not while one is in flight", () => {
+		const onReachEnd = vi.fn()
+		const view = render(
+			<AgentSessionsList sessions={[session]} hasMore onReachEnd={onReachEnd} loadingMore={false} />,
+		)
+
+		const first = MockIntersectionObserver.instances[0]!
+		expect(first.observe).toHaveBeenCalledOnce()
+		first.callback([{ isIntersecting: true } as IntersectionObserverEntry], first as never)
+		expect(onReachEnd).toHaveBeenCalledOnce()
+
+		view.rerender(<AgentSessionsList sessions={[session]} hasMore onReachEnd={onReachEnd} loadingMore />)
+		expect(first.disconnect).toHaveBeenCalledOnce()
+		expect(view.getByText("Loading more sessions…")).toBeTruthy()
+
+		const second = MockIntersectionObserver.instances[1]!
+		second.callback([{ isIntersecting: true } as IntersectionObserverEntry], second as never)
+		expect(onReachEnd).toHaveBeenCalledOnce()
+
+		view.unmount()
+		expect(second.disconnect).toHaveBeenCalledOnce()
+	})
+
+	it("renders no sentinel once the backend has no more pages", () => {
+		render(<AgentSessionsList sessions={[session]} hasMore={false} />)
+		expect(MockIntersectionObserver.instances).toHaveLength(0)
+	})
+
+	it("explains the retention cap instead of paging further", () => {
+		const view = render(<AgentSessionsList sessions={[session]} isCapped />)
+		expect(MockIntersectionObserver.instances).toHaveLength(0)
+		expect(view.getByText(/Showing the 1 most recent sessions/)).toBeTruthy()
+	})
+})

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react"
 import { Link } from "@tanstack/react-router"
 
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@maple/ui/components/ui/empty"
@@ -29,11 +30,51 @@ function absoluteTs(startTime: string): string {
 
 interface AgentSessionsListProps {
 	sessions: ReadonlyArray<AgentSessionRow>
-	/** The request's limit — rows at the cap mean older sessions were cut off. */
-	limit: number
+	/** Fetch the next page — invoked when the bottom sentinel scrolls into view. */
+	onReachEnd?: () => void
+	/** Whether more pages remain (renders the sentinel + footer). */
+	hasMore?: boolean
+	/** Whether a next page is currently in flight. */
+	loadingMore?: boolean
+	/** The client retention guard stopped pagination before the backend ended. */
+	isCapped?: boolean
 }
 
-export function AgentSessionsList({ sessions, limit }: AgentSessionsListProps) {
+function observeReachEnd(element: HTMLDivElement, onReachEnd: () => void): () => void {
+	const observer = new IntersectionObserver(
+		(entries) => {
+			if (entries[0]?.isIntersecting) onReachEnd()
+		},
+		{ rootMargin: "400px 0px" },
+	)
+	observer.observe(element)
+	return () => observer.disconnect()
+}
+
+function SessionsSentinel({
+	onReachEnd,
+	loadingMore,
+}: Pick<AgentSessionsListProps, "onReachEnd" | "loadingMore">) {
+	const elementRef = useCallback(
+		(element: HTMLDivElement | null) => {
+			if (!element) return
+			return observeReachEnd(element, () => {
+				if (!loadingMore) onReachEnd?.()
+			})
+		},
+		[loadingMore, onReachEnd],
+	)
+
+	return <div ref={elementRef} aria-hidden className="h-px w-full" />
+}
+
+export function AgentSessionsList({
+	sessions,
+	onReachEnd,
+	hasMore = false,
+	loadingMore = false,
+	isCapped = false,
+}: AgentSessionsListProps) {
 	if (sessions.length === 0) {
 		return (
 			<Empty>
@@ -151,11 +192,20 @@ export function AgentSessionsList({ sessions, limit }: AgentSessionsListProps) {
 				)
 			})}
 
-			{sessions.length >= limit && (
+			{hasMore && <SessionsSentinel onReachEnd={onReachEnd} loadingMore={loadingMore} />}
+
+			{isCapped && (
 				<p className="py-3 text-sm text-muted-foreground">
-					Showing the {limit.toLocaleString()} most recent sessions — narrow the time range to see
-					older ones
+					Showing the {sessions.length.toLocaleString()} most recent sessions — narrow the time
+					range to see older ones
 				</p>
+			)}
+
+			{loadingMore && (
+				<div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+					<span className="size-4 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
+					Loading more sessions…
+				</div>
 			)}
 		</div>
 	)

--- a/apps/web/src/hooks/use-infinite-ai-sessions.ts
+++ b/apps/web/src/hooks/use-infinite-ai-sessions.ts
@@ -1,0 +1,117 @@
+import * as React from "react"
+import { Result } from "@/lib/effect-atom"
+
+import { listAiSessions } from "@/api/warehouse/ai-sessions"
+import { listAiSessionsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
+import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
+import type { AgentSessionRow } from "@/components/agent-sessions/agent-sessions-list"
+import { logClientError } from "@/lib/services/common/telemetry"
+import { mapleRuntime } from "@/lib/registry"
+
+export const AI_SESSIONS_PAGE_SIZE = 50
+const PAGE_SIZE = AI_SESSIONS_PAGE_SIZE
+export const MAX_RETAINED_AI_SESSIONS = 500
+
+/**
+ * The filter inputs the agent-sessions route assembles (resolved time window +
+ * sidebar filters). Pagination params are added by this hook — callers must not
+ * set `limit`/`offset` themselves.
+ */
+export interface AiSessionsFilterInputs {
+	startTime: string
+	endTime: string
+	vendorIds?: ReadonlyArray<string>
+	serviceNames?: ReadonlyArray<string>
+}
+
+interface AiSessionsPage {
+	data: ReadonlyArray<AgentSessionRow>
+}
+
+/**
+ * Offset-based infinite scroll for the agent-sessions list, mirroring
+ * `useInfiniteReplays`. The first page flows through the cached result atom (so
+ * it shares the route's skeleton/refresh semantics); later pages are fetched
+ * imperatively and accumulated. Pages reset whenever the filter inputs change.
+ */
+export function useInfiniteAiSessions(filterInputs: AiSessionsFilterInputs) {
+	const filterKey = React.useMemo(() => JSON.stringify(filterInputs), [filterInputs])
+
+	// Refreshable AND retained: on an absolute time range the atom key never
+	// rolls, so Reload only works through the refresh subscription; and a filter
+	// change builds a new key whose first read is `Initial`, which retention
+	// turns into a dimmed list rather than a skeleton flash.
+	const firstPageResult = useRefreshableAtomValue(
+		listAiSessionsResultAtom({ data: { ...filterInputs, limit: PAGE_SIZE, offset: 0 } }),
+	)
+
+	const [additionalPages, setAdditionalPages] = React.useState<AiSessionsPage[]>([])
+	const [isFetchingNextPage, setIsFetchingNextPage] = React.useState(false)
+	const [paginationStopped, setPaginationStopped] = React.useState(false)
+	const filterKeyRef = React.useRef(filterKey)
+	const isFetchingRef = React.useRef(false)
+
+	React.useEffect(() => {
+		filterKeyRef.current = filterKey
+		setAdditionalPages([])
+		setIsFetchingNextPage(false)
+		setPaginationStopped(false)
+		isFetchingRef.current = false
+	}, [filterKey])
+
+	const allData = React.useMemo<ReadonlyArray<AgentSessionRow>>(() => {
+		const firstPageData = Result.isSuccess(firstPageResult) ? firstPageResult.value.data : []
+		const additionalData = additionalPages.flatMap((p) => p.data)
+		return [...firstPageData, ...additionalData].slice(0, MAX_RETAINED_AI_SESSIONS)
+	}, [firstPageResult, additionalPages])
+	const isCapped = allData.length >= MAX_RETAINED_AI_SESSIONS
+
+	const hasNextPage = React.useMemo(() => {
+		if (isCapped) return false
+		if (paginationStopped) return false
+		if (!Result.isSuccess(firstPageResult)) return false
+		if (additionalPages.length === 0) {
+			return firstPageResult.value.data.length === PAGE_SIZE
+		}
+		const lastPage = additionalPages[additionalPages.length - 1]
+		return lastPage.data.length === PAGE_SIZE
+	}, [firstPageResult, additionalPages, paginationStopped, isCapped])
+
+	const fetchNextPage = React.useCallback(() => {
+		if (isFetchingRef.current || !hasNextPage) return
+		isFetchingRef.current = true
+		setIsFetchingNextPage(true)
+
+		const currentKey = filterKeyRef.current
+		const offset = allData.length
+
+		mapleRuntime
+			.runPromise(listAiSessions({ data: { ...filterInputs, limit: PAGE_SIZE, offset } }))
+			.then((result) => {
+				if (filterKeyRef.current !== currentKey) return
+				setAdditionalPages((prev) => [...prev, { data: result.data }])
+			})
+			.catch((error) => {
+				if (filterKeyRef.current !== currentKey) return
+				// Terminate pagination on failure so the sentinel stops asking;
+				// otherwise hasNextPage stays true and the list loops on the error.
+				setPaginationStopped(true)
+				logClientError("ai_session.pagination_failed", error)
+			})
+			.finally(() => {
+				if (filterKeyRef.current === currentKey) {
+					setIsFetchingNextPage(false)
+				}
+				isFetchingRef.current = false
+			})
+	}, [filterInputs, allData.length, hasNextPage])
+
+	return {
+		firstPageResult,
+		allData,
+		isFetchingNextPage,
+		hasNextPage,
+		isCapped,
+		fetchNextPage,
+	}
+}

--- a/apps/web/src/routes/agent-sessions/index.tsx
+++ b/apps/web/src/routes/agent-sessions/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Schema } from "effect"
 
@@ -7,16 +8,13 @@ import { AgentSessionsFilterSidebar } from "@/components/agent-sessions/agent-se
 import { NotFoundError } from "@/components/route-error"
 import { QueryErrorState } from "@/components/common/query-error-state"
 import { Result, useAtomValue } from "@/lib/effect-atom"
-import {
-	aiSessionsFacetsResultAtom,
-	listAiSessionsResultAtom,
-} from "@/lib/services/atoms/warehouse-query-atoms"
+import { aiSessionsFacetsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import type { TimeRange } from "@/components/time-range-picker/types"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
-import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
+import { useInfiniteAiSessions } from "@/hooks/use-infinite-ai-sessions"
 import { useOrganizationFeatureFlags } from "@/hooks/use-organization-feature-flags"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 import { ToolbarStat } from "@maple/ui/components/toolbar"
@@ -27,8 +25,6 @@ const agentSessionsSearchSchema = Schema.Struct({
 	service: Schema.optional(Schema.String),
 	...TimeRangeSearchFields,
 })
-
-const AGENT_SESSIONS_LIMIT = 50
 
 export const Route = createFileRoute("/agent-sessions/")({
 	component: AgentSessionsPage,
@@ -95,24 +91,25 @@ function AgentSessionsBody({
 		search.endTime,
 		search.timePreset ?? "24h",
 	)
-	const window = { startTime, endTime, limit: AGENT_SESSIONS_LIMIT }
-	// Refreshable (not plain useAtomValue): on an absolute time range the atom
-	// key never rolls, so Reload only works through the refresh subscription.
-	const result = useRefreshableAtomValue(
-		listAiSessionsResultAtom({
-			data: {
-				...window,
-				vendorIds: search.vendor ? [search.vendor] : undefined,
-				serviceNames: search.service ? [search.service] : undefined,
-			},
+	// Memoized on the resolved values: the hook keys its accumulated pages on
+	// these inputs, and a fresh object per render would reset them every time.
+	const filterInputs = useMemo(
+		() => ({
+			startTime,
+			endTime,
+			vendorIds: search.vendor ? [search.vendor] : undefined,
+			serviceNames: search.service ? [search.service] : undefined,
 		}),
+		[startTime, endTime, search.vendor, search.service],
 	)
+	const { firstPageResult, allData, hasNextPage, isCapped, isFetchingNextPage, fetchNextPage } =
+		useInfiniteAiSessions(filterInputs)
 	// The sidebar's counts come from the UNFILTERED window, so picking a vendor
 	// doesn't erase the others from the list. Plain useAtomValue keeps this off
 	// the Reload subscription — the facets refetch when the window rolls, which
 	// is enough.
 	const facetsResult = useAtomValue(aiSessionsFacetsResultAtom({ data: { startTime, endTime } }))
-	const sessions = Result.isSuccess(result) ? result.value.data : []
+	const sessions = allData
 
 	const headerActions = (
 		<div className="flex flex-wrap items-center gap-2">
@@ -144,7 +141,7 @@ function AgentSessionsBody({
 					</DashboardLayout.Header>
 				</DashboardLayout.Sticky>
 				<DashboardLayout.Scroll>
-					{Result.builder(result)
+					{Result.builder(firstPageResult)
 						.onInitial(() => (
 							<div className="divide-y divide-border">
 								{Array.from({ length: 8 }).map((_, i) => (
@@ -161,8 +158,14 @@ function AgentSessionsBody({
 						.onError((error) => (
 							<QueryErrorState error={error} titleOverride="Failed to load agent sessions" />
 						))
-						.onSuccess((value) => (
-							<AgentSessionsList sessions={value.data} limit={AGENT_SESSIONS_LIMIT} />
+						.onSuccess(() => (
+							<AgentSessionsList
+								sessions={allData}
+								hasMore={hasNextPage}
+								isCapped={isCapped}
+								loadingMore={isFetchingNextPage}
+								onReachEnd={fetchNextPage}
+							/>
 						))
 						.render()}
 				</DashboardLayout.Scroll>

--- a/packages/domain/src/http/ai-sessions.ts
+++ b/packages/domain/src/http/ai-sessions.ts
@@ -21,6 +21,14 @@ export class ListAiSessionsRequest extends Schema.Class<ListAiSessionsRequest>("
 	limit: Schema.optional(
 		Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 100 })),
 	),
+	/**
+	 * Rows to skip, for the list's infinite scroll. Offset-based like the
+	 * replays list: the page re-runs the aggregation and drops the first `offset`
+	 * sessions, which is fine at the volumes an org's agent traffic reaches
+	 * (~10k index rows a day) and lets the client keep a single ordered list
+	 * without a session-keyed cursor the aggregation cannot cheaply seek to.
+	 */
+	offset: Schema.optional(Schema.Number.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))),
 	// Both filters land on the session-detection subquery, so `serviceNames`
 	// means "the session-bearing spans came from this service", not "the trace
 	// touched it" — see `aiSessionListQuery`.

--- a/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
+++ b/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
@@ -114,6 +114,7 @@ SELECT
         GROUP BY sessionId
         ORDER BY startTime DESC
         LIMIT 25
+        OFFSET 25
         FORMAT JSON
 
 -- builder:ai-sessions:aiSessionSpansQuery:default

--- a/packages/query-engine-integrations/src/ai/ai-sessions.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.test.ts
@@ -150,6 +150,20 @@ describe("aiSessionListQuery", () => {
 		expect(sql).toContain("LIMIT 25")
 	})
 
+	it("skips past the previous pages on the outermost level only", () => {
+		const { sql } = compileUnsafe(aiSessionListQuery({ limit: 50, offset: 100 }), params)
+
+		// The offset must apply to the ordered SESSION rows — the derived per-trace
+		// level has no order to page over.
+		expect(sql).toContain("LIMIT 50\n        OFFSET 100")
+		expect(sql.split("OFFSET").length - 1).toBe(1)
+	})
+
+	it("emits no OFFSET clause for the first page", () => {
+		expect(compileUnsafe(aiSessionListQuery({ offset: 0 }), params).sql).not.toContain("OFFSET")
+		expect(compileUnsafe(aiSessionListQuery(), params).sql).not.toContain("OFFSET")
+	})
+
 	it("pads the fan-out window rather than dropping it", () => {
 		const { sql } = compileUnsafe(aiSessionListQuery(), params)
 		const [fanOut, detection] = sql.split("TraceId IN (SELECT")

--- a/packages/query-engine-integrations/src/ai/ai-sessions.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.ts
@@ -167,6 +167,8 @@ const sessionKey = (rawSessionId: CH.Expr<string>, traceId: CH.Expr<string>): CH
 export interface AiSessionListOpts {
 	/** Sessions returned, most recently started first. */
 	readonly limit?: number
+	/** Sessions skipped before `limit` applies — the list's next page. */
+	readonly offset?: number
 	readonly vendorIds?: readonly string[]
 	readonly serviceNames?: readonly string[]
 }
@@ -231,6 +233,7 @@ export interface AiSessionListOutput {
  */
 export function aiSessionListQuery(opts: AiSessionListOpts = {}) {
 	const limit = opts.limit ?? 50
+	const offset = opts.offset ?? 0
 
 	// No vendor-presence predicate: `ai_trace_index_mv` admits only spans with a
 	// non-empty vendor id, so membership in the table IS the detection predicate.
@@ -326,43 +329,43 @@ export function aiSessionListQuery(opts: AiSessionListOpts = {}) {
 		])
 		.groupBy("traceId")
 
-	return (
-		fromQuery(perTrace, "session_traces")
-			.select(($) => ({
-				// The grouping key, and the only level that can compute it: the
-				// derived table is one row per trace, so a trace with no session id
-				// of its own becomes a session of one trace here rather than joining
-				// every other sessionless trace under `''`.
-				sessionId: sessionKey($.rawSessionId, $.traceId),
-				vendorId: CH.argMin($.vendorId, $.sessionStart),
-				vendorVersion: CH.argMin($.vendorVersion, $.sessionStart),
-				// `count()`, not `uniq()`: the derived table already emits exactly one
-				// row per trace, so this is exact and cheaper — `uniq` is an
-				// approximate HLL that would start drifting on a very large session.
-				traceCount: CH.count(),
-				spanCount: CH.sum($.spanCount),
-				errorSpanCount: CH.sum($.errorSpanCount),
-				serviceNames: CH.groupUniqArrayArray($.serviceNames),
-				startTime: CH.toString_(CH.min_($.traceStart)),
-				endTime: CH.toString_(fromUnixTimestamp64Nano(CH.max_($.traceEndNanos))),
-				// Nanoseconds first: `Timestamp` is DateTime64(9), and subtracting two
-				// of them yields a Decimal whose scale the wire format then quotes.
-				// Wrapped in `intDiv` because `Expr.sub`/`div` do not parenthesize.
-				durationMs: CH.intDiv(
-					CH.max_($.traceEndNanos).sub(CH.toUnixTimestamp64Nano(CH.min_($.traceStart))),
-					1_000_000,
-				),
-			}))
-			// No `sessionId != ''` guard any more, and none needed: the key is never
-			// empty. It used to keep two unrelated populations apart — a trace whose
-			// session-bearing span has landed in `traces` but not yet in the
-			// `trace_detail_spans` MV read back empty, and every such trace grouped
-			// together under one blank session. Both now key on their own trace id.
-			.groupBy("sessionId")
-			.orderBy(["startTime", "desc"])
-			.limit(limit)
-			.format("JSON")
-	)
+	const sessions = fromQuery(perTrace, "session_traces")
+		.select(($) => ({
+			// The grouping key, and the only level that can compute it: the
+			// derived table is one row per trace, so a trace with no session id
+			// of its own becomes a session of one trace here rather than joining
+			// every other sessionless trace under `''`.
+			sessionId: sessionKey($.rawSessionId, $.traceId),
+			vendorId: CH.argMin($.vendorId, $.sessionStart),
+			vendorVersion: CH.argMin($.vendorVersion, $.sessionStart),
+			// `count()`, not `uniq()`: the derived table already emits exactly one
+			// row per trace, so this is exact and cheaper — `uniq` is an
+			// approximate HLL that would start drifting on a very large session.
+			traceCount: CH.count(),
+			spanCount: CH.sum($.spanCount),
+			errorSpanCount: CH.sum($.errorSpanCount),
+			serviceNames: CH.groupUniqArrayArray($.serviceNames),
+			startTime: CH.toString_(CH.min_($.traceStart)),
+			endTime: CH.toString_(fromUnixTimestamp64Nano(CH.max_($.traceEndNanos))),
+			// Nanoseconds first: `Timestamp` is DateTime64(9), and subtracting two
+			// of them yields a Decimal whose scale the wire format then quotes.
+			// Wrapped in `intDiv` because `Expr.sub`/`div` do not parenthesize.
+			durationMs: CH.intDiv(
+				CH.max_($.traceEndNanos).sub(CH.toUnixTimestamp64Nano(CH.min_($.traceStart))),
+				1_000_000,
+			),
+		}))
+		// No `sessionId != ''` guard any more, and none needed: the key is never
+		// empty. It used to keep two unrelated populations apart — a trace whose
+		// session-bearing span has landed in `traces` but not yet in the
+		// `trace_detail_spans` MV read back empty, and every such trace grouped
+		// together under one blank session. Both now key on their own trace id.
+		.groupBy("sessionId")
+		.orderBy(["startTime", "desc"])
+		.limit(limit)
+	// Only a positive offset is emitted: `OFFSET 0` is a no-op that would still
+	// change the compiled SQL of every first-page read.
+	return (offset > 0 ? sessions.offset(offset) : sessions).format("JSON")
 }
 
 // List facets (UNION ALL — vendor / service)

--- a/packages/query-engine-integrations/src/catalog.ts
+++ b/packages/query-engine-integrations/src/catalog.ts
@@ -67,7 +67,8 @@ export const integrationFixtures: ReadonlyArray<IntegrationFixture> = [
 		compile: () => compileUnsafe(CH.aiSessionListQuery(), window),
 	},
 	{
-		// The vendor/service filters the AI sessions list page sends.
+		// The vendor/service filters the AI sessions list page sends, on its
+		// second page.
 		module: "ai-sessions",
 		name: "aiSessionListQuery",
 		label: "filtered",
@@ -75,6 +76,7 @@ export const integrationFixtures: ReadonlyArray<IntegrationFixture> = [
 			compileUnsafe(
 				CH.aiSessionListQuery({
 					limit: 25,
+					offset: 25,
 					vendorIds: ["eve"],
 					serviceNames: ["maple-slack-agent"],
 				}),


### PR DESCRIPTION
## Summary

The Agent Sessions list stopped at the 50 most recent sessions and told the user to narrow the time range. It now pages the same way the session replays list does: offset-based infinite scroll, first page through the cached result atom, later pages fetched imperatively when a bottom sentinel scrolls into view, capped at 500 retained rows on the client.

- `ListAiSessionsRequest` gains an optional non-negative integer `offset`, validated at the HTTP boundary.
- `aiSessionListQuery` applies it on the outermost (ordered session) level only, and only when positive, so first-page SQL is byte-identical to before. The `filtered` catalog fixture now carries an offset so the ClickHouse e2e sweep covers the clause.
- New `useInfiniteAiSessions` hook mirrors `useInfiniteReplays`: pages reset on any filter/window change, a failed page stops pagination and logs `ai_session.pagination_failed`.
- `AgentSessionsList` renders the sentinel, loading spinner and retention-cap notice instead of the fixed-limit footer.

## Test plan

- [x] `packages/query-engine-integrations`: offset placement + no-`OFFSET`-on-first-page tests; SQL baseline updated
- [x] `apps/web`: `agent-sessions-list.test.tsx` covers the observer lifecycle, the in-flight guard, and the capped state
- [x] `turbo typecheck` on domain, query-engine-integrations, api, web
- [ ] Not verified in a browser: the local web stack was not running and the page needs the `agent_tracing` flag plus more than 50 sessions in the window to exercise paging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790905785&installation_model_id=427786&pr_number=736&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F736&signature=4acd9ecb0e6d1e059519d697240de2eb0bcd39ddb471875cf4bef24039897de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->