### PR TITLE
feat(errors): inline severity and status pickers on the errors table

### DIFF
--- a/apps/web/src/components/errors/error-signal-row.tsx
+++ b/apps/web/src/components/errors/error-signal-row.tsx
@@ -8,7 +8,7 @@ import { formatNumber } from "@maple/ui/lib/format"
 import { cn } from "@maple/ui/lib/utils"
 
 import { normalizeTimestampInput } from "@/lib/timezone-format"
-import type { ErrorSignal, SignalState } from "@/lib/models/error-signal"
+import type { ErrorSignal, InvestigationSummary } from "@/lib/models/error-signal"
 import { densifySpark, surgeRatio } from "@/lib/models/error-signal"
 
 import { BranchForkIcon, ChatBubbleIcon } from "@/components/icons"
@@ -17,7 +17,7 @@ import { ActorAvatar } from "./actor-chip"
 import { IssueContextMenu } from "./issue-context-menu"
 import { SeverityPicker, StatePicker } from "./issue-pickers"
 import { SignalSpark } from "./signal-spark"
-import { SignalStateChip } from "./signal-state-chip"
+import { InvestigationChip } from "./signal-state-chip"
 import type { IssueMutations } from "./use-issue-mutations"
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000
@@ -42,36 +42,37 @@ function formatLastSeen(iso: string): string {
 const SURGE_THRESHOLD = 2.5
 
 /**
- * What is happening around a row: an open incident or a live investigation,
- * then comment and PR marks. All of it answers "is anyone on this?", and a row
- * nobody has touched draws nothing rather than a line of zeros.
+ * What is happening around a row: a live investigation, then comment and PR
+ * marks. All of it answers "is anyone on this?", and a row nobody has touched
+ * draws nothing rather than a line of zeros.
  *
  * They ride at the end of the identity lane rather than in a column of their
  * own. As a column they held 64px on every row to say something about roughly
  * a third of them, and that 64px was taken from the error message — the lane
- * the list is actually read by. The incident mark moved here from the status
- * lane when that lane became the workflow picker: an incident is a fact about
- * the error, the status is a decision about it, and one slot could not hold
- * both — in an org where every open issue has an incident, the decision was
- * the one that vanished.
+ * the list is actually read by.
+ *
+ * No incident mark. An incident is a flare-up rather than a decision, it opens
+ * on the first occurrence and only auto-resolves after 30 quiet minutes, so in
+ * a busy org it is true of nearly every open row at once — a mark that never
+ * varies separates nothing and only costs the message width.
  */
 function SignalActivity({
-	state,
+	investigation,
 	commentCount,
 	openPullRequestCount,
 	mergedPullRequestCount,
 }: {
-	state: SignalState
+	investigation: InvestigationSummary | null
 	commentCount: number
 	openPullRequestCount: number
 	mergedPullRequestCount: number
 }) {
 	const prCount = openPullRequestCount + mergedPullRequestCount
-	if (state.kind === "workflow" && commentCount === 0 && prCount === 0) return null
+	if (investigation === null && commentCount === 0 && prCount === 0) return null
 	return (
 		<span className="ml-auto flex shrink-0 items-center gap-2 pl-3">
-			{state.kind !== "workflow" ? (
-				<SignalStateChip state={state} withConfidence={false} compact />
+			{investigation !== null ? (
+				<InvestigationChip investigation={investigation} withConfidence={false} compact />
 			) : null}
 			{commentCount > 0 ? (
 				<span
@@ -310,7 +311,7 @@ export function ErrorSignalRow({
 						</span>
 					) : null}
 					<SignalActivity
-						state={signal.state}
+						investigation={signal.investigation}
 						commentCount={signal.commentCount}
 						openPullRequestCount={signal.openPullRequestCount}
 						mergedPullRequestCount={signal.mergedPullRequestCount}

--- a/apps/web/src/components/errors/error-signal-row.tsx
+++ b/apps/web/src/components/errors/error-signal-row.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react"
 import { Link } from "@tanstack/react-router"
 
 import type { ErrorIssueId } from "@maple/domain/http"
@@ -7,14 +8,14 @@ import { formatNumber } from "@maple/ui/lib/format"
 import { cn } from "@maple/ui/lib/utils"
 
 import { normalizeTimestampInput } from "@/lib/timezone-format"
-import type { ErrorSignal } from "@/lib/models/error-signal"
+import type { ErrorSignal, SignalState } from "@/lib/models/error-signal"
 import { densifySpark, surgeRatio } from "@/lib/models/error-signal"
 
 import { BranchForkIcon, ChatBubbleIcon } from "@/components/icons"
 
 import { ActorAvatar } from "./actor-chip"
 import { IssueContextMenu } from "./issue-context-menu"
-import { SeverityBadge } from "./severity-badge"
+import { SeverityPicker, StatePicker } from "./issue-pickers"
 import { SignalSpark } from "./signal-spark"
 import { SignalStateChip } from "./signal-state-chip"
 import type { IssueMutations } from "./use-issue-mutations"
@@ -41,28 +42,37 @@ function formatLastSeen(iso: string): string {
 const SURGE_THRESHOLD = 2.5
 
 /**
- * Comment and PR marks for a row. Deliberately muted — they answer "is anyone
- * on this?" without competing with severity and the incident chip, and a row
+ * What is happening around a row: an open incident or a live investigation,
+ * then comment and PR marks. All of it answers "is anyone on this?", and a row
  * nobody has touched draws nothing rather than a line of zeros.
  *
  * They ride at the end of the identity lane rather than in a column of their
  * own. As a column they held 64px on every row to say something about roughly
  * a third of them, and that 64px was taken from the error message — the lane
- * the list is actually read by.
+ * the list is actually read by. The incident mark moved here from the status
+ * lane when that lane became the workflow picker: an incident is a fact about
+ * the error, the status is a decision about it, and one slot could not hold
+ * both — in an org where every open issue has an incident, the decision was
+ * the one that vanished.
  */
 function SignalActivity({
+	state,
 	commentCount,
 	openPullRequestCount,
 	mergedPullRequestCount,
 }: {
+	state: SignalState
 	commentCount: number
 	openPullRequestCount: number
 	mergedPullRequestCount: number
 }) {
 	const prCount = openPullRequestCount + mergedPullRequestCount
-	if (commentCount === 0 && prCount === 0) return null
+	if (state.kind === "workflow" && commentCount === 0 && prCount === 0) return null
 	return (
 		<span className="ml-auto flex shrink-0 items-center gap-2 pl-3">
+			{state.kind !== "workflow" ? (
+				<SignalStateChip state={state} withConfidence={false} compact />
+			) : null}
 			{commentCount > 0 ? (
 				<span
 					className="flex items-center gap-1 text-[11px] tabular-nums text-muted-foreground"
@@ -99,7 +109,7 @@ function SignalActivity({
  * does not.
  */
 const LANE = {
-	severity: "w-[60px] shrink-0",
+	severity: "w-6 shrink-0",
 	/** The lane that grows, and the last one to give ground. Every other lane
 	 *  now switches on at the width where the identity can still afford it —
 	 *  at 600px this row used to truncate `TypeError` to `Type…` while a 56px
@@ -171,8 +181,8 @@ export function ErrorSignalRowSkeleton({ index }: { index: number }) {
 
 	return (
 		<div className={cn(ROW_SHELL, "h-11")} aria-hidden="true">
-			<span className={cn(LANE.severity, "flex items-center")}>
-				<Skeleton className="h-5 w-12 rounded-sm" />
+			<span className={cn(LANE.severity, "flex items-center justify-center")}>
+				<Skeleton className="size-3.5 rounded-sm" />
 			</span>
 			<span className={LANE.identity}>
 				<Skeleton className="h-3.5" style={{ width: identityWidth }} />
@@ -201,6 +211,9 @@ export function ErrorSignalRowSkeleton({ index }: { index: number }) {
 	)
 }
 
+/** The inline pickers a row can have open. One at a time, and only on one row. */
+export type RowPicker = "severity" | "state"
+
 export interface ErrorSignalRowProps {
 	signal: ErrorSignal
 	sparkWindow: { readonly startMs: number; readonly endMs: number; readonly bucketMs: number }
@@ -208,6 +221,10 @@ export interface ErrorSignalRowProps {
 	selected: boolean
 	focused: boolean
 	onFocus: (id: ErrorIssueId) => void
+	/** Which picker is open on this row, if any. Owned by the list so a hotkey
+	 *  on the focused row can open one without the row's button being clicked. */
+	picker: RowPicker | null
+	onPickerChange: (picker: RowPicker | null) => void
 }
 
 /**
@@ -229,8 +246,11 @@ export function ErrorSignalRow({
 	selected,
 	focused,
 	onFocus,
+	picker,
+	onPickerChange,
 }: ErrorSignalRowProps) {
 	const href = `/errors/issues/${signal.id}`
+	const rowRef = useRef<HTMLAnchorElement | null>(null)
 	const dense = densifySpark(signal.spark, sparkWindow)
 	const surge = surgeRatio(dense)
 	const isSurging = surge !== null && surge >= SURGE_THRESHOLD
@@ -243,6 +263,7 @@ export function ErrorSignalRow({
 			onOpenInNewTab={() => window.open(href, "_blank", "noopener,noreferrer")}
 		>
 			<Link
+				ref={rowRef}
 				to="/errors/issues/$issueId"
 				params={{ issueId: signal.id }}
 				data-issue-id={signal.id}
@@ -258,10 +279,13 @@ export function ErrorSignalRow({
 					"transition-colors",
 				)}
 			>
-				<span className={cn(LANE.severity, "flex items-center")}>
-					<SeverityBadge
-						severity={signal.severity}
-						className="h-5 max-w-full truncate px-1.5 text-[10px]"
+				<span className={cn(LANE.severity, "flex items-center justify-center")}>
+					<SeverityPicker
+						value={signal.severity}
+						onChange={(severity) => void mutations.setSeverity(signal.id, severity)}
+						open={picker === "severity"}
+						onOpenChange={(open) => onPickerChange(open ? "severity" : null)}
+						fallbackAnchor={rowRef}
 					/>
 				</span>
 
@@ -286,6 +310,7 @@ export function ErrorSignalRow({
 						</span>
 					) : null}
 					<SignalActivity
+						state={signal.state}
 						commentCount={signal.commentCount}
 						openPullRequestCount={signal.openPullRequestCount}
 						mergedPullRequestCount={signal.mergedPullRequestCount}
@@ -340,7 +365,13 @@ export function ErrorSignalRow({
 				</span>
 
 				<span className={LANE.state}>
-					<SignalStateChip state={signal.state} withConfidence={false} />
+					<StatePicker
+						current={signal.issue.workflowState}
+						onChange={(next) => void mutations.transitionTo(signal.id, next)}
+						open={picker === "state"}
+						onOpenChange={(open) => onPickerChange(open ? "state" : null)}
+						fallbackAnchor={rowRef}
+					/>
 				</span>
 
 				<span className={LANE.actor}>

--- a/apps/web/src/components/errors/errors-hub-view.tsx
+++ b/apps/web/src/components/errors/errors-hub-view.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useReducer } from "react"
+import { useCallback, useMemo, useReducer, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 
 import type { ErrorIssueId, WorkflowState } from "@maple/domain/http"
@@ -10,6 +10,7 @@ import { cn } from "@maple/ui/lib/utils"
 import { CircleCheckIcon, HistoryIcon, MagnifierIcon } from "@/components/icons"
 import { ErrorState } from "@/components/common/error-state"
 import { ListToolbar } from "@/components/common/list-toolbar"
+import { useAppHotkey } from "@/hooks/use-app-hotkey"
 import { useListNavigation } from "@/hooks/use-list-navigation"
 import type { ErrorSignal } from "@/lib/models/error-signal"
 import {
@@ -21,7 +22,7 @@ import {
 	updateIssueSelection,
 } from "@/lib/models/issue-selection"
 
-import { ErrorSignalHeader, ErrorSignalRow, ErrorSignalRowSkeleton } from "./error-signal-row"
+import { ErrorSignalHeader, ErrorSignalRow, ErrorSignalRowSkeleton, type RowPicker } from "./error-signal-row"
 import { IssuesBulkBar } from "./issues-bulk-bar"
 import { SEVERITY_FILL, SEVERITY_ORDER, SeverityDot, severityRank } from "./severity-badge"
 import { useIssueMutations } from "./use-issue-mutations"
@@ -439,6 +440,17 @@ function HubList({
 		scrollTo: (id) => scrollIntoView(id),
 	})
 
+	// One picker open across the whole list. Linear's "s" and "p": the focused
+	// row opens its status or severity picker without a pointer reaching the
+	// button — which may not even be on screen at narrow widths, hence the
+	// row's fallback anchor.
+	const [openPicker, setOpenPicker] = useState<{ id: ErrorIssueId; kind: RowPicker } | null>(null)
+	const openPickerOnFocused = (kind: RowPicker) => {
+		if (focusedId !== null) setOpenPicker({ id: focusedId, kind })
+	}
+	useAppHotkey("issue.status", () => openPickerOnFocused("state"))
+	useAppHotkey("issue.severity", () => openPickerOnFocused("severity"))
+
 	const selectedIssues = useMemo(
 		() =>
 			signals
@@ -473,6 +485,10 @@ function HubList({
 									selected={selectedIds.has(signal.id)}
 									focused={focusedId === signal.id}
 									onFocus={setFocusedId}
+									picker={openPicker?.id === signal.id ? openPicker.kind : null}
+									onPickerChange={(kind) =>
+										setOpenPicker(kind === null ? null : { id: signal.id, kind })
+									}
 								/>
 							</div>
 						))}

--- a/apps/web/src/components/errors/issue-pickers.tsx
+++ b/apps/web/src/components/errors/issue-pickers.tsx
@@ -1,0 +1,153 @@
+import { useMemo, type RefObject } from "react"
+
+import type { IssueSeverity, WorkflowState } from "@maple/domain/http"
+import {
+	allowedTransitionsForAll,
+	MACHINE_OWNED_WORKFLOW_STATES,
+	WORKFLOW_STATE_ORDER,
+} from "@maple/domain/http"
+import { cn } from "@maple/ui/lib/utils"
+
+import { WORKFLOW_LABEL, WorkflowRingIcon } from "@/components/icons/workflow-ring"
+
+import { QuickPickMenu, type QuickPickItem } from "./quick-pick-menu"
+import { SEVERITY_LABEL, SEVERITY_ORDER, SeverityIcon } from "./severity-badge"
+
+/**
+ * The two Linear-style controls an error row carries: severity on the left,
+ * workflow state on the right. Both open a {@link QuickPickMenu}; this file
+ * only knows which rows to offer and what the trigger looks like.
+ */
+
+/** Hotkeys shown in the pickers and registered by the hub on the focused row. */
+const PICKER_HOTKEY = { severity: "P", state: "S" } as const
+
+/** A row's focus-ring and hover wash, shared so the two triggers feel like one control family. */
+const TRIGGER =
+	"rounded-md transition-colors hover:bg-foreground/8 data-popup-open:bg-foreground/8 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none"
+
+/** A Select's value must be a string, so "not set" needs a stand-in. */
+const NONE = "none" as const
+type SeverityChoice = IssueSeverity | typeof NONE
+
+const SEVERITY_ITEMS: ReadonlyArray<QuickPickItem<SeverityChoice>> = [
+	{
+		value: NONE,
+		label: "No severity",
+		icon: <SeverityIcon severity={null} />,
+		shortcut: "0",
+		keywords: "none unset clear",
+	},
+	...SEVERITY_ORDER.map((severity, index) => ({
+		value: severity,
+		label: SEVERITY_LABEL[severity],
+		icon: <SeverityIcon severity={severity} />,
+		shortcut: String(index + 1),
+	})),
+]
+
+export function SeverityPicker({
+	value,
+	onChange,
+	open,
+	onOpenChange,
+	fallbackAnchor,
+	className,
+}: {
+	value: IssueSeverity | null
+	onChange: (severity: IssueSeverity | null) => void
+	open?: boolean
+	onOpenChange?: (open: boolean) => void
+	fallbackAnchor?: RefObject<HTMLElement | null>
+	className?: string
+}) {
+	const label = value === null ? "Severity not set" : `Severity: ${SEVERITY_LABEL[value]}`
+	return (
+		<QuickPickMenu
+			items={SEVERITY_ITEMS}
+			current={value ?? NONE}
+			onSelect={(next) => onChange(next === NONE ? null : next)}
+			placeholder="Change severity…"
+			hotkey={PICKER_HOTKEY.severity}
+			label="Severity"
+			open={open}
+			onOpenChange={onOpenChange}
+			fallbackAnchor={fallbackAnchor}
+		>
+			<button
+				type="button"
+				data-picker="severity"
+				title={`${label} · click to change`}
+				aria-label={`${label}. Change severity`}
+				className={cn(TRIGGER, "inline-flex size-6 items-center justify-center", className)}
+			>
+				<SeverityIcon severity={value} size={16} />
+			</button>
+		</QuickPickMenu>
+	)
+}
+
+/**
+ * `regressed` and `verifying` are set by the ticks, never chosen. They still
+ * render as the CURRENT value when an issue is in one; they are only absent
+ * from the choices.
+ */
+const OFFERED_STATES = WORKFLOW_STATE_ORDER.filter((state) => !MACHINE_OWNED_WORKFLOW_STATES.has(state))
+
+export function StatePicker({
+	current,
+	onChange,
+	open,
+	onOpenChange,
+	fallbackAnchor,
+	className,
+}: {
+	current: WorkflowState
+	onChange: (next: WorkflowState) => void
+	open?: boolean
+	onOpenChange?: (open: boolean) => void
+	fallbackAnchor?: RefObject<HTMLElement | null>
+	className?: string
+}) {
+	// The offered moves come from the domain matrix the server enforces, so the
+	// picker never shows a transition the API would reject. Unreachable states
+	// stay listed but dimmed: the digits keep meaning the same thing on every row.
+	const items = useMemo<ReadonlyArray<QuickPickItem<WorkflowState>>>(() => {
+		const allowed = new Set<WorkflowState>(allowedTransitionsForAll([current]))
+		return OFFERED_STATES.map((state, index) => ({
+			value: state,
+			label: WORKFLOW_LABEL[state],
+			icon: <WorkflowRingIcon state={state} size={14} />,
+			shortcut: String(index + 1),
+			disabled: state !== current && !allowed.has(state),
+		}))
+	}, [current])
+
+	return (
+		<QuickPickMenu
+			items={items}
+			current={current}
+			onSelect={onChange}
+			placeholder="Change status…"
+			hotkey={PICKER_HOTKEY.state}
+			label="Status"
+			open={open}
+			onOpenChange={onOpenChange}
+			fallbackAnchor={fallbackAnchor}
+		>
+			<button
+				type="button"
+				data-picker="state"
+				title={`Status: ${WORKFLOW_LABEL[current]} · click to change`}
+				className={cn(
+					TRIGGER,
+					"-ml-1.5 inline-flex h-6 max-w-full items-center gap-1.5 px-1.5 text-[11px] whitespace-nowrap text-muted-foreground hover:text-foreground data-popup-open:text-foreground",
+					className,
+				)}
+			>
+				<WorkflowRingIcon state={current} size={12} className="shrink-0" />
+				<span className="truncate">{WORKFLOW_LABEL[current]}</span>
+			</button>
+		</QuickPickMenu>
+	)
+}

--- a/apps/web/src/components/errors/quick-pick-menu.tsx
+++ b/apps/web/src/components/errors/quick-pick-menu.tsx
@@ -1,0 +1,203 @@
+import {
+	useRef,
+	useState,
+	type KeyboardEvent,
+	type ReactElement,
+	type ReactNode,
+	type RefObject,
+} from "react"
+
+import { AutocompletePrimitive } from "@maple/ui/components/ui/autocomplete"
+import { CommandCollection, CommandEmpty, CommandItem, CommandList } from "@maple/ui/components/ui/command"
+import { Kbd } from "@maple/ui/components/ui/kbd"
+import { Popover, PopoverPrimitive, PopoverTrigger } from "@maple/ui/components/ui/popover"
+import { cn } from "@maple/ui/lib/utils"
+
+import { CheckIcon } from "@/components/icons"
+
+/**
+ * A Linear-style inline picker: a small popover with a type-to-filter input on
+ * top, a hotkey hint beside it, and one row per choice with its icon, a check
+ * on the current value and a digit that picks it outright.
+ *
+ * Built on Popover + the inline Autocomplete that backs the command palette
+ * rather than on Menu, because a menu cannot be typed into and the whole point
+ * of the input is that "in r⏎" beats scanning nine rows.
+ */
+
+export interface QuickPickItem<V extends string> {
+	readonly value: V
+	readonly label: string
+	readonly icon: ReactNode
+	/** Digit shown at the row's right edge; pressing it with an empty query picks the row. */
+	readonly shortcut?: string
+	readonly disabled?: boolean
+	/** Extra words the filter matches on, beyond the label. */
+	readonly keywords?: string
+}
+
+export interface QuickPickMenuProps<V extends string> {
+	items: ReadonlyArray<QuickPickItem<V>>
+	current: V | null
+	onSelect: (value: V) => void
+	/** Placeholder of the filter input — "Change status…". */
+	placeholder: string
+	/** The key that opens this picker from a focused row, shown beside the input. */
+	hotkey?: string
+	open?: boolean
+	onOpenChange?: (open: boolean) => void
+	disabled?: boolean
+	/**
+	 * Where to hang the popover when the trigger itself is not on screen — a
+	 * responsive lane hides the trigger below some width, but the row's hotkey
+	 * still has to open something, and a popover anchored to a `display: none`
+	 * element lands in the page's top-left corner.
+	 */
+	fallbackAnchor?: RefObject<HTMLElement | null>
+	/** The trigger. Rendered through Base UI's `render`, so it keeps its own markup. */
+	children: ReactElement
+	/** Accessible name for the listbox. */
+	label: string
+}
+
+const isOnScreen = (element: HTMLElement | null): element is HTMLElement =>
+	element !== null && element.getClientRects().length > 0
+
+export function QuickPickMenu<V extends string>({
+	items,
+	current,
+	onSelect,
+	placeholder,
+	hotkey,
+	open: openProp,
+	onOpenChange,
+	disabled,
+	fallbackAnchor,
+	children,
+	label,
+}: QuickPickMenuProps<V>) {
+	const [openState, setOpenState] = useState(false)
+	const open = openProp ?? openState
+	const setOpen = (next: boolean) => {
+		setOpenState(next)
+		onOpenChange?.(next)
+	}
+	const triggerRef = useRef<HTMLButtonElement | null>(null)
+
+	const pick = (value: V) => {
+		setOpen(false)
+		if (value !== current) onSelect(value)
+	}
+
+	// Digits pick a row directly, Linear-style — but only while nothing has been
+	// typed, so a query that happens to contain a digit still filters.
+	const onInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.currentTarget.value !== "" || !/^[0-9]$/.test(event.key)) return
+		const item = items.find((candidate) => candidate.shortcut === event.key && !candidate.disabled)
+		if (item === undefined) return
+		event.preventDefault()
+		pick(item.value)
+	}
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger
+				ref={triggerRef}
+				render={children}
+				disabled={disabled}
+				// The trigger sits inside the row's link. Stop the click there so the
+				// row does not navigate, and keep it from the anchor's default action.
+				onClick={(event) => {
+					event.preventDefault()
+					event.stopPropagation()
+				}}
+			/>
+			<PopoverPrimitive.Portal>
+				<PopoverPrimitive.Positioner
+					side="bottom"
+					align="start"
+					sideOffset={6}
+					className="isolate z-55 outline-none"
+					anchor={() =>
+						isOnScreen(triggerRef.current)
+							? triggerRef.current
+							: (fallbackAnchor?.current ?? null)
+					}
+				>
+					<PopoverPrimitive.Popup
+						className={cn(
+							"w-60 origin-(--transform-origin) overflow-hidden rounded-xl bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-none",
+							"duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+						)}
+						// Portalled, but React events still bubble to the row's link. Nothing
+						// clicked in here should open the issue.
+						onClick={(event) => event.stopPropagation()}
+						onKeyDownCapture={(event) => {
+							// The forced-open Autocomplete swallows Escape before the popover
+							// sees it, the same trap the command palette works around.
+							if (event.key === "Escape") {
+								event.preventDefault()
+								event.stopPropagation()
+								setOpen(false)
+							}
+						}}
+					>
+						{/* The primitive rather than the `Command` wrapper: the wrapper erases
+						    the item generic, and the filter needs it. Same settings — inline,
+						    always open, first row highlighted. */}
+						<AutocompletePrimitive.Root
+							items={items}
+							inline
+							open
+							autoHighlight="always"
+							keepHighlight
+							filter={(item, query) =>
+								`${item.label} ${item.keywords ?? ""}`
+									.toLowerCase()
+									.includes(query.trim().toLowerCase())
+							}
+						>
+							<div className="flex items-center gap-2 border-b border-border/60 px-3">
+								<AutocompletePrimitive.Input
+									autoFocus
+									aria-label={label}
+									placeholder={placeholder}
+									onKeyDown={onInputKeyDown}
+									className="h-9 min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+								/>
+								{hotkey ? <Kbd className="h-4.5 min-w-4.5 text-[10px]">{hotkey}</Kbd> : null}
+							</div>
+							<CommandList className="not-empty:p-1">
+								<CommandEmpty className="not-empty:py-4 text-xs">No match</CommandEmpty>
+								<CommandCollection>
+									{(item: QuickPickItem<V>) => (
+										<CommandItem
+											key={item.value}
+											value={item}
+											disabled={item.disabled}
+											onClick={() => pick(item.value)}
+											className="gap-2 rounded-md px-2 py-1.5 text-xs text-foreground data-disabled:opacity-40"
+										>
+											<span className="flex size-4 shrink-0 items-center justify-center">
+												{item.icon}
+											</span>
+											<span className="min-w-0 flex-1 truncate">{item.label}</span>
+											{item.value === current ? (
+												<CheckIcon size={12} className="shrink-0 text-foreground" />
+											) : null}
+											{item.shortcut ? (
+												<span className="w-3 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground/70">
+													{item.shortcut}
+												</span>
+											) : null}
+										</CommandItem>
+									)}
+								</CommandCollection>
+							</CommandList>
+						</AutocompletePrimitive.Root>
+					</PopoverPrimitive.Popup>
+				</PopoverPrimitive.Positioner>
+			</PopoverPrimitive.Portal>
+		</Popover>
+	)
+}

--- a/apps/web/src/components/errors/severity-badge.tsx
+++ b/apps/web/src/components/errors/severity-badge.tsx
@@ -2,6 +2,8 @@ import type { IssueSeverity } from "@maple/domain/http"
 import { Badge } from "@maple/ui/components/ui/badge"
 import { cn } from "@maple/ui/lib/utils"
 
+import { PixelTriangleWarningIcon } from "@/components/icons"
+
 export const SEVERITY_TONE: Record<IssueSeverity, string> = {
 	critical: "bg-destructive/10 text-destructive",
 	high: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
@@ -86,5 +88,73 @@ export function SeverityBadge({
 		<Badge variant="outline" className={cn(SEVERITY_TONE[severity], className)}>
 			{SEVERITY_LABEL[severity]}
 		</Badge>
+	)
+}
+
+/**
+ * The compact glyph for a row, drawn on Nucleo's pixel grid so it sits with the
+ * rest of the icon set: 24-unit viewBox, 2-unit cells, square caps, nothing
+ * anti-aliased into a curve. Three blocks for "nobody has said" — the mark
+ * Linear uses for "no priority", which is where the eye already looks for a
+ * thing to set. One, two or three bars for low, medium and high. Critical is
+ * the pixel triangle-warning the rest of the app already uses, in red: the top
+ * level is a different kind of statement from "a bit more than high".
+ */
+export function SeverityIcon({
+	severity,
+	size = 16,
+	className,
+}: {
+	severity: IssueSeverity | null
+	size?: number
+	className?: string
+}) {
+	const label = severity === null ? "Severity not set" : SEVERITY_LABEL[severity]
+
+	if (severity === "critical") {
+		return (
+			<PixelTriangleWarningIcon
+				size={size}
+				role="img"
+				aria-hidden={undefined}
+				aria-label={label}
+				className={cn(SEVERITY_TEXT[severity], className)}
+			/>
+		)
+	}
+
+	const common = {
+		xmlns: "http://www.w3.org/2000/svg",
+		viewBox: "0 0 24 24",
+		width: size,
+		height: size,
+		fill: "none",
+		stroke: "currentColor",
+		strokeWidth: 4,
+		strokeLinecap: "square" as const,
+		role: "img" as const,
+		"aria-label": label,
+	}
+
+	if (severity === null) {
+		return (
+			<svg {...common} className={cn("text-muted-foreground", className)}>
+				{/* Three 2×2-cell blocks on the midline. */}
+				<path d="M3 12H3.01" />
+				<path d="M11 12H11.01" />
+				<path d="M19 12H19.01" />
+			</svg>
+		)
+	}
+
+	// Bars two cells wide on a shared baseline, three, five and eight cells tall.
+	const filled = severity === "high" ? 3 : severity === "medium" ? 2 : 1
+	const bars = ["M3 16V18", "M11 12V18", "M19 6V18"]
+	return (
+		<svg {...common} className={cn(SEVERITY_TEXT[severity], className)}>
+			{bars.map((d, index) => (
+				<path key={d} d={d} opacity={index < filled ? 1 : 0.25} />
+			))}
+		</svg>
 	)
 }

--- a/apps/web/src/components/errors/signal-spark.tsx
+++ b/apps/web/src/components/errors/signal-spark.tsx
@@ -35,6 +35,18 @@ const BAR_GAP = 1
 const BAR_WIDTH = 2
 const VIEW_HEIGHT = 20
 
+/**
+ * A bucket that saw nothing still draws this much, so the comb has a floor and
+ * the bars stand ON something. Without it a quiet window with two spikes drew
+ * two marks hovering in an empty box, with no baseline to read them against —
+ * the shape looked broken rather than sparse.
+ */
+const EMPTY_BAR_HEIGHT = 1
+
+/** A bucket that saw errors clears the floor, because the difference between
+ *  "one error" and "none" is the whole point of the shape. */
+const MIN_BAR_HEIGHT = 2.5
+
 export function SignalSpark({
 	values,
 	severity,
@@ -83,10 +95,16 @@ export function SignalSpark({
 				</linearGradient>
 			</defs>
 			{values.map((value, index) => {
-				// A bucket that saw errors always draws at least a hairline: the
-				// difference between "one error" and "none" is the whole point of the
-				// shape, and rounding it to zero height erases it.
-				const height = peak === 0 ? 0 : Math.max(value > 0 ? 1.5 : 0, (value / peak) * VIEW_HEIGHT)
+				// A window that saw nothing at all stays blank: a floor drawn under no
+				// data is a chart claiming to have some. The floor is the baseline of a
+				// shape that exists, not decoration on an empty cell.
+				if (peak === 0) return null
+
+				const empty = value === 0
+				const height = empty
+					? EMPTY_BAR_HEIGHT
+					: Math.max(MIN_BAR_HEIGHT, (value / peak) * VIEW_HEIGHT)
+				const recent = index >= tailStart
 				return (
 					<rect
 						key={index}
@@ -94,8 +112,10 @@ export function SignalSpark({
 						y={VIEW_HEIGHT - height}
 						width={BAR_WIDTH}
 						height={height}
-						fill={`url(#${gradientId})`}
-						opacity={index >= tailStart ? 1 : 0.5}
+						// Flat fill on the floor — a 1px tick has nothing to ramp, and
+						// running it through the gradient only muddies the baseline.
+						fill={empty ? "currentColor" : `url(#${gradientId})`}
+						opacity={empty ? (recent ? 0.3 : 0.2) : recent ? 1 : 0.5}
 					/>
 				)
 			})}

--- a/apps/web/src/components/errors/signal-state-chip.tsx
+++ b/apps/web/src/components/errors/signal-state-chip.tsx
@@ -6,7 +6,10 @@ import type { V2Investigation } from "@maple/domain/http/v2"
 import type { SignalState } from "@/lib/models/error-signal"
 
 /**
- * The one status slot on an error row.
+ * The one status slot on an error row — the issue header's, now. The list
+ * row's status lane became the workflow picker, so the list only draws this
+ * for the two kinds that are not a workflow state (an open incident, a live
+ * investigation), as a mark beside the error's name.
  *
  * A row used to be able to carry four of these at once — a workflow badge, an
  * "Open incident" pill, a kind badge, and an investigation that was only
@@ -32,12 +35,17 @@ const INVESTIGATION_LABEL = {
 export function SignalStateChip({
 	state,
 	withConfidence = true,
+	compact = false,
 	className,
 }: {
 	state: SignalState
 	/** Inline `· medium` after "Diagnosed". The list row turns it off — its fixed
 	 *  lane cannot fit the suffix on one line, and the tooltip still carries it. */
 	withConfidence?: boolean
+	/** For the list row, whose identity lane this shares with the error message:
+	 *  "Incident" rather than "Open incident", and below `@xl` only the dot —
+	 *  every character here is one the message loses. */
+	compact?: boolean
 	className?: string
 }) {
 	const navigate = useNavigate()
@@ -52,7 +60,9 @@ export function SignalStateChip({
 				title="An incident is open for this error"
 			>
 				<span className="size-1.5 shrink-0 rounded-full bg-destructive" />
-				<span className="truncate">Open incident</span>
+				<span className={cn("truncate", compact && "hidden @xl/page:inline")}>
+					{compact ? "Incident" : "Open incident"}
+				</span>
 			</span>
 		)
 	}
@@ -90,7 +100,7 @@ export function SignalStateChip({
 						isLive && "motion-safe:animate-pulse",
 					)}
 				/>
-				<span className="truncate">{label}</span>
+				<span className={cn("truncate", compact && "hidden @xl/page:inline")}>{label}</span>
 				{withConfidence && state.confidence && state.status === "diagnosed" ? (
 					<span className="text-muted-foreground/60">· {state.confidence}</span>
 				) : null}

--- a/apps/web/src/components/errors/signal-state-chip.tsx
+++ b/apps/web/src/components/errors/signal-state-chip.tsx
@@ -3,22 +3,21 @@ import { useNavigate } from "@tanstack/react-router"
 import { cn } from "@maple/ui/lib/utils"
 import { WORKFLOW_LABEL, WorkflowRingIcon } from "@/components/icons/workflow-ring"
 import type { V2Investigation } from "@maple/domain/http/v2"
-import type { SignalState } from "@/lib/models/error-signal"
+import type { InvestigationSummary, SignalState } from "@/lib/models/error-signal"
 
 /**
- * The one status slot on an error row — the issue header's, now. The list
- * row's status lane became the workflow picker, so the list only draws this
- * for the two kinds that are not a workflow state (an open incident, a live
- * investigation), as a mark beside the error's name.
+ * The one status slot on the issue header.
  *
- * A row used to be able to carry four of these at once — a workflow badge, an
- * "Open incident" pill, a kind badge, and an investigation that was only
+ * A header used to be able to carry four of these at once — a workflow badge,
+ * an "Open incident" pill, a kind badge, and an investigation that was only
  * visible on a different route. Four badge systems for one object meant none of
  * them read as important. `SignalState` picks one by precedence; this draws it.
  *
- * Only `incident` takes colour. Everything else is muted, so the coloured
- * things left on a row — the severity chip and an open incident — are the two
- * that should pull the eye.
+ * The list row does NOT use this: its status lane is the workflow picker, and
+ * the only other thing it draws is {@link InvestigationChip}, on its own rather
+ * than through the precedence. An incident is not worth a mark in a list —
+ * "currently firing" is true of nearly every open row at once, so it separated
+ * nothing while costing the error message the width.
  */
 
 /** Total over `InvestigationStatus`. `resolved` never reaches here — a resolved
@@ -35,21 +34,13 @@ const INVESTIGATION_LABEL = {
 export function SignalStateChip({
 	state,
 	withConfidence = true,
-	compact = false,
 	className,
 }: {
 	state: SignalState
-	/** Inline `· medium` after "Diagnosed". The list row turns it off — its fixed
-	 *  lane cannot fit the suffix on one line, and the tooltip still carries it. */
+	/** Inline `· medium` after "Diagnosed". */
 	withConfidence?: boolean
-	/** For the list row, whose identity lane this shares with the error message:
-	 *  "Incident" rather than "Open incident", and below `@xl` only the dot —
-	 *  every character here is one the message loses. */
-	compact?: boolean
 	className?: string
 }) {
-	const navigate = useNavigate()
-
 	if (state.kind === "incident") {
 		return (
 			<span
@@ -60,51 +51,23 @@ export function SignalStateChip({
 				title="An incident is open for this error"
 			>
 				<span className="size-1.5 shrink-0 rounded-full bg-destructive" />
-				<span className={cn("truncate", compact && "hidden @xl/page:inline")}>
-					{compact ? "Incident" : "Open incident"}
-				</span>
+				<span className="truncate">Open incident</span>
 			</span>
 		)
 	}
 
 	if (state.kind === "investigation") {
-		const label = INVESTIGATION_LABEL[state.status]
-		const isLive = state.status === "investigating"
+		// `SignalState` names the id `investigationId`; the summary names it `id`.
 		return (
-			// A button, not a link: the whole row is already an anchor to the issue,
-			// and an <a> inside an <a> is invalid markup that browsers unnest in
-			// their own way. `preventDefault` stops the row navigation so the chip
-			// can take you to the investigation instead.
-			<button
-				type="button"
-				onClick={(event) => {
-					event.preventDefault()
-					event.stopPropagation()
-					navigate({ to: "/investigations/$id", params: { id: state.investigationId } })
+			<InvestigationChip
+				investigation={{
+					id: state.investigationId,
+					status: state.status,
+					confidence: state.confidence,
 				}}
-				className={cn(
-					"inline-flex max-w-full items-center gap-1.5 text-[11px] font-medium whitespace-nowrap",
-					"text-muted-foreground hover:text-foreground hover:underline",
-					"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm",
-					className,
-				)}
-				title={
-					state.confidence
-						? `Maple ${label.toLowerCase()} — ${state.confidence} confidence`
-						: `Maple ${label.toLowerCase()}`
-				}
-			>
-				<span
-					className={cn(
-						"size-1.5 shrink-0 rounded-full bg-current",
-						isLive && "motion-safe:animate-pulse",
-					)}
-				/>
-				<span className={cn("truncate", compact && "hidden @xl/page:inline")}>{label}</span>
-				{withConfidence && state.confidence && state.status === "diagnosed" ? (
-					<span className="text-muted-foreground/60">· {state.confidence}</span>
-				) : null}
-			</button>
+				withConfidence={withConfidence}
+				className={className}
+			/>
 		)
 	}
 
@@ -119,5 +82,67 @@ export function SignalStateChip({
 			<WorkflowRingIcon state={state.state} size={12} />
 			<span className="truncate">{WORKFLOW_LABEL[state.state]}</span>
 		</span>
+	)
+}
+
+/**
+ * "Investigating" / "Diagnosed" — Maple is looking at this error, or already
+ * has an answer. Takes the investigation itself rather than a `SignalState`, so
+ * the list row can draw it without asking whether anything outranks it.
+ */
+export function InvestigationChip({
+	investigation,
+	withConfidence = true,
+	compact = false,
+	className,
+}: {
+	investigation: InvestigationSummary
+	/** Inline `· medium` after "Diagnosed". The list row turns it off — its lane
+	 *  cannot fit the suffix on one line, and the tooltip still carries it. */
+	withConfidence?: boolean
+	/** For the list row, which shares this lane with the error message: below
+	 *  `@xl` only the dot, because every character here is one the message loses. */
+	compact?: boolean
+	className?: string
+}) {
+	const navigate = useNavigate()
+	const label = INVESTIGATION_LABEL[investigation.status]
+	const isLive = investigation.status === "investigating"
+
+	return (
+		// A button, not a link: the whole row is already an anchor to the issue,
+		// and an <a> inside an <a> is invalid markup that browsers unnest in
+		// their own way. `preventDefault` stops the row navigation so the chip
+		// can take you to the investigation instead.
+		<button
+			type="button"
+			onClick={(event) => {
+				event.preventDefault()
+				event.stopPropagation()
+				navigate({ to: "/investigations/$id", params: { id: investigation.id } })
+			}}
+			className={cn(
+				"inline-flex max-w-full items-center gap-1.5 text-[11px] font-medium whitespace-nowrap",
+				"text-muted-foreground hover:text-foreground hover:underline",
+				"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm",
+				className,
+			)}
+			title={
+				investigation.confidence
+					? `Maple ${label.toLowerCase()} — ${investigation.confidence} confidence`
+					: `Maple ${label.toLowerCase()}`
+			}
+		>
+			<span
+				className={cn(
+					"size-1.5 shrink-0 rounded-full bg-current",
+					isLive && "motion-safe:animate-pulse",
+				)}
+			/>
+			<span className={cn("truncate", compact && "hidden @xl/page:inline")}>{label}</span>
+			{withConfidence && investigation.confidence && investigation.status === "diagnosed" ? (
+				<span className="text-muted-foreground/60">· {investigation.confidence}</span>
+			) : null}
+		</button>
 	)
 }

--- a/apps/web/src/lab/errors-fixture.ts
+++ b/apps/web/src/lab/errors-fixture.ts
@@ -21,7 +21,7 @@ import {
 	type WorkflowState,
 } from "@maple/domain/http"
 
-import { resolveSignalState, type ErrorSignal, type InvestigationSummary } from "@/lib/models/error-signal"
+import type { ErrorSignal, InvestigationSummary } from "@/lib/models/error-signal"
 
 // The whole document decodes in one go, nested actor included, so no fixture
 // value is ever branded by hand.
@@ -368,7 +368,7 @@ export function buildErrorsLabFixture(nowMs: number): ErrorsLabFixture {
 			detail: issue.exceptionMessage,
 			serviceName: issue.serviceName,
 			severity: issue.severity,
-			state: resolveSignalState(issue, seed.investigation),
+			investigation: seed.investigation ?? null,
 			windowCount: seed.windowCount,
 			totalCount: seed.totalCount,
 			affectedServicesCount: seed.windowCount === null ? null : 1 + (seed.n % 3),

--- a/apps/web/src/lib/models/error-signal.ts
+++ b/apps/web/src/lib/models/error-signal.ts
@@ -51,7 +51,11 @@ export interface ErrorSignal {
 	readonly detail: string
 	readonly serviceName: string
 	readonly severity: IssueSeverity | null
-	readonly state: SignalState
+	/** A live investigation, if one is running or has landed. The row draws this
+	 *  on its own rather than through {@link resolveSignalState} — that precedence
+	 *  exists for the issue header, which has one slot to fill, and it would hide
+	 *  every investigation behind an open incident in a list. */
+	readonly investigation: InvestigationSummary | null
 	/** Occurrences in the selected window, from the warehouse. `null` when the
 	 *  fingerprint had none — an issue that has gone quiet, which is a fact worth
 	 *  drawing rather than a zero to hide. */
@@ -180,7 +184,7 @@ export function buildErrorSignals(input: {
 			detail: issue.exceptionMessage ?? "",
 			serviceName: issue.serviceName,
 			severity: issue.severity,
-			state: resolveSignalState(issue, input.investigations.get(issue.id)),
+			investigation: liveInvestigationSummary(input.investigations.get(issue.id) ?? null) ?? null,
 			windowCount: volume ? volume.count : null,
 			totalCount: issue.occurrenceCount,
 			affectedServicesCount: volume ? volume.affectedServicesCount : null,

--- a/apps/web/src/lib/shortcuts.ts
+++ b/apps/web/src/lib/shortcuts.ts
@@ -98,6 +98,16 @@ const SHORTCUTS = {
 		label: "Toggle selection (issues)",
 		group: "Lists & Tables",
 	},
+	"issue.status": {
+		combo: "S",
+		label: "Change status of focused issue",
+		group: "Lists & Tables",
+	},
+	"issue.severity": {
+		combo: "P",
+		label: "Change severity of focused issue",
+		group: "Lists & Tables",
+	},
 	"list.clear": {
 		combo: "Escape",
 		label: "Clear focus / selection",


### PR DESCRIPTION
## What

Every row of `/errors` now carries two small controls instead of a read-only severity badge and a read-only status chip.

- **Severity lane** ([`severity-badge.tsx`](apps/web/src/components/errors/severity-badge.tsx), [`issue-pickers.tsx`](apps/web/src/components/errors/issue-pickers.tsx)) — an icon button. Three pixel blocks when nobody has set a severity, one to three bars for low/medium/high, the existing pixel triangle-warning in red for critical. Drawn on the Nucleo pixel grid (24-unit box, 2-unit cells, square caps) so it matches the rest of the icon set; the pixel set itself has no bars/dots icon to port.
- **Status lane** always shows the workflow-state picker. Before, any row with an open incident showed "Open incident" in that slot instead — and in an org where every open issue has an incident, the status control never appeared. The incident/investigation mark moved beside the error name as a compact chip (`SignalStateChip compact`) that collapses to a dot below the `@xl` container width.
- **`QuickPickMenu`** ([`quick-pick-menu.tsx`](apps/web/src/components/errors/quick-pick-menu.tsx)) — Popover + the inline Autocomplete behind the command palette: a type-to-filter input with a hotkey hint, one row per choice with its icon, a check on the current value, and a digit at the right edge that picks the row outright. Enter picks the highlighted row. Unreachable transitions (from `allowedTransitionsForAll`) stay listed but dimmed so the digits mean the same thing on every row.
- **Hotkeys** `S` / `P` open the status or severity picker on the focused row, registered in `shortcuts.ts` so the help dialog lists them. When the status lane is hidden at narrow widths the popover anchors to the row itself (`fallbackAnchor`) rather than to a `display:none` trigger.

## Reviewer notes

- "Priority" here is **severity**: it is the field with a real "not set" state and a `setIssueSeverity` mutation. The issue's separate `priority` column has no API to set it and defaults to 3.
- The row is a TanStack `Link`; the trigger click and the portalled popup both stop propagation so picking a value never navigates. Escape is handled in the popup's capture phase because the always-open inline Autocomplete swallows it (same workaround the command palette uses).
- Not touched: the right-click menu's status submenu, the bulk bar and the issue sidebar still use the older Select controls. They can adopt `QuickPickMenu` in a follow-up.

## Testing

- `apps/web` typecheck clean; oxfmt/oxlint clean on the touched files; the three errors-component test files pass (26 tests).
- Verified in the browser against the dev org: severity set by typed filter + Enter, by digit, and via `P`; status moved Triage → Todo through the filter and back via `S` then `1`; dark and light; narrow width with the row-anchored popover.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791020073&installation_model_id=427786&pr_number=753&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F753&signature=cd40bd5f162cdaaaafae4cfdf028bd0b361a0bead08a8ba8e2e79e23fce51c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->