### PR TITLE
feat(landing): show SigNoz's $49 included usage as a credit on the receipt

### DIFF
--- a/apps/landing/src/components/PricingCalculator.tsx
+++ b/apps/landing/src/components/PricingCalculator.tsx
@@ -5,6 +5,7 @@ import {
 	estimateMaple,
 	estimateVendor,
 	formatCurrency,
+	formatLineAmount,
 	formatSliderValue,
 	MAPLE_PRICING_NOTE,
 	PRICES_VERIFIED,
@@ -170,7 +171,7 @@ export function PricingCalculator({ competitor, compact = false }: { competitor:
 							<div key={item.label} className="flex items-center justify-between text-xs">
 								<span className="text-fg-muted">{item.label}</span>
 								<span className="font-mono text-fg">
-									{item.value === 0 ? "Free" : `$${Math.round(item.value)}`}
+									{item.value === 0 ? "Free" : formatLineAmount(item.value)}
 								</span>
 							</div>
 						))}
@@ -200,7 +201,7 @@ export function PricingCalculator({ competitor, compact = false }: { competitor:
 							<div key={item.label} className="flex items-center justify-between text-xs">
 								<span className="text-fg-muted">{item.label}</span>
 								<span className="font-mono text-fg">
-									{item.value === 0 ? "Free" : `$${Math.round(item.value)}`}
+									{item.value === 0 ? "Free" : formatLineAmount(item.value)}
 								</span>
 							</div>
 						))}

--- a/apps/landing/src/components/compare/Receipts.astro
+++ b/apps/landing/src/components/compare/Receipts.astro
@@ -20,6 +20,7 @@ import {
 	estimateMaple,
 	estimateVendor,
 	formatCurrency,
+	formatLineAmount,
 	MAPLE_PRICING_NOTE,
 	PRICES_VERIFIED,
 	vendorCaveat,
@@ -53,7 +54,7 @@ const verifiedLabel = new Date(`${PRICES_VERIFIED}-15T00:00:00Z`).toLocaleDateSt
 	timeZone: "UTC",
 });
 
-const money = (amount: number) => (amount === 0 ? m.cmp_price_free() : `$${Math.round(amount).toLocaleString()}`);
+const money = (amount: number) => (amount === 0 ? m.cmp_price_free() : formatLineAmount(amount));
 ---
 
 <section id="price" class="scroll-mt-28 border-t border-border bg-bg">

--- a/apps/landing/src/lib/vendor-pricing.ts
+++ b/apps/landing/src/lib/vendor-pricing.ts
@@ -110,6 +110,10 @@ export const formatSliderValue = (config: SliderConfig, value: number): string =
 export const describeWorkload = (vendor: Vendor, values: Record<string, number>): string =>
 	vendorConfigs[vendor].sliders.map((slider) => `${slider.label} ${formatSliderValue(slider, values[slider.key])}`).join(" · ")
 
+/** A receipt line: "$49", or "−$49" for a credit. Callers render 0 as "Free". */
+export const formatLineAmount = (amount: number): string =>
+	`${amount < 0 ? "−" : ""}$${Math.round(Math.abs(amount)).toLocaleString()}`
+
 export const formatCurrency = (amount: number): string => {
 	if (amount >= 100000) return `$${(amount / 1000).toFixed(0)}k`
 	if (amount >= 1000) return `$${(amount / 1000).toFixed(1)}k`
@@ -224,30 +228,31 @@ const openObserve = (values: Record<string, number>): Estimate => {
 const signoz = (values: Record<string, number>): Estimate => {
 	// SigNoz Cloud (Teams) published pricing: logs & traces $0.30/GB ingested at
 	// the default 15-day retention, metrics $0.10 per million samples at the
-	// default 1-month retention, and a $49/mo minimum that *includes* $49 of
-	// usage — the bill is max($49, usage), matching SigNoz's own calculator.
+	// default 1-month retention, and a $49/mo base fee that *includes* $49 of
+	// usage — so the receipt is base fee + usage − (up to) $49 of included
+	// usage, i.e. max($49, usage), matching SigNoz's own calculator.
 	// $49 is the standing base fee, not a promo: SigNoz cut it from $199 in
 	// May 2025 and the struck-through $199 on their page is the old anchor.
 	// Longer retention costs more and is not modeled ($/GB: 15d 0.30, 30d 0.40,
 	// 90d 0.60, 180d 0.80, 1y 1.40; $/mn metric samples: 1mo 0.10, 3mo 0.12,
 	// 6mo 0.15, 13mo 0.18), which biases the estimate in SigNoz's favor.
-	const MINIMUM = 49
+	const BASE_FEE = 49
+	const INCLUDED_USAGE = 49
 	const logCost = values.logVolume * 0.3
 	const traceCost = values.traceVolume * 0.3
 	const metricCost = values.metricSamples * 0.1
 	const usage = logCost + traceCost + metricCost
-	const minimumTopUp = Math.max(0, MINIMUM - usage)
+	const includedUsage = Math.min(INCLUDED_USAGE, usage)
 
 	return {
-		total: Math.max(MINIMUM, usage),
+		total: BASE_FEE + usage - includedUsage,
 		breakdown: [
+			{ label: "Base fee", value: BASE_FEE, detail: "$49/mo Teams plan base fee" },
 			{ label: "Logs", value: logCost, detail: `${values.logVolume} GB × $0.30` },
 			{ label: "Traces", value: traceCost, detail: `${values.traceVolume} GB × $0.30` },
 			{ label: "Metrics", value: metricCost, detail: `${values.metricSamples}M samples × $0.10/M` },
-			...(minimumTopUp > 0
-				? [{ label: "Minimum spend", value: minimumTopUp, detail: "$49/mo minimum includes $49 of usage" }]
-				: []),
-		].filter((item) => item.value > 0),
+			{ label: "Included usage", value: -includedUsage, detail: "$49 of usage included in the base fee" },
+		].filter((item) => item.value !== 0),
 	}
 }
 
@@ -343,7 +348,7 @@ export const vendorCaveat = {
 	openobserve:
 		"OpenObserve modeled at its headline $0.50/GB ingestion rate, which already includes the 30% annual-commitment discount; query fees ($0.01/GB scanned) and extended retention beyond the included 30 days for logs and traces ($0.02/GB per additional 30 days) are not included, which favors OpenObserve.",
 	signoz:
-		"SigNoz modeled on the Teams plan at its default retention (logs and traces $0.30/GB at 15 days, metrics $0.10 per million samples at 1 month) with the $49/mo minimum that includes $49 of usage; longer retention costs more (up to $1.40/GB at 1 year) and is not included, which favors SigNoz. Maple bills per GB, so the Maple estimate converts metric samples at roughly 0.1 KB per data point (0.1 GB per million samples).",
+		"SigNoz modeled on the Teams plan at its default retention (logs and traces $0.30/GB at 15 days, metrics $0.10 per million samples at 1 month) with the $49/mo base fee, from which $49 of usage is subtracted as included; longer retention costs more (up to $1.40/GB at 1 year) and is not included, which favors SigNoz. Maple bills per GB, so the Maple estimate converts metric samples at roughly 0.1 KB per data point (0.1 GB per million samples).",
 } satisfies Record<Vendor, string>
 
 export const MAPLE_PRICING_NOTE =

--- a/apps/landing/src/pages/compare/[slug].md.ts
+++ b/apps/landing/src/pages/compare/[slug].md.ts
@@ -18,6 +18,7 @@ import {
 	describeWorkload,
 	estimateMaple,
 	estimateVendor,
+	formatLineAmount,
 	MAPLE_PRICING_NOTE,
 	PRICES_VERIFIED,
 	vendorCaveat,
@@ -30,7 +31,7 @@ export const getStaticPaths: GetStaticPaths = () =>
 const monthLabel = (checked: string) =>
 	new Date(`${checked}-15T00:00:00Z`).toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" })
 
-const dollars = (amount: number) => `$${Math.round(amount).toLocaleString()}`
+const dollars = (amount: number) => formatLineAmount(amount)
 
 /** Pipes inside a cell would break the row. */
 const cell = (text: string) => text.replace(/\|/g, "\\|")


### PR DESCRIPTION
SigNoz's $49/mo base fee includes $49 of usage. The calculator already priced that correctly as `max($49, usage)`, but the receipt hid it: above $49 of usage the base fee never appeared, and below it a synthetic "Minimum spend" top-up line did.

This models it the way SigNoz bills: a `Base fee $49` line, the per-signal usage lines, and an `Included usage −$49` credit (capped at usage). Totals are unchanged — defaults still come to $110, a 10/10/10 workload still to $49.

Credits are the first negative line items, so a new `formatLineAmount` renders them as `−$49` in the calculator island and in both the HTML and Markdown `/compare` receipts.

Landing vitest green (31/31).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mapletechlabs/maple/pull/774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791375274&installation_model_id=427786&pr_number=774&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F774&signature=b22b27511064f37580c99be24b91f9cf7b05df0274bf12fcbfe2afa6a9f66fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->