### PR TITLE
feat(agent-sessions): name the session detail by its agent, and icon the token legend

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -46,10 +46,12 @@ vi.mock("@/lib/services/atoms/warehouse-query-atoms", async (importOriginal) => 
 })
 
 import type { AiSessionSpan } from "@maple/domain/http"
+import { formatSessionDuration } from "@maple/ui/lib/replay-format"
 import { agentSpan, llmSpan, makeSpan, toolSpan, userMessages } from "@/lib/agent-sessions/span-test-support"
 import { buildSessionSummary, type SessionSummary } from "@/lib/agent-sessions/session-summary"
 import { buildSessionTurns, type SessionTurn } from "@/lib/agent-sessions/session-turns"
 import { SessionFlow } from "./session-flow"
+import { SessionHeader, sessionIdentity } from "./session-header"
 import { SessionOverview } from "./session-overview"
 import { SessionViews, type SessionView } from "./session-views"
 import { SessionWaterfall } from "./session-waterfall"
@@ -1249,5 +1251,53 @@ describe("SessionViews", () => {
 		expect(
 			within(spanPopover()).getByRole("button", { name: "Details" }).getAttribute("aria-pressed"),
 		).toBe("true")
+	})
+})
+
+describe("SessionHeader", () => {
+	it("names the session after its agent, with the framework as a fact beside it", () => {
+		const { turns: vendorTurns, summary: vendorSummary } = sessionOf([
+			agentSpan({ spanId: "v-agent", startMs: 0, durationMs: SECOND, vendorId: "langchain" }),
+		])
+		render(<SessionHeader sessionId="sess-1" summary={vendorSummary} turns={vendorTurns} />)
+		expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("billing-agent")
+		expect(screen.getByText("Framework").nextElementSibling?.textContent).toBe("LangChain")
+	})
+
+	it("demotes the opening prompt to a quoted line rather than making it the title", () => {
+		render(<SessionHeader sessionId="sess-1" summary={summary} turns={turns} />)
+		expect(screen.getByText("“fix the webhook retry backoff”")).toBeTruthy()
+		expect(screen.getByRole("heading", { level: 1 }).textContent).not.toContain("webhook")
+	})
+
+	it("shows the full session id as a copyable fact, never as the heading", () => {
+		render(<SessionHeader sessionId="0f3c9a1e-long-session-id" summary={summary} turns={turns} />)
+		const copy = screen.getByRole("button", { name: "Copy Session ID" })
+		expect(copy.textContent).toBe("0f3c9a1e-long-session-id")
+		expect(screen.getByRole("heading", { level: 1 }).textContent).not.toContain("0f3c9a1e")
+	})
+
+	it("counts turns and names the model beside the duration", () => {
+		render(<SessionHeader sessionId="sess-1" summary={summary} turns={turns} />)
+		expect(screen.getByText("Turns").nextElementSibling?.textContent).toBe("2")
+		expect(screen.getByText("Model").nextElementSibling?.textContent).toBe("claude-sonnet-4-5")
+		expect(screen.getByText("Duration").nextElementSibling?.textContent).toBe(
+			formatSessionDuration(summary.wallClockMs),
+		)
+	})
+
+	it("falls back to the framework, then to a generic name, when no agent is named", () => {
+		expect(sessionIdentity({ agentNames: [], vendorIds: ["claude_agent_sdk"] })).toEqual({
+			heading: "Claude Agent SDK session",
+			framework: undefined,
+		})
+		expect(sessionIdentity({ agentNames: [], vendorIds: ["unknown:foo"] })).toEqual({
+			heading: "Agent session",
+			framework: undefined,
+		})
+		expect(sessionIdentity({ agentNames: ["planner"], vendorIds: [] })).toEqual({
+			heading: "planner",
+			framework: undefined,
+		})
 	})
 })

--- a/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from "react"
+
+import { Badge } from "@maple/ui/components/ui/badge"
+import { formatSessionDuration } from "@maple/ui/lib/replay-format"
+import { formatRelativeTimeOrDate } from "@maple/ui/lib/time-format"
+
+import { CopyableValue } from "@/components/attributes"
+import { UserIcon } from "@/components/icons"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import type { SessionSummary } from "@/lib/agent-sessions/session-summary"
+import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
+import { shortTarget } from "@/lib/agent-sessions/span-filters"
+import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
+import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
+
+/**
+ * The page's heading: what ran, when, on what — the facts a reader needs to
+ * know which session this is before any view opens.
+ *
+ * The heading is the agent's name (or, unnamed, the framework's), never the
+ * session id or the opening prompt: the id says nothing to a human, and the
+ * first line of a prompt is usually a boilerplate instruction that reads as a
+ * title the session doesn't deserve. Both stay on the page, each in its own
+ * place — the prompt as a quoted line under the heading, the id as the last
+ * fact, in full, one click from the clipboard.
+ */
+export function SessionHeader({
+	sessionId,
+	summary,
+	turns,
+}: {
+	sessionId: string
+	summary: SessionSummary
+	turns: readonly SessionTurn[]
+}) {
+	const identity = sessionIdentity(summary)
+	const VendorIcon = vendorIcon(summary.vendorIds[0] ?? "")
+	const turnWord = turns[0]?.anchorKind === "trace" ? "segment" : "turn"
+
+	return (
+		<div className="flex min-w-0 flex-col gap-2">
+			<div className="flex min-w-0 items-center gap-2">
+				<VendorIcon size={18} className="shrink-0 text-muted-foreground" aria-hidden />
+				<DashboardLayout.Title title={identity.heading}>{identity.heading}</DashboardLayout.Title>
+				{summary.failed && <Badge variant="error">Failed</Badge>}
+			</div>
+
+			{summary.title !== undefined && (
+				// Quoted and marked with the user glyph so it reads as what it is —
+				// the first thing the user said — and not as a name for the session.
+				<p className="flex min-w-0 items-center gap-1.5 text-muted-foreground text-sm">
+					<UserIcon size={13} className="shrink-0" aria-hidden />
+					<span className="sr-only">Opening prompt:</span>
+					<span className="min-w-0 truncate" title={summary.title}>
+						“{summary.title}”
+					</span>
+				</p>
+			)}
+
+			<dl className="flex flex-wrap items-baseline gap-x-4 gap-y-1 text-xs">
+				{identity.framework !== undefined && <Fact label="Framework">{identity.framework}</Fact>}
+				<Fact label="Started" title={new Date(summary.startMs).toLocaleString()}>
+					{formatRelativeTimeOrDate(summary.startMs)}
+				</Fact>
+				<Fact label="Duration">{formatSessionDuration(summary.wallClockMs)}</Fact>
+				<Fact label={turns.length === 1 ? capitalize(turnWord) : `${capitalize(turnWord)}s`}>
+					{turns.length}
+				</Fact>
+				{summary.models.length > 0 && (
+					<Fact label="Model" title={summary.models.map((model) => model.model).join(", ")} mono>
+						{firstPlusRest(summary.models.map((model) => shortTarget(model.model)))}
+					</Fact>
+				)}
+				{summary.serviceNames.length > 0 && (
+					<Fact label="Service" title={summary.serviceNames.join(", ")} mono>
+						{firstPlusRest(summary.serviceNames)}
+					</Fact>
+				)}
+				<Fact label="Session ID">
+					<CopyableValue value={sessionId} label="Session ID" className="font-mono">
+						{sessionId}
+					</CopyableValue>
+				</Fact>
+			</dl>
+		</div>
+	)
+}
+
+/**
+ * What to call the session. A named agent is the best name there is; without
+ * one the framework stands in, and without even that the page says "Agent
+ * session" rather than parroting an unidentified vendor id. The framework is
+ * returned separately only when it is not already the heading.
+ */
+export function sessionIdentity(summary: Pick<SessionSummary, "agentNames" | "vendorIds">): {
+	heading: string
+	framework: string | undefined
+} {
+	const vendorId = summary.vendorIds[0]
+	const framework = vendorId === undefined ? undefined : vendorLabel(vendorId)
+	const agentName = summary.agentNames[0]
+	if (agentName !== undefined) return { heading: agentName, framework }
+	if (framework !== undefined && framework !== "Unidentified") {
+		return { heading: `${framework} session`, framework: undefined }
+	}
+	return { heading: "Agent session", framework: undefined }
+}
+
+function Fact({
+	label,
+	title,
+	mono,
+	children,
+}: {
+	label: string
+	title?: string
+	mono?: boolean
+	children: ReactNode
+}) {
+	return (
+		<div className="flex min-w-0 max-w-full items-baseline gap-1.5" title={title}>
+			<dt className="shrink-0 font-semibold text-[10px] text-muted-foreground uppercase tracking-[0.08em]">
+				{label}
+			</dt>
+			<dd className={mono ? "min-w-0 truncate font-mono" : "min-w-0 truncate"}>{children}</dd>
+		</div>
+	)
+}
+
+/** "claude-sonnet-5 +1": the first name, the rest as a count — the full list
+ *  goes in the `title`. */
+function firstPlusRest(names: readonly string[]): string {
+	const [first, ...rest] = names
+	if (first === undefined) return ""
+	return rest.length > 0 ? `${first} +${rest.length}` : first
+}
+
+function capitalize(word: string): string {
+	return word[0]!.toUpperCase() + word.slice(1)
+}

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -1,6 +1,15 @@
 import { useMemo, useState, type ReactNode } from "react"
 
-import { ArrowRightIcon, ChevronRightIcon, CircleXmarkIcon } from "@/components/icons"
+import {
+	ArrowRightIcon,
+	ChatBubbleIcon,
+	ChatBubbleSparkleIcon,
+	ChevronRightIcon,
+	CircleXmarkIcon,
+	DatabaseIcon,
+	FloppyDiskIcon,
+	PaperPlaneIcon,
+} from "@/components/icons"
 import { Button } from "@maple/ui/components/ui/button"
 import { formatNumber, formatPercent } from "@maple/ui/lib/format"
 import { formatSessionDuration } from "@maple/ui/lib/replay-format"
@@ -27,12 +36,27 @@ import type { SpanDetailTab } from "./span-expansion"
 import { SpanPopover } from "./span-popover"
 import { OCCUPANCY_DOT_FILL, OCCUPANCY_FILL, OCCUPANCY_LABEL } from "./span-visuals"
 
+// Each bucket carries a glyph in its own colour: what the tokens WERE — sent,
+// replayed from cache, written to it, replied, thought — rather than a swatch
+// that only says which stripe of the bar is which.
 const TOKEN_BUCKETS = [
-	{ key: "input", label: "Input", fill: "bg-chart-2" },
-	{ key: "cacheRead", label: "Cache read", fill: "bg-chart-4" },
-	{ key: "cacheWrite", label: "Cache write", fill: "bg-chart-5" },
-	{ key: "output", label: "Output", fill: "bg-chart-1" },
-	{ key: "reasoning", label: "Reasoning", fill: "bg-chart-3" },
+	{ key: "input", label: "Input", fill: "bg-chart-2", text: "text-chart-2", icon: PaperPlaneIcon },
+	{ key: "cacheRead", label: "Cache read", fill: "bg-chart-4", text: "text-chart-4", icon: DatabaseIcon },
+	{
+		key: "cacheWrite",
+		label: "Cache write",
+		fill: "bg-chart-5",
+		text: "text-chart-5",
+		icon: FloppyDiskIcon,
+	},
+	{ key: "output", label: "Output", fill: "bg-chart-1", text: "text-chart-1", icon: ChatBubbleIcon },
+	{
+		key: "reasoning",
+		label: "Reasoning",
+		fill: "bg-chart-3",
+		text: "text-chart-3",
+		icon: ChatBubbleSparkleIcon,
+	},
 ] as const
 
 const SEVERITY_DOT = {
@@ -503,7 +527,7 @@ function Rail({ summary }: { summary: SessionSummary }) {
 						</div>
 						{tokenBuckets.map((bucket) => (
 							<div key={bucket.key} className="flex items-center gap-2.5">
-								<span aria-hidden className={cn("size-1.5 rounded-xs", bucket.fill)} />
+								<bucket.icon aria-hidden size={13} className={cn("shrink-0", bucket.text)} />
 								<span className="min-w-0 flex-1 truncate text-xs">{bucket.label}</span>
 								<span className="font-mono text-muted-foreground text-xs tabular-nums">
 									{formatNumber(summary.tokens[bucket.key])}

--- a/apps/web/src/lab/agent-session-lab.tsx
+++ b/apps/web/src/lab/agent-session-lab.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react"
 
+import { SessionHeader } from "@/components/agent-sessions/session-detail/session-header"
 import { SessionViews, type SessionView } from "@/components/agent-sessions/session-detail/session-views"
 import { Toggle } from "@maple/ui/components/ui/toggle"
 import { buildAgentSessionFixture, buildCaptureOffFixture } from "@/lab/agent-session-fixture"
@@ -36,13 +37,13 @@ export function AgentSessionLab({ initialView }: { initialView?: SessionView }) 
 
 	return (
 		<div className="flex h-screen flex-col bg-background">
-			<div className="flex shrink-0 items-center gap-4 border-border border-b px-4 py-3">
-				<div className="min-w-0">
-					<h1 className="font-semibold text-sm">{summary.title ?? "Agent session"}</h1>
-					<p className="text-muted-foreground text-xs">
-						{summary.spanCount} spans · {turns.length} turns
-						{selectedSpanId !== undefined && ` · selected ${selectedSpanId}`}
-					</p>
+			{/* The page's own header, over the fixture — the one place to eyeball it. */}
+			<div className="flex shrink-0 items-start gap-4 border-border border-b px-4 py-3">
+				<div className="min-w-0 flex-1">
+					<SessionHeader sessionId="lab-session-0f3c9a1e2b7d" summary={summary} turns={turns} />
+					{selectedSpanId !== undefined && (
+						<p className="mt-1 text-muted-foreground text-xs">selected {selectedSpanId}</p>
+					)}
 				</div>
 				<div className="ml-auto flex shrink-0 items-center gap-2">
 					<Toggle

--- a/apps/web/src/routes/agent-sessions/$sessionId.tsx
+++ b/apps/web/src/routes/agent-sessions/$sessionId.tsx
@@ -5,17 +5,15 @@ import { Schema } from "effect"
 import type { AiSessionSpan } from "@maple/domain/http"
 import { formatWarehouseDateTime } from "@maple/query-engine"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
-import { formatRelativeTimeOrDate } from "@maple/ui/lib/time-format"
 
 import { SquareSparkleIcon } from "@/components/icons"
-import { CopyableValue } from "@/components/attributes"
 import { Alert, AlertDescription } from "@maple/ui/components/ui/alert"
-import { Badge } from "@maple/ui/components/ui/badge"
 import { Button } from "@maple/ui/components/ui/button"
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@maple/ui/components/ui/empty"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { NotFoundError } from "@/components/route-error"
 import { QueryErrorState } from "@/components/common/query-error-state"
+import { SessionHeader } from "@/components/agent-sessions/session-detail/session-header"
 import {
 	isSessionView,
 	SessionViews,
@@ -27,10 +25,8 @@ import {
 	buildBackToSessionsHref,
 	resolveWindow,
 } from "@/lib/agent-sessions/session-window"
-import { buildSessionSummary, type SessionSummary } from "@/lib/agent-sessions/session-summary"
+import { buildSessionSummary } from "@/lib/agent-sessions/session-summary"
 import { buildSessionTurns } from "@/lib/agent-sessions/session-turns"
-import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
-import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { displayError } from "@/lib/error-messages"
 import { aiSessionSpansResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
@@ -223,47 +219,12 @@ function SessionDetailBody({
 		[navigate, search.span],
 	)
 
-	// Message content is opt-in and off by default, so most sessions have no
-	// opening user message to title the page with.
-	const title = summary.title ?? breadcrumbSessionId(sessionId)
-	// The framework that emitted the session, as its mark — the subtitle names it.
-	const VendorIcon = vendorIcon(summary.vendorIds[0] ?? "")
-
 	return (
 		<SessionShell sessionId={sessionId}>
 			<DashboardLayout.Content>
 				<DashboardLayout.Sticky>
 					<DashboardLayout.Header
-						titleContent={
-							<div className="flex min-w-0 items-center gap-2">
-								<VendorIcon
-									size={16}
-									className="shrink-0 text-muted-foreground"
-									aria-hidden
-								/>
-								<DashboardLayout.Title title={title}>
-									{summary.title === undefined ? (
-										// The id fallback title copies the full session id.
-										<CopyableValue value={sessionId} label="Session ID">
-											{title}
-										</CopyableValue>
-									) : (
-										title
-									)}
-								</DashboardLayout.Title>
-								{summary.failed && <Badge variant="error">Failed</Badge>}
-								{summary.title !== undefined && (
-									<CopyableValue
-										value={sessionId}
-										label="Session ID"
-										className="shrink-0 font-mono font-normal text-muted-foreground text-xs"
-									>
-										{breadcrumbSessionId(sessionId)}
-									</CopyableValue>
-								)}
-							</div>
-						}
-						description={sessionSubtitle(summary)}
+						titleContent={<SessionHeader sessionId={sessionId} summary={summary} turns={turns} />}
 					/>
 				</DashboardLayout.Sticky>
 				{/* `py-0` (the content blocks carry the padding instead) so the views'
@@ -353,15 +314,4 @@ function EmptySession({ sessionId, windowed }: { sessionId: string; windowed: bo
 			</Button>
 		</Empty>
 	)
-}
-
-/** The identifying facts the list row carried and this page had dropped. The
- *  trace count is not one of them — the views below count what they draw. */
-function sessionSubtitle(summary: SessionSummary): string {
-	return [primaryVendorLabel(summary.vendorIds), formatRelativeTimeOrDate(summary.startMs)].join(" · ")
-}
-
-function primaryVendorLabel(vendorIds: readonly string[]): string {
-	const vendorId = vendorIds[0]
-	return vendorId === undefined ? "Agent session" : vendorLabel(vendorId)
 }


### PR DESCRIPTION
## What

**Session detail header rework** (`apps/web/src/components/agent-sessions/session-detail/session-header.tsx`)

The heading was the session id, or the first line of the opening prompt — neither tells a reader which session this is. Now:

- **Heading** = the agent's name (`gen_ai.agent.name`), falling back to `<Framework> session`, then `Agent session`. Vendor mark beside it, `Failed` badge unchanged.
- **Opening prompt** demoted to a quoted, user-glyphed line under the heading — it stays useful for telling sessions apart, but no longer masquerades as a title.
- **Facts strip** (labelled, wraps on narrow widths, sticky in every view): Framework · Started (absolute in tooltip) · Duration · Turns/Segments · Model (`+N`, full list in tooltip) · Service (`+N`) · **Session ID in full, click-to-copy**.
- The breadcrumb keeps the shortened id.

**Token breakdown**: legend swatches → glyphs in each bucket's colour (input = paper plane, cache read = database, cache write = floppy, output = chat bubble, reasoning = sparkle bubble). The stacked bar is unchanged.

**Lab**: `/lab/agent-session` renders the real header over its fixture.

## Verified

- `session-detail.test.tsx`: 67 passing (5 new for the header — naming, prompt demotion, copyable id, facts, identity fallbacks).
- `turbo typecheck --filter=@maple/web` green; oxlint clean on the touched files.
- Eyeballed on the lab page at 1400px and 640px, with and without message capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791285794&installation_model_id=427786&pr_number=769&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F769&signature=5403c4969cf172a495859ce43c0e6ea06564023875d9bf8d2721d6871b6278b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->