### PR TITLE
fix(effect-sdk): skip browser sessions in React Native

### DIFF
--- a/packages/browser-session/src/session/session.test.ts
+++ b/packages/browser-session/src/session/session.test.ts
@@ -32,6 +32,7 @@ const STORAGE_KEY = "maple.session"
 let storage: FakeStorage
 
 beforeEach(() => {
+	vi.stubGlobal("document", {})
 	vi.useFakeTimers()
 	vi.setSystemTime(new Date("2026-05-22T12:00:00Z"))
 	storage = new FakeStorage()
@@ -43,6 +44,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+	vi.unstubAllGlobals()
 	vi.useRealTimers()
 	delete (globalThis as { window?: unknown }).window
 })
@@ -111,6 +113,13 @@ describe("getSession", () => {
 })
 
 describe("getSessionId", () => {
+	it("returns undefined when window exists without a document (React Native)", () => {
+		vi.stubGlobal("document", undefined)
+		vi.stubGlobal("crypto", undefined)
+		expect(getSessionId()).toBeUndefined()
+		expect(storage.getItem(STORAGE_KEY)).toBeNull()
+	})
+
 	it("returns undefined outside a browser (SSR)", () => {
 		delete (globalThis as { window?: unknown }).window
 		expect(getSessionId()).toBeUndefined()

--- a/packages/browser-session/src/session/session.ts
+++ b/packages/browser-session/src/session/session.ts
@@ -302,7 +302,7 @@ function touchSession(now: number): SessionRecord {
  * (SSR) so server renders never mint a session shared across requests.
  */
 export function getSessionId(): string | undefined {
-	if (typeof window === "undefined") return undefined
+	if (typeof window === "undefined" || typeof document === "undefined") return undefined
 	return touchSession(Date.now()).id
 }
 

--- a/packages/effect-sdk/src/client/flushable.test.ts
+++ b/packages/effect-sdk/src/client/flushable.test.ts
@@ -273,7 +273,10 @@ describe("MapleFlush.make (client)", () => {
 		// sessionStorage. The bundled @maple/browser-session core must mint a
 		// session and stamp its id on every span.
 		const store = new Map<string, string>()
+		vi.stubGlobal("document", new EventTarget())
 		vi.stubGlobal("window", {
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
 			sessionStorage: {
 				getItem: (k: string) => store.get(k) ?? null,
 				setItem: (k: string, v: string) => void store.set(k, v),
@@ -283,7 +286,7 @@ describe("MapleFlush.make (client)", () => {
 			rf()
 			vi.unstubAllGlobals()
 		}
-		const telemetry = make(baseConfig)
+		const telemetry = make({ ...baseConfig, replay: { enabled: false } })
 
 		await Effect.runPromise(
 			Effect.succeed(undefined).pipe(Effect.withSpan("op-a"), Effect.provide(telemetry.layer)),

--- a/packages/effect-sdk/src/client/native-session.test.ts
+++ b/packages/effect-sdk/src/client/native-session.test.ts
@@ -1,0 +1,38 @@
+import { getActiveSink, getSessionId } from "@maple/browser-session"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { startClientSession } from "./replay-loader.js"
+import { setupStandaloneSession } from "./standalone-session.js"
+
+const config = {
+	serviceName: "native-test",
+	endpoint: "https://collector.test",
+	ingestKey: "test-key",
+}
+
+describe("browser sessions in React Native", () => {
+	beforeEach(() => {
+		// React Native exposes window without a DOM or browser Web Crypto.
+		vi.stubGlobal("window", {})
+		vi.stubGlobal("document", undefined)
+		vi.stubGlobal("crypto", undefined)
+		vi.stubGlobal("fetch", vi.fn())
+	})
+
+	afterEach(() => vi.unstubAllGlobals())
+
+	it("skips browser capture at client startup", async () => {
+		const session = startClientSession(config)
+		await session.stop()
+		expect(getActiveSink()).toBeUndefined()
+		expect(fetch).not.toHaveBeenCalled()
+	})
+
+	it("skips standalone browser metadata", () => {
+		expect(setupStandaloneSession(config)).toBeUndefined()
+		expect(fetch).not.toHaveBeenCalled()
+	})
+
+	it("does not mint a browser session when a later span requests its id", () => {
+		expect(getSessionId()).toBeUndefined()
+	})
+})

--- a/packages/effect-sdk/src/client/replay-loader.ts
+++ b/packages/effect-sdk/src/client/replay-loader.ts
@@ -71,7 +71,8 @@ export const startClientSession = (config: ClientSessionConfig): ClientSessionHa
 	configurePrivacy(config.privacy)
 	if (!hasConsent()) clearPendingEvents()
 	const ingestKey = config.ingestKey
-	if (typeof window === "undefined" || !ingestKey || readSessionSink()) return noOpHandle
+	if (typeof window === "undefined" || typeof document === "undefined" || !ingestKey || readSessionSink())
+		return noOpHandle
 
 	const engineConfig = {
 		endpoint: config.endpoint.replace(/\/$/, ""),

--- a/packages/effect-sdk/src/client/standalone-session.test.ts
+++ b/packages/effect-sdk/src/client/standalone-session.test.ts
@@ -43,8 +43,11 @@ const setupFetch = () => {
 }
 
 const stubWindow = () => {
+	vi.stubGlobal("document", new EventTarget())
 	const store = new Map<string, string>()
 	vi.stubGlobal("window", {
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
 		sessionStorage: {
 			getItem: (k: string) => store.get(k) ?? null,
 			setItem: (k: string, v: string) => void store.set(k, v),
@@ -60,6 +63,7 @@ const baseConfig = {
 	ingestKey: "secret",
 	environment: "test",
 	serviceVersion: "63c0c0321644dce742e92dfd09fb96e907649bc4",
+	replay: { enabled: false },
 	autoFlushInterval: false as const,
 	flushOnUnload: false as const,
 }

--- a/packages/effect-sdk/src/client/standalone-session.ts
+++ b/packages/effect-sdk/src/client/standalone-session.ts
@@ -78,7 +78,13 @@ export const noteStandaloneSpan = (sessionId: string, traceId: string): void => 
 export const setupStandaloneSession = (
 	options: StandaloneSessionOptions,
 ): MetadataSessionHandle | undefined => {
-	if (typeof window === "undefined" || !options.ingestKey || readSessionSink()) return undefined
+	if (
+		typeof window === "undefined" ||
+		typeof document === "undefined" ||
+		!options.ingestKey ||
+		readSessionSink()
+	)
+		return undefined
 	if (current) return leaseCurrent()
 	const handle = startMetadataSession({
 		endpoint: options.endpoint,


### PR DESCRIPTION
React Native exposes `window` but has no browser `document` or Web Crypto global. The Effect client SDK currently interprets `window` alone as a browser, enters session initialization, and throws at `crypto.randomUUID()` before the application can render. Disabling replay alone does not prevent this: metadata initialization and later span session linking also reach the browser session record.

Require both `window` and `document` before starting the client browser-session controller, starting standalone metadata, or resolving a browser session ID. This leaves OTLP tracing and user identity intact while skipping browser-only session capture in a non-DOM environment.

Add regression coverage for all three entry points and the underlying session-ID helper. Update existing browser fixtures to supply a document and explicitly disable replay where they test metadata/session linking only.

Validation:
- 38 focused tests pass (native-session and browser-session session suites); removing the guard changes produces four failures, all in the new regression cases.
- Formatting and `git diff --check` pass.
- After upgrading the consuming workspace to Effect 4.0.0-rc.112 and Vitest 4.1.11, all 70 tests across the Effect client suites and browser-session session suite pass. Tests use a local alias to the browser-session workspace source. No dependency or lockfile changes are included in this PR.
- The equivalent fix against SDK 0.7.0 was separately verified in an iOS simulator: the shared application runtime initializes and persisted preferences appear on the first render across process restart. Unmodified published 0.7.1 and 0.8.0 also reproduce the crypto crash with native-shaped globals.
