### PR TITLE
perf(agent-sessions): bound what a transcript row costs

### DIFF
--- a/apps/web/perf/agent-transcript.perf.spec.ts
+++ b/apps/web/perf/agent-transcript.perf.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test, type Page } from "@playwright/test"
+
+// The agent-session Transcript view over a big session (see
+// src/lab/bench/agent-transcript-bench.tsx). The list virtualizes, so the
+// gates here are about what one ROW costs: how much DOM a mounted row holds
+// when its body is a 300KB tool result clamped to fourteen lines, and whether
+// scrolling — which mounts rows again and again — stays inside a frame.
+
+async function openBench(page: Page) {
+	await page.goto("/lab/bench/agent-transcript?turns=40")
+	await page.waitForFunction(() => window.__transcriptBench?.ready === true, undefined, {
+		timeout: 60_000,
+	})
+}
+
+async function sweep(page: Page, label: string) {
+	const before = await page.evaluate(() => window.__transcriptBench!.countDom())
+	const metrics = await page.evaluate(() => window.__transcriptBench!.runScroll(160))
+	console.log(`[perf] transcript scroll (${label}):`, JSON.stringify({ before, ...metrics }))
+
+	// Virtualization: the rows on the page are the viewport's plus overscan.
+	expect(before.mountedRows, "initial mounted rows").toBeLessThan(80)
+	expect(metrics.mountedRows, "mounted rows after full scroll").toBeLessThan(80)
+	expect(metrics.frames, "sampled scroll frames").toBeGreaterThan(100)
+	// GitHub's CI runner has no GPU and paints every frame in software, so long
+	// tasks there are environmental (see logs.perf.spec.ts); the DOM gates carry
+	// the signal on CI and blocking time only rejects order-of-magnitude
+	// regressions. Locally the strict gate applies.
+	if (process.env.CI) {
+		expect(metrics.totalBlockingMs, "scroll blocking ms (CI ceiling)").toBeLessThan(4_000)
+	} else {
+		expect(metrics.totalBlockingMs, "scroll blocking ms").toBeLessThan(100)
+	}
+	// The list re-renders when the mounted range moves, not on every measurement.
+	expect(metrics.reactCommits, "list commits per frame").toBeLessThanOrEqual(metrics.frames * 2.5)
+	return metrics
+}
+
+test("Transcript scroll stays inside a frame on a large session", async ({ page }) => {
+	await openBench(page)
+	const metrics = await sweep(page, "payloads collapsed")
+	// A tool card shut is a header; a reply is its markdown, laid out plain.
+	expect(metrics.maxRowNodes, "elements in the heaviest row").toBeLessThan(1_500)
+})
+
+test("Transcript scroll stays inside a frame with every tool payload open", async ({ page }) => {
+	await openBench(page)
+	await page.getByRole("button", { name: "Display options" }).click()
+	await page.getByRole("switch", { name: "Expand tool payloads" }).click()
+	await page.keyboard.press("Escape")
+	await page.waitForTimeout(500)
+
+	const metrics = await sweep(page, "payloads expanded")
+	// A clamped body mounts a bounded preview, so a row is bounded however
+	// big its payload: a 1,200-row JSON result highlighted whole is ~30,000
+	// elements, its preview under a thousand per half.
+	expect(metrics.maxRowNodes, "elements in the heaviest row").toBeLessThan(2_500)
+})

--- a/apps/web/src/atoms/timezone-preference-atoms.ts
+++ b/apps/web/src/atoms/timezone-preference-atoms.ts
@@ -7,15 +7,27 @@ export const SYSTEM_VALUE = "__system__"
 
 const DEFAULT_TIMEZONE = "UTC"
 
+// Whether a zone name is one the runtime knows never changes, and asking is
+// not cheap — building a formatter and running it. Every timestamp the app
+// prints resolves its zone through here, which on a virtualized list is once
+// per row per render: unmemoized it was the single hottest frame in a
+// transcript scroll profile.
+const knownZones = new Map<string, boolean>()
+
 export function isValidIanaTimeZone(value: string): boolean {
 	if (value.trim().length === 0) return false
 
+	const known = knownZones.get(value)
+	if (known !== undefined) return known
+	let valid: boolean
 	try {
 		new Intl.DateTimeFormat("en-US", { timeZone: value }).format(new Date())
-		return true
+		valid = true
 	} catch {
-		return false
+		valid = false
 	}
+	knownZones.set(value, valid)
+	return valid
 }
 
 export function getBrowserTimeZone(): string {

--- a/apps/web/src/components/agent-sessions/session-detail/clamped-text.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/clamped-text.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { ClampedText, previewOf } from "./clamped-text"
+
+afterEach(cleanup)
+
+const lines = (count: number, prefix = "line") => Array.from({ length: count }, (_, i) => `${prefix} ${i}`)
+
+describe("previewOf", () => {
+	it("returns a short body whole", () => {
+		const text = lines(40).join("\n")
+		expect(previewOf(text)).toBe(text)
+	})
+
+	it("cuts a long body at a line boundary", () => {
+		const preview = previewOf(lines(500).join("\n"))
+		expect(preview.split("\n")).toHaveLength(72)
+		expect(preview.endsWith("line 71")).toBe(true)
+	})
+
+	it("cuts one endless line by length", () => {
+		expect(previewOf("x".repeat(50_000))).toHaveLength(8_000)
+	})
+})
+
+describe("ClampedText", () => {
+	it("mounts a long body as a preview, and the whole of it once opened", () => {
+		render(<ClampedText text={lines(1_000, "row").join("\n")} />)
+		expect(screen.queryByText(/row 999/)).toBeNull()
+
+		fireEvent.click(screen.getByRole("button", { name: "Show full" }))
+		expect(screen.getByText(/row 999/)).toBeDefined()
+		expect(screen.getByRole("button", { name: "Show less" })).toBeDefined()
+	})
+
+	it("knows a verbatim body overruns its clamp without measuring it", () => {
+		// jsdom lays nothing out, so a control here can only come from the count.
+		render(<ClampedText text={lines(20).join("\n")} clampLines={12} />)
+		expect(screen.getByRole("button", { name: "Show full" })).toBeDefined()
+	})
+
+	it("grows no control for a body that fits", () => {
+		render(<ClampedText text={"one\ntwo"} />)
+		expect(screen.queryByRole("button")).toBeNull()
+	})
+
+	it("highlights only the preview as JSON", () => {
+		const json = JSON.stringify(
+			Array.from({ length: 2_000 }, (_, i) => ({ i })),
+			null,
+			2,
+		)
+		const { container } = render(<ClampedText text={json} rendering="json" />)
+		expect(container.querySelectorAll(".sh__line")).toHaveLength(72)
+	})
+})

--- a/apps/web/src/components/agent-sessions/session-detail/clamped-text.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/clamped-text.tsx
@@ -1,63 +1,146 @@
-import { useLayoutEffect, useRef, useState, type ReactNode } from "react"
+import { useLayoutEffect, useMemo, useRef, useState } from "react"
 
 import { cn } from "@maple/ui/lib/utils"
 
-/** A message body clamps at ~12 lines with a "show full" control: prompts run
- *  to tens of thousands of tokens, and the list has to stay navigable. */
-const CLAMP_CLASS = "line-clamp-[12]"
+import { MessageResponse } from "@/components/ai-elements/message-response"
+import { highlightCode } from "@/lib/sugar-high"
 
 /**
- * A body that clamps with a "Show full" control. Overflow is measured, not
- * guessed from length: 12 short lines fit and never grow a control, while one
- * very long line wraps past the clamp and does.
+ * The clamps in use, by line count. A table rather than a class string so the
+ * body knows the NUMBER — that is what lets it tell a body overruns its clamp
+ * without asking the layout engine — while Tailwind still sees every class.
+ */
+const CLAMP_CLASSES = {
+	6: "line-clamp-[6]",
+	8: "line-clamp-[8]",
+	12: "line-clamp-[12]",
+	14: "line-clamp-[14]",
+	24: "line-clamp-[24]",
+} as const
+
+export type ClampLines = keyof typeof CLAMP_CLASSES
+
+/** A message body clamps at ~12 lines with a "show full" control: prompts run
+ *  to tens of thousands of tokens, and the list has to stay navigable. */
+const DEFAULT_CLAMP: ClampLines = 12
+
+/**
+ * What a clamped body mounts.
  *
- * Shared by the span expansion and the transcript so a payload reads the same
- * wherever it was opened. Expansion is local by default and CONTROLLED where
- * the caller passes `expanded`: the transcript virtualizes its rows, so a row
- * scrolled out of view unmounts, and local state would take what the reader
- * opened with it.
+ * A CSS clamp hides lines, it does not skip them: a megabyte tool result set
+ * under `line-clamp-[14]` is still laid out whole and, highlighted, is a
+ * hundred thousand elements for fourteen visible lines — and a virtualized
+ * list mounts that again every time the row scrolls back in. So a clamped
+ * body renders a prefix: three times the deepest clamp in use, so that even
+ * markdown with a blank line between every line overruns it, and few enough
+ * that the largest payload costs what a short one does. Once opened, the
+ * whole body mounts.
+ */
+const PREVIEW_LINES = 72
+/** A single line this long wraps past any clamp at any width. */
+const PREVIEW_CHARS = 8_000
+/**
+ * Past this an opened body is set as plain text. Highlighting or laying out
+ * markdown for a payload this size is seconds of work for a wall of elements
+ * nobody reads as prose; the bytes are all still there, and still copy.
+ */
+const RENDER_LIMIT_CHARS = 200_000
+
+/** How a body is set: verbatim, highlighted as JSON, or laid out as markdown. */
+export type ClampedRendering = "text" | "json" | "md"
+
+/** The prefix of `text` a clamped body mounts — `text` itself when it is short. */
+export function previewOf(text: string): string {
+	let end = Math.min(text.length, PREVIEW_CHARS)
+	let lines = 0
+	let at = text.indexOf("\n")
+	while (at !== -1 && at < end) {
+		if (++lines === PREVIEW_LINES) {
+			end = at
+			break
+		}
+		at = text.indexOf("\n", at + 1)
+	}
+	return end === text.length ? text : text.slice(0, end)
+}
+
+/** Whether `text` has more than `lines` lines — stops counting as soon as it knows. */
+function exceedsLines(text: string, lines: number): boolean {
+	let count = 1
+	let at = text.indexOf("\n")
+	while (at !== -1) {
+		if (++count > lines) return true
+		at = text.indexOf("\n", at + 1)
+	}
+	return false
+}
+
+/**
+ * A body that clamps with a "Show full" control. Overflow is measured where
+ * it has to be, not guessed from length: 12 short lines fit and never grow a
+ * control, while one very long line wraps past the clamp and does.
+ *
+ * The body owns its rendering — the JSON highlight, the markdown layout — so
+ * that only what is mounted is ever dressed up: the preview while clamped,
+ * the whole text once opened. Shared by the span expansion and the transcript
+ * so a payload reads the same wherever it was opened. Expansion is local by
+ * default and CONTROLLED where the caller passes `expanded`: the transcript
+ * virtualizes its rows, so a row scrolled out of view unmounts, and local
+ * state would take what the reader opened with it.
  */
 export function ClampedText({
 	text,
-	/** Pre-highlighted markup for the body (sugar-high output). `text` stays the
-	 *  source of truth — it is what overflows measurement and copies see. */
-	html,
-	/** A rendered body (markdown, say) that clamps in place of the raw text.
-	 *  Wins over `html`; the clamp still measures whatever actually rendered. */
-	body,
+	rendering = "text",
 	mono = false,
-	/** Lines before clamping; the default is the expansion's twelve. */
-	clampClass = CLAMP_CLASS,
-	/** Overrides the body's text color — an errored payload reads as one. */
+	clampLines = DEFAULT_CLAMP,
 	toneClass,
+	proseClassName = "text-foreground text-sm leading-relaxed",
 	expanded: controlledExpanded,
 	onToggleExpanded,
 }: {
 	text: string
-	html?: string
-	body?: ReactNode
+	rendering?: ClampedRendering
 	mono?: boolean
-	clampClass?: string
+	/** Lines before clamping; the default is the expansion's twelve. */
+	clampLines?: ClampLines
+	/** Overrides the body's text color — an errored payload reads as one. */
 	toneClass?: string
+	/** The markdown body's prose classes. */
+	proseClassName?: string
 	/** Controlled expansion; omit to keep the state in this component. */
 	expanded?: boolean
 	onToggleExpanded?: () => void
 }) {
 	const [localExpanded, setLocalExpanded] = useState(false)
 	const expanded = controlledExpanded ?? localExpanded
-	const [clamped, setClamped] = useState(false)
 	const bodyRef = useRef<HTMLDivElement>(null)
-	/** Which of the three bodies is mounted. Same text laid out as markdown and
-	 *  as pre-wrapped raw are different heights, so a view switch has to
-	 *  re-measure — and `body` itself is a fresh node every render, so naming
-	 *  the CHOICE is what keeps the effect from running forever. */
-	const rendering = body !== undefined ? "body" : html !== undefined ? "html" : "text"
 
+	const shown = useMemo(() => (expanded ? text : previewOf(text)), [text, expanded])
+	const cut = shown.length < text.length
+	const effective: ClampedRendering =
+		rendering !== "text" && shown.length > RENDER_LIMIT_CHARS ? "text" : rendering
+	const html = useMemo(() => (effective === "json" ? highlightCode(shown) : undefined), [effective, shown])
+
+	// Whether the body overruns its clamp, known without a layout wherever it
+	// can be: a cut preview always does, and a verbatim body with more lines
+	// than the clamp does. Only a short body, or markdown, is measured — and
+	// off the layout the browser was about to do anyway, not by reading
+	// `scrollHeight` in the effect, which forces one. On a list that mounts
+	// rows every scroll frame those forced layouts were most of what a frame
+	// cost. The observer also re-measures on a width change, which a
+	// one-shot read never did.
+	const knownClamped = cut || (effective !== "md" && exceedsLines(shown, clampLines))
+	const [measuredClamped, setMeasuredClamped] = useState(false)
 	useLayoutEffect(() => {
 		const measured = bodyRef.current
-		if (measured === null || expanded) return
-		setClamped(measured.scrollHeight > measured.clientHeight + 1)
-	}, [text, rendering, expanded])
+		if (measured === null || expanded || knownClamped) return
+		const observer = new ResizeObserver(() => {
+			setMeasuredClamped(measured.scrollHeight > measured.clientHeight + 1)
+		})
+		observer.observe(measured)
+		return () => observer.disconnect()
+	}, [expanded, knownClamped])
+	const clamped = knownClamped || measuredClamped
 
 	return (
 		<div className="min-w-0">
@@ -65,18 +148,24 @@ export function ClampedText({
 				ref={bodyRef}
 				className={cn(
 					// A rendered body lays out its own blocks; pre-wrap is for raw text.
-					body === undefined && "whitespace-pre-wrap",
+					effective !== "md" && "whitespace-pre-wrap",
 					"break-words",
 					mono
 						? "font-mono text-muted-foreground text-xs leading-relaxed"
 						: "max-w-[70rem] text-foreground text-sm leading-relaxed",
 					toneClass,
-					!expanded && clampClass,
+					!expanded && CLAMP_CLASSES[clampLines],
 				)}
-				{...(body !== undefined
-					? { children: body }
+				{...(effective === "md"
+					? {
+							children: (
+								<MessageResponse className={proseClassName} mode="static" lightweight>
+									{shown}
+								</MessageResponse>
+							),
+						}
 					: html === undefined
-						? { children: text }
+						? { children: shown }
 						: { dangerouslySetInnerHTML: { __html: html } })}
 			/>
 			{(clamped || expanded) && (
@@ -100,9 +189,13 @@ export function ClampedText({
 /** The first line worth showing of a body — a collapsed disclosure's preview.
  *  Shared so the transcript and the span expansion elide identically. */
 export function firstLine(text: string): string {
-	for (const rawLine of text.split("\n")) {
-		const line = rawLine.trim()
+	let start = 0
+	while (start < text.length) {
+		const end = text.indexOf("\n", start)
+		const line = text.slice(start, end === -1 ? text.length : end).trim()
 		if (line !== "") return line
+		if (end === -1) break
+		start = end + 1
 	}
 	return ""
 }

--- a/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/payload-view.tsx
@@ -2,10 +2,8 @@ import { useMemo } from "react"
 
 import { cn } from "@maple/ui/lib/utils"
 
-import { MessageResponse } from "@/components/ai-elements/message-response"
 import { tryParseJson } from "@/components/attributes"
-import { highlightCode } from "@/lib/sugar-high"
-import { ClampedText } from "./clamped-text"
+import { ClampedText, type ClampLines } from "./clamped-text"
 
 /**
  * The rendered ↔ raw affordances every captured body shares, wherever it is
@@ -16,17 +14,17 @@ import { ClampedText } from "./clamped-text"
  */
 
 /**
- * A payload body, pretty-printed and highlighted where it parses as JSON
- * (object or array — same test as the log body), verbatim otherwise. An
- * emitter-truncated prefix fails the parse and stays verbatim, which is right:
- * pretty-printing a fragment would dress it up as a whole document.
+ * A payload body, pretty-printed where it parses as JSON (object or array —
+ * same test as the log body), verbatim otherwise. An emitter-truncated prefix
+ * fails the parse and stays verbatim, which is right: pretty-printing a
+ * fragment would dress it up as a whole document. Highlighting is the body's
+ * own business (`ClampedText`), which dresses up only what it mounts.
  */
-export function useJsonPayload(text: string): { formatted: string; highlighted: string | undefined } {
+export function useJsonPayload(text: string): { formatted: string; isJson: boolean } {
 	return useMemo(() => {
 		const parsed = tryParseJson(text)
-		if (parsed === null) return { formatted: text, highlighted: undefined }
-		const formatted = JSON.stringify(parsed, null, 2)
-		return { formatted, highlighted: highlightCode(formatted) }
+		if (parsed === null) return { formatted: text, isJson: false }
+		return { formatted: JSON.stringify(parsed, null, 2), isJson: true }
 	}, [text])
 }
 
@@ -36,13 +34,9 @@ export function useJsonPayload(text: string): { formatted: string; highlighted: 
  * a JSON message laid out as markdown collapses its structure into one
  * paragraph. `rendered` names the choice and is what the ViewSwitch shows.
  */
-export function useMessageBody(text: string): {
-	rendered: "md" | "json"
-	formatted: string
-	highlighted: string | undefined
-} {
+export function useMessageBody(text: string): { rendered: "md" | "json"; formatted: string } {
 	const payload = useJsonPayload(text)
-	return { rendered: payload.highlighted === undefined ? "md" : "json", ...payload }
+	return { rendered: payload.isJson ? "json" : "md", formatted: payload.formatted }
 }
 
 /**
@@ -138,7 +132,7 @@ export function MessageBody({
 	text,
 	body,
 	raw,
-	clampClass,
+	clampLines,
 	proseClassName = "text-foreground text-sm leading-relaxed",
 	expanded,
 	onToggleExpanded,
@@ -146,9 +140,9 @@ export function MessageBody({
 	text: string
 	/** The reading chosen by `useMessageBody`, hoisted so the caller's ViewSwitch
 	 *  can label the segment it selects. */
-	body: { rendered: "md" | "json"; formatted: string; highlighted: string | undefined }
+	body: { rendered: "md" | "json"; formatted: string }
 	raw: boolean
-	clampClass?: string
+	clampLines?: ClampLines
 	proseClassName?: string
 	expanded: boolean
 	onToggleExpanded: () => void
@@ -156,14 +150,10 @@ export function MessageBody({
 	return (
 		<ClampedText
 			text={raw ? text : body.formatted}
-			html={raw ? undefined : body.highlighted}
+			rendering={raw ? "text" : body.rendered}
 			mono={!raw && body.rendered === "json"}
-			clampClass={clampClass}
-			body={
-				raw || body.rendered === "json" ? undefined : (
-					<MessageResponse className={proseClassName}>{text}</MessageResponse>
-				)
-			}
+			clampLines={clampLines}
+			proseClassName={proseClassName}
 			expanded={expanded}
 			onToggleExpanded={onToggleExpanded}
 		/>

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useEffect, useMemo, useRef, type ReactNode } from "react"
+import { memo, useDeferredValue, useEffect, useMemo, useRef, type ReactNode } from "react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 
 import type { AiSessionSpan } from "@maple/domain/http"
@@ -28,8 +28,9 @@ import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { callMetaLine, callMetaParts } from "@/lib/agent-sessions/session-summary"
 import { spanModel, type SessionTurn } from "@/lib/agent-sessions/session-turns"
 import {
-	buildTranscript,
+	assembleTranscript,
 	type CaptureCoverage,
+	prepareTranscript,
 	type TranscriptPayload,
 	type TranscriptRow,
 } from "@/lib/agent-sessions/session-transcript"
@@ -122,17 +123,15 @@ export function SessionTranscript({
 	// The build parses every captured payload the query has to search, so it
 	// trails the input by a frame rather than running on the keystroke.
 	const deferredQuery = useDeferredValue(query)
+	// Two steps so a collapse re-runs only the cheap one: the read of every
+	// captured payload is per session and filter, the row list per collapse.
+	const prepared = useMemo(
+		() => prepareTranscript({ turns, toolResults, query: deferredQuery, showThinking }),
+		[turns, toolResults, deferredQuery, showThinking],
+	)
 	const rows = useMemo(
-		() =>
-			buildTranscript({
-				turns,
-				toolResults,
-				query: deferredQuery,
-				showThinking,
-				truncated,
-				collapsedTurns,
-			}),
-		[turns, toolResults, deferredQuery, showThinking, truncated, collapsedTurns],
+		() => assembleTranscript(prepared, { collapsedTurns, truncated }),
+		[prepared, collapsedTurns, truncated],
 	)
 
 	const virtualizer = useVirtualizer({
@@ -148,6 +147,11 @@ export function SessionTranscript({
 		// data swap re-fills mounted rows); without this the ResizeObserver path
 		// calls flushSync mid-lifecycle and React logs an error for every batch.
 		useAnimationFrameWithResizeObserver: true,
+		// Rows are positioned by writing their transform straight to the DOM, so
+		// the list re-renders only when the set of mounted rows changes — not on
+		// every measurement, which on a scroll is several times a frame, each
+		// one a synchronous re-render of every mounted block.
+		directDomUpdates: true,
 	})
 
 	// A pasted `?span=` link lands on the block it names. Once, on mount — after
@@ -179,7 +183,14 @@ export function SessionTranscript({
 		// every row by its height.
 		<div className="pt-2">
 			<div ref={listRef}>
-				<div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+				{/* The virtualizer writes each row's offset — `start` less the margin,
+				    back in this list's own coordinates — and this container's height
+				    itself, as rows are measured; React only mounts and unmounts. */}
+				<div
+					ref={virtualizer.containerRef}
+					className="relative w-full"
+					style={{ height: virtualizer.getTotalSize() }}
+				>
 					{virtualizer.getVirtualItems().map((item) => {
 						const row = rows[item.index]!
 						return (
@@ -187,10 +198,8 @@ export function SessionTranscript({
 								key={item.key}
 								ref={virtualizer.measureElement}
 								data-index={item.index}
+								data-slot="transcript-row"
 								className="absolute inset-x-0 top-0"
-								// `start` is in the page scroller's coordinates; the margin
-								// brings it back to this list's own.
-								style={{ transform: `translateY(${item.start - scrollMargin}px)` }}
 							>
 								<TranscriptBlock
 									row={row}
@@ -224,7 +233,10 @@ interface BlockProps {
 	onSelectSpan: (spanId: string | undefined) => void
 }
 
-function TranscriptBlock(props: BlockProps) {
+/** Memoized: the list re-renders whenever the mounted range moves, and a block
+ *  whose props have not changed — nearly all of them, on every scroll — has
+ *  nothing to redo. Every callback it takes is stable for the same reason. */
+const TranscriptBlock = memo(function TranscriptBlock(props: BlockProps) {
 	const { row } = props
 	switch (row.kind) {
 		case "turn":
@@ -258,7 +270,7 @@ function TranscriptBlock(props: BlockProps) {
 		case "divider":
 			return <DividerBlock {...props} row={row} />
 	}
-}
+})
 
 /* -------------------------------------------------------------------------- */
 /* Shell                                                                      */
@@ -490,7 +502,7 @@ function UserBlock({
 												part.kind === "text" ? part.text : `[${part.kind}]`,
 											)
 											.join("\n")}
-										clampClass="line-clamp-[6]"
+										clampLines={6}
 										expanded={disclosed(openRows, key, false)}
 										onToggleExpanded={() => onToggleRow(key)}
 									/>
@@ -646,15 +658,15 @@ function AssistantBlock({
 							<div className="min-w-0 grow">
 								<ClampedText
 									text={errorRaw ? row.span.statusMessage : error.formatted}
-									html={errorRaw ? undefined : error.highlighted}
+									rendering={!errorRaw && error.isJson ? "json" : "text"}
 									mono
-									clampClass="line-clamp-[14]"
+									clampLines={14}
 									toneClass="text-[13px] text-destructive/90"
 									expanded={disclosed(openRows, `${row.key}:error-text`, false)}
 									onToggleExpanded={() => onToggleRow(`${row.key}:error-text`)}
 								/>
 							</div>
-							{error.highlighted !== undefined && (
+							{error.isJson && (
 								<ViewSwitch
 									rendered="json"
 									raw={errorRaw}
@@ -905,7 +917,7 @@ function PayloadSection({
 	onToggleRow: (key: string) => void
 	textKey: string
 }) {
-	const { formatted, highlighted } = useJsonPayload(payload.text)
+	const { formatted, isJson } = useJsonPayload(payload.text)
 	const rawKey = `${textKey}:raw`
 	const raw = disclosed(openRows, rawKey, false)
 
@@ -935,7 +947,7 @@ function PayloadSection({
 				    The switch only appears where the two differ. */}
 				{payload.text !== "" && (
 					<span className="-my-1 ml-auto flex items-center">
-						{highlighted !== undefined && (
+						{isJson && (
 							<ViewSwitch
 								rendered="json"
 								raw={raw}
@@ -952,9 +964,9 @@ function PayloadSection({
 			{payload.text !== "" && (
 				<ClampedText
 					text={raw ? payload.text : formatted}
-					html={raw ? undefined : highlighted}
+					rendering={!raw && isJson ? "json" : "text"}
 					mono
-					clampClass="line-clamp-[14]"
+					clampLines={14}
 					toneClass={tone}
 					expanded={disclosed(openRows, textKey, false)}
 					onToggleExpanded={() => onToggleRow(textKey)}

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react"
 
 import {
 	ChartBarHorizontalIcon,
@@ -104,10 +104,22 @@ export function SessionViews({
 		setRevealedSpanId(undefined)
 		setRevealedTurnId(undefined)
 	}
-	const selectSpan = (spanId: string | undefined) => {
-		clearRevealed()
-		onSelectSpan(spanId)
-	}
+	// Stable, like the two toggles below: the transcript's rows are memoized
+	// on their props, and a callback minted per render would re-render every
+	// mounted block on every scroll.
+	const selectSpan = useCallback(
+		(spanId: string | undefined) => {
+			setRevealedSpanId(undefined)
+			setRevealedTurnId(undefined)
+			onSelectSpan(spanId)
+		},
+		[onSelectSpan],
+	)
+	const toggleTurn = useCallback(
+		(turnId: string) => setCollapsedTurns((previous) => toggled(previous, turnId)),
+		[],
+	)
+	const toggleRow = useCallback((key: string) => setOpenRows((previous) => toggled(previous, key)), [])
 	const changeView = (next: SessionView) => {
 		clearRevealed()
 		onViewChange(next)
@@ -300,7 +312,7 @@ export function SessionViews({
 						agentSpansOnly={agentSpansOnly}
 						collapseIdle={collapseIdle}
 						collapsedTurns={collapsedTurns}
-						onToggleTurn={(turnId) => setCollapsedTurns((previous) => toggled(previous, turnId))}
+						onToggleTurn={toggleTurn}
 						selectedSpanId={selectedSpanId}
 						revealedSpanId={revealedSpanId}
 						revealedTurnId={revealedTurnId}
@@ -339,9 +351,9 @@ export function SessionViews({
 						showPayloads={showPayloads}
 						truncated={truncated}
 						collapsedTurns={collapsedTurns}
-						onToggleTurn={(turnId) => setCollapsedTurns((previous) => toggled(previous, turnId))}
+						onToggleTurn={toggleTurn}
 						openRows={openRows}
-						onToggleRow={(key) => setOpenRows((previous) => toggled(previous, key))}
+						onToggleRow={toggleRow}
 						selectedSpanId={selectedSpanId}
 						onSelectSpan={selectSpan}
 					/>

--- a/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/span-expansion.tsx
@@ -19,7 +19,6 @@ import {
 	CopyIcon,
 	ExternalLinkIcon,
 } from "@/components/icons"
-import { MessageResponse } from "@/components/ai-elements/message-response"
 import {
 	AttributesSection,
 	CopyableValue,
@@ -44,7 +43,7 @@ import {
 import { classifyAiSpan, spanFailed, spanTtftMs } from "@/lib/agent-sessions/session-turns"
 import { callMetaLine, formatCost } from "@/lib/agent-sessions/session-summary"
 import { payload } from "@/lib/agent-sessions/session-transcript"
-import { ClampedText, firstLine } from "./clamped-text"
+import { ClampedText, type ClampLines, firstLine } from "./clamped-text"
 import { toggled, useJsonPayload, useMessageBody, ViewSwitch } from "./payload-view"
 import { Pill } from "./pill"
 import { ToolIo } from "./tool-io"
@@ -59,7 +58,7 @@ export type SpanDetailTab = "details" | "messages" | "tools" | "logs"
 
 /** The overlay is a reading surface, not a peek, so a payload gets twice the
  *  transcript's twelve lines before it asks to be expanded. */
-const PANEL_CLAMP = "line-clamp-[24]"
+const PANEL_CLAMP: ClampLines = 24
 
 export function SpanExpansion({
 	span,
@@ -347,14 +346,10 @@ function SystemMessageRow({ message }: { message: SpanMessage }) {
 					<div className="min-w-0 grow">
 						<ClampedText
 							text={raw ? text : body.formatted}
-							html={raw ? undefined : body.highlighted}
+							rendering={raw ? "text" : body.rendered}
 							mono={!raw && body.rendered === "json"}
-							clampClass={PANEL_CLAMP}
-							body={
-								raw || body.rendered === "json" ? undefined : (
-									<MessageResponse className="text-sm">{text}</MessageResponse>
-								)
-							}
+							clampLines={PANEL_CLAMP}
+							proseClassName="text-sm"
 						/>
 					</div>
 					<ViewSwitch rendered={body.rendered} raw={raw} onRawChange={setRaw} />
@@ -427,14 +422,10 @@ function TextPart({ text, raw }: { text: string; raw: boolean }) {
 	return (
 		<ClampedText
 			text={raw ? text : body.formatted}
-			html={raw ? undefined : body.highlighted}
+			rendering={raw ? "text" : body.rendered}
 			mono={!raw && body.rendered === "json"}
-			clampClass={PANEL_CLAMP}
-			body={
-				raw || body.rendered === "json" ? undefined : (
-					<MessageResponse className="text-sm">{text}</MessageResponse>
-				)
-			}
+			clampLines={PANEL_CLAMP}
+			proseClassName="text-sm"
 		/>
 	)
 }
@@ -454,7 +445,7 @@ function ReasoningPart({ part }: { part: Extract<SpanMessagePart, { kind: "reaso
 						: "No reasoning text was captured."}
 				</p>
 			) : (
-				<ClampedText text={part.text} clampClass={PANEL_CLAMP} />
+				<ClampedText text={part.text} clampLines={PANEL_CLAMP} />
 			)}
 		</div>
 	)
@@ -603,7 +594,7 @@ function PayloadCard({
  * captured bytes stay one click away, and the copy takes what is displayed.
  */
 function PayloadBody({ text, copyLabel }: { text: string; copyLabel: string }) {
-	const { formatted, highlighted } = useJsonPayload(text)
+	const { formatted, isJson } = useJsonPayload(text)
 	const [raw, setRaw] = useState(false)
 
 	return (
@@ -611,12 +602,12 @@ function PayloadBody({ text, copyLabel }: { text: string; copyLabel: string }) {
 			<div className="min-w-0 grow">
 				<ClampedText
 					text={raw ? text : formatted}
-					html={raw ? undefined : highlighted}
-					clampClass={PANEL_CLAMP}
+					rendering={!raw && isJson ? "json" : "text"}
+					clampLines={PANEL_CLAMP}
 					mono
 				/>
 			</div>
-			{highlighted !== undefined && (
+			{isJson && (
 				<ViewSwitch rendered="json" raw={raw} onRawChange={setRaw} className="self-start" />
 			)}
 			<CopyButton value={raw ? text : formatted} label={copyLabel} className="-my-1 shrink-0" />

--- a/apps/web/src/components/agent-sessions/session-detail/tool-io.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/tool-io.tsx
@@ -3,7 +3,7 @@ import { formatBytes } from "@maple/ui/lib/format"
 import { cn } from "@maple/ui/lib/utils"
 
 import { ArrowDownIcon, ArrowUpIcon, CircleQuestionIcon } from "@/components/icons"
-import { ClampedText } from "./clamped-text"
+import { ClampedText, type ClampLines } from "./clamped-text"
 import { disclosed, useJsonPayload, ViewSwitch } from "./payload-view"
 import { Pill } from "./pill"
 
@@ -34,8 +34,8 @@ export interface ToolIoPayload {
 
 /** Arguments are context and clamp shorter; the result is what the reader
  *  opened the card for, and keeps the twelve-line body of every other payload. */
-const IN_CLAMP = "line-clamp-[8]"
-const OUT_CLAMP = "line-clamp-[14]"
+const IN_CLAMP: ClampLines = 8
+const OUT_CLAMP: ClampLines = 14
 
 const LABEL = "font-medium font-mono text-[10px] uppercase tracking-[0.1em]"
 const META = "font-mono text-[10px] text-muted-foreground"
@@ -92,7 +92,7 @@ export function ToolIo({
 					label="Sent"
 					name="arguments"
 					payload={args}
-					clampClass={IN_CLAMP}
+					clampLines={IN_CLAMP}
 					textKey={`${keyPrefix}:args-text`}
 					openRows={openRows}
 					onToggleRow={onToggleRow}
@@ -108,7 +108,7 @@ export function ToolIo({
 					payload={result}
 					meta={resultMeta}
 					failed={failed}
-					clampClass={OUT_CLAMP}
+					clampLines={OUT_CLAMP}
 					textKey={`${keyPrefix}:result-text`}
 					openRows={openRows}
 					onToggleRow={onToggleRow}
@@ -146,7 +146,7 @@ function IoHalf({
 	payload,
 	meta,
 	failed = false,
-	clampClass,
+	clampLines,
 	textKey,
 	openRows,
 	onToggleRow,
@@ -159,12 +159,12 @@ function IoHalf({
 	payload: ToolIoPayload
 	meta?: string
 	failed?: boolean
-	clampClass: string
+	clampLines: ClampLines
 	textKey: string
 	openRows: ReadonlySet<string>
 	onToggleRow: (key: string) => void
 }) {
-	const { formatted, highlighted } = useJsonPayload(payload.text)
+	const { formatted, isJson } = useJsonPayload(payload.text)
 	const rawKey = `${textKey}:raw`
 	const raw = disclosed(openRows, rawKey, false)
 
@@ -205,7 +205,7 @@ function IoHalf({
 					    The switch only appears where the two differ. */}
 					{payload.text !== "" && (
 						<span className="-my-1 ml-auto flex items-center">
-							{highlighted !== undefined && (
+							{isJson && (
 								<ViewSwitch
 									rendered="json"
 									raw={raw}
@@ -222,9 +222,9 @@ function IoHalf({
 				{payload.text !== "" && (
 					<ClampedText
 						text={raw ? payload.text : formatted}
-						html={raw ? undefined : highlighted}
+						rendering={!raw && isJson ? "json" : "text"}
 						mono
-						clampClass={clampClass}
+						clampLines={clampLines}
 						toneClass={failed ? "text-destructive/90" : undefined}
 						expanded={disclosed(openRows, textKey, false)}
 						onToggleExpanded={() => onToggleRow(textKey)}

--- a/apps/web/src/components/ai-elements/message-response.tsx
+++ b/apps/web/src/components/ai-elements/message-response.tsx
@@ -10,9 +10,19 @@ import { mermaid } from "@streamdown/mermaid"
 import { memo } from "react"
 import { Streamdown, type PluginConfig } from "streamdown"
 
-export type MessageResponseProps = ComponentProps<typeof Streamdown>
+export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
+	/**
+	 * Markdown layout only — no Shiki, KaTeX or Mermaid. For a body that is
+	 * mounted over and over rather than once: a virtualized transcript mounts a
+	 * reply again every time it scrolls back into view, and tokenizing its code
+	 * fences each time was most of the work in a scroll frame. Code still
+	 * renders, as a plain block.
+	 */
+	lightweight?: boolean
+}
 
 const streamdownPlugins = { cjk, code, math, mermaid } as PluginConfig
+const lightweightPlugins = { cjk } as PluginConfig
 
 /**
  * Markdown renderer for assistant text. Memoized on `children` identity so a
@@ -21,10 +31,10 @@ const streamdownPlugins = { cjk, code, math, mermaid } as PluginConfig
  * per token is visible as jank.
  */
 export const MessageResponse = memo(
-	({ className, ...props }: MessageResponseProps) => (
+	({ className, lightweight = false, ...props }: MessageResponseProps) => (
 		<Streamdown
 			className={cn("size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
-			plugins={streamdownPlugins}
+			plugins={lightweight ? lightweightPlugins : streamdownPlugins}
 			{...props}
 		/>
 	),

--- a/apps/web/src/lab/bench/agent-transcript-bench.tsx
+++ b/apps/web/src/lab/bench/agent-transcript-bench.tsx
@@ -1,0 +1,394 @@
+import { Profiler, useMemo, useState, type ProfilerOnRenderCallback } from "react"
+
+import type { AiSessionGenAiValues, AiSessionSpan } from "@maple/domain/http"
+
+import { SessionViews } from "@/components/agent-sessions/session-detail/session-views"
+import { useMountEffect } from "@/hooks/use-mount-effect"
+import { buildSessionSummary } from "@/lib/agent-sessions/session-summary"
+import { buildSessionTurns } from "@/lib/agent-sessions/session-turns"
+import { agentSpan, llmSpan, toolSpan, userMessages } from "@/lib/agent-sessions/span-test-support"
+
+/**
+ * The transcript view over a session big enough to hurt: tens of turns, every
+ * call carrying its prompt and reply, every tool call carrying a result that
+ * runs to hundreds of kilobytes. The list virtualizes, so what this measures
+ * is the cost of a ROW — what mounting one puts in the DOM, and what it costs
+ * to mount it again after it scrolled out.
+ *
+ * `window.__transcriptBench` is the harness `perf/agent-transcript.perf.spec.ts`
+ * drives: `runScroll()` sweeps the page scroller top to bottom one frame per
+ * step and reports frame timing, long tasks and React commit work, alongside
+ * how much DOM the mounted rows hold.
+ */
+
+interface TranscriptBenchMetrics {
+	frames: number
+	frameP95Ms: number
+	droppedFrames: number
+	longTasks: number
+	totalBlockingMs: number
+	reactCommits: number
+	reactDurationMs: number
+	reactMaxCommitMs: number
+	/** Rows the virtualizer has mounted once the sweep ends. */
+	mountedRows: number
+	/** Elements under the list once the sweep ends — the DOM the rows cost. */
+	listNodes: number
+	/** The most elements any one mounted row holds. */
+	maxRowNodes: number
+}
+
+interface TranscriptBenchHarness {
+	ready: boolean
+	/** How long the first commit that painted the list took. */
+	mountCommitMs: number
+	runScroll: (steps?: number) => Promise<TranscriptBenchMetrics>
+	countDom: () => Pick<TranscriptBenchMetrics, "mountedRows" | "listNodes" | "maxRowNodes">
+}
+
+declare global {
+	interface Window {
+		__transcriptBench?: TranscriptBenchHarness
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fixture                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const SECOND = 1000
+const TURN_GAP_MS = 90 * SECOND
+const VENDOR_ID = "claude_agent_sdk"
+
+/** Deterministic, so two runs of the bench render the same bytes. */
+function mulberry32(seed: number): () => number {
+	let state = seed >>> 0
+	return () => {
+		state = (state + 0x6d2b79f5) >>> 0
+		let t = state
+		t = Math.imul(t ^ (t >>> 15), t | 1)
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+	}
+}
+
+const WORDS =
+	"retry backoff webhook idempotency charge invoice customer ledger dispatch queue partition replica latency p95 deploy rollback config jitter attempt handler schema migration index cursor".split(
+		" ",
+	)
+
+function prose(random: () => number, words: number): string {
+	const out: string[] = []
+	for (let i = 0; i < words; i++) {
+		const word = WORDS[Math.floor(random() * WORDS.length)]!
+		out.push(i > 0 && i % 17 === 0 ? `${word}.` : word)
+	}
+	return out.join(" ")
+}
+
+const SYSTEM_INSTRUCTIONS = [
+	"You are a careful coding agent working in a payments monorepo.",
+	"",
+	"## Rules",
+	"",
+	...Array.from({ length: 160 }, (_, i) => `${i + 1}. Rule ${i + 1}: ${prose(mulberry32(i), 14)}`),
+].join("\n")
+
+function markdownReply(random: () => number, paragraphs: number): string {
+	const blocks: string[] = []
+	for (let p = 0; p < paragraphs; p++) {
+		blocks.push(prose(random, 40 + Math.floor(random() * 50)))
+		if (p % 3 === 1) {
+			blocks.push(
+				["```ts", ...Array.from({ length: 12 }, (_, i) => `const step${i} = retry(${i}, { jitter: ${random().toFixed(3)} })`), "```"].join(
+					"\n",
+				),
+			)
+		}
+		if (p % 4 === 2) {
+			blocks.push(Array.from({ length: 5 }, (_, i) => `- **item ${i}** — ${prose(random, 9)}`).join("\n"))
+		}
+	}
+	return blocks.join("\n\n")
+}
+
+/** A warehouse-shaped result: rows of one query, sized by `rows`. */
+function jsonResult(random: () => number, rows: number): Record<string, unknown> {
+	return {
+		query_id: `q_${Math.floor(random() * 1e9).toString(16)}`,
+		elapsed_ms: Math.round(random() * 4000),
+		rows: Array.from({ length: rows }, (_, i) => ({
+			t: new Date(Date.UTC(2026, 7, 25, 13, 50) + i * 60_000).toISOString(),
+			service: `checkout-api-${i % 7}`,
+			p95_ms: Number((80 + random() * 900).toFixed(2)),
+			count: Math.floor(random() * 5000),
+			error_rate: Number((random() * 0.05).toFixed(4)),
+			region: random() > 0.5 ? "eu-central-1" : "us-east-1",
+		})),
+	}
+}
+
+function textResult(random: () => number, lines: number): string {
+	return Array.from({ length: lines }, (_, i) => `${String(i + 1).padStart(4, " ")}  ${prose(random, 10)}`).join("\n")
+}
+
+function usage(inputTokens: number, outputTokens: number): AiSessionGenAiValues {
+	return {
+		usageInputTokens: inputTokens,
+		usageOutputTokens: outputTokens,
+		usageCost: inputTokens * 0.000003 + outputTokens * 0.000015,
+	}
+}
+
+/**
+ * `turns` turns, each: one agent span, three model calls (the last one the
+ * closing reply, the others each dispatching a tool), and two tool spans whose
+ * results run from ten kilobytes to a few hundred.
+ */
+export function buildLargeSessionFixture(turns: number, seed = 1): readonly AiSessionSpan[] {
+	const random = mulberry32(seed)
+	const spans: AiSessionSpan[] = []
+	const tools = ["run_sql", "read_file", "search_traces", "grep_repo"]
+
+	for (let turn = 0; turn < turns; turn++) {
+		const traceId = `trace-big-${turn}`
+		const agentId = `big-${turn}-agent`
+		const t = turn * TURN_GAP_MS
+		spans.push(
+			agentSpan({
+				spanId: agentId,
+				traceId,
+				startMs: t,
+				durationMs: 60 * SECOND,
+				agentName: "coding-agent",
+				vendorId: VENDOR_ID,
+			}),
+		)
+		const prompt = `${prose(random, 30 + Math.floor(random() * 600))}\n\n\`\`\`\n${textResult(random, 8)}\n\`\`\``
+		for (let call = 0; call < 3; call++) {
+			const closing = call === 2
+			const tool = closing ? undefined : tools[(turn + call) % tools.length]!
+			const callId = `big-${turn}-${call}`
+			spans.push(
+				llmSpan({
+					spanId: `big-${turn}-l${call}`,
+					parentSpanId: agentId,
+					traceId,
+					startMs: t + call * 20 * SECOND,
+					durationMs: 4 * SECOND,
+					spanName: "chat claude-opus-5",
+					model: "claude-opus-5",
+					ttftSeconds: 0.6,
+					vendorId: VENDOR_ID,
+					genAi: {
+						...usage(20_000 + turn * 3_000 + call * 4_000, 800 + call * 400),
+						systemInstructions: SYSTEM_INSTRUCTIONS,
+						inputMessages: call === 0 ? userMessages(prompt) : undefined,
+						outputMessages: [
+							{
+								role: "assistant",
+								parts: [
+									...(call % 2 === 0
+										? [{ type: "reasoning", content: prose(random, 200 + Math.floor(random() * 200)) }]
+										: []),
+									{ type: "text", content: markdownReply(random, closing ? 6 + Math.floor(random() * 6) : 1) },
+									...(tool === undefined
+										? []
+										: [
+												{
+													type: "tool_call",
+													id: callId,
+													name: tool,
+													arguments: {
+														sql: `SELECT * FROM traces WHERE turn = ${turn} AND call = ${call}`,
+														filters: Array.from({ length: 12 }, (_, i) => ({ key: `attr.${i}`, value: prose(random, 3) })),
+													},
+												},
+											]),
+								],
+							},
+						],
+						responseFinishReasons: [closing ? "stop" : "tool_use"],
+					},
+				}),
+			)
+			if (tool !== undefined) {
+				const textual = (turn * 3 + call) % 6 === 0
+				spans.push(
+					toolSpan({
+						spanId: `big-${turn}-t${call}`,
+						parentSpanId: agentId,
+						traceId,
+						startMs: t + call * 20 * SECOND + 5 * SECOND,
+						durationMs: 2 * SECOND,
+						serviceName: "warehouse-mcp",
+						toolName: tool,
+						vendorId: VENDOR_ID,
+						genAi: {
+							toolCallId: callId,
+							toolCallArguments: {
+								sql: `SELECT * FROM traces WHERE turn = ${turn} AND call = ${call}`,
+								filters: Array.from({ length: 12 }, (_, i) => ({ key: `attr.${i}`, value: prose(random, 3) })),
+							},
+							toolCallResult: textual
+								? textResult(random, 300 + Math.floor(random() * 300))
+								: jsonResult(random, 80 + Math.floor(random() * 1_200)),
+						},
+					}),
+				)
+			}
+		}
+	}
+	return spans
+}
+
+/* -------------------------------------------------------------------------- */
+/* Bench                                                                      */
+/* -------------------------------------------------------------------------- */
+
+function percentile(values: number[], p: number): number {
+	if (values.length === 0) return 0
+	const sorted = [...values].sort((a, b) => a - b)
+	return sorted[Math.min(sorted.length - 1, Math.round((p / 100) * (sorted.length - 1)))] ?? 0
+}
+
+/** The virtualizer's row wrappers — by slot, not `data-index`, which the tab
+ *  panel around the list carries too. */
+const LIST_SELECTOR = '[data-transcript-bench] [data-slot="transcript-row"]'
+
+function countDom(): Pick<TranscriptBenchMetrics, "mountedRows" | "listNodes" | "maxRowNodes"> {
+	const rows = Array.from(document.querySelectorAll(LIST_SELECTOR))
+	let listNodes = 0
+	let maxRowNodes = 0
+	for (const row of rows) {
+		const nodes = row.querySelectorAll("*").length
+		listNodes += nodes
+		maxRowNodes = Math.max(maxRowNodes, nodes)
+	}
+	return { mountedRows: rows.length, listNodes, maxRowNodes }
+}
+
+export function AgentTranscriptBench({ turns }: { turns: number }) {
+	const spans = useMemo(() => buildLargeSessionFixture(turns), [turns])
+	const sessionTurns = useMemo(() => buildSessionTurns(spans), [spans])
+	const summary = useMemo(() => buildSessionSummary({ spans, turns: sessionTurns }), [spans, sessionTurns])
+	const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>(undefined)
+
+	const recorder = useMemo(() => {
+		let commits = 0
+		let duration = 0
+		let maxCommit = 0
+		let firstCommit: number | undefined
+		const onRender: ProfilerOnRenderCallback = (_id, _phase, actualDuration) => {
+			commits++
+			duration += actualDuration
+			maxCommit = Math.max(maxCommit, actualDuration)
+			firstCommit ??= actualDuration
+		}
+		return {
+			onRender,
+			reset: () => {
+				commits = 0
+				duration = 0
+				maxCommit = 0
+			},
+			snapshot: () => ({ commits, duration, maxCommit }),
+			firstCommit: () => firstCommit ?? 0,
+		}
+	}, [])
+
+	useMountEffect(() => {
+		const harness: TranscriptBenchHarness = {
+			ready: false,
+			mountCommitMs: 0,
+			countDom,
+			runScroll: async (steps = 160) => {
+				const scroller = document.querySelector<HTMLElement>('[data-transcript-bench] [data-slot="page-scroll-area"]')
+				if (!scroller) throw new Error("Transcript benchmark scroller not found")
+				recorder.reset()
+				const frames: number[] = []
+				const longTasks: PerformanceEntry[] = []
+				let previous = performance.now()
+				let frameHandle = 0
+				let running = true
+				let observer: PerformanceObserver | undefined
+				try {
+					observer = new PerformanceObserver((list) => longTasks.push(...list.getEntries()))
+					observer.observe({ entryTypes: ["longtask"] })
+				} catch {
+					// Firefox/WebKit do not expose Long Tasks; frame and React metrics remain valid.
+				}
+				const sample = (now: number) => {
+					frames.push(now - previous)
+					previous = now
+					if (running) frameHandle = requestAnimationFrame(sample)
+				}
+				frameHandle = requestAnimationFrame(sample)
+				for (let step = 0; step <= steps; step++) {
+					// Re-read every step: measured rows grow the list as the sweep goes.
+					const maxScroll = scroller.scrollHeight - scroller.clientHeight
+					scroller.scrollTop = maxScroll * (step / steps)
+					await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+				}
+				await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+				running = false
+				cancelAnimationFrame(frameHandle)
+				observer?.disconnect()
+				const react = recorder.snapshot()
+				return {
+					frames: frames.length,
+					frameP95Ms: percentile(frames, 95),
+					droppedFrames: frames.filter((duration) => duration > (1000 / 60) * 1.5).length,
+					longTasks: longTasks.length,
+					totalBlockingMs: longTasks.reduce((sum, entry) => sum + Math.max(0, entry.duration - 50), 0),
+					reactCommits: react.commits,
+					reactDurationMs: react.duration,
+					reactMaxCommitMs: react.maxCommit,
+					...countDom(),
+				}
+			},
+		}
+		window.__transcriptBench = harness
+		const poll = () => {
+			if (document.querySelector(LIST_SELECTOR) !== null) {
+				harness.mountCommitMs = recorder.firstCommit()
+				harness.ready = true
+				return
+			}
+			requestAnimationFrame(poll)
+		}
+		requestAnimationFrame(poll)
+		return () => {
+			if (window.__transcriptBench === harness) delete window.__transcriptBench
+		}
+	})
+
+	return (
+		<div data-transcript-bench className="flex h-screen flex-col bg-background text-foreground">
+			<div className="flex shrink-0 items-center gap-3 border-border border-b px-4 py-2 text-xs">
+				<span className="font-semibold">Transcript bench</span>
+				<span className="text-muted-foreground">
+					{turns} turns · {summary.spanCount} spans ·{" "}
+					{(JSON.stringify(spans).length / 1_048_576).toFixed(1)} MB of spans
+				</span>
+			</div>
+			{/* The same scroller slot the page gives the list, so the virtualizer
+			    takes the production path rather than its bare-render fallback. */}
+			<div data-slot="page-scroll-area" className="flex min-h-0 flex-1 flex-col overflow-auto px-4">
+				<div className="flex min-h-64 shrink-0 grow flex-col">
+					<Profiler id="agent-transcript-bench" onRender={recorder.onRender}>
+						<SessionViews
+							view="transcript"
+							onViewChange={() => {}}
+							turns={sessionTurns}
+							summary={summary}
+							truncated={false}
+							selectedSpanId={selectedSpanId}
+							onSelectSpan={setSelectedSpanId}
+						/>
+					</Profiler>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/apps/web/src/lab/registry.ts
+++ b/apps/web/src/lab/registry.ts
@@ -122,6 +122,14 @@ export const LAB_ENTRIES: ReadonlyArray<LabEntry> = [
 		session: "none",
 	},
 	{
+		path: "/lab/bench/agent-transcript",
+		title: "Agent transcript",
+		description:
+			"The session Transcript view over a synthetic session of `?turns=` turns (default 40) whose tool results run to hundreds of kilobytes — row mount cost and scroll perf, via window.__transcriptBench.",
+		kind: "bench",
+		session: "none",
+	},
+	{
 		path: "/lab/bench/logs",
 		title: "Logs table",
 		description: "The real LogsTableView over 2,000 synthetic rows × 12 chips — hover and scroll perf.",

--- a/apps/web/src/lib/agent-sessions/session-transcript.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-transcript.test.ts
@@ -5,7 +5,14 @@ import type { AiSessionSpan } from "@maple/domain/http"
 import { buildAgentSessionFixture } from "@/lab/agent-session-fixture"
 
 import { buildSessionTurns } from "./session-turns"
-import { buildTranscript, payload, type TranscriptInput, type TranscriptRow } from "./session-transcript"
+import {
+	assembleTranscript,
+	buildTranscript,
+	payload,
+	prepareTranscript,
+	type TranscriptInput,
+	type TranscriptRow,
+} from "./session-transcript"
 import { sessionToolResults } from "./span-detail"
 import { agentSpan, llmSpan, makeSpan, toolSpan, T0 } from "./span-test-support"
 
@@ -1961,5 +1968,28 @@ describe("buildTranscript — investigation fan-out", () => {
 		expect(kinds(rows)).not.toContain("lane-open")
 		expect(kinds(rows)).not.toContain("parallel")
 		expect(findRows(rows, "turn")).toHaveLength(5)
+	})
+})
+
+describe("prepare / assemble", () => {
+	// The view memoizes the read of the session and re-runs only the assembly
+	// when a turn is collapsed, so the split has to be exact: one read, any
+	// set of collapsed turns, the same rows the one-shot build produces.
+	it("reads the session once for every collapse", () => {
+		const spans = buildAgentSessionFixture()
+		const turns = buildSessionTurns(spans)
+		const read = { turns, toolResults: sessionToolResults(spans), query: "", showThinking: true }
+		const prepared = prepareTranscript(read)
+
+		const open = new Set<string>()
+		const collapsed = new Set([turns[0]!.id, turns[4]!.id])
+		for (const collapsedTurns of [open, collapsed]) {
+			expect(assembleTranscript(prepared, { collapsedTurns, truncated: false })).toEqual(
+				buildTranscript({ ...read, collapsedTurns, truncated: false }),
+			)
+		}
+		expect(assembleTranscript(prepared, { collapsedTurns: collapsed, truncated: false }).length).toBeLessThan(
+			assembleTranscript(prepared, { collapsedTurns: open, truncated: false }).length,
+		)
 	})
 })

--- a/apps/web/src/lib/agent-sessions/session-transcript.ts
+++ b/apps/web/src/lib/agent-sessions/session-transcript.ts
@@ -245,6 +245,34 @@ export interface TranscriptInput {
 const CAPTURE_BANNER_THRESHOLD = 0.5
 
 export function buildTranscript(input: TranscriptInput): readonly TranscriptRow[] {
+	return assembleTranscript(prepareTranscript(input), input)
+}
+
+/** What the read of the session takes: everything but the two inputs a
+ *  reader flips row by row, which only `assembleTranscript` sees. */
+export type PrepareInput = Omit<TranscriptInput, "collapsedTurns" | "truncated">
+
+/** The session read once: every turn's rows, and the session-wide facts the
+ *  assembly needs to order them. */
+export interface PreparedTranscript {
+	readonly turnRows: readonly TurnRows[]
+	/** Parallel-turn markers by the turn that opens each cluster. */
+	readonly concurrent: ReadonlyMap<string, TranscriptRow | undefined>
+	readonly filtering: boolean
+	/** Capture is the exception this session, so one banner says so up top. */
+	readonly bannerUp: boolean
+	readonly capturedCalls: number
+	readonly anyAiActivity: boolean
+}
+
+/**
+ * The expensive half of the build — a JSON parse per captured span, then the
+ * forest walk, for every turn — done once per session and filter. Collapsing
+ * a turn changes which rows are EMITTED, not what they are, so it re-runs only
+ * `assembleTranscript`: on a session of megabytes that is the difference
+ * between a click and a stall.
+ */
+export function prepareTranscript(input: PrepareInput): PreparedTranscript {
 	// `classifyAiSpan` re-reads the same attributes every time the build asks
 	// what a span is, and a build asks five to eight times per span. One cache
 	// for the whole build, alongside the per-turn message cache.
@@ -272,6 +300,14 @@ export function buildTranscript(input: TranscriptInput): readonly TranscriptRow[
 	// have agent work keeps placeholders for the turns without it.
 	const anyAiActivity = turnRows.some((entry) => entry.aiSpanCount > 0)
 
+	return { turnRows, concurrent, filtering, bannerUp, capturedCalls, anyAiActivity }
+}
+
+/** The cheap half: the row list, in order, for what the reader has open. */
+export function assembleTranscript(
+	{ turnRows, concurrent, filtering, bannerUp, capturedCalls, anyAiActivity }: PreparedTranscript,
+	{ collapsedTurns, truncated }: Pick<TranscriptInput, "collapsedTurns" | "truncated">,
+): readonly TranscriptRow[] {
 	const body: TranscriptRow[] = []
 	for (const entry of turnRows) {
 		// The fallback turn partition is one turn per trace, so a session of pure
@@ -311,7 +347,7 @@ export function buildTranscript(input: TranscriptInput): readonly TranscriptRow[
 				anyCaptured: false,
 			})
 		}
-		if (!input.collapsedTurns.has(entry.turn.id)) {
+		if (!collapsedTurns.has(entry.turn.id)) {
 			body.push(
 				...(indent === 0
 					? entry.rows
@@ -339,7 +375,7 @@ export function buildTranscript(input: TranscriptInput): readonly TranscriptRow[
 
 	// Truncation drops the END of the session, so the divider is terminal and
 	// unconditional: it says where the reading stops, not where the agent did.
-	if (input.truncated) {
+	if (truncated) {
 		rows.push({
 			kind: "divider",
 			key: "divider:truncated",
@@ -366,7 +402,7 @@ interface TurnRows {
 
 function buildTurn(
 	turn: SessionTurn,
-	input: TranscriptInput,
+	input: PrepareInput,
 	categoryOf: (span: AiSessionSpan) => AiSpanCategory,
 ): TurnRows {
 	// Non-AI spans are the app's own HTTP/DB work sharing the agent's traces and
@@ -388,15 +424,6 @@ function buildTurn(
 		toolNames: distinct(
 			toolSpans.map((span) => span.genAi.toolName).filter((name): name is string => name !== undefined),
 		),
-	}
-
-	// A collapsed turn renders its header and nothing else, so none of the work
-	// below — a JSON parse per captured span, then the forest walk — would ever
-	// reach the page. With a filter on it does reach it: the filter decides
-	// whether the header itself survives, and that is read off the rows.
-	const filtering = input.query.trim() !== ""
-	if (input.collapsedTurns.has(turn.id) && !filtering) {
-		return { turn, header, rows: [], llmSpans, aiSpanCount: spans.length }
 	}
 
 	// `spanMessages` re-walks the captured JSON on every call and a turn asks for
@@ -444,7 +471,7 @@ function buildTurn(
 
 interface TurnContext {
 	readonly turn: SessionTurn
-	readonly input: TranscriptInput
+	readonly input: PrepareInput
 	/** Per-turn cache over `spanMessages` — the captured JSON is parsed once. */
 	readonly messagesOf: (span: AiSessionSpan) => readonly SpanMessage[]
 	/** Per-build cache over `classifyAiSpan`. */

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -75,6 +75,7 @@ import { Route as InfraContainersContainerNameRouteImport } from './routes/infra
 import { Route as InfraKubernetesIndexRouteImport } from './routes/infra/kubernetes/index'
 import { Route as InfraPlanetscaleIndexRouteImport } from './routes/infra/planetscale/index'
 import { Route as InfraPlanetscaleDbNameRouteImport } from './routes/infra/planetscale/$dbName'
+import { Route as LabBenchAgentTranscriptRouteImport } from './routes/lab/bench/agent-transcript'
 import { Route as LabBenchInfraRouteImport } from './routes/lab/bench/infra'
 import { Route as LabBenchLogsRouteImport } from './routes/lab/bench/logs'
 import { Route as LabBenchOverviewRouteImport } from './routes/lab/bench/overview'
@@ -424,6 +425,11 @@ const InfraPlanetscaleDbNameRoute = InfraPlanetscaleDbNameRouteImport.update({
   path: '/infra/planetscale/$dbName',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LabBenchAgentTranscriptRoute = LabBenchAgentTranscriptRouteImport.update({
+  id: '/bench/agent-transcript',
+  path: '/bench/agent-transcript',
+  getParentRoute: () => LabRouteRoute,
+} as any)
 const LabBenchInfraRoute = LabBenchInfraRouteImport.update({
   id: '/bench/infra',
   path: '/bench/infra',
@@ -571,6 +577,7 @@ export interface FileRoutesByFullPath {
   '/infra/cloudflare/$zoneName': typeof InfraCloudflareZoneNameRoute
   '/infra/containers/$containerName': typeof InfraContainersContainerNameRoute
   '/infra/planetscale/$dbName': typeof InfraPlanetscaleDbNameRoute
+  '/lab/bench/agent-transcript': typeof LabBenchAgentTranscriptRoute
   '/lab/bench/infra': typeof LabBenchInfraRoute
   '/lab/bench/logs': typeof LabBenchLogsRoute
   '/lab/bench/overview': typeof LabBenchOverviewRoute
@@ -653,6 +660,7 @@ export interface FileRoutesByTo {
   '/infra/cloudflare/$zoneName': typeof InfraCloudflareZoneNameRoute
   '/infra/containers/$containerName': typeof InfraContainersContainerNameRoute
   '/infra/planetscale/$dbName': typeof InfraPlanetscaleDbNameRoute
+  '/lab/bench/agent-transcript': typeof LabBenchAgentTranscriptRoute
   '/lab/bench/infra': typeof LabBenchInfraRoute
   '/lab/bench/logs': typeof LabBenchLogsRoute
   '/lab/bench/overview': typeof LabBenchOverviewRoute
@@ -737,6 +745,7 @@ export interface FileRoutesById {
   '/infra/cloudflare/$zoneName': typeof InfraCloudflareZoneNameRoute
   '/infra/containers/$containerName': typeof InfraContainersContainerNameRoute
   '/infra/planetscale/$dbName': typeof InfraPlanetscaleDbNameRoute
+  '/lab/bench/agent-transcript': typeof LabBenchAgentTranscriptRoute
   '/lab/bench/infra': typeof LabBenchInfraRoute
   '/lab/bench/logs': typeof LabBenchLogsRoute
   '/lab/bench/overview': typeof LabBenchOverviewRoute
@@ -822,6 +831,7 @@ export interface FileRouteTypes {
     | '/infra/cloudflare/$zoneName'
     | '/infra/containers/$containerName'
     | '/infra/planetscale/$dbName'
+    | '/lab/bench/agent-transcript'
     | '/lab/bench/infra'
     | '/lab/bench/logs'
     | '/lab/bench/overview'
@@ -904,6 +914,7 @@ export interface FileRouteTypes {
     | '/infra/cloudflare/$zoneName'
     | '/infra/containers/$containerName'
     | '/infra/planetscale/$dbName'
+    | '/lab/bench/agent-transcript'
     | '/lab/bench/infra'
     | '/lab/bench/logs'
     | '/lab/bench/overview'
@@ -987,6 +998,7 @@ export interface FileRouteTypes {
     | '/infra/cloudflare/$zoneName'
     | '/infra/containers/$containerName'
     | '/infra/planetscale/$dbName'
+    | '/lab/bench/agent-transcript'
     | '/lab/bench/infra'
     | '/lab/bench/logs'
     | '/lab/bench/overview'
@@ -1541,6 +1553,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InfraPlanetscaleDbNameRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/lab/bench/agent-transcript': {
+      id: '/lab/bench/agent-transcript'
+      path: '/bench/agent-transcript'
+      fullPath: '/lab/bench/agent-transcript'
+      preLoaderRoute: typeof LabBenchAgentTranscriptRouteImport
+      parentRoute: typeof LabRouteRoute
+    }
     '/lab/bench/infra': {
       id: '/lab/bench/infra'
       path: '/bench/infra'
@@ -1660,6 +1679,7 @@ interface LabRouteRouteChildren {
   LabTimelineRoute: typeof LabTimelineRoute
   LabWidgetsRoute: typeof LabWidgetsRoute
   LabIndexRoute: typeof LabIndexRoute
+  LabBenchAgentTranscriptRoute: typeof LabBenchAgentTranscriptRoute
   LabBenchInfraRoute: typeof LabBenchInfraRoute
   LabBenchLogsRoute: typeof LabBenchLogsRoute
   LabBenchOverviewRoute: typeof LabBenchOverviewRoute
@@ -1679,6 +1699,7 @@ const LabRouteRouteChildren: LabRouteRouteChildren = {
   LabTimelineRoute: LabTimelineRoute,
   LabWidgetsRoute: LabWidgetsRoute,
   LabIndexRoute: LabIndexRoute,
+  LabBenchAgentTranscriptRoute: LabBenchAgentTranscriptRoute,
   LabBenchInfraRoute: LabBenchInfraRoute,
   LabBenchLogsRoute: LabBenchLogsRoute,
   LabBenchOverviewRoute: LabBenchOverviewRoute,

--- a/apps/web/src/routes/lab/bench/agent-transcript.tsx
+++ b/apps/web/src/routes/lab/bench/agent-transcript.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Schema } from "effect"
+
+import { AgentTranscriptBench } from "@/lab/bench/agent-transcript-bench"
+
+/** `?turns=` sizes the session; the default is big enough that an unbounded
+ *  row shows up in the numbers without the page taking a minute to build.
+ *  A number, not a string: the router JSON-parses search values, so `?turns=40`
+ *  arrives as `40`. */
+const searchSchema = Schema.Struct({ turns: Schema.optional(Schema.Number) })
+
+const DEFAULT_TURNS = 40
+
+export const Route = createFileRoute("/lab/bench/agent-transcript")({
+	component: AgentTranscriptBenchRoute,
+	validateSearch: Schema.toStandardSchemaV1(searchSchema),
+})
+
+function AgentTranscriptBenchRoute() {
+	const { turns } = Route.useSearch()
+	return (
+		<AgentTranscriptBench
+			turns={turns !== undefined && Number.isInteger(turns) && turns > 0 ? turns : DEFAULT_TURNS}
+		/>
+	)
+}


### PR DESCRIPTION
## Why

The Transcript view already virtualized its rows, yet a large session still scrolled badly. On a 40-turn / 9 MB synthetic session (new bench, below) the p95 scroll frame was **49 ms**, a quarter of frames dropped, with long tasks. A CPU profile put the cost in the rows, not the list.

## What the profile found, and the fix for each

| Cost | Fix |
| --- | --- |
| `isValidIanaTimeZone` built and ran an `Intl.DateTimeFormat` on every row render — the single hottest function | Memoise validity per zone name (`timezone-preference-atoms.ts`) |
| Every virtualizer notification (several per frame while scrolling) synchronously re-rendered every mounted block | `memo(TranscriptBlock)`, stable callbacks from `SessionViews`, and `directDomUpdates` so the virtualizer writes offsets to the DOM and React re-renders only on a range change |
| A clamped body mounted its whole payload — a CSS clamp hides lines, it doesn't skip them, so a 300 KB tool result under `line-clamp-[14]` was tens of thousands of highlighted elements, remounted every time the row scrolled back in | `ClampedText` owns its rendering and mounts a bounded preview (72 lines / 8 K chars) while clamped, highlighting or laying out only that; the whole body mounts on "Show full", as plain text past 200 K chars |
| `scrollHeight` read in a layout effect: a forced layout per body per mount | The clamp is now a line count (`clampLines`), so a cut preview or a verbatim body with more lines than the clamp needs no measurement; the rest is measured by a `ResizeObserver` off the layout the browser was doing anyway (and re-measures on resize, which the one-shot read never did) |
| Shiki tokenised every code fence on every mount | Transcript bodies use `MessageResponse lightweight` (cjk only) in `mode="static"`. **Trade-off:** code fences in transcript replies render as plain blocks, not syntax-highlighted. Chat is unchanged. |
| Collapsing a turn re-ran the whole build | `buildTranscript` = `prepareTranscript` (per session + filter) + `assembleTranscript` (per collapse); the view memoises them separately. `buildTranscript` itself is unchanged for callers. |

## Numbers

Headless Chromium, dev build, 160-step sweep over the 40-turn bench.

| payloads collapsed | before | after |
| --- | --- | --- |
| frame p95 | 49 ms | 10 ms |
| dropped frames | 40 / 163 | 0 |
| long tasks / blocking | 2 / 139 ms | 0 / 0 |
| React render time over the sweep | 1805 ms | 520 ms |
| max commit | 40 ms | 14 ms |

Every tool payload open (no baseline taken — it did not finish inside the harness timeout before): p95 25 ms, 7 dropped frames, 7 ms blocking, heaviest row 1,105 elements.

## Bench and gate

- `/lab/bench/agent-transcript?turns=N` builds the session (three model calls and two tool calls per turn, results from 10 KB to a few hundred) and exposes `window.__transcriptBench`.
- `perf/agent-transcript.perf.spec.ts` runs both scenarios and gates mounted rows, elements per row, blocking time (CI ceiling like the logs spec) and commits per frame.

## Tests

- `clamped-text.test.tsx`: preview cut rules, "Show full" on a cut body, no control for a body that fits, JSON highlight covers only the preview.
- `session-transcript.test.ts`: prepare + assemble equals the one-shot build for any set of collapsed turns.
- `tsc`, oxlint, and the agent-sessions / lab suites are green; both perf gates pass locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791057377&installation_model_id=427786&pr_number=755&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F755&signature=b784b311cceda3bb29d90ab00c5a3dfa06de10c39e0da405c8d26b3be7012584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->