### PR TITLE
chore(web): upgrade @tanstack/react-table to v9

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,7 +54,7 @@
 		"@tanstack/react-db": "0.3.5",
 		"@tanstack/react-hotkeys": "0.10.0",
 		"@tanstack/react-router": "^1.170.16",
-		"@tanstack/react-table": "^8.21.3",
+		"@tanstack/react-table": "^9.2.4",
 		"@tanstack/react-virtual": "^3.14.3",
 		"@xyflow/react": "catalog:ui",
 		"class-variance-authority": "catalog:ui",

--- a/apps/web/src/components/traces/traces-table.tsx
+++ b/apps/web/src/components/traces/traces-table.tsx
@@ -5,7 +5,13 @@ import { Result } from "@/lib/effect-atom"
 import { Link, useNavigate } from "@tanstack/react-router"
 import { ExcludedEmptyHint } from "@maple/ui/components/filters/excluded-empty-hint"
 import { traceFilterChips } from "@/lib/traces/trace-filter-chips"
-import { type ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table"
+import {
+	columnSizingFeature,
+	type ColumnDef,
+	flexRender,
+	tableFeatures,
+	useTable,
+} from "@tanstack/react-table"
 import { useVirtualizer } from "@tanstack/react-virtual"
 
 import { Badge } from "@maple/ui/components/ui/badge"
@@ -128,6 +134,12 @@ function SortableHeader({
 	)
 }
 
+/**
+ * v9 registers features explicitly. Sorting is server-side and nothing else here is table-driven,
+ * so column sizing — the declared widths the header cells read back — is the only one needed.
+ */
+const TABLE_FEATURES = tableFeatures({ columnSizingFeature })
+
 const ROW_HEIGHT = 44
 
 const HEADER_CELL_CLASS = "h-10 px-2 text-left align-middle font-medium text-muted-foreground"
@@ -234,7 +246,7 @@ function TracesTableView({
 	const { effectiveTimezone } = useTimezonePreference()
 	const scrollContainerRef = React.useRef<HTMLDivElement>(null)
 
-	const columns = React.useMemo<ColumnDef<Trace>[]>(
+	const columns = React.useMemo<ColumnDef<typeof TABLE_FEATURES, Trace>[]>(
 		() => [
 			{
 				accessorKey: "traceId",
@@ -369,10 +381,10 @@ function TracesTableView({
 		[effectiveTimezone, sortBy, sortDir, onSortChange],
 	)
 
-	const table = useReactTable({
+	const table = useTable({
+		features: TABLE_FEATURES,
 		data: allData,
 		columns,
-		getCoreRowModel: getCoreRowModel(),
 	})
 
 	const { rows } = table.getRowModel()
@@ -500,7 +512,7 @@ function TracesTableView({
 										}
 									}}
 								>
-									{row.getVisibleCells().map((cell) => {
+									{row.getAllCells().map((cell) => {
 										const { responsive, cellClass } = columnClasses(cell.column.id)
 										return (
 											<td

--- a/bun.lock
+++ b/bun.lock
@@ -250,7 +250,7 @@
         "@tanstack/react-db": "0.3.5",
         "@tanstack/react-hotkeys": "0.10.0",
         "@tanstack/react-router": "^1.170.16",
-        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-table": "^9.2.4",
         "@tanstack/react-virtual": "^3.14.3",
         "@xyflow/react": "catalog:ui",
         "class-variance-authority": "catalog:ui",
@@ -1961,7 +1961,7 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
-    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+    "@tanstack/react-table": ["@tanstack/react-table@9.2.4", "", { "dependencies": { "@tanstack/react-store": "^0.11.1", "@tanstack/table-core": "9.2.4" }, "peerDependencies": { "react": ">=18" } }, "sha512-Rzp1Q4e0/nIgEjmISYR5HeEgLTNtrG+C7NFZf/AbCxPO5hg+zC3yNGwcoECigUk8SFzzvhXbd2rFdtP2ZiGrfA=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.9", "", { "dependencies": { "@tanstack/virtual-core": "3.17.7" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ=="],
 
@@ -1975,7 +1975,7 @@
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
-    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+    "@tanstack/table-core": ["@tanstack/table-core@9.2.4", "", { "dependencies": { "@tanstack/store": "^0.11.1" } }, "sha512-GwdDyGGr6UXAtubF14yAwcXvdaogqfsQgIk89Suebjxob/Rjq2xvfmXsjDF1rQmKmhHsJm9TOY7myxv3i6geJw=="],
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.7", "", {}, "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA=="],
 
@@ -4263,6 +4263,8 @@
 
     "@tanstack/react-hotkeys/@tanstack/react-store": ["@tanstack/react-store@0.11.0", "", { "dependencies": { "@tanstack/store": "0.11.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w=="],
 
+    "@tanstack/react-table/@tanstack/react-store": ["@tanstack/react-store@0.11.1", "", { "dependencies": { "@tanstack/store": "0.11.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ=="],
+
     "@tanstack/router-generator/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@tanstack/router-plugin/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
@@ -4274,6 +4276,8 @@
     "@tanstack/router-utils/@babel/generator": ["@babel/generator@7.29.8", "", { "dependencies": { "@babel/parser": "^7.29.8", "@babel/types": "^7.29.8", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg=="],
 
     "@tanstack/router-utils/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "@tanstack/table-core/@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
@@ -4780,6 +4784,8 @@
     "@tanstack/devtools-bundler-core/oxc-parser/@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
 
     "@tanstack/react-hotkeys/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
+
+    "@tanstack/react-table/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 


### PR DESCRIPTION
## What

Upgrades `@tanstack/react-table` from `^8.21.3` to `^9.2.4` and migrates the single consumer,
`apps/web/src/components/traces/traces-table.tsx`.

v9 drops the bundle-every-feature table constructor in favour of explicit feature registration, so
the traces table now declares only what it uses:

- `useReactTable` → `useTable`; the `getCoreRowModel()` option is gone (core is automatic).
- New module-scope `TABLE_FEATURES = tableFeatures({ columnSizingFeature })`. Sizing is the only
  feature this table needs — `header.getSize()` is what makes the declared column widths
  authoritative under `table-fixed`. Sorting is server-side (the list is paged, so reordering the
  fetched window would sort the wrong rows), so no sorting feature and no sorted row model.
- `ColumnDef<Trace>` → `ColumnDef<typeof TABLE_FEATURES, Trace>`.
- `row.getVisibleCells()` → `row.getAllCells()`. In v9 `getVisibleCells` sits behind
  `columnVisibilityFeature`; nothing here ever sets visibility state, so the two are equivalent
  without pulling that feature in.

`flexRender` is unchanged in v9, so both render call sites are untouched, as is the
`getSize() !== 150` sentinel — v9 keeps the same 150px default column size.

## Why

Keeps the dependency on the supported major. The migration surface turned out to be one file and
~16 lines; doing it now is cheaper than doing it alongside a future table feature.

## Verification

- `bun run --filter=@maple/web typecheck` — clean. v9's typed feature registry is the real safety
  net here: an unregistered feature is a type error at the call site, not a runtime `undefined`.
- oxlint clean (3 warnings, all pre-existing); oxfmt applied.
- Browser-verified against the local API: `/traces` renders 76 traces with all six headers at their
  exact declared widths (Trace ID 100, Services 160, Spans 70, Duration 100, Status 80, Root Span
  flexing to fill 896px), confirming sizing and the default-size sentinel still behave. No
  table-related console errors.

## For the reviewer

Virtual scrolling and the infinite-fetch threshold were **not** exercised live — the verification
browser pane was hidden, which freezes `requestAnimationFrame` and pins the virtualizer at its first
window. That code path is untouched by this change (`@tanstack/react-virtual` is a separate package
and its usage is identical), but a manual scroll on `/traces` is worth a moment before merge.

The repo-wide typecheck and test suite were not run locally; nothing else in the repo imports
react-table, so CI is the check that matters.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791067647&installation_model_id=427786&pr_number=758&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F758&signature=7e742deb161db5f7f0e149145b3630555e1833acc9aa0774fa916d8f41247726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->