### PR TITLE
fix(effect-sdk): skip browser sessions in React Native

### DIFF
--- a/packages/browser-session/src/session/session.test.ts
+++ b/packages/browser-session/src/session/session.test.ts
@@ -36,15 +36,16 @@ beforeEach(() => {
 	vi.setSystemTime(new Date("2026-05-22T12:00:00Z"))
 	storage = new FakeStorage()
 	resetVisitorCacheForTests()
-	;(globalThis as { window?: unknown }).window = {
+	vi.stubGlobal("window", {
 		sessionStorage: storage,
 		localStorage: new FakeStorage(),
-	}
+	})
+	vi.stubGlobal("document", { cookie: "" })
 })
 
 afterEach(() => {
 	vi.useRealTimers()
-	delete (globalThis as { window?: unknown }).window
+	vi.unstubAllGlobals()
 })
 
 describe("getSession", () => {
@@ -111,6 +112,13 @@ describe("getSession", () => {
 })
 
 describe("getSessionId", () => {
+	it("does not mint a browser session in React Native", () => {
+		vi.stubGlobal("document", undefined)
+		vi.stubGlobal("crypto", undefined)
+		expect(getSessionId()).toBeUndefined()
+		expect(storage.getItem(STORAGE_KEY)).toBeNull()
+	})
+
 	it("returns undefined outside a browser (SSR)", () => {
 		delete (globalThis as { window?: unknown }).window
 		expect(getSessionId()).toBeUndefined()

--- a/packages/browser-session/src/session/session.ts
+++ b/packages/browser-session/src/session/session.ts
@@ -299,10 +299,10 @@ function touchSession(now: number): SessionRecord {
 /**
  * Resolve the active session id, minting/rotating as needed. Safe to call per
  * span: the activity touch is throttled. Returns `undefined` outside a browser
- * (SSR) so server renders never mint a session shared across requests.
+ * DOM (SSR, React Native), where browser sessions must not be minted.
  */
 export function getSessionId(): string | undefined {
-	if (typeof window === "undefined") return undefined
+	if (typeof window === "undefined" || typeof document === "undefined") return undefined
 	return touchSession(Date.now()).id
 }
 

--- a/packages/effect-sdk/README.md
+++ b/packages/effect-sdk/README.md
@@ -87,7 +87,7 @@ When `MAPLE_INGEST_KEY` is unset, the SDK runs in no-op mode: buffers are draine
 
 The same `MAPLE_ENDPOINT` / `MAPLE_INGEST_KEY` / `MAPLE_ENVIRONMENT` env vars apply, read from the Workers `env` binding.
 
-## Client (Browser)
+## Client (Browser and React Native)
 
 All configuration must be provided programmatically since browsers don't have access to environment variables.
 
@@ -105,6 +105,24 @@ const program = Effect.log("Hello!").pipe(Effect.withSpan("hello"))
 
 Effect.runPromise(program.pipe(Effect.provide(TracerLive)))
 ```
+
+### React Native
+
+Use the explicit `@maple-dev/effect-sdk/client` entry point with a compatible
+Effect 4 version (see `peerDependencies`). `Maple.layer` and `MapleFlush.make`
+can export Effect traces, logs, and metrics using the runtime's `fetch`,
+`TextEncoder`, and `TextDecoder`. `identify()` and `clearIdentity()` still
+control `user.id` on Effect spans.
+
+React Native's `window` does not imply a browser DOM. Browser sessions, replay,
+and automatic `session.id` linking are skipped when `document` is absent;
+browser session events (`track`) are not exported in this environment. Native
+app lifecycle flushing and global native error capture require integration by
+the host app; the browser handlers below do not provide those integrations.
+
+Regression coverage uses React Native-shaped globals and the real OTLP layers
+with a mocked HTTP transport. It does not certify a particular Expo, Hermes,
+or device version.
 
 ### Uncaught errors (built in)
 

--- a/packages/effect-sdk/src/client/flushable.test.ts
+++ b/packages/effect-sdk/src/client/flushable.test.ts
@@ -269,21 +269,28 @@ describe("MapleFlush.make (client)", () => {
 
 	it("stamps session.id from the self-managed session when no sink is published", async () => {
 		const { calls, restore: rf } = setupFetch()
-		// Standalone: no @maple-dev/browser sink, just a browser-like window with
+		// Standalone: no @maple-dev/browser sink, just a browser DOM with
 		// sessionStorage. The bundled @maple/browser-session core must mint a
 		// session and stamp its id on every span.
 		const store = new Map<string, string>()
-		vi.stubGlobal("window", {
-			sessionStorage: {
-				getItem: (k: string) => store.get(k) ?? null,
-				setItem: (k: string, v: string) => void store.set(k, v),
-			},
-		})
+		vi.stubGlobal(
+			"window",
+			Object.assign(new EventTarget(), {
+				sessionStorage: {
+					getItem: (k: string) => store.get(k) ?? null,
+					setItem: (k: string, v: string) => void store.set(k, v),
+				},
+			}),
+		)
+		vi.stubGlobal(
+			"document",
+			Object.assign(new EventTarget(), { cookie: "", visibilityState: "visible" }),
+		)
 		restore = () => {
 			rf()
 			vi.unstubAllGlobals()
 		}
-		const telemetry = make(baseConfig)
+		const telemetry = make({ ...baseConfig, replay: { enabled: false } })
 
 		await Effect.runPromise(
 			Effect.succeed(undefined).pipe(Effect.withSpan("op-a"), Effect.provide(telemetry.layer)),
@@ -309,6 +316,7 @@ describe("MapleFlush.make (client)", () => {
 			const sessionAttr = span.attributes.find((a) => a.key === "session.id")
 			expect(sessionAttr?.value.stringValue).toBe(stored.id)
 		}
+		await telemetry.dispose()
 	})
 
 	it("flushes on pagehide and dispose() removes the unload listeners", async () => {

--- a/packages/effect-sdk/src/client/flushable.ts
+++ b/packages/effect-sdk/src/client/flushable.ts
@@ -85,7 +85,7 @@ export interface MapleClientFlushableConfig {
 	 * Post session metadata rows for the standalone session so it appears in
 	 * Maple's Sessions UI (list entry + linked traces, no replay recording).
 	 * Default `true`; no-ops when `@maple-dev/browser` is on the page (it owns
-	 * the session rows), during SSR, or without an ingest key.
+	 * the session rows), without a browser DOM, or without an ingest key.
 	 */
 	readonly emitSessionMeta?: boolean | undefined
 	/**

--- a/packages/effect-sdk/src/client/layer.ts
+++ b/packages/effect-sdk/src/client/layer.ts
@@ -31,7 +31,7 @@ export interface MapleClientConfig {
 	 * Post session metadata rows for the standalone session so it appears in
 	 * Maple's Sessions UI (list entry + linked traces, no replay recording).
 	 * Default `true`; no-ops when `@maple-dev/browser` is on the page (it owns
-	 * the session rows), during SSR, or without an ingest key.
+	 * the session rows), without a browser DOM, or without an ingest key.
 	 */
 	readonly emitSessionMeta?: boolean | undefined
 	/**

--- a/packages/effect-sdk/src/client/react-native.test.ts
+++ b/packages/effect-sdk/src/client/react-native.test.ts
@@ -1,0 +1,155 @@
+// SAFETY-FILE: OTLP payloads are produced by the real SDK and decoded only for assertions.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+interface Attribute {
+	readonly key: string
+	readonly value: { readonly stringValue?: string }
+}
+
+interface OtlpPayload {
+	readonly resourceSpans?: ReadonlyArray<{
+		readonly scopeSpans: ReadonlyArray<{
+			readonly spans: ReadonlyArray<{
+				readonly name: string
+				readonly attributes: ReadonlyArray<Attribute>
+			}>
+		}>
+	}>
+	readonly resourceLogs?: ReadonlyArray<{
+		readonly scopeLogs: ReadonlyArray<{
+			readonly logRecords: ReadonlyArray<{ readonly body: { readonly stringValue?: string } }>
+		}>
+	}>
+	readonly resourceMetrics?: ReadonlyArray<{
+		readonly scopeMetrics: ReadonlyArray<{
+			readonly metrics: ReadonlyArray<{ readonly name: string }>
+		}>
+	}>
+}
+
+const config = {
+	serviceName: "native-test",
+	endpoint: "https://collector.test",
+	ingestKey: "test-key",
+	autoFlushInterval: false as const,
+}
+
+beforeEach(() => {
+	vi.resetModules()
+	// React Native exposes window, but has neither a DOM nor Web Crypto.
+	// Keep its fetch/encoding primitives: this suite mocks only the transport.
+	vi.stubGlobal("window", globalThis)
+	vi.stubGlobal("navigator", { product: "ReactNative" })
+	for (const name of [
+		"document",
+		"crypto",
+		"location",
+		"localStorage",
+		"sessionStorage",
+		"addEventListener",
+		"removeEventListener",
+	])
+		vi.stubGlobal(name, undefined)
+})
+
+afterEach(async () => {
+	const { clearIdentity } = await import("./index.js")
+	const { resetConsentForTests } = await import("@maple/browser-session")
+	clearIdentity()
+	resetConsentForTests()
+	vi.unstubAllGlobals()
+})
+
+describe("React Native client telemetry", () => {
+	it.each(["layer", "flushable"] as const)(
+		"imports and exports traces, logs, metrics, and identity with %s",
+		async (preset) => {
+			const posts: Array<{ readonly request: Request; readonly body: OtlpPayload }> = []
+			vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = new Request(input, init)
+				posts.push({ request, body: await request.json() })
+				return new Response(null, { status: 200 })
+			})
+			// Import the public client entry only after removing browser globals, so
+			// eager module initialization is covered too. No telemetry modules are mocked.
+			const { Maple, MapleFlush } = await import("./index.js")
+			const { Effect, ManagedRuntime, Metric } = await import("effect")
+			const telemetry = preset === "flushable" ? MapleFlush.make(config) : undefined
+			const runtime = ManagedRuntime.make(telemetry?.layer ?? Maple.layer(config))
+			try {
+				await runtime.runPromise(
+					Effect.gen(function* () {
+						yield* Maple.identify("native-user")
+						yield* Effect.log("native-log").pipe(Effect.withSpan("native-span"))
+						yield* Maple.clearIdentity
+						yield* Effect.void.pipe(Effect.withSpan("anonymous-span"))
+						yield* Metric.update(Metric.counter("native_counter"), 1)
+					}),
+				)
+			} finally {
+				try {
+					await runtime.dispose()
+				} finally {
+					await telemetry?.dispose()
+				}
+			}
+
+			const spans = posts.flatMap(
+				({ body }) =>
+					body.resourceSpans?.flatMap((resource) =>
+						resource.scopeSpans.flatMap((scope) => scope.spans),
+					) ?? [],
+			)
+			expect(spans.map((span) => span.name)).toEqual(["native-span", "anonymous-span"])
+			expect(spans[0].attributes).toContainEqual({
+				key: "user.id",
+				value: { stringValue: "native-user" },
+			})
+			expect(spans[1].attributes.some((attribute) => attribute.key === "user.id")).toBe(false)
+			expect(
+				spans.every((span) => span.attributes.every((attribute) => attribute.key !== "session.id")),
+			).toBe(true)
+			const logs = posts.flatMap(
+				({ body }) =>
+					body.resourceLogs?.flatMap((resource) =>
+						resource.scopeLogs.flatMap((scope) => scope.logRecords),
+					) ?? [],
+			)
+			expect(logs).toContainEqual(expect.objectContaining({ body: { stringValue: "native-log" } }))
+			const metrics = posts.flatMap(
+				({ body }) =>
+					body.resourceMetrics?.flatMap((resource) =>
+						resource.scopeMetrics.flatMap((scope) => scope.metrics),
+					) ?? [],
+			)
+			expect(metrics).toContainEqual(expect.objectContaining({ name: "native_counter" }))
+			expect(new Set(posts.map(({ request }) => request.url))).toEqual(
+				new Set([
+					"https://collector.test/v1/traces",
+					"https://collector.test/v1/logs",
+					"https://collector.test/v1/metrics",
+				]),
+			)
+			for (const { request } of posts) {
+				expect(request.headers.get("authorization")).toBe("Bearer test-key")
+			}
+		},
+	)
+
+	it("skips standalone browser metadata without requiring Web Crypto", async () => {
+		const { setupStandaloneSession } = await import("./standalone-session.js")
+		expect(setupStandaloneSession(config)).toBeUndefined()
+	})
+
+	it("still configures consent when browser session startup is skipped", async () => {
+		const { startClientSession } = await import("./replay-loader.js")
+		const { getActiveSink, hasConsent } = await import("@maple/browser-session")
+		const session = startClientSession({ ...config, privacy: { requireConsent: true } })
+		try {
+			expect(hasConsent()).toBe(false)
+			expect(getActiveSink()).toBeUndefined()
+		} finally {
+			await session.stop()
+		}
+	})
+})

--- a/packages/effect-sdk/src/client/replay-loader.ts
+++ b/packages/effect-sdk/src/client/replay-loader.ts
@@ -71,7 +71,9 @@ export const startClientSession = (config: ClientSessionConfig): ClientSessionHa
 	configurePrivacy(config.privacy)
 	if (!hasConsent()) clearPendingEvents()
 	const ingestKey = config.ingestKey
-	if (typeof window === "undefined" || !ingestKey || readSessionSink()) return noOpHandle
+	// React Native exposes window without a browser DOM or Web Crypto.
+	if (typeof window === "undefined" || typeof document === "undefined" || !ingestKey || readSessionSink())
+		return noOpHandle
 
 	const engineConfig = {
 		endpoint: config.endpoint.replace(/\/$/, ""),

--- a/packages/effect-sdk/src/client/standalone-session.test.ts
+++ b/packages/effect-sdk/src/client/standalone-session.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@effect/vitest"
 import { getActiveSink } from "@maple/browser-session"
 import { Effect } from "effect"
 import { afterEach, beforeEach, expect, vi } from "vitest"
-import { make } from "./flushable.js"
+import { make as makeTelemetry } from "./flushable.js"
 import { resetStandaloneSessionForTests } from "./standalone-session.js"
 import { identify } from "./user.js"
 
@@ -42,15 +42,19 @@ const setupFetch = () => {
 	return { metaPosts, restore: () => void (globalThis.fetch = original) }
 }
 
-const stubWindow = () => {
+const stubBrowser = () => {
 	const store = new Map<string, string>()
-	vi.stubGlobal("window", {
-		sessionStorage: {
-			getItem: (k: string) => store.get(k) ?? null,
-			setItem: (k: string, v: string) => void store.set(k, v),
-		},
-		location: { href: "https://app.example.com/dashboard" },
-	})
+	vi.stubGlobal(
+		"window",
+		Object.assign(new EventTarget(), {
+			sessionStorage: {
+				getItem: (k: string) => store.get(k) ?? null,
+				setItem: (k: string, v: string) => void store.set(k, v),
+			},
+			location: { href: "https://app.example.com/dashboard" },
+		}),
+	)
+	vi.stubGlobal("document", Object.assign(new EventTarget(), { cookie: "", visibilityState: "visible" }))
 	return store
 }
 
@@ -62,16 +66,25 @@ const baseConfig = {
 	serviceVersion: "63c0c0321644dce742e92dfd09fb96e907649bc4",
 	autoFlushInterval: false as const,
 	flushOnUnload: false as const,
+	replay: { enabled: false },
 }
 
 describe("standalone session emission (client)", () => {
 	let restore: () => void
+	const clients: Array<ReturnType<typeof makeTelemetry>> = []
+	const make = (config: Parameters<typeof makeTelemetry>[0]) => {
+		const client = makeTelemetry(config)
+		clients.push(client)
+		return client
+	}
 
 	beforeEach(() => {
 		resetStandaloneSessionForTests()
 	})
 
-	afterEach(() => {
+	afterEach(async () => {
+		await Promise.all(clients.splice(0).map((client) => client.dispose()))
+		resetStandaloneSessionForTests()
 		identify(undefined)
 		restore?.()
 		vi.unstubAllGlobals()
@@ -80,7 +93,7 @@ describe("standalone session emission (client)", () => {
 	it("posts an active session row on make() with the stored session id", async () => {
 		const { metaPosts, restore: r } = setupFetch()
 		restore = r
-		const store = stubWindow()
+		const store = stubBrowser()
 
 		make(baseConfig)
 
@@ -107,7 +120,7 @@ describe("standalone session emission (client)", () => {
 	it("normalizes cleared identity to an anonymous session row", async () => {
 		const { metaPosts, restore: r } = setupFetch()
 		restore = r
-		stubWindow()
+		stubBrowser()
 		identify("user_to_clear")
 		identify(undefined)
 
@@ -120,7 +133,7 @@ describe("standalone session emission (client)", () => {
 	it("keeps persisted click/error totals and adds live capture deltas", async () => {
 		const { metaPosts, restore: r } = setupFetch()
 		restore = r
-		const store = stubWindow()
+		const store = stubBrowser()
 		store.set(
 			"maple.session",
 			JSON.stringify({
@@ -160,7 +173,7 @@ describe("standalone session emission (client)", () => {
 	it("keeps the session alive while a second client runtime still holds it", async () => {
 		const { metaPosts, restore: r } = setupFetch()
 		restore = r
-		stubWindow()
+		stubBrowser()
 
 		const first = make(baseConfig)
 		const second = make(baseConfig)
@@ -180,7 +193,7 @@ describe("standalone session emission (client)", () => {
 	it("treats a repeated dispose of the same runtime as a no-op", async () => {
 		const { metaPosts, restore: r } = setupFetch()
 		restore = r
-		stubWindow()
+		stubBrowser()
 
 		const telemetry = make(baseConfig)
 		await new Promise((resolve) => setTimeout(resolve, 0))
@@ -199,7 +212,7 @@ describe("standalone session emission (client)", () => {
 			rf()
 			delete g.__MAPLE_BROWSER_SESSION__
 		}
-		stubWindow()
+		stubBrowser()
 
 		make(baseConfig)
 
@@ -213,7 +226,7 @@ describe("standalone session emission (client)", () => {
 
 		make(baseConfig) // node: no window
 
-		stubWindow()
+		stubBrowser()
 		make({ ...baseConfig, ingestKey: undefined }) // window but no key
 
 		await new Promise((resolve) => setTimeout(resolve, 0))
@@ -223,7 +236,7 @@ describe("standalone session emission (client)", () => {
 	it("attaches observed trace ids to the ended row and rotates sessions", async () => {
 		const { metaPosts, restore: r } = setupFetch()
 		restore = r
-		const store = stubWindow()
+		const store = stubBrowser()
 
 		const telemetry = make(baseConfig)
 		await Effect.runPromise(

--- a/packages/effect-sdk/src/client/standalone-session.ts
+++ b/packages/effect-sdk/src/client/standalone-session.ts
@@ -78,7 +78,13 @@ export const noteStandaloneSpan = (sessionId: string, traceId: string): void => 
 export const setupStandaloneSession = (
 	options: StandaloneSessionOptions,
 ): MetadataSessionHandle | undefined => {
-	if (typeof window === "undefined" || !options.ingestKey || readSessionSink()) return undefined
+	if (
+		typeof window === "undefined" ||
+		typeof document === "undefined" ||
+		!options.ingestKey ||
+		readSessionSink()
+	)
+		return undefined
 	if (current) return leaseCurrent()
 	const handle = startMetadataSession({
 		endpoint: options.endpoint,


### PR DESCRIPTION
React Native exposes `window` without a browser DOM or Web Crypto, so initializing the client SDK tries to create a browser session and crashes at `crypto.randomUUID()`. Guard both session startup paths and the shared per-span `getSessionId()` lookup with `document` availability. Consent configuration still runs before the early return.

Add regression tests that import the public client entry with React Native-shaped globals and exercise the real OTLP layers through a mocked HTTP transport. Both `Maple.layer` and `MapleFlush.make` export traces, logs, metrics, and user identity without creating browser sessions. Update browser fixtures and document the native scope, including unsupported browser session events/replay and host-owned lifecycle/error integration.

Validation:
- Reproduced the original startup crash in both presets; applying only the startup guards still reproduced the crash on the first span; all three guards pass.
- 315 tests pass: Effect SDK (126), shared browser session (170), and browser SDK (19).
- Both affected package typechecks, scoped Effect lint, formatting checks, and the Effect SDK build pass.
- Built client entry smoke-tested with Effect `4.0.0-rc.112` and native-shaped globals; committed tests use the repository's pinned `4.0.0-rc.111`.

This PR fixes browser-session detection. The validation runs under Node with mocked HTTP, not an Expo/Hermes device build; it does not establish full native SDK compatibility.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791285176&installation_model_id=427786&pr_number=767&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F767&signature=e1a5aac3b59776f60c04b4fd923604665cfbcc268ee0db72c56246de44a56d8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->