### PR TITLE
fix(sync): stop Electric's stale-handle warning becoming permanent

### DIFF
--- a/apps/electric-sync/src/routes/headers.test.ts
+++ b/apps/electric-sync/src/routes/headers.test.ts
@@ -32,6 +32,32 @@ describe("shapeResponseHeaders", () => {
 		)
 	})
 
+	it("caps every freshness directive at a minute", () => {
+		// Electric's completed-chunk headers, verbatim: a week of freshness and a
+		// month of stale-while-revalidate, both keyed to a handle that dies with the
+		// ECS task. Neither may reach the browser at that length.
+		assert.strictEqual(
+			syncResponseHeaders({
+				"cache-control": "public, max-age=604800, stale-while-revalidate=2629746",
+			})["cache-control"],
+			"private, max-age=60, stale-while-revalidate=60",
+		)
+	})
+
+	it("leaves a value already under the cap alone", () => {
+		assert.strictEqual(
+			syncResponseHeaders({ "cache-control": "public, max-age=5, s-maxage=5" })["cache-control"],
+			"private, max-age=5, s-maxage=5",
+		)
+	})
+
+	it("drops immutable, which a capped max-age cannot undo", () => {
+		assert.strictEqual(
+			syncResponseHeaders({ "cache-control": "public, max-age=604800, immutable" })["cache-control"],
+			"private, max-age=60",
+		)
+	})
+
 	it("still strips content-encoding / content-length", () => {
 		const headers = syncResponseHeaders({
 			"content-encoding": "gzip",

--- a/apps/electric-sync/src/routes/headers.ts
+++ b/apps/electric-sync/src/routes/headers.ts
@@ -21,18 +21,70 @@ const appendVary = (existing: string | undefined, header: string): string => {
 }
 
 /**
+ * Ceiling on how long a browser may hold a shape chunk, and why there is one.
+ *
+ * Electric marks a *completed* log chunk immutable and cacheable for days — sound
+ * on its own terms, because a chunk is addressed by `handle` + `offset` and a
+ * given handle's bytes never change. But a handle only lives as long as the
+ * shape storage that minted it, and ours is task-local storage on a singleton
+ * ECS task that is replaced whole on every deploy (see `apps/electric`). So the
+ * two lifetimes disagree by orders of magnitude: the browser keeps chunks for a
+ * week under a handle Electric forgets on the next deploy.
+ *
+ * What that costs is not a stale read — the client notices — it is a permanent
+ * one. On a 409 the client writes the dead handle into `localStorage`
+ * (`electric_expired_shapes`, LRU-capped, no TTL) and sends it as
+ * `expired_handle` on every later request for that shape. A disk-cached chunk
+ * still tagged with that handle then trips its stale-cache detector on every
+ * page load, and the cache-buster retry that recovers clears neither side, so it
+ * recurs for as long as both entries survive.
+ *
+ * A minute keeps the burst-coalescing that the cache header is actually for
+ * (an initial sync fetches its chunks back-to-back) while bounding the window to
+ * far less than a deploy.
+ */
+const MAX_BROWSER_CACHE_SECONDS = 60
+
+/**
+ * Rewrites every freshness directive down to the cap, leaving smaller values
+ * alone. `stale-while-revalidate` is in the list and not an afterthought:
+ * Electric pairs a long `max-age` with a *month* of it, and a browser that
+ * honours it serves the stale chunk for that whole month — capping `max-age`
+ * alone would have moved the bug rather than fixed it.
+ */
+const CAPPED_AGE_DIRECTIVES = /\b(s-maxage|max-age|stale-while-revalidate|stale-if-error)=(\d+)/gi
+
+const capMaxAge = (cacheControl: string): string =>
+	cacheControl.replace(CAPPED_AGE_DIRECTIVES, (directive, name: string, seconds: string) =>
+		Number(seconds) > MAX_BROWSER_CACHE_SECONDS ? `${name}=${MAX_BROWSER_CACHE_SECONDS}` : directive,
+	)
+
+/**
+ * Drops `immutable`, which tells a browser to skip revalidation entirely for the
+ * whole freshness lifetime — the one directive a capped `max-age` cannot undo.
+ */
+const dropImmutable = (cacheControl: string): string =>
+	cacheControl
+		.split(",")
+		.map((directive) => directive.trim())
+		.filter((directive) => directive.toLowerCase() !== "immutable")
+		.join(", ")
+
+/**
  * Shapes the headers we return to the browser from an upstream Electric response.
  * Pure and exported so tests can assert the cache-isolation guarantees.
  *
  * Electric marks the initial snapshot / historical log chunks `cache-control:
- * public` so a CDN can fan them out. But our client-facing URL carries NO org — it
- * is `?shape=<name>&offset=…`, byte-identical for every tenant, with the org
- * derived from the bearer. A shared cache keyed on that URL would serve one org's
- * rows to another (the same cross-tenant leak the server-pinned `org_id` WHERE
- * exists to prevent, one layer up). So, per Electric's auth guide, we:
+ * public` so a CDN can fan them out. But our client-facing URL is not a tenant
+ * boundary: the org comes from the bearer, and the `org=` the web app sends is
+ * unverified — a cache-key hint, not a credential. Anyone can send another org's
+ * id, so a shared cache trusting that URL would hand one org's rows to another
+ * (the same cross-tenant leak the server-pinned `org_id` WHERE exists to prevent,
+ * one layer up). So, per Electric's auth guide, we:
  *   - add `Vary: Authorization` so any compliant cache keys on the bearer (→ org);
  *   - downgrade `public` → `private` so no shared CDN/proxy holds an org's rows at
- *     all (live `no-store` responses are left untouched).
+ *     all (live `no-store` responses are left untouched);
+ *   - cap `max-age` and drop `immutable` — see `MAX_BROWSER_CACHE_SECONDS`.
  * We also drop content-encoding/content-length, which misdescribe the re-wrapped
  * body. Effect lowercases header keys, so we match on lowercase names.
  */
@@ -43,8 +95,8 @@ export const syncResponseHeaders = (upstream: Readonly<Record<string, string>>):
 	headers.vary = appendVary(headers.vary, "Authorization")
 
 	const cacheControl = headers["cache-control"]
-	if (cacheControl && /\bpublic\b/.test(cacheControl)) {
-		headers["cache-control"] = cacheControl.replace(/\bpublic\b/g, "private")
+	if (cacheControl) {
+		headers["cache-control"] = dropImmutable(capMaxAge(cacheControl.replace(/\bpublic\b/g, "private")))
 	}
 
 	return headers

--- a/apps/web/src/lib/collections/shape-fetch.ts
+++ b/apps/web/src/lib/collections/shape-fetch.ts
@@ -11,9 +11,10 @@ import { tracedFetch } from "@/lib/services/common/telemetry"
 
 /**
  * URL of the standalone `apps/electric-sync` ElectricSQL shape proxy. Every
- * collection points its ShapeStream here with `?shape=<name>`; the proxy
- * authenticates, injects the org scope, and forwards to Electric. Never point a
- * ShapeStream at Electric directly — it has no auth.
+ * collection points its ShapeStream here with `?shape=<name>&org=<id>`; the proxy
+ * authenticates, injects the org scope from the BEARER (never from `org=`, which
+ * is there for cache keying only — see `createSyncedCollection`), and forwards to
+ * Electric. Never point a ShapeStream at Electric directly — it has no auth.
  */
 export const syncProxyUrl = `${electricSyncBaseUrl}/api/sync/shape`
 
@@ -87,7 +88,23 @@ export const createSyncedCollection = <A extends Row<unknown>>(config: {
 		getKey: config.getKey,
 		shapeOptions: {
 			url: syncProxyUrl,
-			params: { shape: config.shape, ...(config.scope ? { scope: config.scope } : undefined) },
+			params: {
+				shape: config.shape,
+				// Present so the URL differs per tenant, and read by NOBODY: the proxy
+				// forwards only Electric's own cursor params and derives the org from
+				// the bearer, so this cannot widen what a client can reach.
+				//
+				// It exists because the URL is a cache key in three places that are all
+				// org-blind without it. The ShapeStream derives its internal shape key
+				// from this URL minus the cursor params, and that key indexes a
+				// `localStorage` map of expired shape handles (`electric_expired_shapes`,
+				// no TTL) shared by every org a user visits — one org's dead handle rode
+				// along on another's requests and tripped the client's stale-cache
+				// detector. The browser's HTTP cache and any intermediary key on it too,
+				// where `Vary: Authorization` was the only thing keeping tenants apart.
+				org: config.orgId,
+				...(config.scope ? { scope: config.scope } : undefined),
+			},
 			fetchClient: mapleSyncFetch,
 			...(config.parser ? { parser: config.parser } : undefined),
 		},


### PR DESCRIPTION
## What

Two changes that stop `[Electric] Received stale cached response with expired shape handle` from firing on most page loads.

1. **`apps/electric-sync/src/routes/headers.ts`** — cap `max-age`, `s-maxage`, `stale-while-revalidate` and `stale-if-error` at 60s and strip `immutable`, on top of the existing `public` → `private` downgrade.
2. **`apps/web/src/lib/collections/shape-fetch.ts`** — send `org=<id>` on the shape URL.

## Why

### The CDN the warning names is not misconfigured

Worth stating up front, because the warning sends you looking in the wrong place. Nothing shared sits in front of the electric-sync worker (`electric-sync.maple.dev` is not a proxied record), and while `electric.maple.dev` *is* Cloudflare-proxied at the ALB, it answers `cf-cache-status: DYNAMIC` — no Cache Everything rule on `/v1/*`. `buildUpstreamSyncUrl` already forwards `handle`, `offset`, `expired_handle` and `cache-buster`, so that key was complete anyway.

The cache doing the replay is the **browser's own**, and what made it permanent is a lifetime mismatch on our side.

### The lifetime mismatch

Electric marks a completed log chunk immutable and cacheable for a week, paired with a month of `stale-while-revalidate`. Sound on its own terms — a chunk is addressed by `handle` + `offset` and its bytes never change. But a handle lives only as long as the shape storage that minted it, and ours is task-local storage on a singleton ECS task replaced whole on every deploy (`apps/electric/alchemy.run.ts`). We passed those headers straight through, so browsers held chunks for **days** under handles Electric forgets in **minutes**.

The cost is not a stale read — the client notices — it is a *permanent* one:

1. On a 409 the client writes the dead handle into `localStorage` (`electric_expired_shapes`, LRU-capped at 250, **no TTL**) and sends it as `expired_handle` on every later request for that shape.
2. A disk-cached chunk still tagged with that handle trips the stale-cache detector on every page load.
3. The cache-buster retry that recovers clears neither side, so it recurs indefinitely.

Capping `max-age` alone would have moved the bug rather than fixed it: a browser honouring the month of `stale-while-revalidate` keeps serving the stale chunk for that month. Hence all four directives plus `immutable`, which is the one directive a capped `max-age` cannot undo.

### The org-blind URL (independent, latent)

The client-facing URL carried no org, and the ShapeStream derives its internal shape key from that URL minus the cursor params. That key indexes the `localStorage` expired-handle map — so **one entry per shape name was shared by every org a user visits**, and one org's dead handle rode along on another's requests. The browser HTTP cache and any intermediary keyed on it too, with `Vary: Authorization` the only thing holding tenants apart.

## Reviewer notes

- **`org=` is not a trust surface.** `decodeSyncRequest` reads only `shape`/`scope`, and only Electric's own cursor params reach upstream, so the org still comes solely from the bearer. Because the param is client-authored and unverified it is a cache-key hint, not a credential — which is exactly why `Vary: Authorization` and the `private` downgrade both stay. The `headers.ts` doc comment previously said the URL "carries NO org"; it now spells out this distinction instead.
- **Existing damage is sticky.** Users who already tripped this keep a no-TTL `localStorage` entry plus a disk-cached chunk. The cap stops new ones forming and old chunks age out within 7 days; a hard reload clears it immediately.
- **This does not stop the 409 storms**, only their persistence on the client. Every `apps/electric` deploy still invalidates every handle, because the task is a `desiredCount: 1` singleton on storage that dies with it and deploys run `minimumHealthyPercent: 0 / maximumPercent: 100`. Giving it durable storage is the EFS-vs-EBS call already written up in that file's comments — deliberately left for its own PR.
- Branched from `main` rather than `fix/pods-live-lifecycle`, which was already merged and byte-identical to `main`.

## Testing

- `apps/electric-sync`: 79 tests pass, including three new ones covering Electric's completed-chunk header verbatim, a value already under the cap, and `immutable` removal.
- `bun typecheck`: 41/41.
- `bun run lint`: clean.
- `apps/web`: 2365 pass. One pre-existing failure, `guided-setup.test.tsx:57` asserting `isClerkAuthEnabled === false` — it reads Clerk keys from a local `.env.local`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790985392&installation_model_id=427786&pr_number=752&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F752&signature=57ac58220e7a81bc9f6d544e1b18f2de6da753b6e0f30283137948edcd6946ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
