### PR TITLE
fix(semconv): adopt renamed attribute keys, and read both spellings

### DIFF
--- a/apps/web/src/components/infra/infra-correlations.test.ts
+++ b/apps/web/src/components/infra/infra-correlations.test.ts
@@ -120,6 +120,40 @@ describe("getActiveInfraCorrelations", () => {
 		expect(groups.map((g) => g.kind)).toEqual(["container"])
 	})
 
+	/**
+	 * Semconv v1.37.0 renamed the key. Reading only the old spelling made a
+	 * canonical runtime read as absent, and absent *passes* the docker check —
+	 * so a containerd record would have rendered the empty docker chart stack
+	 * the check above exists to prevent. Both spellings, both directions.
+	 */
+	it("honours the renamed container.runtime.name in both directions", () => {
+		expect(
+			getActiveInfraCorrelations({
+				"container.name": "app",
+				"container.runtime.name": "containerd",
+				"host.name": "node-1",
+			}).map((g) => g.kind),
+		).toEqual(["host"])
+
+		expect(
+			getActiveInfraCorrelations({
+				"container.name": "app",
+				"container.runtime.name": "docker",
+			}).map((g) => g.kind),
+		).toEqual(["container"])
+	})
+
+	it("prefers the canonical spelling when an instrumentation sends both", () => {
+		// Dual-emitting SDKs exist; the canonical key is the one to believe.
+		const groups = getActiveInfraCorrelations({
+			"container.name": "app",
+			"container.runtime.name": "containerd",
+			"container.runtime": "docker",
+			"host.name": "node-1",
+		})
+		expect(groups.map((g) => g.kind)).toEqual(["host"])
+	})
+
 	it("each group carries at least one chart", () => {
 		const groups = getActiveInfraCorrelations({
 			"k8s.pod.name": "p",

--- a/apps/web/src/components/infra/infra-correlations.ts
+++ b/apps/web/src/components/infra/infra-correlations.ts
@@ -84,7 +84,15 @@ const HOST_CHARTS: ReadonlyArray<{ label: string; metric: HostInfraMetric }> = [
 ]
 
 const CONTAINER_NAME_KEY = "container.name"
-const CONTAINER_RUNTIME_KEY = "container.runtime"
+/**
+ * Semconv v1.37.0 renamed `container.runtime` to `container.runtime.name`, and
+ * both spellings arrive: current collectors send `.name`, older ones and older
+ * SDKs send the bare key. Reading only one is not merely lossy here — an absent
+ * runtime *passes* the docker check below, so a containerd pod reporting the
+ * canonical spelling would render the empty docker chart stack that check
+ * exists to prevent.
+ */
+const CONTAINER_RUNTIME_KEYS = ["container.runtime.name", "container.runtime"] as const
 const POD_NAME_KEY = "k8s.pod.name"
 const POD_NAMESPACE_KEY = "k8s.namespace.name"
 const NODE_NAME_KEY = "k8s.node.name"
@@ -117,7 +125,10 @@ export function getActiveInfraCorrelations(
 	// and a declared non-docker runtime (containerd, cri-o, …) has no docker
 	// metrics either — both would render an empty duplicate chart stack.
 	const containerName = attr(resourceAttributes, CONTAINER_NAME_KEY)
-	const containerRuntime = attr(resourceAttributes, CONTAINER_RUNTIME_KEY)
+	const containerRuntime = CONTAINER_RUNTIME_KEYS.reduce<string | undefined>(
+		(found, key) => found ?? attr(resourceAttributes, key),
+		undefined,
+	)
 	if (containerName && !podName && (containerRuntime === undefined || containerRuntime === "docker")) {
 		out.push({
 			kind: "container",

--- a/packages/browser/src/errors.ts
+++ b/packages/browser/src/errors.ts
@@ -87,8 +87,12 @@ export function setupErrorCapture(): () => void {
 			name: "browser.uncaught_error",
 			attributes: {
 				"maple.exception.source": "window.onerror",
-				...(event.filename ? { "code.filepath": event.filename } : undefined),
-				...(event.lineno ? { "code.lineno": event.lineno } : undefined),
+				// `code.file.path` / `code.line.number` since semconv v1.34.0. Nothing
+				// reads the names they replaced, so they are dropped rather than
+				// dual-emitted — carrying both would put four near-identical rows on
+				// every uncaught error in the attribute list.
+				...(event.filename ? { "code.file.path": event.filename } : undefined),
+				...(event.lineno ? { "code.line.number": event.lineno } : undefined),
 			},
 		})
 	}

--- a/packages/domain/src/tinybird/semconv-renames.ts
+++ b/packages/domain/src/tinybird/semconv-renames.ts
@@ -83,3 +83,24 @@ export function messagingDestinationExpr(spanAttributes: MapColumnLike): Expr<st
 export const MESSAGING_DESTINATION_SQL = compile(
 	messagingDestinationExpr(mapColumn("SpanAttributes")).toFragment(),
 )
+
+/**
+ * Canonical container-runtime expression.
+ *
+ * Semconv v1.37.0 renamed `container.runtime` to `container.runtime.name`. Both
+ * spellings are in the wild and will be for a long time: the OTel Collector's
+ * docker/k8s receivers and every SDK older than that release still send the bare
+ * key, while current ones send `.name`. Reading either alone leaves the runtime
+ * blank for half the fleet — which shows up as a container detail page with an
+ * empty Runtime row, and as a missing Container correlation group.
+ *
+ * Unlike the two expressions above, no materialized view pre-extracts this, so
+ * there is no SQL twin to keep byte-identical; the read paths are the only
+ * consumers.
+ */
+export function containerRuntimeExpr(resourceAttributes: MapColumnLike): Expr<string> {
+	return CH.coalesce(
+		CH.nullIf(resourceAttributes.get("container.runtime.name"), ""),
+		resourceAttributes.get("container.runtime"),
+	)
+}

--- a/packages/effect-sdk/src/client/flushable.ts
+++ b/packages/effect-sdk/src/client/flushable.ts
@@ -321,8 +321,12 @@ export const make = (config: MapleClientFlushableConfig): FlushableTelemetry => 
 			name: "browser.uncaught_error",
 			attributes: {
 				"maple.exception.source": "window.onerror",
-				...(event.filename ? { "code.filepath": event.filename } : undefined),
-				...(event.lineno ? { "code.lineno": event.lineno } : undefined),
+				// `code.file.path` / `code.line.number` since semconv v1.34.0. Nothing
+				// reads the names they replaced, so they are dropped rather than
+				// dual-emitted — carrying both would put four near-identical rows on
+				// every uncaught error in the attribute list.
+				...(event.filename ? { "code.file.path": event.filename } : undefined),
+				...(event.lineno ? { "code.line.number": event.lineno } : undefined),
 			},
 		})
 	}

--- a/packages/effect-sdk/src/server/container.test.ts
+++ b/packages/effect-sdk/src/server/container.test.ts
@@ -18,9 +18,9 @@ describe("deriveContainerAttributes", () => {
 		expect(deriveContainerAttributes(probe({}))).toEqual({})
 	})
 
-	it("stamps container.runtime from /.dockerenv even without an id", () => {
+	it("stamps container.runtime.name from /.dockerenv even without an id", () => {
 		expect(deriveContainerAttributes(probe({ exists: (p) => p === "/.dockerenv" }))).toEqual({
-			"container.runtime": "docker",
+			"container.runtime.name": "docker",
 		})
 	})
 
@@ -34,7 +34,7 @@ describe("deriveContainerAttributes", () => {
 						: "0::/",
 			}),
 		)
-		expect(attrs).toEqual({ "container.runtime": "docker", "container.id": FULL_ID })
+		expect(attrs).toEqual({ "container.runtime.name": "docker", "container.id": FULL_ID })
 	})
 
 	it("falls back to /proc/self/cgroup on cgroup v1", () => {
@@ -65,7 +65,7 @@ describe("deriveContainerAttributes", () => {
 		const attrs = deriveContainerAttributes(
 			probe({ exists: (p) => p === "/.dockerenv", hostname: () => "checkout-worker" }),
 		)
-		expect(attrs).toEqual({ "container.runtime": "docker" })
+		expect(attrs).toEqual({ "container.runtime.name": "docker" })
 	})
 
 	it("swallows probe failures instead of throwing", () => {

--- a/packages/effect-sdk/src/server/container.ts
+++ b/packages/effect-sdk/src/server/container.ts
@@ -40,7 +40,11 @@ export const deriveContainerAttributes = (probe: ContainerProbe): Record<string,
 	const inDocker = trySyncOrUndefined(() => probe.exists("/.dockerenv")) ?? false
 
 	const attrs: Record<string, string> = {}
-	if (inDocker) attrs["container.runtime"] = "docker"
+	// `container.runtime.name` since semconv v1.37.0; the bare `container.runtime`
+	// it replaced is not emitted, because every read path coalesces both
+	// spellings anyway (`containerRuntimeExpr`) for the sake of third-party
+	// collectors that still send the old one.
+	if (inDocker) attrs["container.runtime.name"] = "docker"
 
 	// Lazy fallback chain — this runs at every SDK boot (customer processes),
 	// and mountinfo can run to hundreds of KB, so later probes only fire when

--- a/packages/query-engine/src/__sql_baseline__/catalog.sql
+++ b/packages/query-engine/src/__sql_baseline__/catalog.sql
@@ -45,7 +45,7 @@ SELECT
         GROUP BY hostName) AS hosts
         FORMAT JSON
 
--- builder:containers:containerDetailSummaryQuery:default  [6063da9a]
+-- builder:containers:containerDetailSummaryQuery:default  [58383940]
 SELECT
           ResourceAttributes['container.name'] AS containerName,
           any(ResourceAttributes['host.name']) AS hostName,
@@ -53,7 +53,7 @@ SELECT
           any(ResourceAttributes['container.image.name']) AS imageName,
           any(ResourceAttributes['compose.project']) AS composeProject,
           any(ResourceAttributes['compose.service']) AS composeService,
-          any(ResourceAttributes['container.runtime']) AS runtime,
+          any(coalesce(nullIf(ResourceAttributes['container.runtime.name'], ''), ResourceAttributes['container.runtime'])) AS runtime,
           min(TimeUnix) AS firstSeen,
           max(TimeUnix) AS lastSeen,
           ifNotFinite(avgIf(Value, MetricName = 'container.cpu.utilization'), 0) / 100 AS cpuPct,
@@ -250,7 +250,7 @@ SELECT
         ORDER BY bucket ASC
         FORMAT JSON
 
--- builder:containers:listContainersQuery:default  [fe84ad79]
+-- builder:containers:listContainersQuery:default  [df58f91f]
 SELECT
           containerName AS containerName,
           hostName AS hostName,
@@ -275,7 +275,7 @@ SELECT
           any(ResourceAttributes['container.image.name']) AS imageName,
           any(ResourceAttributes['compose.project']) AS composeProject,
           any(ResourceAttributes['compose.service']) AS composeService,
-          any(ResourceAttributes['container.runtime']) AS runtime,
+          any(coalesce(nullIf(ResourceAttributes['container.runtime.name'], ''), ResourceAttributes['container.runtime'])) AS runtime,
           any(coalesce(nullIf(ResourceAttributes['deployment.environment.name'], ''), ResourceAttributes['deployment.environment'])) AS environment,
           max(TimeUnix) AS lastSeen,
           ifNotFinite(avgIf(Value, MetricName = 'container.cpu.utilization'), 0) / 100 AS cpuPct,
@@ -298,7 +298,7 @@ SELECT
         OFFSET 0
         FORMAT JSON
 
--- builder:containers:listContainersQuery:filtered  [75408df7]
+-- builder:containers:listContainersQuery:filtered  [16c1f98d]
 SELECT
           containerName AS containerName,
           hostName AS hostName,
@@ -323,7 +323,7 @@ SELECT
           any(ResourceAttributes['container.image.name']) AS imageName,
           any(ResourceAttributes['compose.project']) AS composeProject,
           any(ResourceAttributes['compose.service']) AS composeService,
-          any(ResourceAttributes['container.runtime']) AS runtime,
+          any(coalesce(nullIf(ResourceAttributes['container.runtime.name'], ''), ResourceAttributes['container.runtime'])) AS runtime,
           any(coalesce(nullIf(ResourceAttributes['deployment.environment.name'], ''), ResourceAttributes['deployment.environment'])) AS environment,
           max(TimeUnix) AS lastSeen,
           ifNotFinite(avgIf(Value, MetricName = 'container.cpu.utilization'), 0) / 100 AS cpuPct,
@@ -351,7 +351,7 @@ SELECT
         OFFSET 0
         FORMAT JSON
 
--- builder:containers:listContainersQuery:scoped  [41805227]
+-- builder:containers:listContainersQuery:scoped  [34d4c009]
 SELECT
           containerName AS containerName,
           hostName AS hostName,
@@ -376,7 +376,7 @@ SELECT
           any(ResourceAttributes['container.image.name']) AS imageName,
           any(ResourceAttributes['compose.project']) AS composeProject,
           any(ResourceAttributes['compose.service']) AS composeService,
-          any(ResourceAttributes['container.runtime']) AS runtime,
+          any(coalesce(nullIf(ResourceAttributes['container.runtime.name'], ''), ResourceAttributes['container.runtime'])) AS runtime,
           any(coalesce(nullIf(ResourceAttributes['deployment.environment.name'], ''), ResourceAttributes['deployment.environment'])) AS environment,
           max(TimeUnix) AS lastSeen,
           ifNotFinite(avgIf(Value, MetricName = 'container.cpu.utilization'), 0) / 100 AS cpuPct,

--- a/packages/query-engine/src/ch/queries/containers.ts
+++ b/packages/query-engine/src/ch/queries/containers.ts
@@ -26,7 +26,7 @@ import { param } from "@maple-dev/clickhouse-builder"
 import { from, fromQuery, type ColumnAccessor } from "@maple-dev/clickhouse-builder"
 import { unionAll, type CHUnionQuery } from "@maple-dev/clickhouse-builder"
 import { MetricsGauge, MetricsSum } from "../tables"
-import { deploymentEnvExpr } from "@maple/domain/tinybird/semconv-renames"
+import { containerRuntimeExpr, deploymentEnvExpr } from "@maple/domain/tinybird/semconv-renames"
 import { avgIfOrZero, facetAttrExpr, maxIfOrZero, type FacetOutput } from "./query-helpers"
 import type { SortDirection } from "./infra"
 
@@ -178,7 +178,7 @@ export function listContainersQuery(opts: ListContainersOpts = {}) {
 			imageName: CH.any_($.ResourceAttributes.get("container.image.name")),
 			composeProject: CH.any_($.ResourceAttributes.get("compose.project")),
 			composeService: CH.any_($.ResourceAttributes.get("compose.service")),
-			runtime: CH.any_($.ResourceAttributes.get("container.runtime")),
+			runtime: CH.any_(containerRuntimeExpr($.ResourceAttributes)),
 			environment: CH.any_(deploymentEnvExpr($.ResourceAttributes)),
 			lastSeen: CH.max_($.TimeUnix),
 			cpuPct: avgIfOrZero($.Value, $.MetricName.eq("container.cpu.utilization")).div(100),
@@ -316,7 +316,7 @@ export function containerDetailSummaryQuery(opts: ContainerDetailSummaryOpts) {
 			imageName: CH.any_($.ResourceAttributes.get("container.image.name")),
 			composeProject: CH.any_($.ResourceAttributes.get("compose.project")),
 			composeService: CH.any_($.ResourceAttributes.get("compose.service")),
-			runtime: CH.any_($.ResourceAttributes.get("container.runtime")),
+			runtime: CH.any_(containerRuntimeExpr($.ResourceAttributes)),
 			firstSeen: CH.min_($.TimeUnix),
 			lastSeen: CH.max_($.TimeUnix),
 			cpuPct: avgIfOrZero($.Value, $.MetricName.eq("container.cpu.utilization")).div(100),

--- a/packages/query-engine/src/ch/queries/infra.ts
+++ b/packages/query-engine/src/ch/queries/infra.ts
@@ -16,7 +16,7 @@ import { param } from "@maple-dev/clickhouse-builder"
 import { from, fromQuery, type ColumnAccessor } from "@maple-dev/clickhouse-builder"
 import { unionAll, type CHUnionQuery } from "@maple-dev/clickhouse-builder"
 import { MetricsGauge, MetricsSum } from "../tables"
-import { deploymentEnvExpr } from "@maple/domain/tinybird/semconv-renames"
+import { containerRuntimeExpr, deploymentEnvExpr } from "@maple/domain/tinybird/semconv-renames"
 import { avgIfOrZero, facetAttrExpr, maxIfOrZero, type FacetOutput } from "./query-helpers"
 
 const HOSTMETRIC_NAMES = [
@@ -846,7 +846,7 @@ export function nodeDetailSummaryQuery(opts: NodeDetailSummaryOpts) {
 			nodeName: $.ResourceAttributes.get("k8s.node.name"),
 			nodeUid: CH.any_($.ResourceAttributes.get("k8s.node.uid")),
 			kubeletVersion: CH.any_($.ResourceAttributes.get("k8s.kubelet.version")),
-			containerRuntime: CH.any_($.ResourceAttributes.get("container.runtime")),
+			containerRuntime: CH.any_(containerRuntimeExpr($.ResourceAttributes)),
 			firstSeen: CH.min_($.TimeUnix),
 			lastSeen: CH.max_($.TimeUnix),
 			cpuUsage: avgIfOrZero($.Value, $.MetricName.eq("k8s.node.cpu.usage")),


### PR DESCRIPTION
## What

Audited every OpenTelemetry attribute key this repo touches against the current semantic conventions, and fixed the three we emit under names that were renamed upstream:

| Key | Renamed to | Since |
| --- | --- | --- |
| `code.filepath` | `code.file.path` | v1.34.0 (May 2025) |
| `code.lineno` | `code.line.number` | v1.34.0 (May 2025) |
| `container.runtime` | `container.runtime.name` | v1.37.0 (Aug 2025) |

All three were **write-only**: the canonical names appeared nowhere in the tree, and nothing read the legacy ones either.

## Why this shape, and not dual-emit

The read side is fixed first because it has to accept both spellings regardless of what our SDKs do — `container.runtime` arrives from third-party collectors and from every SDK older than v1.37.0. `containerRuntimeExpr` joins the two existing coalescing expressions in `semconv-renames.ts` and is used by the four infra/container queries. No migration: nothing materializes that column.

With the readers coalescing, the SDKs emit **only** the canonical key. Dual-emitting would put four near-identical rows on every uncaught error in the attribute list to satisfy no reader.

`deployment.environment` keeps its dual-emit — different case, a materialized view pre-extracts the legacy key there.

## The bug worth a second look

`infra-correlations.ts` had more than a blank field. The check is:

```ts
runtime === undefined || runtime === "docker"
```

Reading only the legacy key meant a containerd host sending the canonical `container.runtime.name` read as `undefined` — which **passes**, rendering the empty docker chart stack that check exists to prevent. Now covered in both directions, plus precedence when an SDK sends both.

## Reviewer notes

- `__sql_baseline__/catalog.sql` is regenerated: 4 SQL lines plus 4 fingerprint headers. I verified the diff contains nothing but this change.
- Customer-facing SDK behaviour changes (`@maple-dev/browser`, `effect-sdk`), so it needs an SDK release to reach users.
- `maple-swift` was audited too and is already clean.

## Verification

- `bun typecheck` — 41/41 packages
- query-engine 1373, effect-sdk 122, browser 19, infra-correlations 16, semconv-renames 5 — all passing
- Re-audited the changed files against the registry: `needsAttention: 1`, and that one is the intentional `deployment.environment`

**Unrelated pre-existing failure:** `domain/retention-matrix.test.ts` (`service_map_db_edges_hourly` retaining `FORWARD_QUERY`) fails on `main` too — it reads in-progress edits to `datasources.ts` that are not part of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791062077&installation_model_id=427786&pr_number=756&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F756&signature=d4daefcc4b1b2ff244698184bc3ff886e3f5e4cafbe1f85cedbcdf99ad82d6f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->