### PR TITLE
fix(query-engine): render second-precision bounds per column, not per route

### DIFF
--- a/lib/clickhouse-builder/src/ch/literal.test.ts
+++ b/lib/clickhouse-builder/src/ch/literal.test.ts
@@ -135,3 +135,57 @@ describe("param.of", () => {
 		expect(compileCHUnsafe(query, { level: "warn" }).sql).toContain("OrgId = 'warn'")
 	})
 })
+
+// A `DateTime` column and the `DateTime64` beside it in the same table cannot
+// share one rendering of one bound: the fraction is load-bearing on the 64-bit
+// column and a `TYPE_MISMATCH` on the other. Placeholders carry kind and name
+// independently, so both read the very same param and differ only in encoding.
+describe("param.dateTimeSeconds", () => {
+	const Spans = CH.table("spans", {
+		OrgId: T.string,
+		TimestampTime: T.dateTimeString,
+		Timestamp: T.dateTime64String,
+	})
+
+	const spansWhereSql = (
+		build: Parameters<ReturnType<typeof CH.from<"spans", typeof Spans.columns>>["where"]>[0],
+		params: Record<string, unknown>,
+	) =>
+		compileCHUnsafe(
+			CH.from(Spans)
+				.select(($) => ({ id: $.OrgId }))
+				.where(build),
+			params,
+		)
+			.sql.split("WHERE")[1]
+			?.trim()
+
+	it("floors a fractional bound to whole seconds", () => {
+		expect(
+			spansWhereSql(($) => [$.TimestampTime.gte(CH.param.dateTimeSeconds("startTime"))], {
+				startTime: "2026-01-01 12:30:00.123456789",
+			}),
+		).toBe("TimestampTime >= '2026-01-01 12:30:00'")
+	})
+
+	it("leaves a bound that is already second-precision alone", () => {
+		expect(
+			spansWhereSql(($) => [$.TimestampTime.gte(CH.param.dateTimeSeconds("startTime"))], {
+				startTime: "2026-01-01 12:30:00",
+			}),
+		).toBe("TimestampTime >= '2026-01-01 12:30:00'")
+	})
+
+	// The point of the kind: one param value, two encodings, in one WHERE.
+	it("renders the same param differently per column precision", () => {
+		expect(
+			spansWhereSql(
+				($) => [
+					$.TimestampTime.gte(CH.param.dateTimeSeconds("startTime")),
+					$.Timestamp.gte(CH.param.dateTimeString("startTime")),
+				],
+				{ startTime: "2026-01-01 12:30:00.500" },
+			)?.replace(/\s+/g, " "),
+		).toBe("TimestampTime >= '2026-01-01 12:30:00' AND Timestamp >= '2026-01-01 12:30:00.500'")
+	})
+})

--- a/lib/clickhouse-builder/src/ch/param.ts
+++ b/lib/clickhouse-builder/src/ch/param.ts
@@ -134,6 +134,7 @@ const paramTypes = new Map<ParamKind, Schema.Codec<any, any>>([
 	["float", T.float64.literalSchema],
 	["bool", T.bool.literalSchema],
 	["dateTime", T.dateTime.literalSchema],
+	["dateTimeSeconds", T.CHDateTimeSecondsLiteral],
 ])
 
 /** The codec a placeholder's kind names, or `undefined` for an unknown kind. */
@@ -181,6 +182,22 @@ export const param = {
 	 * and a param has to agree with the column it bounds.
 	 */
 	dateTimeString: makeParam<string>("dateTime"),
+
+	/**
+	 * The same bound, floored to whole seconds.
+	 *
+	 * For a column declared `DateTime` (not `DateTime64`) that shares a param with
+	 * a `DateTime64` column beside it — `logs.TimestampTime` next to
+	 * `logs.Timestamp`, `trace_list_mv.Timestamp` next to `traces.Timestamp`. The
+	 * fraction is load-bearing on the 64-bit column (a log search can legitimately
+	 * span 200ms) and a hard `TYPE_MISMATCH` on the other, so one rendering cannot
+	 * serve both. Placeholders carry kind and name independently, so this reads the
+	 * very same `startTime` value and only encodes it differently.
+	 *
+	 * Widening is safe where these appear: they bound a partition/index key for
+	 * pruning, and the exact `DateTime64` predicate still decides the result.
+	 */
+	dateTimeSeconds: makeParam<string>("dateTimeSeconds"),
 
 	/**
 	 * A param of any column type, resolved through that type's own codec.

--- a/lib/clickhouse-builder/src/ch/types.ts
+++ b/lib/clickhouse-builder/src/ch/types.ts
@@ -136,6 +136,31 @@ const CHDateTimeFromDate: Schema.Codec<Date, string> = Schema.String.pipe(
 const CHDateTimeFromString: Schema.Codec<string, string> = Schema.String.pipe(Schema.check(isChDateTime))
 
 /**
+ * The same, floored to whole seconds.
+ *
+ * A `DateTime` column rejects a fractional literal outright — `TimestampTime >=
+ * '2026-09-01 02:40:00.000'` is `TYPE_MISMATCH`, not a rounding — while the
+ * `DateTime64` column beside it in the same table needs that fraction kept. The
+ * two cannot share one rendering of one bound, which is what
+ * {@link param.dateTimeSeconds} exists to resolve: same param value, floored
+ * encoding, so a second-precision column gets a literal it can parse.
+ *
+ * The `DateTime.Utc` and `Date` arms already floor via `chDateTimeLiteral`;
+ * only the string passthrough needed teaching.
+ */
+export const CHDateTimeSecondsLiteral: Schema.Codec<string, string> = Schema.String.pipe(
+	Schema.check(isChDateTime),
+	Schema.decodeTo(Schema.String, {
+		decode: SchemaGetter.transform((value: string) => value),
+		encode: SchemaGetter.transform((value: string) => {
+			const trimmed = value.trim()
+			const dot = trimmed.indexOf(".")
+			return dot === -1 ? trimmed : trimmed.slice(0, dot)
+		}),
+	}),
+)
+
+/**
  * Everything a DateTime column can be compared against.
  *
  * Union order is the encode order: the first member whose type matches wins, so

--- a/packages/query-engine/src/ch/queries/activity.ts
+++ b/packages/query-engine/src/ch/queries/activity.ts
@@ -31,7 +31,7 @@ export interface ActiveOrgsOutput {
 export function activeOrgsByErrorEventsQuery() {
 	return from(ErrorEventsByTime)
 		.select(($) => ({ orgId: $.OrgId }))
-		.where(($) => [$.Timestamp.gte(param.dateTimeString("startTime"))])
+		.where(($) => [$.Timestamp.gte(param.dateTimeSeconds("startTime"))])
 		.groupBy("orgId")
 		.format("JSON")
 		.route("ingest")
@@ -42,7 +42,7 @@ export function activeOrgsByErrorEventsQuery() {
 export function activeOrgsByTracesQuery() {
 	return from(TracesAggregatesHourly)
 		.select(($) => ({ orgId: $.OrgId }))
-		.where(($) => [$.Hour.gte(param.dateTimeString("startTime"))])
+		.where(($) => [$.Hour.gte(param.dateTimeSeconds("startTime"))])
 		.groupBy("orgId")
 		.format("JSON")
 		.route("ingest")
@@ -53,7 +53,7 @@ export function activeOrgsByTracesQuery() {
 export function activeOrgsByLogsQuery() {
 	return from(LogsAggregatesHourly)
 		.select(($) => ({ orgId: $.OrgId }))
-		.where(($) => [$.Hour.gte(param.dateTimeString("startTime"))])
+		.where(($) => [$.Hour.gte(param.dateTimeSeconds("startTime"))])
 		.groupBy("orgId")
 		.format("JSON")
 		.route("ingest")

--- a/packages/query-engine/src/ch/queries/anomaly.ts
+++ b/packages/query-engine/src/ch/queries/anomaly.ts
@@ -56,8 +56,8 @@ export function anomalyTraceSignalsQuery(opts: AnomalyTraceSignalsOpts) {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.IsEntryPoint.eq(1),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			CH.toHour($.Hour).in_(...opts.hoursOfDay),
 		])
 		.groupBy("serviceName", "deploymentEnv", "hour")
@@ -89,8 +89,8 @@ export function anomalyLogVolumeQuery(opts: AnomalyTraceSignalsOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			CH.toHour($.Hour).in_(...opts.hoursOfDay),
 		])
 		.groupBy("serviceName", "deploymentEnv", "hour")
@@ -121,8 +121,8 @@ export function anomalyErrorSpikeCurrentQuery(opts: { limit?: number }) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("fingerprintHash", "deploymentEnv")
 		.orderBy(["count", "desc"])
@@ -151,8 +151,8 @@ export function anomalyErrorSpikeBaselineQuery(opts: { limit?: number }) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lt(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lt(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("fingerprintHash", "deploymentEnv", "h")
 
@@ -200,8 +200,8 @@ export function anomalyTraceSignalTimeseriesQuery() {
 			$.IsEntryPoint.eq(1),
 			$.ServiceName.eq(param.string("serviceName")),
 			$.DeploymentEnv.eq(param.string("deploymentEnv")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("hour")
 		.orderBy(["hour", "asc"])
@@ -225,8 +225,8 @@ export function anomalyLogVolumeTimeseriesQuery() {
 			$.OrgId.eq(param.string("orgId")),
 			$.ServiceName.eq(param.string("serviceName")),
 			$.DeploymentEnv.eq(param.string("deploymentEnv")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("hour")
 		.orderBy(["hour", "asc"])
@@ -255,8 +255,8 @@ export function anomalyErrorSpikeTimeseriesQuery() {
 				$.OrgId.eq(param.string("orgId")),
 				$.FingerprintHash.eq(CH.toUInt64(param.string("fingerprintHash"))),
 				$.DeploymentEnv.eq(param.string("deploymentEnv")),
-				$.Timestamp.gte(param.dateTimeString("startTime")),
-				$.Timestamp.lte(param.dateTimeString("endTime")),
+				$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+				$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			])
 			.groupBy("bucket")
 			.orderBy(["bucket", "asc"])
@@ -283,8 +283,8 @@ export function anomalyErrorSpikeServiceTimeseriesQuery() {
 			$.OrgId.eq(param.string("orgId")),
 			$.ServiceName.eq(param.string("serviceName")),
 			$.DeploymentEnv.eq(param.string("deploymentEnv")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("bucket")
 		.orderBy(["bucket", "asc"])

--- a/packages/query-engine/src/ch/queries/attribute-keys.ts
+++ b/packages/query-engine/src/ch/queries/attribute-keys.ts
@@ -23,8 +23,8 @@ export function attributeKeysQuery(opts: AttributeKeysQueryOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			$.AttributeScope.eq(opts.scope),
 		])
 		.groupBy("attributeKey")
@@ -53,8 +53,8 @@ export function spanAttributeValuesQuery(opts: AttributeValuesOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			$.AttributeScope.eq("span"),
 			$.AttributeKey.eq(opts.attributeKey),
 		])
@@ -72,8 +72,8 @@ export function resourceAttributeValuesQuery(opts: AttributeValuesOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			$.AttributeScope.eq("resource"),
 			$.AttributeKey.eq(opts.attributeKey),
 		])
@@ -91,8 +91,8 @@ export function logAttributeValuesQuery(opts: AttributeValuesOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			$.AttributeScope.eq("log"),
 			$.AttributeKey.eq(opts.attributeKey),
 		])
@@ -165,8 +165,8 @@ export function metricAttributeValuesQuery(opts: AttributeValuesOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			$.AttributeScope.eq("metric"),
 			$.AttributeKey.eq(opts.attributeKey),
 		])

--- a/packages/query-engine/src/ch/queries/errors.ts
+++ b/packages/query-engine/src/ch/queries/errors.ts
@@ -171,8 +171,8 @@ export function errorsByTypeQuery(opts: ErrorsByTypeOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			CH.whenTrue(!!opts.rootOnly, () => $.ParentSpanId.eq("")),
 			...sharedFilterConditions($, opts),
 			opts.fingerprintHashes?.length
@@ -206,8 +206,8 @@ export function errorsTimeseriesQuery(opts: ErrorsTimeseriesOpts) {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			fingerprintHashEq($.FingerprintHash, opts.fingerprintHash),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			opts.services?.length ? CH.inList($.ServiceName, opts.services) : undefined,
 		])
 		.groupBy("bucket")
@@ -249,8 +249,8 @@ export function errorsSparkQuery(opts: ErrorsSparkOpts) {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			fingerprintHashIn($.FingerprintHash, opts.fingerprintHashes),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			...sharedFilterConditions($, opts),
 		])
 		.groupBy("fingerprintHash", "bucket")
@@ -550,8 +550,8 @@ export function tracesDurationStatsQuery(opts: TracesDurationStatsOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			CH.when(services, (v: readonly string[]) =>
 				matchOrIn($.ServiceName, v, mm?.serviceName === "contains"),
 			),
@@ -631,8 +631,8 @@ export function tracesFacetsQuery(opts: TracesFacetsOpts): CHUnionQuery<TracesFa
 	const baseWhere = ($: ColumnAccessor<typeof TraceListMv.columns>): Array<CH.Condition | undefined> => {
 		const conditions: Array<CH.Condition | undefined> = [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 		]
 
 		const services = inclusionValues(opts.serviceName, opts.serviceNames)
@@ -784,8 +784,8 @@ export function errorsFacetsQuery(opts: ErrorsFacetsOpts): CHUnionQuery<ErrorsFa
 		(except: ErrorsFilterDimension) =>
 		($: ColumnAccessor<typeof table.columns>): Array<CH.Condition | undefined> => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			CH.whenTrue(!!opts.rootOnly, () => $.ParentSpanId.eq("")),
 			...sharedFilterConditions($, opts, except),
 			opts.fingerprintHashes?.length
@@ -878,8 +878,8 @@ export function errorsSummaryQuery(opts: ErrorsSummaryOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			CH.whenTrue(!!opts.rootOnly, () => $.ParentSpanId.eq("")),
 			...sharedFilterConditions($, opts),
 			opts.fingerprintHashes?.length
@@ -913,8 +913,8 @@ export function errorsSummaryQuery(opts: ErrorsSummaryOpts) {
 				}))
 				.where(($) => [
 					$.OrgId.eq(param.string("orgId")),
-					$.Timestamp.gte(param.dateTimeString("startTime")),
-					$.Timestamp.lte(param.dateTimeString("endTime")),
+					$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+					$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 					opts.services?.length ? CH.inList($.ServiceName, opts.services) : undefined,
 					opts.deploymentEnvs?.length ? CH.inList($.DeploymentEnv, opts.deploymentEnvs) : undefined,
 				]),
@@ -945,8 +945,8 @@ export function errorsSummaryQuery(opts: ErrorsSummaryOpts) {
 			}))
 			.where(($) => [
 				$.OrgId.eq(param.string("orgId")),
-				$.Hour.gte(param.dateTimeString("startTime")),
-				$.Hour.lte(param.dateTimeString("endTime")),
+				$.Hour.gte(param.dateTimeSeconds("startTime")),
+				$.Hour.lte(param.dateTimeSeconds("endTime")),
 				opts.services?.length ? CH.inList($.ServiceName, opts.services) : undefined,
 			]),
 	)
@@ -994,8 +994,8 @@ export function errorIssuesQuery(opts: ErrorIssuesOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			opts.services?.length ? CH.inList($.ServiceName, opts.services) : undefined,
 			opts.deploymentEnvs?.length ? CH.inList($.DeploymentEnv, opts.deploymentEnvs) : undefined,
 			opts.fingerprintHashes?.length
@@ -1032,8 +1032,8 @@ export function errorTickIssuesQuery() {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Minute.gte(param.dateTimeString("startTime")),
-			$.Minute.lt(param.dateTimeString("endTime")),
+			$.Minute.gte(param.dateTimeSeconds("startTime")),
+			$.Minute.lt(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("fingerprintHash")
 		.format("JSON")
@@ -1062,8 +1062,8 @@ export function errorTickBootstrapIssuesQuery() {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lt(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lt(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("fingerprintHash")
 		.format("JSON")
@@ -1095,8 +1095,8 @@ export function errorFingerprintsQuery(opts: ErrorFingerprintsOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			opts.services?.length ? CH.inList($.ServiceName, opts.services) : undefined,
 			opts.deploymentEnvs?.length ? CH.inList($.DeploymentEnv, opts.deploymentEnvs) : undefined,
 		])
@@ -1121,8 +1121,8 @@ export function errorIssueTimeseriesQuery() {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.FingerprintHash.eq(CH.toUInt64(param.string("fingerprintHash"))),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("bucket")
 		.orderBy(["bucket", "asc"])
@@ -1155,8 +1155,8 @@ export function errorIssueSampleTracesQuery(opts: { limit?: number }) {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.FingerprintHash.eq(CH.toUInt64(param.string("fingerprintHash"))),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 		])
 		.orderBy(["timestamp", "desc"])
 		.limit(opts.limit ?? 25)
@@ -1193,8 +1193,8 @@ export function errorIssueVersionsSinceQuery(opts: { limit?: number } = {}) {
 			.where(($) => [
 				$.OrgId.eq(param.string("orgId")),
 				$.FingerprintHash.eq(CH.toUInt64(param.string("fingerprintHash"))),
-				$.Timestamp.gte(param.dateTimeString("startTime")),
-				$.Timestamp.lte(param.dateTimeString("endTime")),
+				$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+				$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			])
 			.groupBy("serviceVersion")
 			.orderBy(["count", "desc"])
@@ -1215,8 +1215,8 @@ export function errorIssueEnvironmentsQuery(opts: { limit?: number } = {}) {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.FingerprintHash.eq(CH.toUInt64(param.string("fingerprintHash"))),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			$.DeploymentEnv.neq(""),
 		])
 		.groupBy("name")
@@ -1259,8 +1259,8 @@ export function errorDetailTracesQuery(opts: ErrorDetailTracesOpts) {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			fingerprintHashEq($.FingerprintHash, opts.fingerprintHash),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			CH.whenTrue(!!opts.rootOnly, () => $.ParentSpanId.eq("")),
 			opts.services?.length ? CH.inList($.ServiceName, opts.services) : undefined,
 		])

--- a/packages/query-engine/src/ch/queries/liveness.ts
+++ b/packages/query-engine/src/ch/queries/liveness.ts
@@ -66,8 +66,8 @@ export function serviceLivenessQuery(opts: ServiceLivenessOpts = {}) {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.ServiceName.eq(param.string("serviceName")),
-			$.Minute.gte(param.dateTimeString("startTime")),
-			$.Minute.lte(param.dateTimeString("endTime")),
+			$.Minute.gte(param.dateTimeSeconds("startTime")),
+			$.Minute.lte(param.dateTimeSeconds("endTime")),
 			opts.scopeToEnvironment ? $.DeploymentEnv.eq(param.string("deploymentEnv")) : undefined,
 		])
 		.format("JSON")
@@ -106,8 +106,8 @@ export function orgTelemetryPulseQuery(): CHUnionQuery<TelemetryPulseOutput> {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 		])
 
 	const logs = from(Logs)
@@ -118,8 +118,8 @@ export function orgTelemetryPulseQuery(): CHUnionQuery<TelemetryPulseOutput> {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.TimestampTime.gte(param.dateTimeString("startTime")),
-			$.TimestampTime.lte(param.dateTimeString("endTime")),
+			$.TimestampTime.gte(param.dateTimeSeconds("startTime")),
+			$.TimestampTime.lte(param.dateTimeSeconds("endTime")),
 			$.Timestamp.gte(param.dateTimeString("startTime")),
 			$.Timestamp.lte(param.dateTimeString("endTime")),
 		])

--- a/packages/query-engine/src/ch/queries/logs.ts
+++ b/packages/query-engine/src/ch/queries/logs.ts
@@ -211,8 +211,8 @@ function rawLogsTimeRange($: ColumnAccessor<typeof Logs.columns>): Array<CH.Cond
 	return [
 		// TimestampTime is the partition/index key; this filter unlocks
 		// partition pruning. Timestamp filter retained for sub-second accuracy.
-		$.TimestampTime.gte(param.dateTimeString("startTime")),
-		$.TimestampTime.lte(param.dateTimeString("endTime")),
+		$.TimestampTime.gte(param.dateTimeSeconds("startTime")),
+		$.TimestampTime.lte(param.dateTimeSeconds("endTime")),
 		$.Timestamp.gte(param.dateTimeString("startTime")),
 		$.Timestamp.lte(param.dateTimeString("endTime")),
 	]
@@ -330,7 +330,7 @@ export function logsTimeseriesQuery(opts: LogsTimeseriesOpts): CHQuery<ColumnDef
 			}))
 			.where(($) => [
 				$.OrgId.eq(param.string("orgId")),
-				$.Hour.gte(param.dateTimeString("startTime")),
+				$.Hour.gte(param.dateTimeSeconds("startTime")),
 				// `param.dateTimeString("endTime")` substitutes as a quoted string literal;
 				// `toStartOfHour` only accepts Date/DateTime, so wrap with `toDateTime`.
 				$.Hour.lt(CH.toStartOfHour(CH.toDateTime(param.dateTimeString("endTime")))),
@@ -355,8 +355,8 @@ export function logsTimeseriesQuery(opts: LogsTimeseriesOpts): CHQuery<ColumnDef
 			$.OrgId.eq(param.string("orgId")),
 			// TimestampTime is the partition/index key; this filter unlocks
 			// partition pruning. Timestamp filter retained for sub-second accuracy.
-			$.TimestampTime.gte(param.dateTimeString("startTime")),
-			$.TimestampTime.lte(param.dateTimeString("endTime")),
+			$.TimestampTime.gte(param.dateTimeSeconds("startTime")),
+			$.TimestampTime.lte(param.dateTimeSeconds("endTime")),
 			$.Timestamp.gte(param.dateTimeString("startTime")),
 			$.Timestamp.lte(param.dateTimeString("endTime")),
 			...serviceSeverityConditions($, opts),
@@ -592,8 +592,8 @@ export function logsListQuery(opts: LogsListOpts) {
 
 	const baseWhere = ($: ColumnAccessor<typeof Logs.columns>): Array<CH.Condition | undefined> => [
 		$.OrgId.eq(param.string("orgId")),
-		$.TimestampTime.gte(param.dateTimeString("startTime")),
-		$.TimestampTime.lte(param.dateTimeString("endTime")),
+		$.TimestampTime.gte(param.dateTimeSeconds("startTime")),
+		$.TimestampTime.lte(param.dateTimeSeconds("endTime")),
 		$.Timestamp.gte(param.dateTimeString("startTime")),
 		$.Timestamp.lte(param.dateTimeString("endTime")),
 		...serviceSeverityConditions($, opts),
@@ -696,8 +696,8 @@ export function getLogByKeyQuery(opts: LogByKeyOpts) {
 			$.OrgId.eq(param.string("orgId")),
 			// TimestampTime is the partition/index key; bounding it unlocks
 			// partition pruning. Timestamp.eq pins the exact sub-second row.
-			$.TimestampTime.gte(param.dateTimeString("startTime")),
-			$.TimestampTime.lte(param.dateTimeString("endTime")),
+			$.TimestampTime.gte(param.dateTimeSeconds("startTime")),
+			$.TimestampTime.lte(param.dateTimeSeconds("endTime")),
 			$.Timestamp.eq(param.dateTimeString("timestamp")),
 			CH.when(opts.serviceName, (v: string) => $.ServiceName.eq(v)),
 			CH.when(opts.traceId, (v: string) => $.TraceId.eq(v)),
@@ -787,8 +787,8 @@ function logsFacetsQueryFromMv(
 		$: ColumnAccessor<typeof LogsAggregatesHourly.columns>,
 	): Array<CH.Condition | undefined> => [
 		$.OrgId.eq(param.string("orgId")),
-		$.Hour.gte(param.dateTimeString("startTime")),
-		$.Hour.lte(param.dateTimeString("endTime")),
+		$.Hour.gte(param.dateTimeSeconds("startTime")),
+		$.Hour.lte(param.dateTimeSeconds("endTime")),
 		CH.when(opts.serviceName, (v: string) => $.ServiceName.eq(v)),
 		CH.when(opts.severity, (v: string) => $.SeverityText.eq(v)),
 		opts.environments?.length ? CH.inList($.DeploymentEnv, opts.environments) : undefined,
@@ -862,8 +862,8 @@ function logsFacetsQueryFromRaw(
 ): CHUnionQuery<LogsFacetsOutput> {
 	const baseWhere = ($: ColumnAccessor<typeof Logs.columns>): Array<CH.Condition | undefined> => [
 		$.OrgId.eq(param.string("orgId")),
-		$.TimestampTime.gte(param.dateTimeString("startTime")),
-		$.TimestampTime.lte(param.dateTimeString("endTime")),
+		$.TimestampTime.gte(param.dateTimeSeconds("startTime")),
+		$.TimestampTime.lte(param.dateTimeSeconds("endTime")),
 		$.Timestamp.gte(param.dateTimeString("startTime")),
 		$.Timestamp.lte(param.dateTimeString("endTime")),
 		CH.when(opts.serviceName, (v: string) => $.ServiceName.eq(v)),

--- a/packages/query-engine/src/ch/queries/metrics.ts
+++ b/packages/query-engine/src/ch/queries/metrics.ts
@@ -549,7 +549,7 @@ export function listMetricsQuery(opts: ListMetricsOpts) {
 			// Floor the start bound to the hour so the oldest catalog bucket
 			// (Hour is already hour-truncated) isn't dropped for mid-hour ranges.
 			$.Hour.gte(CH.toStartOfInterval(CH.toDateTime(param.dateTimeString("startTime")), 3600)),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			CH.when(opts.serviceName, (v: string) => $.ServiceName.eq(v)),
 			CH.when(opts.metricType, (v: string) => $.MetricType.eq(v)),
 			CH.when(opts.search, (v: string) => $.MetricName.ilike(`%${v}%`)),
@@ -583,7 +583,7 @@ export function metricsSummaryQuery(opts?: MetricsSummaryOpts) {
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.Hour.gte(CH.toStartOfInterval(CH.toDateTime(param.dateTimeString("startTime")), 3600)),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			CH.when(opts?.serviceName, (v: string) => $.ServiceName.eq(v)),
 		])
 		.groupBy("metricType")

--- a/packages/query-engine/src/ch/queries/query-helpers.ts
+++ b/packages/query-engine/src/ch/queries/query-helpers.ts
@@ -408,8 +408,8 @@ export function serviceOverviewWhereConditions(
 	const services = inclusionValues(opts.serviceName, opts.serviceNames)
 	const conditions: Array<CH.Condition | undefined> = [
 		$.OrgId.eq(param.string("orgId")),
-		$.Timestamp.gte(param.dateTimeString("startTime")),
-		$.Timestamp.lte(param.dateTimeString("endTime")),
+		$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+		$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 		CH.when(services, (v: readonly string[]) =>
 			matchOrIn($.ServiceName, v, mm?.serviceName === "contains"),
 		),
@@ -514,10 +514,10 @@ export function tracesAggregatesWhereConditions(
 		$.OrgId.eq(param.string("orgId")),
 		hourBounds
 			? $.Hour.gte(CH.rawExpr(hourBounds.gte, T.dateTimeString))
-			: $.Hour.gte(param.dateTimeString("startTime")),
+			: $.Hour.gte(param.dateTimeSeconds("startTime")),
 		hourBounds
 			? $.Hour.lt(CH.rawExpr(hourBounds.lt, T.dateTimeString))
-			: $.Hour.lte(param.dateTimeString("endTime")),
+			: $.Hour.lte(param.dateTimeSeconds("endTime")),
 		CH.when(services, (v: readonly string[]) =>
 			matchOrIn($.ServiceName, v, mm?.serviceName === "contains"),
 		),

--- a/packages/query-engine/src/ch/queries/service-infra.ts
+++ b/packages/query-engine/src/ch/queries/service-infra.ts
@@ -131,7 +131,7 @@ export function serviceWorkloadsSQL(
     .where(($) => [
       $.OrgId.eq(param.string("orgId")),
       $.Hour.gte(CH.toStartOfHour(CH.toDateTime(param.dateTimeString("startTime")))),
-      $.Hour.lte(param.dateTimeString("endTime")),
+      $.Hour.lte(param.dateTimeSeconds("endTime")),
       CH.inList($.ServiceName, opts.services),
     ])
     .groupBy("serviceName");

--- a/packages/query-engine/src/ch/queries/service-map-rollup.ts
+++ b/packages/query-engine/src/ch/queries/service-map-rollup.ts
@@ -90,8 +90,8 @@ export function serviceMapEdgesExistingHoursSQL(params: {
 		.select(($) => ({ hourTs: CH.toUnixTimestamp($.Hour) }))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lt(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lt(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("hourTs")
 		.format("JSON")
@@ -128,8 +128,8 @@ export function serviceMapResolutionsExistingHoursSQL(params: {
 		.select(($) => ({ hourTs: CH.toUnixTimestamp($.Hour) }))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Hour.gte(param.dateTimeString("startTime")),
-			$.Hour.lt(param.dateTimeString("endTime")),
+			$.Hour.gte(param.dateTimeSeconds("startTime")),
+			$.Hour.lt(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("hourTs")
 		.format("JSON")

--- a/packages/query-engine/src/ch/queries/service-map.ts
+++ b/packages/query-engine/src/ch/queries/service-map.ts
@@ -1318,7 +1318,7 @@ export function servicePlatformsSQL(
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.Hour.gte(CH.toStartOfHour(CH.toDateTime(param.dateTimeString("startTime")))),
-			$.Hour.lte(param.dateTimeString("endTime")),
+			$.Hour.lte(param.dateTimeSeconds("endTime")),
 			$.ServiceName.neq(""),
 			opts.deploymentEnv ? $.DeploymentEnv.eq(opts.deploymentEnv) : undefined,
 		])

--- a/packages/query-engine/src/ch/queries/traces.ts
+++ b/packages/query-engine/src/ch/queries/traces.ts
@@ -1100,8 +1100,8 @@ export function slowTracesQuery(opts: SlowTracesOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			CH.when(opts.service, (v: string) => $.ServiceName.eq(v)),
 			CH.when(opts.environment, (v: string) => $.DeploymentEnv.eq(v)),
 		])
@@ -1347,8 +1347,8 @@ export function traceSummariesQuery(opts: TraceSummariesOpts) {
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 			matchingTraceIds ? subqueryCond(matchingTraceIds, (sql) => `TraceId IN (${sql})`) : undefined,
 			opts.cursor
 				? $.Timestamp.lt(opts.cursor.timestamp).or(
@@ -1558,8 +1558,8 @@ function traceListMvWhereConditions(
 	const spanNames = inclusionValues(opts.spanName, opts.spanNames)
 	const conditions: Array<CH.Condition | undefined> = [
 		$.OrgId.eq(param.string("orgId")),
-		$.Timestamp.gte(param.dateTimeString("startTime")),
-		$.Timestamp.lte(param.dateTimeString("endTime")),
+		$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+		$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 		CH.when(services, (v: readonly string[]) =>
 			matchOrIn($.ServiceName, v, mm?.serviceName === "contains"),
 		),
@@ -1806,8 +1806,8 @@ export function traceServicesByTraceIdsQuery(opts: TraceServicesByTraceIdsOpts) 
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
 			$.TraceId.in_(...opts.traceIds),
-			$.Timestamp.gte(param.dateTimeString("startTime")),
-			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.Timestamp.gte(param.dateTimeSeconds("startTime")),
+			$.Timestamp.lte(param.dateTimeSeconds("endTime")),
 		])
 		.groupBy("traceId")
 		.limit(opts.traceIds.length)


### PR DESCRIPTION
## What

A `DateTime` column rejects a fractional literal outright — `TimestampTime >= '2026-09-01 02:40:00.500'` is `TYPE_MISMATCH`, not a rounding — while the `DateTime64` column beside it in the same table needs that fraction kept. One rendering of one bound cannot serve both, and `logsListQuery` filters on both `Logs.TimestampTime` (`DateTime`) and `Logs.Timestamp` (`DateTime64(9)`) in a single WHERE.

Today precision is chosen by the **caller**, and the code already shows people working around it:

- `widget-summary.http.ts` formats the rollup bound to seconds and the raw-trace timeseries bound to milliseconds, with a comment explaining the split.
- `telemetry.http.ts` carries an `options.precision === "second"` switch for the same reason.

That only holds while a route fans out to tables of one precision. `TinybirdDateTime` accepts `.\d{1,9}`, so any client can send a fractional bound into a query that touches both.

## How

`param.dateTimeSeconds` reads the very same param value and only encodes it differently — placeholders carry kind and name independently. The precision decision moves from the caller to the column, which is the only place that knows.

Widening is safe where these appear: they bound a partition/index key for pruning, and the exact `DateTime64` predicate still decides the result.

## Correctness

Every one of the ~100 converted sites was checked against its column type in `datasources.ts`. All land on `t.dateTime()` columns (error_events, trace_list_mv, the `*_hourly`/`*_minutely` rollups, `Logs.TimestampTime`, `ServiceOverviewSpans`).

Deliberately **not** converted, all `DateTime64`: `traces.Timestamp`, `logs.Timestamp`, `TraceDetailSpans`, session/product events, `alert_checks`. Sites that wrap the bound in `toDateTime(...)` are also left alone.

## Tests

Three cases added to `literal.test.ts`: a fractional bound floors, an already-second-precision bound passes through, and the same param renders both ways in one WHERE.

- `@maple-dev/clickhouse-builder` 251 passed
- `@maple/query-engine` 1373 passed
- `@maple/domain` 693 passed
- `bun typecheck` 41/41, `bun run lint` clean

## Note

The working tree this came from also carried `forwardQuery: "SELECT *"` on four rollup datasources. That is **not** included here — it broke `retention-matrix.test.ts`, which pins those rollups as FORWARD_QUERY-free, and both `materializations.ts:1502` and `datasources.ts:1654` record that a leftover forward query makes every later deploy fail. Those rollups use `deploymentMethod: "alter"` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791065809&installation_model_id=427786&pr_number=757&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F757&signature=c41ad34fdc4ad8689cdc76b5d3249dfd2040d1a244d3891fe9308d0fce0b78aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->