### PR TITLE
fix(llm): correct glm-5.3-flash's context/output limits

### DIFF
--- a/apps/api/src/platform/Llm.ts
+++ b/apps/api/src/platform/Llm.ts
@@ -184,10 +184,16 @@ const withUsageAccounting = (model: LanguageModel): LanguageModel =>
 const MODEL_LIMITS: Record<string, { readonly context: number; readonly output: number }> = {
 	// Verified against OpenRouter's public model catalogue.
 	"openai/gpt-5.6-luna": { context: 1_050_000, output: 128_000 },
-	// Context set from the operator-supplied figure, not the catalogue. Output is not stated with
-	// it, so it stays at the conservative default; raise it with `MAPLE_TRIAGE_MODEL_OUTPUT` if
-	// completions are being cut short.
-	"z-ai/glm-5.3-flash:nitro": { context: 130_000, output: 8_000 },
+	// Verified against OpenRouter's public model catalogue: context_length 1_310_720,
+	// top_provider.max_completion_tokens 131_072. The prior 130_000/8_000 pair was an
+	// operator-supplied guess, off by ~10x on context — it made `isNearContextLimit` trip
+	// far earlier than the model can actually take, so investigations with long tool-call
+	// transcripts were hitting `dropOldestToolStep` repeatedly, and each drop invalidates
+	// OpenRouter's implicit-prefix cache for the rest of the turn (this route gets no
+	// explicit cache breakpoints — see `chat/loop/context.ts`). Kept a notch under the
+	// catalogue numbers rather than exactly at them, same conservative-margin reasoning as
+	// the other rows here.
+	"z-ai/glm-5.3-flash:nitro": { context: 1_000_000, output: 128_000 },
 	// Moonshot's own `kimi-k2.6` is 262_144, but Cloudflare does not publish the window its Workers
 	// AI deployment actually serves, and a serving deployment is usually narrower than upstream's
 	// maximum. Held at the conservative default until someone measures it; override with

--- a/apps/slack-agent/.env.local.example
+++ b/apps/slack-agent/.env.local.example
@@ -6,7 +6,7 @@
 OPENROUTER_API_KEY=
 # Optional overrides (defaults live in agent/agent.ts):
 # OPENROUTER_MODEL=z-ai/glm-5.3-flash:nitro   # must stream structured tool calls — see README Notes
-# OPENROUTER_CONTEXT_WINDOW=130000
+# OPENROUTER_CONTEXT_WINDOW=1000000
 # Model for the thread follow-up relevance gate (one tiny RESPOND/PASS call per
 # un-mentioned thread reply — agent/lib/follow-up-relevance.ts). A small, fast
 # model is ideal here; unset, it follows OPENROUTER_MODEL.

--- a/apps/slack-agent/agent/agent.ts
+++ b/apps/slack-agent/agent/agent.ts
@@ -34,7 +34,7 @@ if (missingModelEnv.length > 0 && !isEveBuildInvocation) {
  * always streams.
  */
 const modelId = process.env.OPENROUTER_MODEL ?? "z-ai/glm-5.3-flash:nitro"
-const contextWindowTokens = Number(process.env.OPENROUTER_CONTEXT_WINDOW ?? 130_000)
+const contextWindowTokens = Number(process.env.OPENROUTER_CONTEXT_WINDOW ?? 1_000_000)
 
 /**
  * Durable workflow state ("world").


### PR DESCRIPTION
## Summary
- `MODEL_LIMITS["z-ai/glm-5.3-flash:nitro"]` was `{context: 130_000, output: 8_000}`, an operator guess left over from the switch off `openai/gpt-5.6-luna`. OpenRouter's catalogue actually reports `context_length: 1_310_720` and `top_provider.max_completion_tokens: 131_072` for this model — the config was undersized by ~10x on context.
- The undersized window made `isNearContextLimit` (`apps/api/src/chat/loop/context.ts`) trip far earlier than the model can take. Investigations run long tool-call transcripts (warehouse/trace payloads), so they were repeatedly hitting the `dropOldestToolStep` fallback — and each drop mutates the transcript prefix, invalidating OpenRouter's implicit-prefix cache for the rest of the turn (this route gets no explicit cache breakpoints). That compounded token burn on exactly the highest-cost workload, which is what's been driving the higher-than-expected cost since the model switch.
- Bumped to `{context: 1_000_000, output: 128_000}` — a margin under the catalogue ceiling, consistent with the conservative-margin convention already used for the other rows in this table.
- Carried the identical fix into `apps/slack-agent` (`agent/agent.ts` default + `.env.local.example`), which had the same wrong `130000` figure from the same commit.

## Test plan
- [x] `bun run --cwd apps/api test src/platform/Llm.test.ts src/chat/loop/context.test.ts` — 27 passed
- [x] `bun typecheck` — only pre-existing, unrelated failures (`@maple/electric-sync` missing `@maple/alchemy-portless`; `apps/slack-agent` `instrumentation.ts` OTel type mismatch), confirmed present before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791043609&installation_model_id=427786&pr_number=754&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F754&signature=cf0dd94a1fef1f14c638c6da9838275aabe82d89094cf657d606dc4fc689fd38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->