### PR TITLE
fix(infra): pods list live by default, and a terminated pod is "Ended" not "Down"

### DIFF
--- a/apps/api/src/routes/internal/query-engine.http.ts
+++ b/apps/api/src/routes/internal/query-engine.http.ts
@@ -1387,7 +1387,9 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleInternalApi, "query
 								saturation: Number(row.saturation) || 0,
 							})),
 							// The denominator has to match the predicate the list ran, or a scoped
-							// view reads "Top 17 of 541". The scope counts are already computed.
+							// view reads "Top 17 of 541". The scope counts are already computed
+							// within the requested lifecycle, so only the unscoped case has to
+							// pick which lifecycle total it wants.
 							totalCount:
 								Number(
 									payload.scope === "saturated"
@@ -1396,9 +1398,12 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleInternalApi, "query
 											? countRow?.elevatedPods
 											: payload.scope === "unbounded"
 												? countRow?.unboundedPods
-												: payload.scope === "stale"
-													? countRow?.stalePods
-													: countRow?.totalPods,
+												: payload.lifecycle === "ended"
+													? countRow?.endedPods
+													: payload.lifecycle === "all"
+														? Number(countRow?.livePods ?? 0) +
+															Number(countRow?.endedPods ?? 0)
+														: countRow?.livePods,
 								) ||
 								// A failed count must not render as "0 of 0" under a list with rows.
 								rows.length,
@@ -1410,11 +1415,11 @@ export const HttpQueryEngineLive = HttpApiBuilder.group(MapleInternalApi, "query
 						const tenant = yield* CurrentTenant.Context
 						const row = yield* runQueryFirst(Queries.podsSummary, tenant, payload)
 						return new PodsSummaryResponse({
-							totalPods: Number(row?.totalPods) || 0,
+							livePods: Number(row?.livePods) || 0,
+							endedPods: Number(row?.endedPods) || 0,
 							saturatedPods: Number(row?.saturatedPods) || 0,
 							elevatedPods: Number(row?.elevatedPods) || 0,
 							unboundedPods: Number(row?.unboundedPods) || 0,
-							stalePods: Number(row?.stalePods) || 0,
 						})
 					}),
 				)

--- a/apps/web/src/api/warehouse/infra.ts
+++ b/apps/web/src/api/warehouse/infra.ts
@@ -58,7 +58,10 @@ export type PodSortKey = "saturation" | "cpuUsage" | "cpuLimitPct" | "memoryLimi
 export type SortDirection = "asc" | "desc"
 
 /** One-click fleet scopes from the summary band. */
-export type PodScope = "saturated" | "elevated" | "unbounded" | "stale"
+export type PodScope = "saturated" | "elevated" | "unbounded"
+
+/** Which slice of the window's pods to list — see the domain contract. */
+export type PodLifecycle = "live" | "ended" | "all"
 
 export interface InfraPresenceInput {
 	startTime: string
@@ -207,6 +210,8 @@ export interface ListPodsInput {
 	workloadKind?: WorkloadKind
 	workloadName?: string
 	scope?: PodScope
+	/** Server-side default is `live`. */
+	lifecycle?: PodLifecycle
 	sortBy?: PodSortKey
 	sortDir?: SortDirection
 	limit?: number
@@ -245,6 +250,7 @@ export function listPods({ data }: { data: ListPodsInput }) {
 					workloadKind: data.workloadKind,
 					workloadName: data.workloadName,
 					scope: data.scope,
+					lifecycle: data.lifecycle,
 					sortBy: data.sortBy,
 					sortDir: data.sortDir,
 					limit: data.limit,

--- a/apps/web/src/components/infra/format.test.ts
+++ b/apps/web/src/components/infra/format.test.ts
@@ -13,12 +13,12 @@ describe("deriveHostStatus", () => {
 		expect(deriveHostStatus("2026-04-24T11:58:30Z", now)).toBe("idle")
 	})
 
-	it("returns down when last-seen is older than 10x scrape interval", () => {
-		expect(deriveHostStatus("2026-04-24T11:55:00Z", now)).toBe("down")
+	it("returns ended when last-seen is older than 10x scrape interval", () => {
+		expect(deriveHostStatus("2026-04-24T11:55:00Z", now)).toBe("ended")
 	})
 
-	it("returns down for a malformed ISO string", () => {
-		expect(deriveHostStatus("not-a-date", now)).toBe("down")
+	it("returns ended for a malformed ISO string", () => {
+		expect(deriveHostStatus("not-a-date", now)).toBe("ended")
 	})
 })
 

--- a/apps/web/src/components/infra/format.ts
+++ b/apps/web/src/components/infra/format.ts
@@ -3,7 +3,17 @@ import { toEpochMs } from "@maple/ui/lib/time-format"
 // Generic number/byte/percent formatting lives in `@maple/ui/lib/format`; only
 // infra-specific status policy stays here.
 
-export type HostStatus = "active" | "idle" | "down"
+/**
+ * Collector freshness, which is all a metrics window can honestly report.
+ *
+ * `ended` is deliberately not "down": a series that stops mid-window means the
+ * resource stopped reporting, and for a pod on an autoscaled fleet that is
+ * almost always a normal termination — scale-in, a rollout, a replaced Fargate
+ * task. Calling that an error painted the expected case red. A real down state
+ * needs an expectation signal (`k8s.pod.phase`, or a workload's available vs
+ * desired replicas), and belongs beside these rather than instead of them.
+ */
+export type HostStatus = "active" | "idle" | "ended"
 export type SeverityLevel = "ok" | "warn" | "crit"
 
 export function severityLevel(fraction: number): SeverityLevel {
@@ -17,11 +27,11 @@ const SCRAPE_INTERVAL_MS = 30_000
 
 export function deriveHostStatus(lastSeenIso: string, reference: number | string = Date.now()): HostStatus {
 	const lastSeen = toEpochMs(lastSeenIso)
-	if (!Number.isFinite(lastSeen)) return "down"
+	if (!Number.isFinite(lastSeen)) return "ended"
 	const referenceMs = typeof reference === "number" ? reference : toEpochMs(reference)
 	const ref = Number.isFinite(referenceMs) ? referenceMs : Date.now()
 	const age = ref - lastSeen
 	if (age < SCRAPE_INTERVAL_MS * 2) return "active"
 	if (age < SCRAPE_INTERVAL_MS * 10) return "idle"
-	return "down"
+	return "ended"
 }

--- a/apps/web/src/components/infra/severity-tokens.ts
+++ b/apps/web/src/components/infra/severity-tokens.ts
@@ -40,20 +40,20 @@ export const BAR_VALUE_TONE: Record<SeverityLevel, string> = {
 export const STATUS_DOT: Record<HostStatus, string> = {
 	active: "bg-[var(--severity-info)]",
 	idle: "bg-muted-foreground/60",
-	down: "bg-[var(--severity-error)]",
+	ended: "bg-muted-foreground/40",
 } satisfies Record<HostStatus, string>
 
 /** Status dot ring. */
 export const STATUS_RING: Record<HostStatus, string> = {
 	active: "ring-[color-mix(in_oklab,var(--severity-info)_45%,transparent)]",
 	idle: "ring-border",
-	down: "ring-[color-mix(in_oklab,var(--severity-error)_45%,transparent)]",
+	ended: "ring-border",
 } satisfies Record<HostStatus, string>
 
 const STATUS_LABEL: Record<HostStatus, string> = {
 	active: "Active",
 	idle: "Idle",
-	down: "Down",
+	ended: "Ended",
 } satisfies Record<HostStatus, string>
 
 /** Human-readable status word, paired with color so it is never the sole signal. */

--- a/apps/web/src/components/infra/status-badge.tsx
+++ b/apps/web/src/components/infra/status-badge.tsx
@@ -6,7 +6,7 @@ import { statusLabel } from "./severity-tokens"
 const STATUS_TEXT: Record<HostStatus, string> = {
 	active: "text-[var(--severity-info)]",
 	idle: "text-muted-foreground",
-	down: "text-[var(--severity-error)]",
+	ended: "text-muted-foreground",
 } satisfies Record<HostStatus, string>
 
 interface HostStatusBadgeProps {

--- a/apps/web/src/routes/infra/index.tsx
+++ b/apps/web/src/routes/infra/index.tsx
@@ -37,7 +37,7 @@ const STATUS_FILTERS: ReadonlyArray<{ value: StatusFilter; label: string }> = [
 	{ value: "all", label: "All" },
 	{ value: "active", label: "Active" },
 	{ value: "idle", label: "Idle" },
-	{ value: "down", label: "Down" },
+	{ value: "ended", label: "Ended" },
 ]
 
 function InfraPage() {
@@ -162,7 +162,7 @@ function FleetView({
 	)
 
 	const counts = useMemo(() => {
-		const c: Record<HostStatus, number> = { active: 0, idle: 0, down: 0 } satisfies Record<
+		const c: Record<HostStatus, number> = { active: 0, idle: 0, ended: 0 } satisfies Record<
 			HostStatus,
 			number
 		>

--- a/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
@@ -24,7 +24,7 @@ import {
 
 const DEFAULT_PRESET = "12h"
 
-const NodeStatusParam = Schema.optional(Schema.Literals(["active", "idle", "down"]))
+const NodeStatusParam = Schema.optional(Schema.Literals(["active", "idle", "ended"]))
 
 const nodesSearchSchema = Schema.Struct({
 	q: Schema.optional(Schema.String),
@@ -44,9 +44,10 @@ export const Route = createFileRoute("/infra/kubernetes/nodes/")({
 
 /**
  * The states are collector freshness, not Kubernetes conditions: a node is
- * "Down" here when no kubelet metric has arrived recently, which is a fact about
- * the collector as much as about the node. `k8s.node.condition_ready` is
- * collected but unqueried — when it lands, it belongs beside these, not instead.
+ * "Ended" here when no kubelet metric has arrived recently, which on an ASG or
+ * a Karpenter-managed fleet usually means the node was scaled in, not that it
+ * failed — so it reads neutral. `k8s.node.condition_ready` is collected but
+ * unqueried; when it lands it belongs beside these, not instead.
  */
 const STATUS_CELLS: ReadonlyArray<{
 	status: HostStatus
@@ -55,13 +56,13 @@ const STATUS_CELLS: ReadonlyArray<{
 }> = [
 	{ status: "active", hint: "reporting", tone: "info" },
 	{ status: "idle", hint: "quiet >1m", tone: "warn" },
-	{ status: "down", hint: "silent >5m", tone: "crit" },
+	{ status: "ended", hint: "silent >5m", tone: "neutral" },
 ]
 
 const STATUS_SEGMENT: Record<HostStatus, string> = {
 	active: "bg-[var(--severity-info)]",
 	idle: "bg-[var(--severity-warn)]",
-	down: "bg-[var(--severity-error)]",
+	ended: "bg-muted-foreground/40",
 } satisfies Record<HostStatus, string>
 
 function NodesPage() {
@@ -148,7 +149,7 @@ function NodesPage() {
 
 					// The band counts the whole scope as of the window's end, so it keeps
 					// saying what the search and the status cell just hid.
-					const counts = { active: 0, idle: 0, down: 0 } satisfies Record<HostStatus, number>
+					const counts = { active: 0, idle: 0, ended: 0 } satisfies Record<HostStatus, number>
 					for (const node of nodes) counts[deriveHostStatus(node.lastSeen, endTime)]++
 
 					const q = searchText.trim().toLowerCase()

--- a/apps/web/src/routes/infra/kubernetes/pods/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/pods/index.tsx
@@ -33,14 +33,19 @@ import {
 const PAGE_SIZE = 50
 const DEFAULT_PRESET = "12h"
 
-/** A one-click scope from the band. `undefined` means the whole fleet. */
-type PodScope = "saturated" | "elevated" | "unbounded" | "stale"
+/**
+ * A one-click scope from the band. `undefined` means the live fleet, which is
+ * what the list shows by default — see `PodLifecycle` in the domain contract.
+ * `ended` is a lifecycle rather than a saturation bucket, but it rides in the
+ * same URL param so the band stays one uniform row of cells.
+ */
+type PodScope = "saturated" | "elevated" | "unbounded" | "ended"
 
 const PodSortKeyParam = Schema.optional(
 	Schema.Literals(["saturation", "cpuUsage", "cpuLimitPct", "memoryLimitPct", "podName", "lastSeen"]),
 )
 const SortDirParam = Schema.optional(Schema.Literals(["asc", "desc"]))
-const ScopeParam = Schema.optional(Schema.Literals(["saturated", "elevated", "unbounded", "stale"]))
+const ScopeParam = Schema.optional(Schema.Literals(["saturated", "elevated", "unbounded", "ended"]))
 
 const podsSearchSchema = Schema.Struct({
 	q: Schema.optional(Schema.String),
@@ -83,7 +88,7 @@ const SCOPE_LABEL: Record<PodScope, string> = {
 	saturated: "at or above 90% of a limit",
 	elevated: "at or above 60% of a limit",
 	unbounded: "running with no limits set",
-	stale: "whose collector has gone quiet",
+	ended: "no longer running",
 } satisfies Record<PodScope, string>
 
 function PodsPage() {
@@ -127,6 +132,8 @@ function PodsPage() {
 	const searchText = search.q ?? ""
 	const debouncedSearch = useDebouncedValue(searchText, 300)
 
+	// "Ended" is the lifecycle dial, not a saturation bucket: the other three
+	// scopes narrow the live fleet, this one swaps which fleet is on screen.
 	const podsResult = useAtomValue(
 		listPodsResultAtom({
 			data: {
@@ -134,7 +141,8 @@ function PodsPage() {
 				endTime,
 				...filters,
 				search: debouncedSearch.trim() || undefined,
-				scope,
+				scope: scope === "ended" ? undefined : scope,
+				lifecycle: scope === "ended" ? "ended" : "live",
 				sortBy,
 				sortDir,
 				limit: PAGE_SIZE,
@@ -181,6 +189,13 @@ function PodsPage() {
 		}
 		patchSearch({ sortBy: key, sortDir: key === "podName" ? "asc" : "desc" })
 	}
+
+	// An unfiltered page can come back empty because the fleet is entirely gone
+	// rather than never instrumented — a job that finished, an environment scaled
+	// to zero. The band already knows, so the empty state can stop guessing.
+	const endedPods = Result.builder(summaryResult)
+		.onSuccess((counts) => counts.endedPods)
+		.orElse(() => 0)
 
 	const hasStructuredFilter = Object.values(filters).some((v) => (v?.length ?? 0) > 0)
 	const hasAnyNarrowing = hasStructuredFilter || Boolean(searchText.trim()) || Boolean(scope)
@@ -253,22 +268,22 @@ function PodsPage() {
 								tone: "warn",
 							},
 							{
-								scope: "stale",
-								label: "Stale collector",
-								hint: ">5m",
-								value: counts.stalePods,
+								scope: "ended",
+								label: "Ended",
+								hint: "not running",
+								value: counts.endedPods,
 								tone: "neutral",
 							},
 						]
 						const healthy = Math.max(
-							counts.totalPods - counts.saturatedPods - counts.elevatedPods,
+							counts.livePods - counts.saturatedPods - counts.elevatedPods,
 							0,
 						)
 						return (
 							<FleetBand
-								total={counts.totalPods}
-								noun="pod"
-								caption="share of the fleet by peak utilization"
+								total={counts.livePods}
+								noun="live pod"
+								caption="share of the live fleet by peak utilization"
 								segments={[
 									{ key: "healthy", count: healthy, className: "bg-muted-foreground/35" },
 									{
@@ -305,12 +320,26 @@ function PodsPage() {
 										<EmptyMedia variant="icon">
 											<FolderIcon size={16} />
 										</EmptyMedia>
-										<EmptyTitle>No pods reporting yet</EmptyTitle>
+										<EmptyTitle>
+											{endedPods > 0
+												? "Nothing running right now"
+												: "No pods reporting yet"}
+										</EmptyTitle>
 										<EmptyDescription>
-											Install the Maple Kubernetes Helm chart so the kubelet stats
-											receiver can start collecting per-pod CPU and memory metrics.
+											{endedPods > 0
+												? `Every pod that reported in this window has since ended. Open the Ended scope to see the ${endedPods.toLocaleString()} that ran.`
+												: "Install the Maple Kubernetes Helm chart so the kubelet stats receiver can start collecting per-pod CPU and memory metrics."}
 										</EmptyDescription>
 									</EmptyHeader>
+									{endedPods > 0 ? (
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => patchSearch({ scope: "ended" })}
+										>
+											Show ended pods
+										</Button>
+									) : null}
 								</Empty>
 							)
 						}

--- a/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
@@ -64,7 +64,7 @@ const KIND_OPTIONS = [
  * pods view is where a spike shows.
  */
 function scopeOf(workload: WorkloadRow, referenceTime: string): WorkloadScope | null {
-	if (deriveHostStatus(workload.lastSeen, referenceTime) === "down") return "stale"
+	if (deriveHostStatus(workload.lastSeen, referenceTime) === "ended") return "stale"
 	const level = severityLevel(Math.max(workload.avgCpuLimitPct, workload.avgMemoryLimitPct))
 	if (level === "crit") return "saturated"
 	if (level === "warn") return "elevated"

--- a/packages/domain/src/http/query-engine.ts
+++ b/packages/domain/src/http/query-engine.ts
@@ -1207,7 +1207,14 @@ const PodSortKeyLiteral = Schema.Literals([
 const SortDirectionLiteral = Schema.Literals(["asc", "desc"])
 
 /** One-click fleet scopes from the browse summary band. */
-const PodScopeLiteral = Schema.Literals(["saturated", "elevated", "unbounded", "stale"])
+const PodScopeLiteral = Schema.Literals(["saturated", "elevated", "unbounded"])
+
+/**
+ * Which slice of the window's pods to return. A windowed list is the union of
+ * everything that reported at any point in it, so on an autoscaled fleet most
+ * of those pods no longer exist. Defaults to `live` server-side.
+ */
+const PodLifecycleLiteral = Schema.Literals(["live", "ended", "all"])
 
 export class ListPodsRequest extends Schema.Class<ListPodsRequest>("ListPodsRequest")({
 	startTime: TinybirdDateTime,
@@ -1236,6 +1243,7 @@ export class ListPodsRequest extends Schema.Class<ListPodsRequest>("ListPodsRequ
 	workloadKind: Schema.optional(WorkloadKindLiteral),
 	workloadName: Schema.optional(Schema.String),
 	scope: Schema.optional(PodScopeLiteral),
+	lifecycle: Schema.optional(PodLifecycleLiteral),
 	sortBy: Schema.optional(PodSortKeyLiteral),
 	sortDir: Schema.optional(SortDirectionLiteral),
 	limit: Schema.optional(Schema.Number),
@@ -1286,11 +1294,13 @@ export class PodsSummaryRequest extends Schema.Class<PodsSummaryRequest>("PodsSu
 }) {}
 
 export class PodsSummaryResponse extends Schema.Class<PodsSummaryResponse>("PodsSummaryResponse")({
-	totalPods: Schema.Number,
+	/** Still reporting at the window's end — the fleet as it stands. */
+	livePods: Schema.Number,
+	/** Reported earlier in the window and stopped: scale-in, a rollout, a cycled task. */
+	endedPods: Schema.Number,
 	saturatedPods: Schema.Number,
 	elevatedPods: Schema.Number,
 	unboundedPods: Schema.Number,
-	stalePods: Schema.Number,
 }) {}
 
 // Containers (Docker) — docker_stats receiver rows, identity (container.name,

--- a/packages/query-engine/src/ch/queries/infra.test.ts
+++ b/packages/query-engine/src/ch/queries/infra.test.ts
@@ -167,18 +167,31 @@ describe("listPodsQuery", () => {
 	it("filters the saturated scope outside the grouping", () => {
 		const { sql } = compileUnsafe(listPodsQuery({ scope: "saturated" }), baseParams)
 		expect(sql).toContain("GROUP BY podName) AS pods")
-		expect(sql).toContain("WHERE saturation >= 0.9")
+		expect(sql).toContain("AND saturation >= 0.9")
 	})
 
 	it("treats a pod with no limit metrics as unbounded, not as healthy", () => {
 		const { sql } = compileUnsafe(listPodsQuery({ scope: "unbounded" }), baseParams)
-		expect(sql).toContain("WHERE (saturation = 0 AND cpuUsagePeak > 0)")
+		expect(sql).toContain("AND (saturation = 0 AND cpuUsagePeak > 0)")
 	})
 
-	it("scopes stale pods relative to the window end, not wall-clock now", () => {
-		const { sql } = compileUnsafe(listPodsQuery({ scope: "stale" }), baseParams)
+	// Ending is the normal end of a pod's life on an autoscaled fleet, so the
+	// list must not lead with pods that no longer exist.
+	it("lists only live pods by default", () => {
+		const { sql } = compileUnsafe(listPodsQuery({}), baseParams)
+		expect(sql).toContain("WHERE lastSeen >= '2024-01-02 00:00:00' - INTERVAL 300 SECOND")
+	})
+
+	it("scopes the lifecycle relative to the window end, not wall-clock now", () => {
+		const { sql } = compileUnsafe(listPodsQuery({ lifecycle: "ended" }), baseParams)
 		expect(sql).toContain("WHERE lastSeen < '2024-01-02 00:00:00' - INTERVAL 300 SECOND")
 		expect(sql).not.toMatch(/__PARAM_\w+__/)
+	})
+
+	it("drops the lifecycle predicate entirely for the whole window", () => {
+		const { sql } = compileUnsafe(listPodsQuery({ lifecycle: "all" }), baseParams)
+		expect(sql).not.toContain("lastSeen >=")
+		expect(sql).not.toContain("lastSeen <")
 	})
 
 	it("emits no scope predicate when none is asked for", () => {
@@ -192,15 +205,28 @@ describe("listPodsSummaryQuery", () => {
 	it("aggregates per pod first so the band counts are exact, not HLL estimates", () => {
 		const { sql } = compileUnsafe(listPodsSummaryQuery({}), baseParams)
 		expect(sql).toContain("GROUP BY podName")
-		expect(sql).toContain("count() AS totalPods")
-		expect(sql).toContain("countIf(saturation >= 0.9) AS saturatedPods")
-		expect(sql).toContain("countIf((saturation >= 0.6 AND saturation < 0.9)) AS elevatedPods")
+		expect(sql).toContain("countIf(lastSeen >= '2024-01-02 00:00:00' - INTERVAL 300 SECOND) AS livePods")
+		expect(sql).toContain("countIf(lastSeen < '2024-01-02 00:00:00' - INTERVAL 300 SECOND) AS endedPods")
 		expect(sql).not.toContain("uniq(")
 		expect(sql).not.toMatch(/__PARAM_\w+__/)
 	})
 
-	it("counts unbounded pods as burning CPU with no limit samples at all", () => {
+	// The band's buckets are the list's denominator, so they have to count the
+	// same slice of the fleet the list is showing — live, by default.
+	it("counts the saturation buckets within the requested lifecycle", () => {
 		const { sql } = compileUnsafe(listPodsSummaryQuery({}), baseParams)
+		expect(sql).toContain(
+			"countIf((lastSeen >= '2024-01-02 00:00:00' - INTERVAL 300 SECOND AND saturation >= 0.9)) AS saturatedPods",
+		)
+	})
+
+	it("counts every bucket over the whole window when lifecycle is all", () => {
+		const { sql } = compileUnsafe(listPodsSummaryQuery({ lifecycle: "all" }), baseParams)
+		expect(sql).toContain("countIf(saturation >= 0.9) AS saturatedPods")
+	})
+
+	it("counts unbounded pods as burning CPU with no limit samples at all", () => {
+		const { sql } = compileUnsafe(listPodsSummaryQuery({ lifecycle: "all" }), baseParams)
 		expect(sql).toContain("countIf((limitSamples = 0 AND cpuUsagePeak > 0)) AS unboundedPods")
 	})
 

--- a/packages/query-engine/src/ch/queries/infra.ts
+++ b/packages/query-engine/src/ch/queries/infra.ts
@@ -325,6 +325,8 @@ export interface ListPodsOpts {
 	sortDir?: SortDirection
 	/** One-click fleet scope from the summary band. */
 	scope?: PodScope
+	/** Defaults to `live` — see PodLifecycle. */
+	lifecycle?: PodLifecycle
 	limit?: number
 	offset?: number
 }
@@ -335,7 +337,20 @@ export interface ListPodsOpts {
  * the grouped query and filters outside it — same plan ClickHouse would produce
  * for HAVING, and it keeps the unscoped query (the common case) single-level.
  */
-export type PodScope = "saturated" | "elevated" | "unbounded" | "stale"
+export type PodScope = "saturated" | "elevated" | "unbounded"
+
+/**
+ * Which slice of the window's pods the caller wants.
+ *
+ * A windowed pod list is the union of everything that reported at any point in
+ * it, so on an autoscaled fleet most of those pods no longer exist — scaled in
+ * by an HPA, rolled out by a deploy, replaced when a Fargate task or spot node
+ * was cycled. Ending is the normal end of a pod's life, not a fault, so the
+ * list defaults to `live` and offers the rest as a deliberate scope. Without
+ * this the ranking, the denominator and the fleet band all mix the dead in with
+ * the running.
+ */
+export type PodLifecycle = "live" | "ended" | "all"
 
 export interface ListPodsOutput {
 	readonly podName: string
@@ -441,8 +456,37 @@ const podFilterConditions = (
 	),
 ]
 
-/** Ten collection intervals at the chart's 30s default. */
-const STALE_POD_SECONDS = 300
+/**
+ * Ten collection intervals at the chart's 30s default. A pod whose newest
+ * datapoint predates this is one whose series ended, which for a pod means it
+ * stopped existing — the same cutoff `deriveHostStatus` uses in the web app, so
+ * the badge on a row and the predicate that selected it never disagree.
+ */
+const ENDED_POD_SECONDS = 300
+
+/**
+ * `lastSeen` is an aggregate, so these belong outside the grouping. The cutoff
+ * rides on `endTime` rather than wall-clock now, so a window that ended an hour
+ * ago still reports who was live *then*.
+ */
+type PodLifecycleColumns = { lastSeen: CH.Expr<string> }
+const endedCutoff = () => CH.intervalSub(param.dateTimeString("endTime"), ENDED_POD_SECONDS)
+const podLiveCondition = ($: PodLifecycleColumns) => $.lastSeen.gte(endedCutoff())
+const podEndedCondition = ($: PodLifecycleColumns) => $.lastSeen.lt(endedCutoff())
+
+const podLifecycleCondition = (
+	$: PodLifecycleColumns,
+	lifecycle: PodLifecycle,
+): CH.Condition | undefined => {
+	switch (lifecycle) {
+		case "live":
+			return podLiveCondition($)
+		case "ended":
+			return podEndedCondition($)
+		case "all":
+			return undefined
+	}
+}
 
 export function listPodsQuery(opts: ListPodsOpts = {}) {
 	const sortBy = opts.sortBy ?? "saturation"
@@ -512,7 +556,10 @@ export function listPodsQuery(opts: ListPodsOpts = {}) {
 			memoryLimitPctPeak: $.memoryLimitPctPeak,
 			saturation: $.saturation,
 		}))
-		.where(($) => [opts.scope ? podScopeCondition($, opts.scope) : undefined])
+		.where(($) => [
+			podLifecycleCondition($, opts.lifecycle ?? "live"),
+			opts.scope ? podScopeCondition($, opts.scope) : undefined,
+		])
 		.orderBy(...(orderBy as Array<[never, SortDirection]>))
 		.limit(opts.limit ?? 50)
 		.offset(opts.offset ?? 0)
@@ -528,7 +575,6 @@ function podScopeCondition(
 	$: {
 		saturation: CH.Expr<number>
 		cpuUsagePeak: CH.Expr<number>
-		lastSeen: CH.Expr<string>
 	},
 	scope: PodScope,
 ): CH.Condition {
@@ -539,8 +585,6 @@ function podScopeCondition(
 			return $.saturation.gte(0.6).and($.saturation.lt(0.9))
 		case "unbounded":
 			return $.saturation.eq(0).and($.cpuUsagePeak.gt(0))
-		case "stale":
-			return $.lastSeen.lt(CH.intervalSub(param.dateTimeString("endTime"), STALE_POD_SECONDS))
 	}
 }
 
@@ -551,15 +595,20 @@ function podScopeCondition(
 // the size of the page.
 
 export interface ListPodsSummaryOutput {
-	readonly totalPods: number
+	/** Still reporting at the window's end — the fleet as it stands. */
+	readonly livePods: number
+	/**
+	 * Reported earlier in the window and stopped. Scale-in, a rollout, a cycled
+	 * Fargate task: expected churn, counted separately so it can be offered as a
+	 * scope instead of inflating the denominator.
+	 */
+	readonly endedPods: number
 	/** Peak of either limit ≥ 0.9 — matches severityLevel("crit") in the web app. */
 	readonly saturatedPods: number
 	/** Peak of either limit in [0.6, 0.9). */
 	readonly elevatedPods: number
 	/** Burning CPU with no limit set at all — invisible to a saturation ranking. */
 	readonly unboundedPods: number
-	/** Last scrape older than ten collection intervals (5 min at the 30s default). */
-	readonly stalePods: number
 }
 
 /**
@@ -587,16 +636,23 @@ export function listPodsSummaryQuery(opts: ListPodsOpts = {}) {
 		.where(($) => [...podBaseConditions($), ...podFilterConditions($, opts)])
 		.groupBy("podName")
 
+	// Live/ended are absolute so the band can always offer "and N more that
+	// ended"; the saturation buckets are counted WITHIN the requested lifecycle
+	// so they stay a valid denominator for the list that ran beside them.
+	const lifecycle = opts.lifecycle ?? "live"
 	return fromQuery(perPod, "pods")
-		.select(($) => ({
-			totalPods: CH.count(),
-			saturatedPods: CH.countIf($.saturation.gte(0.9)),
-			elevatedPods: CH.countIf($.saturation.gte(0.6).and($.saturation.lt(0.9))),
-			unboundedPods: CH.countIf($.limitSamples.eq(0).and($.cpuUsagePeak.gt(0))),
-			stalePods: CH.countIf(
-				$.lastSeen.lt(CH.intervalSub(param.dateTimeString("endTime"), STALE_POD_SECONDS)),
-			),
-		}))
+		.select(($) => {
+			const inScope = podLifecycleCondition($, lifecycle)
+			const within = (condition: CH.Condition) =>
+				CH.countIf(inScope ? inScope.and(condition) : condition)
+			return {
+				livePods: CH.countIf(podLiveCondition($)),
+				endedPods: CH.countIf(podEndedCondition($)),
+				saturatedPods: within($.saturation.gte(0.9)),
+				elevatedPods: within($.saturation.gte(0.6).and($.saturation.lt(0.9))),
+				unboundedPods: within($.limitSamples.eq(0).and($.cpuUsagePeak.gt(0))),
+			}
+		})
 		.format("JSON")
 }
 

--- a/packages/query-engine/src/registry/queries.ts
+++ b/packages/query-engine/src/registry/queries.ts
@@ -959,6 +959,9 @@ const listPodsFilters = (payload: ListPodsRequest) => ({
 	excludedComputeTypes: payload.excludedComputeTypes,
 	workloadKind: payload.workloadKind,
 	workloadName: payload.workloadName,
+	// Lifecycle rides with the filters, not the scope: the denominator has to
+	// count the same slice of the fleet the page is showing.
+	lifecycle: payload.lifecycle,
 })
 
 export const listPods = defineQuery({


### PR DESCRIPTION
The Kubernetes pods view painted most of an autoscaled fleet red — hundreds of rows marked **Down** on a fleet where nothing was actually failing. Two causes, both fixed here.

## Why "Down" fired on the normal case

`deriveHostStatus` returned `"down"` — styled `--severity-error` — for any resource whose newest datapoint was older than 5 minutes. But `lastSeen` is `max(TimeUnix)` over a whole query window (12h by default), so "down" really meant *"this pod's metric series ended"*. On an autoscaled fleet that is the normal end of a pod's life: HPA scale-in, a rolling deploy, a replaced Fargate task, a reclaimed spot node.

Continuity alone cannot prove a resource is down, so the state is now `ended` and reads neutral (`text-muted-foreground`, `bg-muted-foreground/40` dot) instead of error red. A genuine down signal needs an *expectation* — `k8s.pod.phase`, or a workload's available-vs-desired replicas — and belongs beside these states, not instead of them.

## Why the list was full of dead pods

The list returned the union of everything that reported anywhere in the window, with no notion of who was still running. Dead pods inflated the "N pods in scope" denominator and outranked live ones in the default saturation sort.

`PodLifecycle` (`"live" | "ended" | "all"`) now defaults to **live**, cutting at the same 300s-before-`endTime` threshold the badge uses — so the predicate that selected a row and the badge on it cannot disagree. It rides in `listPodsFilters` rather than with the scope, so `listPodsCount` narrows identically and the page can't read "50 of 656".

## What changed

- `HostStatus` is `"active" | "idle" | "ended"`; `down` is gone. Shared policy, so nodes, hosts and workloads get the same treatment — an ASG or Karpenter scaling a node out is the same non-event.
- `listPodsQuery` applies the lifecycle outside the grouping, alongside the scope predicate.
- `listPodsSummaryQuery` returns `livePods`/`endedPods` as absolute counts, with the three saturation buckets counted *within* the requested lifecycle so the band stays a valid denominator for the list beside it.
- The old `stale` scope was the same idea under a worse name — it is now the `ended` lifecycle, and the band's fourth cell. Clicking it swaps which fleet is on screen rather than narrowing the live one.
- The band header reads "N live pods in scope · share of the live fleet by peak utilization".
- The unfiltered empty state no longer says "install the Helm chart" when the fleet has simply all ended (a finished job, an environment scaled to zero) — it points at the Ended scope with the count.

## Reviewer notes

- **Breaking URLs:** shared links carrying `?scope=stale` (pods) or `?status=down` (nodes) will now fail `validateSearch`. I took the clean rename over carrying both literals — flag it if you'd rather keep the old values decoding.
- **Not verified against real data.** The local dev org has no Kubernetes metrics, so this is covered by SQL-shape tests but the visual pass on the screen is unverified. Worth a look on an org with a live fleet.
- **Follow-up left out:** facet counts in the filter sidebar are still window-wide rather than live-scoped, so the sidebar can offer a namespace that yields zero rows. Bounded the diff deliberately.
- The natural next step is the expectation signal — `k8s.pod.phase`, `k8s.pod.status_reason`, `k8s.container.restarts`, and `k8s.deployment.desired` vs `.available` are all collected by default in `deploy/k8s-infra` but unqueried. That is what would let "Down" mean something again, at the workload level where replicas *missing* (rather than churning) is the actual incident.

`bun typecheck`, `bun run lint`, and the query-engine + web infra test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790984562&installation_model_id=427786&pr_number=751&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F751&signature=d2c44ca0dee028fb6e89943ce415df3c532a75eba9f7d2607885520d82228de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->