### PR TITLE
fix(cli): realign remote mode with the current v2 API

### DIFF
--- a/apps/cli/src/commands/traces.ts
+++ b/apps/cli/src/commands/traces.ts
@@ -33,7 +33,7 @@ export const traces = Command.make("traces", {
 	limit: f.limit,
 	offset: f.offset,
 }).pipe(
-	Command.withDescription("Search traces/spans in local Maple"),
+	Command.withDescription("Search traces/spans"),
 	Command.withHandler(
 		Effect.fnUntraced(function* (a) {
 			const range = yield* resolveRangeChecked(a)

--- a/apps/cli/src/core/operations.ts
+++ b/apps/cli/src/core/operations.ts
@@ -121,7 +121,7 @@ export const findErrors = (p: { range: Range; service?: string; environment?: st
 		() =>
 			unsupportedInRemote(
 				"errors_by_type",
-				"/v2/error_issues returns triage issues keyed by an opaque `erris_…` id, not exception-type counts over a window.",
+				"/v2/error_issues lists one triage issue per fingerprint, so it cannot report how many services an error spans, and it only covers fingerprints a sweep has already turned into issues.",
 			),
 		"errors_by_type",
 	)
@@ -135,11 +135,7 @@ export const errorDetail = (p: { fingerprintHash: string; range: Range; service?
 			includeTimeseries: true,
 			limit: p.limit,
 		}),
-		() =>
-			unsupportedInRemote(
-				"error_detail_traces",
-				"v2 identifies errors by an opaque `erris_…` issue id and offers no lookup from a fingerprint hash.",
-			),
+		(client) => Remote.errorDetail(client, p),
 		"error_detail_traces",
 	)
 

--- a/apps/cli/src/core/remote-ops.test.ts
+++ b/apps/cli/src/core/remote-ops.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "bun:test"
 import { Effect, Exit, Schema } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
+import { encodePublicId } from "@maple/domain/http/v2"
 import * as Remote from "./remote-ops"
 import { makeV2Client, toV2Timestamp } from "./v2-client"
 
@@ -80,6 +81,45 @@ const listEnvelope = (data: ReadonlyArray<unknown>) => ({
 	has_more: false,
 	next_cursor: null,
 })
+
+const ISSUE_ID = encodePublicId("iss", "018f2b3c-4d5e-6f70-8192-a3b4c5d6e7f8")
+
+/** A full `V2ErrorIssue` — the client decodes the response, so a partial stub fails. */
+const errorIssue = {
+	id: ISSUE_ID,
+	object: "error_issue",
+	kind: "error",
+	fingerprint_hash: "12345",
+	service_name: "api",
+	exception_type: "TypeError",
+	exception_message: "boom",
+	error_label: "TypeError: boom",
+	top_frame: "src/index.ts:12",
+	workflow_state: "triage",
+	priority: 1,
+	severity: null,
+	severity_source: null,
+	source_ref: null,
+	assigned_actor: null,
+	lease_holder: null,
+	lease_expires_at: null,
+	claimed_at: null,
+	notes: null,
+	first_seen_at: "2026-08-15T12:00:00.000Z",
+	last_seen_at: "2026-08-15T12:30:00.000Z",
+	occurrence_count: 3,
+	resolved_at: null,
+	last_resolved_at: null,
+	last_regressed_at: null,
+	regression_count: 0,
+	resolved_versions: [],
+	snooze_until: null,
+	archived_at: null,
+	has_open_incident: false,
+	comment_count: 0,
+	open_pull_request_count: 0,
+	merged_pull_request_count: 0,
+}
 
 beforeEach(() => {
 	requests = []
@@ -179,6 +219,136 @@ describe("remote-ops request shapes", () => {
 			end_time: "2026-08-15T12:30:02.000Z",
 			filters: { trace_id: traceId },
 		})
+	})
+
+	it("listMetrics returns local mode's column names, not the v2 wire names", async () => {
+		stubV2(() =>
+			listEnvelope([
+				{
+					object: "metric",
+					name: "http.server.duration",
+					type: "histogram",
+					service_name: "api",
+					description: "Request duration",
+					unit: "ms",
+					is_monotonic: false,
+					data_point_count: 42,
+					first_seen: "2026-08-15T12:00:00.000Z",
+					last_seen: "2026-08-15T13:00:00.000Z",
+				},
+			]),
+		)
+		const rows = await Effect.runPromise(
+			Effect.flatMap(v2Client, (v2) => Remote.listMetrics(v2, { range: RANGE })),
+		)
+
+		// `maple metrics` prints the row's own keys, so a pass-through of the v2
+		// resource renamed every column when the same command ran remotely.
+		expect(rows[0]).toEqual({
+			metricName: "http.server.duration",
+			metricType: "histogram",
+			serviceName: "api",
+			metricDescription: "Request duration",
+			metricUnit: "ms",
+			dataPointCount: 42,
+			firstSeen: "2026-08-15T12:00:00.000Z",
+			lastSeen: "2026-08-15T13:00:00.000Z",
+			isMonotonic: false,
+		})
+	})
+
+	it("tracesTimeseries merges the per-aggregation series onto local mode's columns", async () => {
+		const point = (value: number) => ({
+			object: "trace_timeseries",
+			aggregation: "count",
+			start_time: "2026-08-15T12:00:00.000Z",
+			end_time: "2026-08-15T13:00:00.000Z",
+			bucket_seconds: 60,
+			group_by: null,
+			series: [{ group: null, points: [{ timestamp: "2026-08-15T12:00:00.000Z", value }] }],
+		})
+		let call = 0
+		stubV2(() => point(++call))
+		const rows = await Effect.runPromise(
+			Effect.flatMap(v2Client, (v2) => Remote.tracesTimeseries(v2, { range: RANGE })),
+		)
+
+		expect(rows).toHaveLength(1)
+		expect(Object.keys(rows[0]!).sort()).toEqual(
+			[
+				"avgDuration",
+				"bucket",
+				"count",
+				"errorRate",
+				"groupName",
+				"p50Duration",
+				"p95Duration",
+				"p99Duration",
+			].sort(),
+		)
+	})
+
+	it("errorDetail resolves a fingerprint through /v2/error_issues", async () => {
+		const traceId = "7f3a4b5c6d7e8f901234567890abcdef"
+		const requests = stubV2((url) => {
+			if (url.includes(`/v2/error_issues/${ISSUE_ID}`)) {
+				return {
+					...errorIssue,
+					timeseries: [{ bucket: "2026-08-15T12:00:00.000Z", count: 3 }],
+					sample_traces: [
+						{
+							trace_id: traceId,
+							span_id: "0123456789abcdef",
+							service_name: "api",
+							timestamp: "2026-08-15T12:30:00.000Z",
+							exception_message: "boom",
+							duration_micros: 1500,
+						},
+					],
+					incidents: [],
+					environments: [],
+				}
+			}
+			if (url.includes("/v2/error_issues")) return listEnvelope([errorIssue])
+			if (url.includes("/logs/search")) return listEnvelope([])
+			return {
+				id: traceId,
+				object: "trace",
+				start_time: "2026-08-15T12:30:00.000Z",
+				end_time: "2026-08-15T12:30:02.000Z",
+				duration_ms: 2000,
+				span_count: 3,
+				service_count: 2,
+				truncated: false,
+				spans: [],
+			}
+		})
+		const result = await Effect.runPromise(
+			Effect.flatMap(v2Client, (v2) =>
+				Remote.errorDetail(v2, { fingerprintHash: "12345", range: RANGE, limit: 5 }),
+			),
+		)
+
+		const lookup = new URL(requests[0]!.url)
+		expect(lookup.pathname).toBe("/v2/error_issues")
+		expect(lookup.searchParams.get("fingerprint_hash")).toBe("12345")
+		// The lookup is unwindowed on purpose — a fingerprint is an identity, and
+		// the list's window filters triage activity, not the events asked about.
+		expect(lookup.searchParams.get("start_time")).toBeNull()
+		expect(new URL(requests[1]!.url).searchParams.get("sample_limit")).toBe("5")
+		expect(result.traces[0]).toMatchObject({ traceId, spanCount: 3, errorMessage: "boom" })
+		expect(result.timeseries).toEqual([{ bucket: "2026-08-15T12:00:00.000Z", count: 3 }])
+	})
+
+	it("errorDetail says what remote mode cannot see when no issue matches", async () => {
+		stubV2(() => listEnvelope([]))
+		const exit = await Effect.runPromise(
+			Effect.flatMap(v2Client, (v2) =>
+				Effect.exit(Remote.errorDetail(v2, { fingerprintHash: "12345", range: RANGE })),
+			),
+		)
+
+		expect(Exit.isFailure(exit)).toBe(true)
 	})
 })
 

--- a/apps/cli/src/core/remote-ops.ts
+++ b/apps/cli/src/core/remote-ops.ts
@@ -12,6 +12,8 @@ import { Schema } from "effect"
 import { ServiceName, SpanId, TraceId } from "@maple/domain"
 import { clusterLogPatterns } from "@maple/query-engine/observability"
 import type {
+	ErrorDetailOutput,
+	ErrorDetailTrace,
 	InspectTraceOutput,
 	LogEntry,
 	SearchLogsOutput,
@@ -21,8 +23,9 @@ import type {
 	SpanNode,
 	SpanResult,
 } from "@maple/query-engine/observability"
+import type { ListMetricsOutput } from "@maple/domain/tinybird"
 import type { Range } from "./time"
-import { type MapleV2Client, toV2Window, unsupportedInRemote } from "./v2-client"
+import { type MapleV2Client, remoteFailure, toV2Window, unsupportedInRemote } from "./v2-client"
 
 /**
  * v2 list endpoints cap `limit` at 100 (LIST_LIMIT_MAX) and paginate by opaque
@@ -105,12 +108,14 @@ export const searchTraces = (
 		offset?: number
 	},
 ): Effect.Effect<SearchTracesOutput, unknown> => {
-	// Local mode switches to a span-level scan whenever a span name is given
-	// without --root-only. v2 search only ever returns root-based summaries.
-	if (p.spanName && !p.rootOnly) {
+	// Local mode answers a span-name filter with a span-level scan, matching the
+	// name as a substring. /v2/traces/search only ever returns root-based
+	// summaries and matches the name exactly, so neither the rows nor the
+	// matching are what `--span-name` means here.
+	if (p.spanName) {
 		return unsupportedInRemote(
 			"span_search",
-			"filtering traces by span name searches individual spans, and /v2/traces/search only returns root spans.",
+			"filtering by span name searches individual spans by substring, and /v2/traces/search returns root spans matched on an exact name.",
 		)
 	}
 	if (p.offset !== undefined && p.offset > 0) {
@@ -333,10 +338,16 @@ export const mineLogPatterns = (
 		},
 	)
 
+/**
+ * v2 speaks snake_case resources; local mode returns the warehouse's
+ * `ListMetricsOutput` rows. `maple metrics` must print the same columns either
+ * way, so the resource is mapped back onto the local row shape rather than
+ * passed through — the pass-through renamed every column in remote mode.
+ */
 export const listMetrics = (
 	client: MapleV2Client,
 	p: { range: Range; service?: string; search?: string; limit?: number },
-) =>
+): Effect.Effect<ReadonlyArray<ListMetricsOutput>, unknown> =>
 	Effect.map(
 		client.metrics.list({
 			query: {
@@ -346,7 +357,20 @@ export const listMetrics = (
 				...(p.search ? { search: p.search } : undefined),
 			},
 		}),
-		(list) => list.data,
+		(list) =>
+			list.data.map(
+				(m): ListMetricsOutput => ({
+					metricName: m.name,
+					metricType: m.type,
+					serviceName: m.service_name,
+					metricDescription: m.description,
+					metricUnit: m.unit,
+					dataPointCount: m.data_point_count,
+					firstSeen: m.first_seen,
+					lastSeen: m.last_seen,
+					isMonotonic: m.is_monotonic,
+				}),
+			),
 	)
 
 /**
@@ -358,13 +382,18 @@ export const listMetrics = (
  * `apdex` is deliberately absent: v2 requires an explicit
  * `apdex_threshold_ms` and the command exposes no threshold flag, so any value
  * chosen here would be invented.
+ *
+ * The row keys are local mode's (`bucket`, `groupName`, `avgDuration`, …), not
+ * v2's: `maple timeseries`/`breakdown` print whatever keys the row carries, so
+ * naming them after the wire made the same command emit different columns per
+ * backend. The apdex columns local mode also returns are simply absent here.
  */
 const TRACE_AGGREGATIONS = [
 	["count", "count"],
-	["avgDurationMs", "avg_duration"],
-	["p50DurationMs", "p50_duration"],
-	["p95DurationMs", "p95_duration"],
-	["p99DurationMs", "p99_duration"],
+	["avgDuration", "avg_duration"],
+	["p50Duration", "p50_duration"],
+	["p95Duration", "p95_duration"],
+	["p99Duration", "p99_duration"],
 	["errorRate", "error_rate"],
 ] as const
 
@@ -425,15 +454,13 @@ export const tracesTimeseries = (
 			for (const series of result.series) {
 				for (const point of series.points) {
 					const key = `${point.timestamp}\0${series.group ?? ""}`
-					const row = rows.get(key) ?? { timestamp: point.timestamp, group: series.group }
+					const row = rows.get(key) ?? { bucket: point.timestamp, groupName: series.group ?? "" }
 					row[field] = point.value
 					rows.set(key, row)
 				}
 			}
 		})
-		return Array.from(rows.values()).sort((a, b) =>
-			String(a.timestamp).localeCompare(String(b.timestamp)),
-		)
+		return Array.from(rows.values()).sort((a, b) => String(a.bucket).localeCompare(String(b.bucket)))
 	})
 
 export const tracesBreakdown = (
@@ -476,4 +503,96 @@ export const tracesBreakdown = (
 			}
 		})
 		return Array.from(rows.values())
+	})
+
+/**
+ * `maple error <fingerprint-hash>` over v2.
+ *
+ * This used to be local-only on the grounds that v2 keyed errors by an opaque
+ * `erris_…` id with no way in from a fingerprint hash. `/v2/error_issues`
+ * gained a `fingerprint_hash` filter, so the hash resolves to an issue and the
+ * issue detail carries the timeseries and sample traces the command prints.
+ *
+ * One real difference from local mode: v2 answers from Maple's triage issues,
+ * so a fingerprint that was never swept into an issue has no detail to show
+ * and fails rather than returning an empty page. Local mode reads the raw
+ * error events and would show the traces regardless.
+ *
+ * The per-trace fan-out is what `V2ErrorIssueSampleTrace` does not carry —
+ * span count, participating services, the root span's name. It is bounded by
+ * the caller's own `--limit`.
+ */
+export const errorDetail = (
+	client: MapleV2Client,
+	p: { fingerprintHash: string; range: Range; service?: string; limit?: number },
+): Effect.Effect<ErrorDetailOutput, unknown> =>
+	Effect.gen(function* () {
+		const sampleLimit = Math.min(Math.max(p.limit ?? 5, 1), V2_LIST_MAX)
+		// Deliberately unwindowed: a fingerprint is an identity, and the issue
+		// list's window filters on triage activity rather than on the events the
+		// command is about. Windowing the lookup would report "no such error" for
+		// a real fingerprint whose issue was last touched outside --since.
+		const issues = yield* client.errorIssues.list({
+			query: {
+				fingerprint_hash: p.fingerprintHash,
+				limit: 1,
+				...(p.service ? { service_name: p.service } : undefined),
+			},
+		})
+		const issue = issues.data[0]
+		if (!issue) {
+			return yield* remoteFailure(
+				"error_detail_traces",
+				`No error issue matches fingerprint ${p.fingerprintHash}. Remote mode reads Maple's triage issues; run with --local to read the raw error events.`,
+			)
+		}
+
+		const detail = yield* client.errorIssues.retrieve({
+			params: { id: issue.id },
+			query: { ...toV2Window(p.range), sample_limit: sampleLimit },
+		})
+
+		const traces = yield* Effect.forEach(
+			detail.sample_traces,
+			(sample, index) =>
+				Effect.gen(function* () {
+					const trace = yield* client.traces.retrieve({ params: { trace_id: sample.trace_id } })
+					// Logs for the first three only, matching local mode: they are a
+					// glance at context, not the point of the command.
+					const logs =
+						index < 3
+							? yield* client.logs.search({
+									payload: {
+										start_time: trace.start_time,
+										end_time: trace.end_time,
+										limit: 10,
+										filters: { trace_id: sample.trace_id },
+									},
+								})
+							: undefined
+					const root = trace.spans.find((s) => s.parent_span_id === null)
+					return {
+						traceId: sample.trace_id,
+						rootSpanName: root?.name ?? "",
+						durationMs: trace.duration_ms,
+						spanCount: trace.span_count,
+						services: Array.from(new Set(trace.spans.map((s) => s.service_name))),
+						startTime: sample.timestamp,
+						errorMessage: sample.exception_message,
+						logs: (logs?.data ?? []).slice(0, 5).map((l) => ({
+							timestamp: l.timestamp,
+							severityText: l.severity_text || "INFO",
+							body: l.body,
+						})),
+					} satisfies ErrorDetailTrace
+				}),
+			{ concurrency: 5 },
+		)
+
+		return {
+			fingerprintHash: p.fingerprintHash,
+			timeRange: p.range,
+			traces,
+			timeseries: detail.timeseries.map((point) => ({ bucket: point.bucket, count: point.count })),
+		} satisfies ErrorDetailOutput
 	})

--- a/apps/cli/src/core/v2-client.ts
+++ b/apps/cli/src/core/v2-client.ts
@@ -55,6 +55,14 @@ export const unsupportedInRemote = (pipeName: string, reason: string) =>
 		}),
 	)
 
+/**
+ * A remote operation that v2 supports but that found nothing to answer with —
+ * distinct from `unsupportedInRemote`, which reports a missing capability and
+ * points at local mode. Tagged so `bin.ts` treats it as an expected outcome.
+ */
+export const remoteFailure = (pipeName: string, message: string) =>
+	Effect.fail(new WarehouseClientError({ message, pipeName }))
+
 const errorMessage = (error: unknown): string => {
 	if (error instanceof Error) return error.message
 	if (typeof error === "object" && error !== null && "message" in error) {

--- a/docs/http-api-migration.md
+++ b/docs/http-api-migration.md
@@ -41,10 +41,10 @@ Rebuilding the CLI's remote mode on v2 surfaced capabilities local mode has and 
 
 - **No attribute discovery.** Nothing in `/v2` returns the attribute keys or values observed in telemetry; `/v2/attribute_mappings` is mapping configuration. This blocks `maple attributes` entirely and is the largest gap.
 - **`/v2/traces/search` cannot sort.** It filters by `min_duration_ms` but has no order parameter, so "slowest N traces" is unexpressible.
-- **No span-level search.** Search returns root-based `V2TraceSummary`; there is no way to list spans matching a name.
+- **No span-level search.** Search returns root-based `V2TraceSummary`; there is no way to list spans matching a name, and its `span_name` filter matches exactly where the CLI matches a substring.
 - **Breakdown returns one aggregation per request.** A combined ranking (count + latency + error rate) needs N calls and cannot be ordered server-side by a composite.
-- **No fingerprint → issue lookup.** v2 keys errors by opaque `erris_…` ids, so a fingerprint hash cannot be resolved to an issue.
-- **No exception-type aggregate.** `/v2/error_issues` returns triage objects, not `(exception_type, service, count)` over a window.
+- ~~**No fingerprint → issue lookup.**~~ Closed: `/v2/error_issues` takes a `fingerprint_hash` filter, and the CLI's `maple error <fp>` runs on it remotely.
+- **No exception-type aggregate.** `/v2/error_issues` holds one triage object per fingerprint — it covers only fingerprints a sweep has turned into issues, and cannot say how many services an error spans, which `maple errors` prints.
 - **No window comparison.** Nothing corresponds to `service_overview_compare`.
 - **Offset pagination.** v2 lists seek by opaque cursor and cap at 100 rows, so `--offset` cannot be honoured.
 

--- a/docs/local-mode.md
+++ b/docs/local-mode.md
@@ -436,10 +436,15 @@ with the reason rather than returning a narrower answer:
 | `maple attributes keys` / `values`  | v2 exposes no attribute-discovery surface (`/v2/attribute_mappings` is mapping config, not observed keys).       |
 | `maple slow-traces`                 | `/v2/traces/search` filters by minimum duration but cannot order by it.                                          |
 | `maple top-ops`                     | Needs count, latency and error rate ranked together; `/v2/traces/breakdown` returns one aggregation per request. |
-| `maple traces --span-name`          | v2 search returns root-based summaries, not matched spans. `--root-only` works remotely.                         |
-| `maple errors` / `maple error <fp>` | v2 keys errors by an opaque `erris_…` issue id with no lookup from a fingerprint hash.                           |
+| `maple traces --span-name`          | v2 search returns root-based summaries matched on an exact name, not spans matched by substring.                 |
+| `maple errors`                      | `/v2/error_issues` holds one issue per fingerprint, so it cannot report how many services an error spans.        |
 | `maple compare`                     | v2 has no window-comparison endpoint.                                                                            |
 | `maple diagnose`                    | Its error breakdown depends on the exception-type aggregates above.                                              |
+
+`maple error <fp>` **does** work remotely: `/v2/error_issues?fingerprint_hash=`
+resolves the hash to an issue, and the issue detail carries the timeseries and
+sample traces. It reads Maple's triage issues rather than raw error events, so a
+fingerprint no sweep has turned into an issue fails instead of showing traces.
 
 Remote mode also inherits v2's pagination: lists cap at 100 rows per page and
 seek by opaque cursor, so `--offset` is rejected rather than silently ignored.


### PR DESCRIPTION
Audited every `maple` command against the current `/v2` contract. The typed client still compiles against it — no endpoint or parameter renames — and auth is intact (`/api/auth/cli/device`, `/cli/device/token`, `/session`, `DELETE /cli/session`), with the login key still minted as `kind: "standard"` / `scopes: null`, which clears every v2 scope gate. Three things had drifted.

## Two commands printed different columns per backend

`operations.ts` promises that an operation returns the same shape in both modes. It didn't:

- `maple metrics` passed the v2 resource straight through (`name`, `service_name`, `data_point_count`) where local mode returns the warehouse's `ListMetricsOutput` (`metricName`, `serviceName`, `dataPointCount`).
- `maple timeseries` / `maple breakdown` emitted `timestamp`/`group`/`avgDurationMs` against local's `bucket`/`groupName`/`avgDuration`.

Both now map onto local mode's row shape. Nothing caught this because the local side goes through the untyped executor, so the parity is now pinned by tests.

## `maple error <fingerprint-hash>` works remotely

It refused on the grounds that v2 offered no way in from a fingerprint hash. `/v2/error_issues` has taken a `fingerprint_hash` filter since `0432f69f9b` (2026-08-19), so the command now runs: fingerprint → issue → issue detail for the timeseries and sample traces, then a per-trace fetch for the span count, participating services and root span name that `V2ErrorIssueSampleTrace` doesn't carry (bounded by the caller's own `--limit`, concurrency 5; logs for the first three traces, as local mode does).

One real behavioural difference, documented in code and in `docs/local-mode.md`: remote reads Maple's triage issues, not raw error events, so a fingerprint no sweep has turned into an issue fails with that reason instead of returning an empty page.

## A latent silent drop in trace search

The guard was `p.spanName && !p.rootOnly`, and the filter it fell through to never included `span_name`. There is no `--root-only` flag, so the branch was unreachable — but had it been reached it would have answered a span-name query without the filter. Span-name filtering is now refused outright, with the accurate reason: v2 matches a span name **exactly** and returns root summaries, where `--span-name` means a substring match over spans.

## Still genuinely local-only

Re-checked against the live contract and unchanged: attribute discovery (nothing in `/v2` returns observed keys or values — `/v2/attribute_mappings` is mapping config), sorting trace search by duration, a combined operation ranking, window comparison, raw SQL, and `--offset` (v2 is cursor-only, capped at 100).

Their wording was stale in a smaller way, as were `docs/local-mode.md` and `docs/http-api-migration.md`: all cited an `erris_…` issue id. The prefix is `iss_`, and the real blocker for `maple errors` is that one issue per fingerprint cannot report how many services an error spans, and only covers fingerprints a sweep has already turned into issues.

## Reviewer notes

- `remoteFailure` is new in `v2-client.ts`, deliberately distinct from `unsupportedInRemote`: one reports "v2 could answer this but found nothing", the other "v2 cannot express this, use `--local`". Both are tagged so `bin.ts` treats them as expected outcomes.
- Five new tests in `remote-ops.test.ts` follow that file's rule — assert the outbound request, since that is what drifts. `apps/cli`: 538 pass, typecheck clean.

## Not addressed

Two live gaps, left for a separate call: v2 has a `/v2/environments` group with no CLI command, and trace filters have grown `status_code`, `http_route`, `http_status_code`, `service_namespace` and attribute filters that no flag exposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791069679&installation_model_id=427786&pr_number=759&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F759&signature=92001e6305104535d011f266d2fcffb692488368d3ec7de787b7b145f53021bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->