### PR TITLE
feat(infra): derive worker env types from alchemy bindings, bind web to api

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -286,6 +286,7 @@ export default Alchemy.Stack(
 			: yield* createMapleWeb({
 					stage,
 					domains,
+					api,
 					apiUrl,
 					ingestUrl,
 					electricSyncUrl,

--- a/apps/alerting/alchemy.run.ts
+++ b/apps/alerting/alchemy.run.ts
@@ -34,6 +34,59 @@ export interface CreateAlertingWorkerOptions {
 }
 
 /**
+ * The alerting worker's resource bindings, split from the `Config`-sourced env
+ * so `InferEnv` can derive `AlertingWorkerEnv` below.
+ */
+const makeWorkerBindings = ({
+	stage,
+	mapleDb,
+}: {
+	stage: MapleStage
+	mapleDb: Cloudflare.Hyperdrive.Connection | undefined
+}) => ({
+	// Ref stages attach MAPLE_DB via worker.bind below.
+	...(mapleDb ? { MAPLE_DB: mapleDb } : undefined),
+	// Cross-script binding to the investigation fan-out Workflow hosted by the
+	// api worker. Alert, error, and anomaly ticks start investigations when
+	// incidents open. The first arg is the physical workflow name; `scriptName`
+	// makes this a reference-only binding (the api worker owns the workflow
+	// resource).
+	INVESTIGATION_FANOUT_WORKFLOW: Cloudflare.Workflow<{
+		orgId: string
+		investigationId: string
+		maxWidth: number
+		reservedPasses: number
+		attempt: number
+	}>(resolveWorkerName("investigation-fanout", stage), {
+		className: "InvestigationFanoutWorkflow",
+		scriptName: resolveWorkerName("api", stage),
+	}),
+	// Production only: preview/stg workers run the same email crons against
+	// their own DB branches, so a binding here means every live stage sends
+	// its own copy of onboarding/digest/alert emails to real users.
+	...(stage.kind === "prd"
+		? {
+				EMAIL: Cloudflare.Email.SendEmail("email", {
+					allowedSenderAddresses: ["notifications@noreply.maple.dev"],
+				}),
+			}
+		: undefined),
+})
+
+/**
+ * The alerting worker's runtime env, derived from the declaration above — one
+ * source of truth, imported (type-only) by `src/worker.ts`.
+ *
+ * `Partial` because a binding's absence is a real runtime state: ref stages
+ * attach MAPLE_DB after the Worker exists, EMAIL is prd-only, and `alchemy
+ * dev` emulation does not cover every binding. The configuration vars stay
+ * `unknown` on purpose: config is read through the Effect ConfigProvider
+ * (`layerFromEnv` → the shared `Env` service), never off `env` directly.
+ */
+export type AlertingWorkerEnv = Partial<Cloudflare.InferEnv<ReturnType<typeof makeWorkerBindings>>> &
+	Record<string, unknown>
+
+/**
  * Everything in the alerting worker's env that comes from configuration rather
  * than from a resource. Largely the api worker's set — the two share 32 keys,
  * which is why the groups live in `@maple/infra/env`.
@@ -74,22 +127,6 @@ export const createAlertingWorker = ({ stage, mapleDb, dev, devEnv }: CreateAler
 		// `alerting` binds its own Hyperdrive config on prd — it issues ~97% of the
 		// workers' Postgres traffic and was starving the api's connection pool.
 		const hyperdriveRefId = resolveHyperdriveRefId(stage, "alerting")
-		// Cross-script binding to the investigation fan-out Workflow hosted by the
-		// api worker. Alert, error, and anomaly ticks start investigations when
-		// incidents open. The
-		// first arg is the physical workflow name; `scriptName` makes this a
-		// reference-only binding (the api worker owns the workflow resource).
-		const investigationFanoutWorkflow = Cloudflare.Workflow<{
-			orgId: string
-			investigationId: string
-			maxWidth: number
-			reservedPasses: number
-			attempt: number
-		}>(resolveWorkerName("investigation-fanout", stage), {
-			className: "InvestigationFanoutWorkflow",
-			scriptName: resolveWorkerName("api", stage),
-		})
-
 		const worker = yield* Cloudflare.Worker("alerting", {
 			name: resolveWorkerName("alerting", stage),
 			main: path.join(import.meta.dirname, "src", "worker.ts"),
@@ -103,19 +140,7 @@ export const createAlertingWorker = ({ stage, mapleDb, dev, devEnv }: CreateAler
 			// from both sending during cutover.
 			crons: ["* * * * *", "*/5 * * * *", "*/15 * * * *", "0 * * * *"],
 			env: {
-				// Ref stages attach MAPLE_DB via worker.bind below.
-				...(mapleDb ? { MAPLE_DB: mapleDb } : undefined),
-				INVESTIGATION_FANOUT_WORKFLOW: investigationFanoutWorkflow,
-				// Production only: preview/stg workers run the same email crons against
-				// their own DB branches, so a binding here means every live stage sends
-				// its own copy of onboarding/digest/alert emails to real users.
-				...(stage.kind === "prd"
-					? {
-							EMAIL: Cloudflare.Email.SendEmail("email", {
-								allowedSenderAddresses: ["notifications@noreply.maple.dev"],
-							}),
-						}
-					: undefined),
+				...makeWorkerBindings({ stage, mapleDb }),
 				...configuredEnv,
 				...devEnv,
 			},

--- a/apps/alerting/src/worker.ts
+++ b/apps/alerting/src/worker.ts
@@ -42,6 +42,7 @@ import {
 import * as MapleCloudflareSDK from "@maple-dev/effect-sdk/cloudflare"
 import { layerFromEnv, layerFromEnvRecord, runScheduledEffect } from "@maple/effect-cloudflare"
 import { Cause, Effect, Layer, Match } from "effect"
+import type { AlertingWorkerEnv } from "../alchemy.run.ts"
 
 // Module-scope construction; `flush(env)` resolves env on first call. The
 // in-isolate buffers coalesce concurrent scheduled ticks into one POST per
@@ -52,10 +53,6 @@ const telemetry = MapleCloudflareSDK.make({
 	repositoryUrl: "https://github.com/MapleTechLabs/maple",
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
 })
-
-interface AlertingWorkerEnv {
-	readonly [key: string]: unknown
-}
 
 export const buildLayer = (env: AlertingWorkerEnv) => {
 	// Keep config and binding services on the same invocation-scoped env record;

--- a/apps/api/alchemy.run.ts
+++ b/apps/api/alchemy.run.ts
@@ -239,6 +239,114 @@ const apiConfiguredEnv = (stage: MapleStage, domains: MapleDomains) =>
 export type MapleApiWorker = Cloudflare.Worker & Rpc<MapleApiRpcContract>
 
 /**
+ * The api worker's resource bindings, split from the `Config`-sourced env so
+ * `InferEnv` can derive `MapleApiWorkerEnv` below.
+ */
+const makeWorkerBindings = ({
+	stage,
+	mapleDb,
+	replayBlobs,
+	mcpSessions,
+	vcsSyncQueue,
+	vcsSyncQueueName,
+	planetScaleWebhookQueue,
+	planetScaleWebhookQueueName,
+}: {
+	stage: MapleStage
+	mapleDb: Cloudflare.Hyperdrive.Connection | undefined
+	replayBlobs: Cloudflare.R2.Bucket
+	mcpSessions: Cloudflare.KV.Namespace
+	vcsSyncQueue: Cloudflare.Queues.Queue
+	vcsSyncQueueName: string
+	planetScaleWebhookQueue: Cloudflare.Queues.Queue
+	planetScaleWebhookQueueName: string
+}) => ({
+	// Ref stages attach MAPLE_DB via worker.bind below.
+	...(mapleDb ? { MAPLE_DB: mapleDb } : undefined),
+	// Workers AI (`env.AI`, the v1 `Ai()` binding), driving the AI-triage agent on
+	// `@opencode-ai/ai`. v2 emits the `{ type: "ai" }` binding by attaching an AI Gateway
+	// resource, which also fronts model calls with caching/rate-limits/logging.
+	// NOTE: the deploy token needs the account-level "AI Gateway: Edit" permission
+	// for this resource.
+	AI: Cloudflare.AI.Gateway("maple-api-ai"),
+	// Durable chat transcripts, one Durable Object per "<orgId>:<tabId>". v2
+	// provisions new DO classes as SQLite-backed by default. Class is exported
+	// from src/worker.ts.
+	CHAT_SESSION: Cloudflare.DurableObject("chat-session", { className: "ChatSession" }),
+	MCP_SESSIONS: mcpSessions,
+	// Read side of the replay payload store; absent bindings degrade to
+	// inline-only hydration (see platform/ReplayBlobStore.ts).
+	REPLAY_BLOBS: replayBlobs,
+	VCS_SYNC_QUEUE: vcsSyncQueue,
+	VCS_SYNC_QUEUE_NAME: vcsSyncQueueName,
+	PLANETSCALE_WEBHOOK_QUEUE: planetScaleWebhookQueue,
+	PLANETSCALE_WEBHOOK_QUEUE_NAME: planetScaleWebhookQueueName,
+	// Long-running schema-apply: chunks heavy backfill migrations across durable
+	// steps so they never hit the Worker request budget. Class is exported from
+	// src/worker.ts. The first Workflow arg IS the physical workflow name; the
+	// api worker hosts it (no scriptName), so alchemy registers it after deploy.
+	CLICKHOUSE_SCHEMA_APPLY_WORKFLOW: Cloudflare.Workflow<{ orgId: string }>(
+		resolveWorkerName("schema-apply", stage),
+		{ className: "ClickHouseSchemaApplyWorkflow" },
+	),
+	// Fan-out investigation: N lens agents in parallel, then a validator that
+	// promotes one cause and records why each rival lost. Class is exported from
+	// src/worker.ts.
+	INVESTIGATION_FANOUT_WORKFLOW: Cloudflare.Workflow<{
+		orgId: string
+		investigationId: string
+		maxWidth: number
+		reservedPasses: number
+		attempt: number
+	}>(resolveWorkerName("investigation-fanout", stage), {
+		className: "InvestigationFanoutWorkflow",
+	}),
+	API_V2_RATE_LIMITER: Cloudflare.RateLimit("API_V2_RATE_LIMITER", {
+		namespaceId: 2026071801,
+		simple: { limit: 600, period: 60 },
+	}),
+	CLI_AUTH_RATE_LIMITER: Cloudflare.RateLimit("CLI_AUTH_RATE_LIMITER", {
+		namespaceId: 2026072101,
+		simple: { limit: 30, period: 60 },
+	}),
+	MCP_OAUTH_RATE_LIMITER: Cloudflare.RateLimit("MCP_OAUTH_RATE_LIMITER", {
+		namespaceId: 2026072102,
+		simple: { limit: 60, period: 60 },
+	}),
+	// Authenticated POST /mcp, per credential. A short window so a runaway
+	// agent loop is cut off in seconds, at twice the v2 API's throughput.
+	MCP_TOOLS_RATE_LIMITER: Cloudflare.RateLimit("MCP_TOOLS_RATE_LIMITER", {
+		namespaceId: 2026082901,
+		simple: { limit: 120, period: 10 },
+	}),
+	API_V2_RATE_LIMIT_PARTITION: formatMapleStage(stage),
+	// Production only: preview/stg workers run the same email crons against
+	// their own DB branches, so a binding here means every live stage sends
+	// its own copy of onboarding/digest/alert emails to real users.
+	...(stage.kind === "prd"
+		? {
+				EMAIL: Cloudflare.Email.SendEmail("email", {
+					allowedSenderAddresses: ["notifications@noreply.maple.dev"],
+				}),
+			}
+		: undefined),
+})
+
+/**
+ * The api worker's runtime env, derived from the declaration above — one
+ * source of truth, imported (type-only) by `src/worker.ts`.
+ *
+ * `Partial` because a binding's absence is a real runtime state: ref stages
+ * attach MAPLE_DB after the Worker exists, EMAIL is prd-only, pr previews bind
+ * no database, and `alchemy dev` emulation does not cover every binding. The
+ * configuration vars stay `unknown` on purpose: config is read through the
+ * Effect ConfigProvider (`WorkerConfigProviderLayer` → `platform/Env.ts`),
+ * never off `env` directly.
+ */
+export type MapleApiWorkerEnv = Partial<Cloudflare.InferEnv<ReturnType<typeof makeWorkerBindings>>> &
+	Record<string, unknown>
+
+/**
  * A dev stage's managed Hyperdrive, origin parsed from MAPLE_PG_URL (Hyperdrive
  * wants a structured origin). Created once at the root for api and alerting.
  */
@@ -307,32 +415,6 @@ export const createMapleApi = ({
 			title: resolveWorkerName("mcp-sessions", stage),
 		})
 
-		// Long-running schema-apply: chunks heavy backfill migrations across durable
-		// steps so they never hit the Worker request budget. Class is exported from
-		// src/worker.ts. The first Workflow arg IS the physical workflow name; the
-		// api worker hosts it (no scriptName), so alchemy registers it after deploy.
-		const schemaApplyWorkflow = Cloudflare.Workflow<{ orgId: string }>(
-			resolveWorkerName("schema-apply", stage),
-			{ className: "ClickHouseSchemaApplyWorkflow" },
-		)
-
-		// Fan-out investigation: N lens agents in parallel, then a validator that
-		// promotes one cause and records why each rival lost. Class is exported from
-		// src/worker.ts.
-		const investigationFanoutWorkflow = Cloudflare.Workflow<{
-			orgId: string
-			investigationId: string
-			maxWidth: number
-			reservedPasses: number
-			attempt: number
-		}>(resolveWorkerName("investigation-fanout", stage), {
-			className: "InvestigationFanoutWorkflow",
-		})
-
-		// Durable chat transcripts, one Durable Object per "<orgId>:<tabId>". v2 provisions new
-		// DO classes as SQLite-backed by default. Class is exported from src/worker.ts.
-		const chatSession = Cloudflare.DurableObject("chat-session", { className: "ChatSession" })
-
 		// Vendor-agnostic VCS sync queue (commit backfill + webhook deltas). The same
 		// `api` worker is both producer (binding) and consumer (Queues.Consumer
 		// below). Under `alchemy dev` both halves are emulated in-process from this
@@ -381,54 +463,16 @@ export const createMapleApi = ({
 			//               installs that predate the webhook
 			crons: ["0 */12 * * *", "0 * * * *", "0 */6 * * *"],
 			env: {
-				// Ref stages attach MAPLE_DB via worker.bind below.
-				...(mapleDb ? { MAPLE_DB: mapleDb } : undefined),
-				// Workers AI (`env.AI`, the v1 `Ai()` binding), driving the AI-triage agent on
-				// `@opencode-ai/ai`. v2 emits the `{ type: "ai" }` binding by attaching an AI Gateway
-				// resource, which also fronts model calls with caching/rate-limits/logging.
-				// NOTE: the deploy token needs the account-level "AI Gateway: Edit" permission
-				// for this resource.
-				AI: Cloudflare.AI.Gateway("maple-api-ai"),
-				CHAT_SESSION: chatSession,
-				MCP_SESSIONS: mcpSessions,
-				// Read side of the replay payload store; absent bindings degrade to
-				// inline-only hydration (see platform/ReplayBlobStore.ts).
-				REPLAY_BLOBS: replayBlobs,
-				VCS_SYNC_QUEUE: vcsSyncQueue,
-				VCS_SYNC_QUEUE_NAME: vcsSyncQueueName,
-				PLANETSCALE_WEBHOOK_QUEUE: planetScaleWebhookQueue,
-				PLANETSCALE_WEBHOOK_QUEUE_NAME: planetScaleWebhookQueueName,
-				CLICKHOUSE_SCHEMA_APPLY_WORKFLOW: schemaApplyWorkflow,
-				INVESTIGATION_FANOUT_WORKFLOW: investigationFanoutWorkflow,
-				API_V2_RATE_LIMITER: Cloudflare.RateLimit("API_V2_RATE_LIMITER", {
-					namespaceId: 2026071801,
-					simple: { limit: 600, period: 60 },
+				...makeWorkerBindings({
+					stage,
+					mapleDb,
+					replayBlobs,
+					mcpSessions,
+					vcsSyncQueue,
+					vcsSyncQueueName,
+					planetScaleWebhookQueue,
+					planetScaleWebhookQueueName,
 				}),
-				CLI_AUTH_RATE_LIMITER: Cloudflare.RateLimit("CLI_AUTH_RATE_LIMITER", {
-					namespaceId: 2026072101,
-					simple: { limit: 30, period: 60 },
-				}),
-				MCP_OAUTH_RATE_LIMITER: Cloudflare.RateLimit("MCP_OAUTH_RATE_LIMITER", {
-					namespaceId: 2026072102,
-					simple: { limit: 60, period: 60 },
-				}),
-				// Authenticated POST /mcp, per credential. A short window so a runaway
-				// agent loop is cut off in seconds, at twice the v2 API's throughput.
-				MCP_TOOLS_RATE_LIMITER: Cloudflare.RateLimit("MCP_TOOLS_RATE_LIMITER", {
-					namespaceId: 2026082901,
-					simple: { limit: 120, period: 10 },
-				}),
-				API_V2_RATE_LIMIT_PARTITION: formatMapleStage(stage),
-				// Production only: preview/stg workers run the same email crons against
-				// their own DB branches, so a binding here means every live stage sends
-				// its own copy of onboarding/digest/alert emails to real users.
-				...(stage.kind === "prd"
-					? {
-							EMAIL: Cloudflare.Email.SendEmail("email", {
-								allowedSenderAddresses: ["notifications@noreply.maple.dev"],
-							}),
-						}
-					: undefined),
 				...configuredEnv,
 				...devEnv,
 			},

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -18,9 +18,10 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
 import { serverErrorSpanMiddleware } from "./http/server-error-span"
 import { v2WorkerUnavailableResponse } from "./http/v2-worker-unavailable"
 import { API_CORS_RESPONSE_HEADERS, apiCorsPreflightResponse } from "./http/api-cors"
-import { persistSession, preloadSession, type SessionsBinding } from "./mcp/lib/session-store"
+import { persistSession, preloadSession } from "./mcp/lib/session-store"
 import { makeRecoverablePromiseMemo } from "./platform/recoverable-promise-memo"
 import { classifyWorkerQueue } from "./queue-dispatch"
+import type { MapleApiWorkerEnv } from "../alchemy.run.ts"
 
 const WorkerFileSystemLive = FileSystem.layerNoop({})
 
@@ -143,7 +144,7 @@ const handlerMemo = makeRecoverablePromiseMemo(buildHandler)
 // RPC has no HttpApi request to construct the application services for it, so
 // it gets a sibling isolate-wide ManagedRuntime. Its headless service graph
 // stays behind a dynamic import, preserving the worker's startup-CPU budget.
-const buildRpcRuntime = async (env: Record<string, unknown>) => {
+const buildRpcRuntime = async (env: MapleApiWorkerEnv) => {
 	const [{ InvestigationServicesLive }, { layerPg }] = await Promise.all([
 		import("./runtime/mcp-service-graph"),
 		import("@/platform/DatabasePgLive"),
@@ -196,7 +197,7 @@ const encodeRpcError = (error: unknown): unknown => {
 const runInternalRpc = async (
 	method: InternalRpcMethod,
 	input: unknown,
-	env: Record<string, unknown>,
+	env: MapleApiWorkerEnv,
 	ctx: ExecutionContext,
 ) => {
 	const [runtime, { callMcpToolRpc, listMcpToolsRpc, submitDiagnosisRpc }] = await Promise.all([
@@ -269,14 +270,6 @@ const healthResponse = (): Response =>
 		headers: { ...API_CORS_RESPONSE_HEADERS, "content-type": "text/plain; charset=utf-8" },
 	})
 
-const readMcpSessionsBinding = (env: Record<string, unknown>): SessionsBinding | undefined => {
-	const candidate = env.MCP_SESSIONS
-	if (candidate && typeof candidate === "object" && "get" in candidate && "put" in candidate) {
-		return candidate as SessionsBinding
-	}
-	return undefined
-}
-
 type McpFrame = { method: string; id: string }
 
 // Peek the JSON-RPC body without consuming the request stream. Returns the
@@ -305,16 +298,12 @@ const peekMcpFrame = (body: string): McpFrame => {
 // no-ops in some paths — sessions stay in-memory only and the next isolate 404s.
 // Driving the KV preload+put from this outer async context means the bindings
 // come from `env` directly — no AsyncLocalStorage required.
-const handle = async (
-	request: Request,
-	env: Record<string, unknown>,
-	ctx: ExecutionContext,
-): Promise<Response> => {
+const handle = async (request: Request, env: MapleApiWorkerEnv, ctx: ExecutionContext): Promise<Response> => {
 	if (isHealthRequest(request)) return healthResponse()
 	if (request.method === "OPTIONS") return apiCorsPreflightResponse()
 
 	const isMcp = isMcpPost(request)
-	const kv = isMcp ? readMcpSessionsBinding(env) : undefined
+	const kv = isMcp ? env.MCP_SESSIONS : undefined
 	const reqSid = isMcp ? request.headers.get("mcp-session-id") : null
 	// Start the expensive cold handler build and the independent KV read before
 	// buffering an MCP body. Warm requests resolve both promises immediately;
@@ -418,7 +407,7 @@ export { ChatSession } from "./chat/ChatSession"
 // as the route graph above) to keep module-scope evaluation light.
 const handleQueue = async (
 	batch: MessageBatch<unknown>,
-	env: Record<string, unknown>,
+	env: MapleApiWorkerEnv,
 	ctx: ExecutionContext,
 ): Promise<void> => {
 	const queueKind = classifyWorkerQueue(batch.queue, env)
@@ -467,7 +456,7 @@ const SLACK_RECONCILE_CRON = "0 */6 * * *"
 
 const handleScheduled = async (
 	event: ScheduledController,
-	env: Record<string, unknown>,
+	env: MapleApiWorkerEnv,
 	ctx: ExecutionContext,
 ): Promise<void> => {
 	if (event.cron === SCRAPE_RETENTION_CRON) {
@@ -527,7 +516,7 @@ const handleScheduled = async (
  * encoded with Alchemy's wire envelope so a plain Worker caller can recover tagged
  * Effect errors via `toRpcAsync`.
  */
-export default class MapleApiWorker extends WorkerEntrypoint<Record<string, unknown>> {
+export default class MapleApiWorker extends WorkerEntrypoint<MapleApiWorkerEnv> {
 	override fetch(request: Request): Promise<Response> {
 		return handle(request, this.env, this.ctx)
 	}

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -4,19 +4,43 @@ import * as Command from "alchemy/Command"
 import * as Output from "alchemy/Output"
 import * as Effect from "effect/Effect"
 import {
+	assertBindingParity,
 	CLOUDFLARE_WORKER_PLACEMENT,
 	resolveWorkerName,
 	type MapleDomains,
 	type MapleStage,
 } from "@maple/infra/cloudflare"
+import type { MapleApiWorker } from "../api/alchemy.run.ts"
+import type { WebWorkerEnv } from "./src/worker-env.ts"
 
 export interface CreateMapleWebOptions {
 	stage: MapleStage
 	domains: MapleDomains
+	api: MapleApiWorker
 	apiUrl: string
 	ingestUrl: string
 	electricSyncUrl: string
 }
+
+// The share-preview lookups ride the service binding worker-to-worker; the URL
+// is still bound because bindings address requests by absolute URL, and a
+// deployment without the binding falls back to fetching it over the public
+// domain. A dev stage without an api domain binds neither, and previews
+// degrade to the generic card.
+const makeWorkerEnv = ({ api, apiUrl }: { api: MapleApiWorker; apiUrl: string }) => ({
+	...(apiUrl === "" ? undefined : { MAPLE_API_BASE_URL: apiUrl }),
+	API: api,
+})
+
+// Drift gate for `src/worker-env.ts`, whose Env is structural because the SPA's
+// tsconfig cannot see `@cloudflare/workers-types` (see the note there). This
+// program proves the deployed env satisfies what the worker reads; a renamed
+// key or retyped value fails `tsc -p tsconfig.alchemy.json`. ASSETS is not in
+// `env:` — the assets prop injects it — so the runtime type stands in for it.
+assertBindingParity<
+	WebWorkerEnv,
+	Cloudflare.InferEnv<ReturnType<typeof makeWorkerEnv>> & { ASSETS: WebWorkerEnv["ASSETS"] }
+>()
 
 // The web dashboard is a Vite SPA: `vite build` emits a flat `dist/` and
 // `src/worker.ts` is a tiny assets-fallback worker (unknown routes → SPA
@@ -27,6 +51,7 @@ export interface CreateMapleWebOptions {
 export const createMapleWeb = ({
 	stage,
 	domains,
+	api,
 	apiUrl,
 	ingestUrl,
 	electricSyncUrl,
@@ -59,15 +84,16 @@ export const createMapleWeb = ({
 			},
 		})
 
-		const worker = yield* Cloudflare.Worker<{ MAPLE_API_BASE_URL: string }, Cloudflare.AssetsWithHash>(
+		const worker = yield* Cloudflare.Worker<ReturnType<typeof makeWorkerEnv>, Cloudflare.AssetsWithHash>(
 			"app",
 			{
 				name: resolveWorkerName("web", stage),
 				main: path.join(import.meta.dirname, "src", "worker.ts"),
-				// The bundle bakes this in for the browser (VITE_API_BASE_URL above);
-				// the Worker needs it too, at runtime, for the share-link social
-				// previews it resolves server-side before the SPA ever boots.
-				env: { MAPLE_API_BASE_URL: apiUrl },
+				// The bundle bakes the URL in for the browser (VITE_API_BASE_URL
+				// above); the Worker gets it too, plus the api service binding, for
+				// the share-link social previews it resolves server-side before the
+				// SPA ever boots.
+				env: makeWorkerEnv({ api, apiUrl }),
 				assets: {
 					directory: build.outdir,
 					hash: Output.map(build.hash, (h) => h.output ?? ""),

--- a/apps/web/src/og/alert-chart.ts
+++ b/apps/web/src/og/alert-chart.ts
@@ -14,6 +14,7 @@
 import { alertChartCardNode, ALERT_CARD_HEIGHT, ALERT_CARD_WIDTH } from "./alert-chart-card"
 import { renderNode, type AssetFetcher } from "./render"
 import type { StaticChartSpec } from "@maple/widgets/chart/static-chart"
+import type { ApiTarget } from "../worker-env"
 
 /** The API has to answer before an image request is worth abandoning. */
 const API_TIMEOUT_MS = 4000
@@ -34,7 +35,7 @@ interface AlertChartSeriesResponse {
  * a copy of the URL which of those it was.
  */
 export const renderAlertChartImage = async (
-	apiBaseUrl: string,
+	api: ApiTarget,
 	chartId: string,
 	assets: AssetFetcher,
 ): Promise<Response> => {
@@ -42,12 +43,14 @@ export const renderAlertChartImage = async (
 
 	let series: AlertChartSeriesResponse
 	try {
-		const response = await fetch(new URL("/v2/share/alert-chart", apiBaseUrl), {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({ chartId }),
-			signal: AbortSignal.timeout(API_TIMEOUT_MS),
-		})
+		const response = await api.fetch(
+			new Request(new URL("/v2/share/alert-chart", api.baseUrl), {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ chartId }),
+				signal: AbortSignal.timeout(API_TIMEOUT_MS),
+			}),
+		)
 		if (!response.ok) return notFound
 		series = (await response.json()) as AlertChartSeriesResponse
 	} catch {

--- a/apps/web/src/og/share-preview.ts
+++ b/apps/web/src/og/share-preview.ts
@@ -22,6 +22,7 @@
 import { ogCardNode } from "./card"
 import { renderOgCard, type AssetFetcher, type EmbeddedImage } from "./render"
 import { ogMetaAdditions, ogMetaReplacements, type ShareOgMeta } from "./share-links"
+import type { ApiTarget } from "../worker-env"
 
 /**
  * The slice of Cloudflare's `HTMLRewriter` this module uses.
@@ -53,13 +54,15 @@ const META_CACHE_SECONDS = 300
  */
 const API_TIMEOUT_MS = 1500
 
-const postJson = (apiBaseUrl: string, path: string, body: unknown): Promise<Response> =>
-	fetch(new URL(path, apiBaseUrl), {
-		method: "POST",
-		headers: { "content-type": "application/json" },
-		body: JSON.stringify(body),
-		signal: AbortSignal.timeout(API_TIMEOUT_MS),
-	})
+const postJson = (api: ApiTarget, path: string, body: unknown): Promise<Response> =>
+	api.fetch(
+		new Request(new URL(path, api.baseUrl), {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(body),
+			signal: AbortSignal.timeout(API_TIMEOUT_MS),
+		}),
+	)
 
 const digest = async (value: string): Promise<string> => {
 	const bytes = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value))
@@ -80,10 +83,7 @@ interface CachedMeta {
  * a synthetic host built from a digest of the token, so the token is never a
  * cache key and cannot be read back out of one.
  */
-export const fetchShareOgMeta = async (
-	apiBaseUrl: string,
-	token: string,
-): Promise<ShareOgMeta | undefined> => {
+export const fetchShareOgMeta = async (api: ApiTarget, token: string): Promise<ShareOgMeta | undefined> => {
 	const cache = await caches.open("share-og-meta")
 	const key = new Request(`https://share-og-meta.invalid/${await digest(token)}`)
 
@@ -92,7 +92,7 @@ export const fetchShareOgMeta = async (
 
 	let meta: ShareOgMeta | undefined
 	try {
-		const response = await postJson(apiBaseUrl, "/v2/share/og-meta", { token })
+		const response = await postJson(api, "/v2/share/og-meta", { token })
 		meta = response.ok ? ((await response.json()) as ShareOgMeta) : undefined
 	} catch {
 		// A timeout or a network failure is not cached: the next request should
@@ -179,7 +179,7 @@ const fetchOrgLogo = async (url: string): Promise<EmbeddedImage | undefined> => 
  * revoked.
  */
 export const renderShareOgImage = async (
-	apiBaseUrl: string,
+	api: ApiTarget,
 	ogId: string,
 	assets: AssetFetcher,
 ): Promise<Response> => {
@@ -187,7 +187,7 @@ export const renderShareOgImage = async (
 
 	let card: Parameters<typeof ogCardNode>[0]
 	try {
-		const response = await postJson(apiBaseUrl, "/v2/share/og-card", { ogId })
+		const response = await postJson(api, "/v2/share/og-card", { ogId })
 		if (!response.ok) return notFound
 		card = (await response.json()) as typeof card
 	} catch {

--- a/apps/web/src/worker-env.ts
+++ b/apps/web/src/worker-env.ts
@@ -1,0 +1,49 @@
+/**
+ * The Worker's runtime environment, as this app is allowed to see it.
+ *
+ * Structural on purpose, like the `HTMLRewriter` slice in `og/share-preview.ts`:
+ * this app's tsconfig is a browser one (`lib: DOM`), and importing
+ * `@cloudflare/workers-types` to describe two bindings would retype the entire
+ * SPA. The other direction is checked instead — `alchemy.run.ts` asserts that
+ * the env it deploys satisfies this type, under the tsconfig that *can* see the
+ * Workers types (`tsconfig.alchemy.json`), so a drifted key or type fails CI
+ * there rather than 404ing in production here.
+ *
+ * Everything except `ASSETS` is optional because absence is a real runtime
+ * state, not a type error: this worker only exists on deployed stages (`bun
+ * dev` serves the SPA through Vite, not through this worker), and a dev-stage
+ * deploy without an api domain binds neither key.
+ */
+export interface WebWorkerEnv {
+	readonly ASSETS: { fetch: (request: Request) => Promise<Response> }
+	/**
+	 * The API this deployment's pages talk to, for the share-preview lookups.
+	 * Absent in a build that has not set it — every preview then falls back to
+	 * the generic card, which is the same behaviour as before previews existed.
+	 */
+	readonly MAPLE_API_BASE_URL?: string
+	/**
+	 * Service binding to the api Worker. When present, share-preview traffic
+	 * rides worker-to-worker instead of leaving Cloudflare and re-entering
+	 * through the public domain.
+	 */
+	readonly API?: { fetch: (request: Request) => Promise<Response> }
+}
+
+/**
+ * How this worker reaches the API: the base URL that names it (bindings still
+ * address requests by absolute URL) and the fetch that carries them — the
+ * service binding when bound, the global `fetch` when a deployment lacks it.
+ */
+export interface ApiTarget {
+	readonly baseUrl: string
+	readonly fetch: (request: Request) => Promise<Response>
+}
+
+/** No base URL means no API: previews degrade to the generic card. */
+export const apiTarget = (env: WebWorkerEnv): ApiTarget | undefined => {
+	const baseUrl = env.MAPLE_API_BASE_URL
+	if (baseUrl === undefined || baseUrl === "") return undefined
+	const api = env.API
+	return { baseUrl, fetch: api === undefined ? fetch : (request) => api.fetch(request) }
+}

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -1,17 +1,7 @@
 import { alertChartIdFromPath, ogIdFromPath, shareTokenFromPath } from "./og/share-links"
 import { renderAlertChartImage } from "./og/alert-chart"
 import { fetchShareOgMeta, renderShareOgImage, shareOgMetaRewriter } from "./og/share-preview"
-
-type Env = {
-	ASSETS: { fetch: (request: Request) => Promise<Response> }
-	/**
-	 * The API this deployment's pages talk to, for the share-preview lookups
-	 * below. Absent in a build that has not set it — every preview then falls
-	 * back to the generic card, which is the same behaviour as before previews
-	 * existed.
-	 */
-	MAPLE_API_BASE_URL?: string
-}
+import { apiTarget, type ApiTarget, type WebWorkerEnv } from "./worker-env"
 
 /**
  * Frame and referrer policy, applied to document responses.
@@ -71,28 +61,32 @@ const applyDocumentSecurityHeaders = (response: Response, pathname: string): Res
  * different HTML is cloaking, and the tags change nothing for a human — the app
  * replaces the head as soon as it boots.
  */
-const applyShareOgMeta = async (response: Response, url: URL, env: Env): Promise<Response> => {
-	const apiBaseUrl = env.MAPLE_API_BASE_URL
+const applyShareOgMeta = async (
+	response: Response,
+	url: URL,
+	api: ApiTarget | undefined,
+): Promise<Response> => {
 	const token = shareTokenFromPath(url.pathname)
-	if (apiBaseUrl === undefined || token === undefined || !isHtmlResponse(response)) return response
+	if (api === undefined || token === undefined || !isHtmlResponse(response)) return response
 
-	const meta = await fetchShareOgMeta(apiBaseUrl, token)
+	const meta = await fetchShareOgMeta(api, token)
 	// No meta means an org-only link, a dead one, or an API that did not answer.
 	// All three keep the generic card, and none of them is worth a broken page.
 	return meta === undefined ? response : shareOgMetaRewriter(meta, url.origin).transform(response)
 }
 
 export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
+	async fetch(request: Request, env: WebWorkerEnv): Promise<Response> {
 		const url = new URL(request.url)
+		const api = apiTarget(env)
 
 		// Ahead of the assets lookup: this path has no asset behind it, and the
 		// 404 the assets layer returns for it would fall through to the SPA shell.
 		const ogId = ogIdFromPath(url.pathname)
 		if (ogId !== undefined) {
-			return env.MAPLE_API_BASE_URL === undefined
+			return api === undefined
 				? new Response(null, { status: 404 })
-				: renderShareOgImage(env.MAPLE_API_BASE_URL, ogId, env.ASSETS)
+				: renderShareOgImage(api, ogId, env.ASSETS)
 		}
 
 		// Also ahead of the assets lookup, and for the same reason: `/alerts/…` is
@@ -100,9 +94,9 @@ export default {
 		// `<img>` slot rather than a 404 anyone could diagnose.
 		const chartId = alertChartIdFromPath(url.pathname)
 		if (chartId !== undefined) {
-			return env.MAPLE_API_BASE_URL === undefined
+			return api === undefined
 				? new Response(null, { status: 404 })
-				: renderAlertChartImage(env.MAPLE_API_BASE_URL, chartId, env.ASSETS)
+				: renderAlertChartImage(api, chartId, env.ASSETS)
 		}
 
 		const assetResponse = await env.ASSETS.fetch(request)
@@ -125,7 +119,7 @@ export default {
 			// unknown paths with the shell itself, at status 200. The share preview
 			// therefore has to be applied on this branch too — putting it only on
 			// the fallback below silently disables it in every deployment.
-			return applyShareOgMeta(applyDocumentSecurityHeaders(assetResponse, url.pathname), url, env)
+			return applyShareOgMeta(applyDocumentSecurityHeaders(assetResponse, url.pathname), url, api)
 		}
 
 		// Fetch "/" rather than "/index.html": the assets layer's
@@ -137,6 +131,6 @@ export default {
 		const document = await env.ASSETS.fetch(new Request(new URL("/", url), request))
 		// Reached when the assets layer 404s rather than serving the shell — a
 		// deployment without SPA not-found handling, or a request it declines.
-		return applyShareOgMeta(applyDocumentSecurityHeaders(document, url.pathname), url, env)
+		return applyShareOgMeta(applyDocumentSecurityHeaders(document, url.pathname), url, api)
 	},
 }

--- a/packages/infra/src/cloudflare/binding-parity.ts
+++ b/packages/infra/src/cloudflare/binding-parity.ts
@@ -1,0 +1,17 @@
+/**
+ * Compile-time drift gate between a worker factory's declared bindings and the
+ * runtime env type its worker code reads (the app's `src/worker-env.ts`).
+ *
+ * `Declared` is `Cloudflare.InferEnv` over the factory's binding map. The
+ * constraint proves every declared binding satisfies the runtime type — a
+ * retyped binding fails on the offending property — and the rest parameter
+ * proves every key the worker knows is still declared: dropping one makes the
+ * call demand an argument whose type names the missing keys.
+ *
+ * Purely a type assertion; the call does nothing at runtime.
+ */
+export const assertBindingParity = <Runtime, Declared extends Runtime>(
+	..._proof: keyof Runtime extends keyof Declared
+		? []
+		: [{ undeclaredBindings: Exclude<keyof Runtime, keyof Declared> }]
+): void => {}

--- a/packages/infra/src/cloudflare/index.ts
+++ b/packages/infra/src/cloudflare/index.ts
@@ -1,1 +1,2 @@
+export * from "./binding-parity.ts"
 export * from "./stage.ts"

--- a/tsconfig.alchemy.json
+++ b/tsconfig.alchemy.json
@@ -8,7 +8,11 @@
 		"noEmit": true,
 		"strict": true,
 		"skipLibCheck": true,
-		"types": ["node"],
+		// workers-types is load-bearing for the binding parity gates: without the
+		// ambient globals (Workflow, Service, KVNamespace, …), the references to
+		// them inside alchemy's InferEnv .d.ts silently resolve to `any` under
+		// skipLibCheck and the assignability half of every gate passes vacuously.
+		"types": ["node", "@cloudflare/workers-types"],
 		// Every `@maple/infra` subpath the stack files import. Listing only some of
 		// them let the rest resolve through node_modules instead, so the root
 		// typecheck and turbo's disagreed about which sources they were checking.


### PR DESCRIPTION
Stacked on #735. One declaration per worker: each app's \`alchemy.run.ts\` builds its bindings through an extracted \`makeWorkerBindings\` helper, and the worker's runtime env type is **derived** from it with \`Cloudflare.InferEnv\` — alchemy's documented async-Worker pattern, adapted to factories (our Workers aren't module-scope consts, so \`InferEnv\` targets the binding map instead of \`typeof Worker\`).

## What changed

- **api / alerting** (canonical form): \`alchemy.run.ts\` exports
  \`type MapleApiWorkerEnv = Partial<Cloudflare.InferEnv<ReturnType<typeof makeWorkerBindings>>> & Record<string, unknown>\`
  and \`src/worker.ts\` imports it type-only. One source of truth, nothing to drift. \`Partial\` because absence is a real runtime state (ref stages attach \`MAPLE_DB\` via \`worker.bind\`, \`EMAIL\` is prd-only, pr previews bind no DB); the config vars stay \`unknown\` because config is read through the Effect ConfigProvider, never off \`env\`. The api's \`WorkerEntrypoint<Record<string, unknown>>\` becomes \`WorkerEntrypoint<MapleApiWorkerEnv>\` and the duck-typed \`readMcpSessionsBinding\` is deleted.
- **web** (the one deliberate divergence): the SPA's tsconfig can't see \`@cloudflare/workers-types\` (it would retype the app — documented in \`og/share-preview.ts\`) and can't compile \`alchemy.run.ts\` (\`node:path\`), so it keeps a structural \`src/worker-env.ts\` plus a one-line \`assertBindingParity\` gate in the alchemy program (helper in \`@maple/infra/cloudflare\`), which proves the deployed env satisfies the runtime type and covers all its keys.
- **web → api service binding**: the server-side share-preview and alert-chart lookups now ride \`env.API\` worker-to-worker through an \`ApiTarget { baseUrl, fetch }\` seam instead of leaving Cloudflare over the public api domain; a deployment without the binding falls back to global \`fetch\`. Side fix: an empty \`apiUrl\` no longer binds \`MAPLE_API_BASE_URL: ""\`, which slipped past the worker's \`undefined\` check.
- **tsconfig.alchemy.json gains \`@cloudflare/workers-types\`** — load-bearing, not cosmetic: without the ambient globals (\`Workflow\`, \`Service\`, …), the references inside alchemy's \`InferEnv\` declarations silently resolve to \`any\` under \`skipLibCheck\`, and any InferEnv-derived type is vacuous for resource bindings. Proven by negative test: with the ambients loaded, retyping a binding fails with a precise TS2344 naming the property, and dropping one fails the web gate naming the key.

## Deliberately unchanged

- **landing** keeps its hardcoded \`API_ORIGIN\`: it is citation content (404 copy, markdown links naming the canonical public API), not a call path.
- **electric-sync / local-ui** bind nothing beyond config/\`ASSETS\`, so there is nothing to derive.

## Verification

\`tsc -p tsconfig.alchemy.json\` and per-app typechecks (web, api, alerting) pass; both drift directions negative-tested; web og tests (30) and api queue-dispatch tests pass; oxlint/oxfmt clean.