### PR TITLE
ci(deploy-prd): assert the api Worker serves the commit the run deployed

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -143,6 +143,10 @@ jobs:
             # Liveness only. Every other prod Worker is covered by the
             # "Prod revision skew" alert, which compares
             # `vcs.ref.head.revision` across services from their own telemetry.
+            # Which services that is, and the fact that it assumes they always
+            # deploy together, is pinned in `PRD_LOCKSTEP_REVISION_SERVICES`
+            # (`packages/infra/src/env.ts`) — change what this workflow deploys
+            # and `env.test.ts` will tell you the rule needs editing too.
             - name: Verify the deployed api serves this commit
               if: ${{ always() && steps.deploy.outcome != 'skipped' }}
               env:

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -127,6 +127,48 @@ jobs:
               env:
                   AWS_ACCOUNT_ID: ${{ steps.aws.outputs.aws-account-id }}
 
+            # Alchemy isolates per-resource failures on purpose: a Worker that
+            # fails to upload never interrupts its siblings, so a deploy can
+            # leave production serving two commits at once. It did on
+            # 2026-09-07 — `api` was rejected with `ScriptStartupError` while
+            # `app`, `landing`, `alerting` and `ingest` all shipped, and prod
+            # ran a 6h-old api behind a current web until someone read the log.
+            #
+            # `always()`: when the deploy step fails this is exactly when the
+            # answer matters — it names which Worker is stale instead of
+            # leaving it in a 4000-line log. It also catches the quieter case
+            # the deploy cannot report at all, where alchemy succeeds but the
+            # script serving traffic is not the one we just uploaded.
+            #
+            # Liveness only. Every other prod Worker is covered by the
+            # "Prod revision skew" alert, which compares
+            # `vcs.ref.head.revision` across services from their own telemetry.
+            - name: Verify the deployed api serves this commit
+              if: ${{ always() && steps.deploy.outcome != 'skipped' }}
+              env:
+                  EXPECTED: ${{ env.COMMIT_SHA }}
+              run: |
+                  set -uo pipefail
+                  # Cloudflare propagates a new script over a few seconds, so a
+                  # single probe races the rollout rather than testing it.
+                  for attempt in 1 2 3 4 5 6; do
+                      served=$(curl -fsS --max-time 10 -D - -o /dev/null https://api.maple.dev/health 2>/dev/null \
+                          | tr -d '\r' | awk 'tolower($1) == "x-maple-revision:" { print $2 }')
+                      [ "$served" = "$EXPECTED" ] && break
+                      echo "attempt $attempt: api serves '${served:-<none>}', expected '$EXPECTED'"
+                      sleep 10
+                  done
+                  if [ "$served" = "$EXPECTED" ]; then
+                      echo "api is serving $EXPECTED"
+                      exit 0
+                  fi
+                  if [ -z "$served" ]; then
+                      echo "::error::api /health returned no x-maple-revision header. Either the Worker predates this check or it is not answering — check the deploy log for a resource that reported 'fail'."
+                  else
+                      echo "::error::PARTIAL DEPLOY — api is serving $served but this run deployed $EXPECTED. The api Worker did not update; other Workers likely did. Find the resource that reported 'fail' in the deploy log above."
+                  fi
+                  exit 1
+
     # A skipped job does not fail its run, so with CI red this workflow reported
     # SUCCESS while nothing deployed — which is how a broken `main` looked like a
     # string of clean deploys for several commits, and why an Electric deploy

--- a/apps/api/src/worker-bridge.test.ts
+++ b/apps/api/src/worker-bridge.test.ts
@@ -59,7 +59,11 @@ const statusCodeOf = (span: ExportedSpan | undefined): number | undefined => {
 	return value === undefined ? undefined : Number(Object.values(value)[0])
 }
 
-const env = { MAPLE_INGEST_KEY: "maple_sk_test", MAPLE_ENDPOINT: "http://ingest.test" }
+const env = {
+	MAPLE_INGEST_KEY: "maple_sk_test",
+	MAPLE_ENDPOINT: "http://ingest.test",
+	COMMIT_SHA: "deadbeefcafe",
+}
 
 class GraphBuildFailure extends Schema.TaggedError<GraphBuildFailure>()("GraphBuildFailure", {
 	message: Schema.String,
@@ -114,6 +118,8 @@ describe("the api Worker through alchemy's bridge", () => {
 			assert.strictEqual(response.status, 200)
 			assert.strictEqual(body, "OK")
 			assert.strictEqual(response.headers.get("access-control-allow-origin"), "*")
+			// What `deploy-prd.yml` asserts against to catch a partial deploy.
+			assert.strictEqual(response.headers.get("x-maple-revision"), "deadbeefcafe")
 		}),
 	)
 

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -501,7 +501,17 @@ export const makeFetch = (app: Effect.Effect<HttpEffect, unknown>) =>
 		const request = yield* HttpServerRequest.HttpServerRequest
 		const path = pathOf(request.url)
 		if (request.method === "GET" && path === "/health") {
-			return HttpServerResponse.text("OK", { headers: API_CORS_RESPONSE_HEADERS })
+			// The revision this isolate is running, so the deploy that just
+			// uploaded a script can assert the script is the one now serving.
+			// Alchemy isolates per-resource failures, so a red deploy still
+			// leaves every sibling Worker updated and this one on the old
+			// bundle — the body stays `OK` and the answer stays graph-free.
+			const revision = (yield* Cloudflare.WorkerEnvironment).COMMIT_SHA
+			return HttpServerResponse.text("OK", {
+				headers: revision
+					? { ...API_CORS_RESPONSE_HEADERS, "x-maple-revision": revision }
+					: API_CORS_RESPONSE_HEADERS,
+			})
 		}
 		if (request.method === "OPTIONS") return HttpServerResponse.fromWeb(apiCorsPreflightResponse())
 

--- a/packages/infra/src/aws/stage.ts
+++ b/packages/infra/src/aws/stage.ts
@@ -167,6 +167,10 @@ export function resolveIngestTaskSize(stage: MapleStage): IngestTaskSize {
  * when the label comes off or the PR closes. A preview gets no `ingest` domain
  * from `resolveMapleDomains`, so its ALB answers plain HTTP on 80 with no ACM
  * certificate — point an OTLP exporter at `http://<alb>/v1/traces`.
+ *
+ * Changing this for prd also breaks the prd revision lockstep — see
+ * `PRD_LOCKSTEP_REVISION_SERVICES` in `../env.ts`, which the "Prod revision
+ * skew" alert rule depends on. `env.test.ts` fails if the two disagree.
  */
 export function stageDeploysIngest(stage: MapleStage): boolean {
 	return stage.kind === "prd" || stage.kind === "stg" || stage.kind === "pr"
@@ -260,6 +264,10 @@ export function resolveCollectorTaskSize(stage: MapleStage): IngestTaskSize {
  * PR previews are excluded for the same reason they get no Electric config at
  * all: no PlanetScale branch, so nothing to replicate from. Dev stages use the
  * docker `electric` service.
+ *
+ * Changing this for prd also breaks the prd revision lockstep — see
+ * `PRD_LOCKSTEP_REVISION_SERVICES` in `../env.ts`, which the "Prod revision
+ * skew" alert rule depends on. `env.test.ts` fails if the two disagree.
  */
 export function stageDeploysElectric(stage: MapleStage): boolean {
 	return stage.kind === "prd" || stage.kind === "stg"

--- a/packages/infra/src/env.test.ts
+++ b/packages/infra/src/env.test.ts
@@ -14,11 +14,13 @@ import {
 	optionalSecret,
 	planetScaleOAuthEnv,
 	plainWithDefault,
+	PRD_LOCKSTEP_REVISION_SERVICES,
 	requiredPlain,
 	selfObservabilityEnv,
 	tinybirdEnv,
 	type WorkerEnv,
 } from "./env.ts"
+import { stageDeploysElectric, stageDeploysIngest } from "./aws/stage.ts"
 
 /**
  * These groups replaced per-worker copies of the same expressions. The parity
@@ -348,6 +350,41 @@ describe("parity with the pre-refactor per-worker expressions", () => {
 		const env = { PLANETSCALE_OAUTH_TOKEN_INFO_URL: "https://auth.planetscale.com/tokeninfo" }
 		expect(run(planetScaleOAuthEnv, env).PLANETSCALE_OAUTH_TOKEN_INFO_URL).toBe(
 			"https://auth.planetscale.com/tokeninfo",
+		)
+	})
+})
+
+/**
+ * The alert rule this pins lives in the Maple database, not in this repo, so
+ * these assertions are the only thing standing between a stack change and a
+ * rule that silently stops matching production.
+ */
+describe("the prd revision lockstep the skew alert depends on", () => {
+	it("covers exactly the services that deploy together and stamp a revision", () => {
+		// If this fails you changed which services ship in one `alchemy deploy
+		// --stage prd`. Edit the SQL of the "Prod revision skew — a Worker missed
+		// the deploy" rule (2a6e9529-5f73-4478-9fa0-432904ff15c8) to match, THEN
+		// update this list. Out of sync, the rule either pages forever on a
+		// service that no longer ships with the rest, or stops covering one
+		// that does.
+		expect([...PRD_LOCKSTEP_REVISION_SERVICES]).toStrictEqual([
+			"alerting",
+			"electric-sync",
+			"ingest",
+			"maple-api",
+			"maple-web",
+		])
+	})
+
+	it("only claims lockstep for the stage-gated services prd actually deploys", () => {
+		// `ingest` and `electric-sync` are the two members behind a stage
+		// predicate. Flip either away from prd and it stops tracking the other
+		// three, so it has to leave the list — and the rule's SQL — in the same
+		// change.
+		const prd = { kind: "prd" } as const
+		expect(PRD_LOCKSTEP_REVISION_SERVICES.includes("ingest")).toBe(stageDeploysIngest(prd))
+		expect(PRD_LOCKSTEP_REVISION_SERVICES.includes("electric-sync")).toBe(
+			stageDeploysElectric(prd),
 		)
 	})
 })

--- a/packages/infra/src/env.ts
+++ b/packages/infra/src/env.ts
@@ -210,6 +210,39 @@ export const selfObservabilityEnv = (stage: MapleStage): Config.Config<WorkerEnv
 		),
 	)
 
+/**
+ * The prd services that stamp `vcs.ref.head.revision` and are deployed by a
+ * SINGLE `alchemy deploy --stage prd` run, so in a healthy production they all
+ * report the same commit.
+ *
+ * That lockstep is what the **"Prod revision skew — a Worker missed the deploy"**
+ * alert rule (`raw_query`, id `2a6e9529-5f73-4478-9fa0-432904ff15c8`) tests: it
+ * counts distinct revisions across exactly these service names and pages when
+ * the count exceeds one. Alchemy isolates per-resource failures on purpose, so
+ * a deploy can update four of these and leave the fifth on its old script —
+ * that is the 2026-09-07 incident, where `api` sat 6h behind `web`.
+ *
+ * **The alert rule lives in the Maple database, not in this repo, so nothing
+ * mechanically couples the two.** This constant and `env.test.ts` are that
+ * coupling. If you change which services deploy together, you MUST edit the
+ * rule's SQL to match — otherwise it either pages forever on a service that no
+ * longer ships with the rest, or silently stops covering one that does.
+ *
+ * What is deliberately NOT here:
+ * - `scraper` — runs in production but is not part of this stack (see the
+ *   dev-only note in `alchemy.run.ts`), so it sits on its own revision.
+ * - `maple-landing`, `maple-ios` — deployed, but stamp no revision.
+ * - api's background service names (`maple-vcs-sync`, `maple-investigations`,
+ *   …) — the same Worker as `maple-api`, so they add no signal.
+ */
+export const PRD_LOCKSTEP_REVISION_SERVICES = [
+	"alerting",
+	"electric-sync",
+	"ingest",
+	"maple-api",
+	"maple-web",
+] as const
+
 /** Cloudflare account integration (account OAuth — Authorization Code + PKCE). */
 export const cloudflareOAuthEnv: Config.Config<WorkerEnv> = merge(
 	optionalPlain("CLOUDFLARE_OAUTH_CLIENT_ID"),


### PR DESCRIPTION
Follow-up to #782, which fixed the crash. This makes the *next* partial deploy announce itself.

## Why a red run wasn't enough

Alchemy isolates per-resource failures on purpose — [`Apply.ts:1302`](https://github.com/MapleTechLabs/maple/blob/main/node_modules/alchemy/src/Apply.ts): a failed resource records its cause and resolves to void "so `Effect.all` does not interrupt sibling fibers", with the aggregate raised at the end. There is no flag to turn this off, and mostly you don't want one.

The consequence is that **a failed deploy still ships everything that didn't depend on the failure.** On 2026-09-07 `api` was rejected with `ScriptStartupError: Invalid URL string` while `app`, `landing`, `alerting` and `ingest` all updated. Ten consecutive runs failed identically. Production ran a 6h-old api behind a current web, and the only signal was a red run in a tab nobody had open.

The user-visible symptom pointed somewhere else entirely: Agent Sessions decoded a response with no `firstAgentName` and reported **"Maple could not complete the warehouse query"** — against a warehouse that was fine.

## What this adds

`/health` carries the running isolate's `COMMIT_SHA` as `x-maple-revision`:

- body stays `OK`, and the response is still built before the route graph — liveness keeps its existing contract (a cold isolate can still report health with an unrelated binding down)
- `worker-bridge.test.ts` pins the header alongside the existing body/CORS assertions

A post-deploy step probes it and fails the job with a message that names the problem:

```
::error::PARTIAL DEPLOY — api is serving 532f32e3… but this run deployed 92944097…
```

instead of leaving it as one `fail` line in a 4000-line log.

**`always()` is deliberate.** A failed deploy is precisely when "which Worker is stale?" is worth answering. It also covers the quieter case the deploy step cannot report at all — a green apply whose script never became the one serving traffic. That one has bitten before: the `deployment-gate` job's own comment records "an Electric deploy nobody had noticed was never running took an hour to spot."

Six probes at 10s: Cloudflare propagates a new script over a few seconds, so a single request races the rollout rather than testing it.

## Scope

Liveness-only — the other Workers have no public endpoint to probe. They're covered by the companion **"Prod revision skew — a Worker missed the deploy"** alert (`raw_query`, critical), which compares `vcs.ref.head.revision` across `maple-api`, `maple-web`, `alerting`, `electric-sync` and `ingest` using their own telemetry.

That rule was validated against real history before being enabled:

| window | value | notes |
|---|---|---|
| 12 buckets over 5 deploys (06 22:00 → 07 04:00) | **1** every bucket | no false positives, incl. back-to-back deploys |
| 07 14:30–15:00 (broken) | **2** | `maple-api=532f32e39` vs four services on `15dd9d3fc` |
| 07 11:30 → 15:00 (broken) | **2–4**, sustained | one isolated 10:30 blip → why `consecutive_breaches: 2` |

At 30min × 2 breaches it fires ~1h in — about 5h before today's was noticed by hand. It went `breached` (`value=3, samples=5`) on its first evaluation.

## Verification

- `bun typecheck` — 41/41
- `bun run --cwd apps/api test worker-bridge` — 4/4
- The workflow step itself only runs on a real prd deploy; first exercise is on merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791387379&installation_model_id=427786&pr_number=783&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F783&signature=dc34e4afac75df83a31de7fc6a7fd3499e172a8f5c0fd9f62166afb169068903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->