### PR TITLE
feat(electric-sync): pilot alchemy's Effect-native worker entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,13 @@ jobs:
             # `turbo typecheck` does not cover tsconfig.alchemy.json (alchemy.run.ts and
             # every apps/*/alchemy.run.ts) — only the root `typecheck` script chains it,
             # and CI calls turbo directly. Without this they ship unchecked.
+            #
+            # electric-sync's Effect-native factory imports its runtime `impl`, which
+            # pulls the worker graph — including `@maple-dev/effect-sdk`, whose types
+            # live in built dist — into this program, so the sdk builds first.
+            - name: Build the libraries the Alchemy entrypoints import
+              if: ${{ matrix.shard == 'quality' }}
+              run: bun turbo build --filter=@maple-dev/effect-sdk
             - name: Typecheck Alchemy entrypoints
               if: ${{ matrix.shard == 'quality' }}
               run: bunx tsc -p tsconfig.alchemy.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,8 +201,11 @@ jobs:
             fail-fast: false
             matrix:
                 include:
+                    # electric-sync's closure too: its Effect-native factory imports
+                    # the runtime impl, so the Alchemy-entrypoints typecheck resolves
+                    # that worker graph through apps/electric-sync/node_modules.
                     - shard: quality
-                      install-filters: "@maple/api"
+                      install-filters: "@maple/api @maple/electric-sync"
                     - shard: effect-lint
                       install-filters: ""
                     - shard: build-web

--- a/apps/electric-sync/alchemy.run.ts
+++ b/apps/electric-sync/alchemy.run.ts
@@ -5,6 +5,7 @@ import * as Portless from "@maple/alchemy-portless"
 import type { MapleDomains, MapleStage } from "@maple/infra/cloudflare"
 import { CLOUDFLARE_WORKER_PLACEMENT, resolveWorkerName } from "@maple/infra/cloudflare"
 import { authEnv, merge, optionalPlain, optionalSecret, selfObservabilityEnv } from "@maple/infra/env"
+import { impl } from "./src/worker.ts"
 
 export interface CreateElectricSyncWorkerOptions {
 	stage: MapleStage
@@ -43,23 +44,32 @@ const electricSyncConfiguredEnv = (stage: MapleStage) =>
 		selfObservabilityEnv(stage),
 	)
 
+// Effect-native worker (the fleet's pilot): `src/worker.ts` carries the
+// runtime `impl`; the stage-derived props stay here, where portless and
+// `@maple/infra` are safe to import. This factory's construct is the only one
+// the stack yields, so its props are the ones deployed (the module's default
+// export exists for the generated bundle entry and is inert).
 export const createElectricSyncWorker = ({ stage, domains, dev }: CreateElectricSyncWorkerOptions) =>
 	Effect.gen(function* () {
 		const configuredEnv = yield* electricSyncConfiguredEnv(stage)
-		const worker = yield* Cloudflare.Worker("electric-sync", {
-			name: resolveWorkerName("electric-sync", stage),
-			main: path.join(import.meta.dirname, "src", "worker.ts"),
-			compatibility: { date: "2026-04-08", flags: ["nodejs_compat"] },
-			placement: CLOUDFLARE_WORKER_PLACEMENT,
-			// Under `bun dev`: a sticky port the app's route follows.
-			dev,
-			workersDev: true,
-			// Custom domain (not a zone route): routes don't create DNS records, so
-			// pr-stage hostnames would be authoritative NXDOMAIN. Custom domains
-			// provision DNS + edge certs automatically.
-			domain: domains.sync,
-			env: configuredEnv,
-		})
+		const worker = yield* Cloudflare.Worker(
+			"electric-sync",
+			{
+				name: resolveWorkerName("electric-sync", stage),
+				main: path.join(import.meta.dirname, "src", "worker.ts"),
+				compatibility: { date: "2026-04-08", flags: ["nodejs_compat"] },
+				placement: CLOUDFLARE_WORKER_PLACEMENT,
+				// Under `bun dev`: a sticky port the app's route follows.
+				dev,
+				workersDev: true,
+				// Custom domain (not a zone route): routes don't create DNS records, so
+				// pr-stage hostnames would be authoritative NXDOMAIN. Custom domains
+				// provision DNS + edge certs automatically.
+				domain: domains.sync,
+				env: configuredEnv,
+			},
+			impl,
+		)
 
 		return worker
 	})

--- a/apps/electric-sync/src/worker.ts
+++ b/apps/electric-sync/src/worker.ts
@@ -9,9 +9,8 @@
 import * as MapleCloudflareSDK from "@maple-dev/effect-sdk/cloudflare"
 import { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
 import * as Cloudflare from "alchemy/Cloudflare"
-import { type Cause, Effect, Layer } from "effect"
+import { Effect, Layer } from "effect"
 import { FetchHttpClient, HttpMiddleware, HttpRouter } from "effect/unstable/http"
-import * as HttpServerError from "effect/unstable/http/HttpServerError"
 
 // Module scope stays near empty (fixed ~1s startup CPU budget); `layer` is
 // stable, `flush(env)` resolves env lazily on first call.
@@ -73,19 +72,11 @@ export const impl = Effect.gen(function* () {
 	const exec = yield* Cloudflare.WorkerExecutionContext
 	const router = yield* HttpRouter.HttpRouter
 
-	// Failures become responses BEFORE the tracer, as `toWebHandler` did: a 404
-	// records an Ok span (effect's RouteNotFound is not a Maple anticipated
-	// error, so letting it escape would error-mark every bot scan). 5xx
-	// residuals log through the OTLP logger; expected 4xx stay quiet.
-	const respond = Effect.fnUntraced(function* (cause: Cause.Cause<unknown>) {
-		const [response, residual] = yield* HttpServerError.causeResponse(cause)
-		if (response.status >= 500) {
-			yield* Effect.logError("electric-sync handler failed", residual)
-		}
-		return response
-	})
-
-	const app = HttpMiddleware.tracer(router.asHttpEffect().pipe(Effect.catchCause(respond)))
+	// `orDie` only narrows the router's `unknown` error channel for alchemy's
+	// fetch type; the bridge's own failure boundary turns Respondable defects
+	// into their responses (RouteNotFound → 404), and the tracer records the
+	// failure exactly as `toWebHandler` did.
+	const app = HttpMiddleware.tracer(router.asHttpEffect().pipe(Effect.orDie))
 
 	return {
 		fetch: Effect.gen(function* () {

--- a/apps/electric-sync/src/worker.ts
+++ b/apps/electric-sync/src/worker.ts
@@ -9,7 +9,7 @@
 import * as MapleCloudflareSDK from "@maple-dev/effect-sdk/cloudflare"
 import { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
 import * as Cloudflare from "alchemy/Cloudflare"
-import { Effect, Layer } from "effect"
+import { type Cause, Effect, Layer } from "effect"
 import { FetchHttpClient, HttpMiddleware, HttpRouter } from "effect/unstable/http"
 import * as HttpServerError from "effect/unstable/http/HttpServerError"
 
@@ -77,19 +77,15 @@ export const impl = Effect.gen(function* () {
 	// records an Ok span (effect's RouteNotFound is not a Maple anticipated
 	// error, so letting it escape would error-mark every bot scan). 5xx
 	// residuals log through the OTLP logger; expected 4xx stay quiet.
-	const app = HttpMiddleware.tracer(
-		router
-			.asHttpEffect()
-			.pipe(
-				Effect.catchCause((cause) =>
-					Effect.flatMap(HttpServerError.causeResponse(cause), ([response, residual]) =>
-						response.status >= 500
-							? Effect.as(Effect.logError("electric-sync handler failed", residual), response)
-							: Effect.succeed(response),
-					),
-				),
-			),
-	)
+	const respond = Effect.fnUntraced(function* (cause: Cause.Cause<unknown>) {
+		const [response, residual] = yield* HttpServerError.causeResponse(cause)
+		if (response.status >= 500) {
+			yield* Effect.logError("electric-sync handler failed", residual)
+		}
+		return response
+	})
+
+	const app = HttpMiddleware.tracer(router.asHttpEffect().pipe(Effect.catchCause(respond)))
 
 	return {
 		fetch: Effect.gen(function* () {

--- a/apps/electric-sync/src/worker.ts
+++ b/apps/electric-sync/src/worker.ts
@@ -1,48 +1,20 @@
+/**
+ * The electric-sync worker in Alchemy's Effect-native form. This module is the
+ * bundle entry: its default export is the Worker construct the generated
+ * runtime entry drives. The stack deploys the same `impl` through
+ * `createElectricSyncWorker` in `../alchemy.run.ts`, which owns the
+ * stage-derived props (constructing the minimal one below is inert — only the
+ * factory's construct is ever yielded).
+ */
 import * as MapleCloudflareSDK from "@maple-dev/effect-sdk/cloudflare"
 import { ANTICIPATED_ERROR_IDENTIFIERS } from "@maple/domain/anticipated-errors"
-import { WorkerConfigProviderLayer } from "@maple/effect-cloudflare"
-import { Context, Effect, FileSystem, Layer, Path } from "effect"
+import * as Cloudflare from "alchemy/Cloudflare"
+import { Effect, Layer } from "effect"
 import { FetchHttpClient, HttpMiddleware, HttpRouter } from "effect/unstable/http"
-import * as Etag from "effect/unstable/http/Etag"
-import * as HttpPlatform from "effect/unstable/http/HttpPlatform"
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
+import * as HttpServerError from "effect/unstable/http/HttpServerError"
 
-const WorkerFileSystemLive = FileSystem.layerNoop({})
-
-const WorkerHttpPlatformLive = Layer.effect(
-	HttpPlatform.HttpPlatform,
-	HttpPlatform.make({
-		platform: "web",
-		compression: HttpPlatform.makeCompressionWeb({
-			algorithms: ["gzip", "deflate"],
-			transform: (algorithm) => HttpPlatform.compressionTransformWeb(algorithm),
-		}),
-		fileResponse: (_path, status, statusText, headers) =>
-			HttpServerResponse.text("File responses are unavailable in the worker runtime", {
-				status,
-				statusText,
-				headers,
-			}),
-		fileWebResponse: (_file, status, statusText, headers) =>
-			HttpServerResponse.text("File responses are unavailable in the worker runtime", {
-				status,
-				statusText,
-				headers,
-			}),
-	}),
-).pipe(Layer.provideMerge(WorkerFileSystemLive), Layer.provideMerge(Etag.layer))
-
-const WorkerPlatformLive = Layer.mergeAll(
-	Path.layer,
-	Etag.layer,
-	WorkerFileSystemLive,
-	WorkerHttpPlatformLive,
-)
-
-// Construct telemetry once at module scope — `layer` is stable, `flush(env)`
-// resolves env lazily on first call. Including `telemetry.layer` in the handler's
-// layer composition is the critical bit: the Tracer reference must live in the
-// same runtime as the route that emits spans.
+// Module scope stays near empty (fixed ~1s startup CPU budget); `layer` is
+// stable, `flush(env)` resolves env lazily on first call.
 const telemetry = MapleCloudflareSDK.make({
 	serviceName: "electric-sync",
 	serviceNamespace: "core",
@@ -50,50 +22,35 @@ const telemetry = MapleCloudflareSDK.make({
 	anticipatedErrorIdentifiers: [...ANTICIPATED_ERROR_IDENTIFIERS],
 })
 
-// `HttpMiddleware.tracer` ends the root server span on a deferred macrotask, but
-// `telemetry.flush` drains synchronously. Yield one macrotask first so `span.end`
-// runs before we drain, otherwise isolated requests silently drop the trace.
-//
-// The SDK now owns this drain — `telemetry.flush` yields a macrotask inside its
-// own serialized body. This local yield is kept deliberately redundant (an extra
-// macrotask is harmless) so a version skew between the worker and the published
-// SDK can't drop spans; remove it once the SDK version carrying that change is
-// pinned here.
+// One macrotask before draining, so `HttpMiddleware.tracer`'s deferred
+// `span.end` lands first — otherwise isolated requests silently drop the trace.
 const flushTelemetry = async (env: Record<string, unknown>): Promise<void> => {
 	await new Promise<void>((resolve) => setTimeout(resolve, 0))
 	await telemetry.flush(env)
 }
 
-// Providing ANY middleware — even a pass-through — avoids the `toWebHandler`
-// scope-propagation hang seen on Cloudflare Workers. Paired with
-// `disableLogger: true` so Effect's default logger does not double-log;
-// application logs flow through the OTLP logger installed by `telemetry.layer`.
-const passThroughMiddleware: HttpMiddleware.HttpMiddleware = (httpApp) => httpApp
-
-// The route + config are imported DYNAMICALLY, not at module scope: the graph
-// reachable from `./routes/shape.http` eagerly builds `@maple/domain` Effect
-// Schema ASTs (via the shared auth helper) at module-evaluation time, and
-// Cloudflare runs only top-level module scope during upload validation (fixed
-// ~1s startup CPU budget). Deferring behind `import()` keeps the top level near
-// empty; the cost moves to the first request's far larger CPU budget.
-const buildHandler = async () => {
-	const { ElectricSyncRouter } = await import("./routes/shape.http")
-	const { ElectricClient } = await import("./electric/ElectricClient")
-	const { TenantResolver } = await import("./auth/TenantResolver")
-	const { SyncConfig } = await import("./config")
-	return HttpRouter.toWebHandler(
-		ElectricSyncRouter.pipe(
+// The route/config graph builds `@maple/domain` Schema ASTs eagerly, so it is
+// imported at layer build — init runs on the first event, off the startup
+// budget. Everything here is value-shaped: the bridge's isolate build scope is
+// never closed on workerd, so a scoped resource acquired at init never releases.
+const AppLayer = Layer.unwrap(
+	Effect.promise(async () => {
+		const [{ ElectricSyncRouter }, { ElectricClient }, { TenantResolver }, { SyncConfig }] =
+			await Promise.all([
+				import("./routes/shape.http"),
+				import("./electric/ElectricClient"),
+				import("./auth/TenantResolver"),
+				import("./config"),
+			])
+		return ElectricSyncRouter.pipe(
 			Layer.provideMerge(
 				HttpRouter.cors({
 					allowedOrigins: ["*"],
 					allowedMethods: ["GET", "OPTIONS"],
 					allowedHeaders: ["*"],
-					// Load-bearing, not hygiene: the electric-* headers must be
-					// readable cross-origin or @electric-sql/client cannot advance
-					// the shape cursor (handle/offset/up-to-date) through the proxy,
-					// and every stream stalls after its first chunk. Dropping an
-					// entry here breaks sync in the browser with nothing failing
-					// server-side, which is why it is spelled out rather than tested.
+					// Load-bearing, not hygiene: without these exposed headers
+					// @electric-sql/client cannot advance the shape cursor through the
+					// proxy, and every stream stalls after its first chunk.
 					exposedHeaders: [
 						"electric-handle",
 						"electric-offset",
@@ -103,58 +60,54 @@ const buildHandler = async () => {
 					],
 				}),
 			),
-			// The route depends on these two services rather than constructing them,
-			// so tests can substitute either one; this is the only place the real
-			// implementations (and the real `fetch`) are wired in.
 			Layer.provideMerge(ElectricClient.layer.pipe(Layer.provide(FetchHttpClient.layer))),
 			Layer.provideMerge(TenantResolver.layer),
 			Layer.provideMerge(SyncConfig.layer),
-			Layer.provideMerge(WorkerPlatformLive),
-			Layer.provideMerge(telemetry.layer),
-			Layer.provideMerge(WorkerConfigProviderLayer),
-		),
-		{ middleware: passThroughMiddleware, disableLogger: true },
-	)
-}
-
-// Single isolate-wide handler — `toWebHandler` builds its own ManagedRuntime
-// lazily and keeps it for the isolate's lifetime. Memoized via the build promise
-// so concurrent first requests share one build.
-let handlerPromise: ReturnType<typeof buildHandler> | undefined
-const getHandler = () => (handlerPromise ??= buildHandler())
-
-const handle = async (
-	request: Request,
-	env: Record<string, unknown>,
-	ctx: ExecutionContext,
-): Promise<Response> => {
-	const { handler } = await getHandler()
-	try {
-		const response = await handler(request, Context.empty() as never)
-		ctx.waitUntil(flushTelemetry(env))
-		return response
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err)
-		// Route the fatal-handler error through the OTLP logger installed by
-		// `telemetry.layer` (drained by `flushTelemetry` below) rather than a raw
-		// `console.error` the exporter can't see. This runs outside the handler's
-		// runtime (the `toWebHandler` promise already rejected), so provide the
-		// telemetry layer to a one-shot fiber; its log record lands in the same
-		// in-isolate buffer the flush drains.
-		Effect.runFork(
-			Effect.logError("electric-sync handler failed").pipe(
-				Effect.annotateLogs({ error: message }),
-				// One-shot recovery fiber after the main handler runtime rejected.
-				// oxlint-disable-next-line effecttsgo/strict-effect-provide
-				Effect.provide(telemetry.layer),
-			),
+			Layer.provideMerge(HttpRouter.layer),
 		)
-		ctx.waitUntil(flushTelemetry(env))
-		return new Response(`worker handler error: ${message}`, { status: 504 })
-	}
-}
+	}),
+)
 
-export default {
-	fetch: (request: Request, env: Record<string, unknown>, ctx: ExecutionContext) =>
-		handle(request, env, ctx),
-}
+// Runs once per isolate (and once at plan time, where alchemy derives the shape).
+export const impl = Effect.gen(function* () {
+	const exec = yield* Cloudflare.WorkerExecutionContext
+	const router = yield* HttpRouter.HttpRouter
+
+	// Failures become responses BEFORE the tracer, as `toWebHandler` did: a 404
+	// records an Ok span (effect's RouteNotFound is not a Maple anticipated
+	// error, so letting it escape would error-mark every bot scan). 5xx
+	// residuals log through the OTLP logger; expected 4xx stay quiet.
+	const app = HttpMiddleware.tracer(
+		router
+			.asHttpEffect()
+			.pipe(
+				Effect.catchCause((cause) =>
+					Effect.flatMap(HttpServerError.causeResponse(cause), ([response, residual]) =>
+						response.status >= 500
+							? Effect.as(Effect.logError("electric-sync handler failed", residual), response)
+							: Effect.succeed(response),
+					),
+				),
+			),
+	)
+
+	return {
+		fetch: Effect.gen(function* () {
+			const env = yield* Cloudflare.WorkerEnvironment
+			const response = yield* app
+			// Drain spans and logs after the response is on the wire.
+			yield* exec.waitUntil(Effect.promise(() => flushTelemetry(env)))
+			return response
+		}).pipe(
+			// The Tracer and Logger go on the handler: alchemy only admits Worker
+			// services in a handler's requirements, and the layer is cheap.
+			// oxlint-disable-next-line effecttsgo/strict-effect-provide
+			Effect.provide(telemetry.layer),
+		),
+	}
+	// This IS the worker's entry point: the bridge builds the provided layer
+	// once per isolate.
+	// oxlint-disable-next-line effecttsgo/strict-effect-provide
+}).pipe(Effect.provide(AppLayer))
+
+export default Cloudflare.Worker("electric-sync", { main: import.meta.url }, impl)


### PR DESCRIPTION
Phase 3 of the alchemy bindings migration, piloted on the smallest real worker — in the alchemy example's single-module shape. The hand-written \`export default { fetch }\` shell is gone: \`src/worker.ts\` default-exports the Worker construct the bundle entry drives and exports the \`impl\` the factory deploys.

## Shape (one file, ~110 lines)

- **\`src/worker.ts\`**: module scope holds only telemetry construction; \`impl\` runs once per isolate on the *first event* (not at script startup) and returns \`fetch\`. Its default export is the minimal construct the generated runtime entry requires — constructing it is inert, so the factory's stage-derived props are the ones deployed, and stack-only imports (portless dev blocks, \`@maple/infra\`) never enter the bundle.
- **\`alchemy.run.ts\`**: the factory keeps every prop it had and passes \`impl\` as the third argument.

## What earned its keep (each tried without first)

- **\`Layer.unwrap\` lazy imports** — the route graph's \`@maple/domain\` Schema ASTs must stay off Cloudflare's fixed startup-CPU budget; init-on-first-event plus the lazy layer preserves the old dynamic-import discipline.
- **The 7-line \`causeResponse\` boundary** — \`Effect.orDie\` was simpler but wrong: effect's \`RouteNotFound\` is not a Maple anticipated error, so escaping the tracer would error-mark every bot-scan 404. Failures become responses before the tracer (as \`toWebHandler\` did); only 5xx residuals log, through the OTLP logger.
- **Telemetry make/flush** — flush rides the Effect-native \`waitUntil\` with the existing macrotask-drain ordering; the Tracer/Logger layer goes on the handler, the admitted place for non-Worker services.

Deleted outright: the \`HttpPlatform\`/\`FileSystem\`/\`Etag\`/\`Path\` layer stack (nothing in the route graph uses them), the pass-through-middleware hang workaround, the vendored \`WorkerConfigProviderLayer\` (the bridge provides an env-backed ConfigProvider).

## Notes for review

- \`impl\` also executes at plan time (alchemy derives the worker's shape from it); its config reads come from the same deploy env the factory resolves.
- Init layers are value-shaped on purpose: the bridge's isolate build scope is never closed on workerd.
- Streaming shape responses transfer their scope to the body stream; nothing wraps the proxy in \`Effect.scoped\`.

## Verification

Typechecks (app + tsconfig.alchemy), oxlint/oxfmt, knip, and all 76 electric-sync tests pass. Ran live under a scoped \`bun dev electric-sync\`: \`GET /api/sync/shape?table=…\` → 400 "Unknown or missing shape" (full service graph exercised), unknown path → 404 with an Ok span and no error log, CORS preflight → 204. Suggest a \`preview\` label before merge to exercise the streaming proxy against a real Electric upstream.