### PR TITLE
feat(agent-sessions): name the model, mark its vendor

### DIFF
--- a/apps/api/src/routes/internal/ai-models.http.test.ts
+++ b/apps/api/src/routes/internal/ai-models.http.test.ts
@@ -45,11 +45,11 @@ const makeHarness = () => {
 	)
 	const { handler, dispose } = HttpRouter.toWebHandler(routes as never, { disableLogger: true })
 
-	const post = async (body: unknown) => {
+	const postTo = async (path: string, body: unknown) => {
 		// SAFETY: the handler's second argument is the Worker environment context,
 		// and this route reads nothing out of it.
 		const response = await handler(
-			new Request("http://maple.test/internal/ai-models/detect", {
+			new Request(`http://maple.test/internal/ai-models/${path}`, {
 				method: "POST",
 				headers: { authorization: "Bearer test-token", "content-type": "application/json" },
 				body: JSON.stringify(body),
@@ -59,7 +59,14 @@ const makeHarness = () => {
 		return { status: response.status, body: JSON.parse(await response.text()) as Record<string, unknown> }
 	}
 
-	return { post, dispose }
+	const post = (body: unknown) => postTo("detect", body)
+	const postMany = async (body: unknown) => {
+		const response = await postTo("detect-many", body)
+		// SAFETY: same as the file header — the array is the route's own output.
+		return { status: response.status, body: response.body as unknown as Array<Record<string, unknown>> }
+	}
+
+	return { post, postMany, dispose }
 }
 
 describe("POST /internal/ai-models/detect", () => {
@@ -127,4 +134,34 @@ describe("POST /internal/ai-models/detect", () => {
 			}
 		},
 	)
+})
+
+describe("POST /internal/ai-models/detect-many", () => {
+	it("answers in request order, one entry per model", async () => {
+		const harness = makeHarness()
+		try {
+			const response = await harness.postMany({
+				models: ["claude-sonnet-4-5-20250929", "my-azure-deployment", "gpt-4o-mini"],
+			})
+			expect(response.status).toBe(200)
+			expect(response.body.map((model) => model.displayName)).toEqual([
+				"Claude Sonnet 4.5",
+				"My Azure Deployment",
+				"GPT-4o-mini",
+			])
+			expect(response.body.map((model) => model.family)).toEqual(["claude", null, null])
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("rejects a batch past the cap rather than resolving it", async () => {
+		const harness = makeHarness()
+		try {
+			const response = await harness.postMany({ models: Array.from({ length: 201 }, () => "gpt-4o") })
+			expect(response.status).toBe(400)
+		} finally {
+			await harness.dispose()
+		}
+	})
 })

--- a/apps/api/src/routes/internal/ai-models.http.ts
+++ b/apps/api/src/routes/internal/ai-models.http.ts
@@ -12,19 +12,38 @@ export const HttpAiModelsInternalLive = HttpApiBuilder.group(
 	MapleInternalApi,
 	"aiModelsInternal",
 	(handlers) =>
-		handlers.handle("detect", ({ payload }) =>
-			Effect.gen(function* () {
-				const tenant = yield* CurrentTenant.Context
-				const detected = detectAiModel(payload.model)
-				// Attributes on the server span, never a child span: this is one call
-				// per model string on a list page. `source: unknown` is the signal that
-				// the catalog wants regenerating.
-				yield* Effect.annotateCurrentSpan({
-					orgId: tenant.orgId,
-					"maple.ai_model.source": detected.source,
-					"maple.ai_model.vendor_slug": detected.vendorSlug ?? "",
-				})
-				return new DetectAiModelResponse(detected)
-			}),
-		),
+		handlers
+			.handle("detect", ({ payload }) =>
+				Effect.gen(function* () {
+					const tenant = yield* CurrentTenant.Context
+					const detected = detectAiModel(payload.model)
+					// Attributes on the server span, never a child span: this is one call
+					// per model string on a list page. `source: unknown` is the signal that
+					// the catalog wants regenerating.
+					yield* Effect.annotateCurrentSpan({
+						orgId: tenant.orgId,
+						"maple.ai_model.source": detected.source,
+						"maple.ai_model.vendor_slug": detected.vendorSlug ?? "",
+					})
+					return new DetectAiModelResponse(detected)
+				}),
+			)
+			.handle("detectMany", ({ payload }) =>
+				Effect.gen(function* () {
+					const tenant = yield* CurrentTenant.Context
+					const detected = payload.models.map(
+						(model) => new DetectAiModelResponse(detectAiModel(model)),
+					)
+					// The batch's shape rather than each model's: an unresolved count
+					// climbing is the same signal `source: unknown` is on the single
+					// endpoint, and it stays one attribute however long the batch is.
+					yield* Effect.annotateCurrentSpan({
+						orgId: tenant.orgId,
+						"maple.ai_model.count": detected.length,
+						"maple.ai_model.unknown_count": detected.filter((model) => model.source === "unknown")
+							.length,
+					})
+					return detected
+				}),
+			),
 )

--- a/apps/web/perf/check-bundle-budget.ts
+++ b/apps/web/perf/check-bundle-budget.ts
@@ -45,7 +45,17 @@ const gzipBytes = chunks.reduce((total, chunk) => total + chunk.gzipBytes, 0)
 // and main had reached 651.7 KB by then. The 33 vendor marks it added cost
 // nothing: the icons chunk hash did not move, they are tree-shaken until a
 // surface renders them.
-const maxGzipBytes = 653 * 1024
+// 682 KB from #783 (2026-09-07): the vendor marks stopped being free. The 33
+// added with the detect contract cost nothing while nothing rendered them;
+// the Agent Sessions list, header, rail and waterfall now do, and the mark
+// table retains all forty in the `icons` chunk startup already loads. Measured
+// against one base, the marks are +27.6 KB (651.5 → 679.1) and the rest of
+// this page is ~0.3; main had reached 652.7 by then, so the honest number is
+// the 680.3 this branch builds. Splitting the marks out was tried and does not
+// work: `@/components/icons` re-exports them, so the barrel's own chunk keeps
+// a static edge to them however they are reached. Dropping the marks from the
+// model lanes is what buys the 27 KB back, not a lazy import.
+const maxGzipBytes = 682 * 1024
 const budgetLabel = `${(maxGzipBytes / 1024).toFixed(1)} KB`
 
 // Anything lazy-only: chat, replay, and every dev-only lab surface. The

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
@@ -13,12 +13,13 @@ import {
 	SquareSparkleIcon,
 	type IconComponent,
 } from "@/components/icons"
+import { useDetectedModels } from "@/hooks/use-detected-models"
 import { formatCost } from "@/lib/agent-sessions/session-summary"
-import { shortTarget } from "@/lib/agent-sessions/span-filters"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
 import { sessionRowId } from "@/lib/agent-sessions/session-window"
 import { TOKEN_BUCKETS, type TokenBucketKey } from "@/lib/agent-sessions/token-buckets"
 import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
+import { ModelLabel } from "./model-label"
 import { sessionIdentity } from "./session-detail/session-header"
 import { CATEGORY_TEXT } from "./session-detail/span-visuals"
 
@@ -59,15 +60,6 @@ function absoluteTs(startTime: string): string {
 }
 
 const plural = (count: number, noun: string) => `${count} ${noun}${count === 1 ? "" : "s"}`
-
-/** "claude-sonnet-5 +1": the first model short, the rest as a count — the full
- *  list goes in the title. Gateways prefix models with a provider path that
- *  would truncate two different models to the same string. */
-function modelsLabel(models: ReadonlyArray<string>): string {
-	const [first, ...rest] = models
-	if (first === undefined) return ""
-	return rest.length > 0 ? `${shortTarget(first)} +${rest.length}` : shortTarget(first)
-}
 
 /** The row's buckets under the detail page's keys, so one palette serves both. */
 function rowTokenBuckets(session: AgentSessionRow): Record<TokenBucketKey, number> {
@@ -149,6 +141,10 @@ export function AgentSessionsList({
 		)
 	}
 
+	// One batch for the whole page, re-asked only when paging brings a model
+	// the list has not seen. Before it lands every row still names its model.
+	const detect = useDetectedModels(sessions.flatMap((session) => session.models))
+
 	return (
 		<div className="@container">
 			{sessions.map((session) => {
@@ -162,6 +158,7 @@ export function AgentSessionsList({
 					agentNames: session.firstAgentName === "" ? [] : [session.firstAgentName],
 					vendorIds: [session.vendorId],
 				})
+				const [firstModel, ...otherModels] = session.models
 				return (
 					<Link
 						key={session.sessionId}
@@ -229,14 +226,18 @@ export function AgentSessionsList({
 						{/* Model lane: what the session ran on. Last lane in, because it is
 						    the one a reader can also get from the filter rail — every lane's
 						    breakpoint is set so the identity lane keeps a legible ~180px
-						    even at the width where the lane appears. */}
-						<div className="hidden w-[9rem] shrink-0 overflow-hidden @7xl:block">
-							<span
-								className="block truncate font-mono text-xs text-muted-foreground"
-								title={session.models.join(", ")}
-							>
-								{modelsLabel(session.models)}
-							</span>
+						    even at the width where the lane appears. The first model by
+						    name and mark, the rest as a count; the raw ids gateways report
+						    stay in the title, where two models that truncate alike are
+						    still told apart. */}
+						<div className="hidden w-[9rem] shrink-0 overflow-hidden text-xs text-muted-foreground @7xl:block">
+							{firstModel !== undefined && (
+								<ModelLabel
+									detected={detect(firstModel)}
+									moreCount={otherModels.length}
+									title={session.models.join(", ")}
+								/>
+							)}
 						</div>
 
 						{/* Activity lane: duration + the work done, in the session page's

--- a/apps/web/src/components/agent-sessions/model-label.test.tsx
+++ b/apps/web/src/components/agent-sessions/model-label.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import type { DetectedModel } from "@/hooks/use-detected-models"
+import { ModelLabel, modelTitle } from "./model-label"
+
+afterEach(cleanup)
+
+const resolved: DetectedModel = {
+	model: "anthropic/claude-sonnet-4-5-20250929",
+	displayName: "Claude Sonnet 4.5",
+	vendorSlug: "anthropic",
+	vendorName: "Anthropic",
+	family: "claude",
+}
+
+// What the hook hands back before the batch lands, and for a model no catalog
+// knows: the shape is the same, so the label branches on nothing.
+const unresolved: DetectedModel = {
+	model: "azure/my-deployment",
+	displayName: "my-deployment",
+	vendorSlug: null,
+	vendorName: null,
+	family: null,
+}
+
+describe("ModelLabel", () => {
+	it("names the model and draws a mark beside it", () => {
+		const { container } = render(<ModelLabel detected={resolved} />)
+
+		expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy()
+		expect(container.querySelector("svg")).toBeTruthy()
+	})
+
+	it("draws the same shape for a model nothing resolved, so the row does not reflow", () => {
+		const { container } = render(<ModelLabel detected={unresolved} />)
+
+		expect(screen.getByText("my-deployment")).toBeTruthy()
+		expect(container.querySelector("svg")).toBeTruthy()
+	})
+
+	it("counts the models a lane has no room for, outside the truncating name", () => {
+		render(<ModelLabel detected={resolved} moreCount={4} />)
+
+		expect(screen.getByText("+4")).toBeTruthy()
+	})
+
+	it("says the vendor and the id the span reported, and defers to a caller's title", () => {
+		expect(modelTitle(resolved)).toBe("Anthropic · anthropic/claude-sonnet-4-5-20250929")
+		expect(modelTitle(unresolved)).toBe("azure/my-deployment")
+
+		const { container } = render(<ModelLabel detected={resolved} title="gpt-4o, claude-opus-5" />)
+		expect(container.querySelector("[title]")?.getAttribute("title")).toBe("gpt-4o, claude-opus-5")
+	})
+})

--- a/apps/web/src/components/agent-sessions/model-label.tsx
+++ b/apps/web/src/components/agent-sessions/model-label.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@maple/ui/lib/utils"
+
+import type { DetectedModel } from "@/hooks/use-detected-models"
+import { modelVendorIcon } from "@/lib/agent-sessions/model-vendor-icon"
+
+/**
+ * A model as a reader should see it: the vendor's mark and the model's name,
+ * in place of the raw id an instrumentation reported.
+ *
+ * The name is prose (`Claude Sonnet 4.5`), so it is not set in mono the way
+ * the id was — and the id is never lost, it moves to the `title` its callers
+ * pass. Nothing here waits on detection: an unresolved model renders its last
+ * path segment beside the generic mark, at the same size, so the row does not
+ * reflow when the batch lands.
+ *
+ * `moreCount` is the "+2" a lane too narrow for a list falls back to. It sits
+ * outside the truncating name so it survives a long first model.
+ */
+export function ModelLabel({
+	detected,
+	moreCount = 0,
+	size = 13,
+	title,
+	className,
+}: {
+	detected: DetectedModel
+	moreCount?: number
+	size?: number
+	title?: string
+	className?: string
+}) {
+	const Icon = modelVendorIcon(detected)
+	return (
+		<span
+			className={cn("flex min-w-0 items-center gap-1.5", className)}
+			title={title ?? modelTitle(detected)}
+		>
+			<Icon size={size} className="shrink-0" aria-hidden />
+			<span className="min-w-0 truncate">{detected.displayName}</span>
+			{moreCount > 0 && <span className="shrink-0 tabular-nums">+{moreCount}</span>}
+		</span>
+	)
+}
+
+/** The `title` for a model shown by name: the vendor, then the id it was reported under. */
+export function modelTitle(detected: DetectedModel): string {
+	return detected.vendorName === null ? detected.model : `${detected.vendorName} · ${detected.model}`
+}

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -554,11 +554,14 @@ describe("SessionOverview", () => {
 		expect(screen.getByText("Reported once for the whole session")).toBeTruthy()
 	})
 
+	// Detection resolves the name from the API; until it answers — and in this
+	// test, which mounts no client — the rail still names the model, and the
+	// gateway-prefixed id it was reported under stays one hover away.
 	it("shows the last path segment of a gateway model id, full id in the title", () => {
 		render(<Overview turns={gatewayTurns} summary={gateway} />)
 
 		const name = screen.getByText("gpt-4o-mini")
-		expect(name.getAttribute("title")).toBe("openrouter/openai/gpt-4o-mini")
+		expect(name.closest("[title]")?.getAttribute("title")).toBe("openrouter/openai/gpt-4o-mini")
 	})
 })
 

--- a/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
@@ -9,9 +9,10 @@ import { UserIcon } from "@/components/icons"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import type { SessionSummary } from "@/lib/agent-sessions/session-summary"
 import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
-import { shortTarget } from "@/lib/agent-sessions/span-filters"
+import { useDetectedModels } from "@/hooks/use-detected-models"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
 import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
+import { ModelLabel } from "../model-label"
 
 /**
  * The page's heading: what ran, when, on what — the facts a reader needs to
@@ -34,8 +35,11 @@ export function SessionHeader({
 	turns: readonly SessionTurn[]
 }) {
 	const identity = sessionIdentity(summary)
+	// The same model set the rail resolves, so both share one batch.
+	const detect = useDetectedModels(summary.models.map((model) => model.model))
 	const VendorIcon = vendorIcon(summary.vendorIds[0] ?? "")
 	const turnWord = turns[0]?.anchorKind === "trace" ? "segment" : "turn"
+	const firstModel = summary.models[0]
 
 	return (
 		<div className="flex min-w-0 flex-col gap-2">
@@ -66,9 +70,14 @@ export function SessionHeader({
 				<Fact label={turns.length === 1 ? capitalize(turnWord) : `${capitalize(turnWord)}s`}>
 					{turns.length}
 				</Fact>
-				{summary.models.length > 0 && (
-					<Fact label="Model" title={summary.models.map((model) => model.model).join(", ")} mono>
-						{firstPlusRest(summary.models.map((model) => shortTarget(model.model)))}
+				{firstModel !== undefined && (
+					<Fact label="Model" title={summary.models.map((model) => model.model).join(", ")}>
+						<ModelLabel
+							detected={detect(firstModel.model)}
+							moreCount={summary.models.length - 1}
+							size={12}
+							title={summary.models.map((model) => model.model).join(", ")}
+						/>
 					</Fact>
 				)}
 				{summary.serviceNames.length > 0 && (

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -23,7 +23,8 @@ import {
 import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
 import { TOKEN_BUCKETS } from "@/lib/agent-sessions/token-buckets"
 import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
-import { shortTarget } from "@/lib/agent-sessions/span-filters"
+import { useDetectedModels } from "@/hooks/use-detected-models"
+import { ModelLabel } from "../model-label"
 import type { SpanDetailTab } from "./span-expansion"
 import { SpanPopover } from "./span-popover"
 import { OCCUPANCY_DOT_FILL, OCCUPANCY_FILL, OCCUPANCY_LABEL } from "./span-visuals"
@@ -425,6 +426,8 @@ function longestGapText(gaps: readonly IdleGap[], turns: readonly SessionTurn[])
 /* -------------------------------------------------------------------------- */
 
 function Rail({ summary }: { summary: SessionSummary }) {
+	// The header resolves the same set, so the two share one batch.
+	const detect = useDetectedModels(summary.models.map((model) => model.model))
 	const tokenBuckets = TOKEN_BUCKETS.filter((bucket) => summary.tokens[bucket.key] > 0)
 	const topModelCost = Math.max(...summary.models.map((model) => model.cost ?? 0), 0)
 	const topToolCalls = summary.tools[0]?.calls ?? 0
@@ -445,9 +448,7 @@ function Rail({ summary }: { summary: SessionSummary }) {
 					summary.models.map((model) => (
 						<div key={model.model} className="space-y-1.5">
 							<div className="flex items-baseline justify-between gap-2">
-								<span className="min-w-0 truncate font-mono text-xs" title={model.model}>
-									{shortTarget(model.model)}
-								</span>
+								<ModelLabel detected={detect(model.model)} size={12} className="text-xs" />
 								<span className="shrink-0 font-mono text-muted-foreground text-xs">
 									{model.cost === undefined ? "no cost" : formatCost(model.cost)} ·{" "}
 									{model.llmCalls} {model.llmCalls === 1 ? "call" : "calls"}

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -28,7 +28,8 @@ import {
 	type SessionTurn,
 	type AiSpanCategory,
 } from "@/lib/agent-sessions/session-turns"
-import { filterSpans, isDelegation, shortTarget } from "@/lib/agent-sessions/span-filters"
+import { filterSpans, isDelegation } from "@/lib/agent-sessions/span-filters"
+import { useDetectedModels, type DetectedModel } from "@/hooks/use-detected-models"
 import { Pill } from "./pill"
 import type { SpanDetailTab } from "./span-expansion"
 import { SpanPopover } from "./span-popover"
@@ -114,6 +115,10 @@ export function SessionWaterfall({
 }: SessionWaterfallProps) {
 	// The page scrolls as one, so the virtualizer rides the page's scroller.
 	const { ref: listRef, getScrollElement, scrollMargin } = usePageScrollMargin()
+
+	// The summary's model set, so the header and the rail share this batch —
+	// the column names a model per row, and a raw id is what it named before.
+	const detect = useDetectedModels(summary.models.map((model) => model.model))
 
 	const spansById = useMemo(
 		() => new Map(turns.flatMap((turn) => turn.spans).map((span) => [span.spanId, span])),
@@ -314,6 +319,7 @@ export function SessionWaterfall({
 											row={row}
 											axis={axis}
 											spansById={spansById}
+											detect={detect}
 											selected={selected}
 											revealed={revealedSpanId === row.span.spanId}
 											focused={focusedId === row.span.spanId}
@@ -565,6 +571,7 @@ function TraceLink({ traceId, timestamp }: { traceId: string; timestamp: string 
 }
 
 function SpanRow({
+	detect,
 	row,
 	axis,
 	spansById,
@@ -573,6 +580,7 @@ function SpanRow({
 	focused,
 	onClick,
 }: {
+	detect: (model: string) => DetectedModel
 	row: Extract<WaterfallRow, { kind: "span" }>
 	axis: SessionAxis
 	spansById: ReadonlyMap<string, AiSessionSpan>
@@ -590,9 +598,10 @@ function SpanRow({
 	// by shape, and a failure takes the glyph over outright.
 	const Glyph = errored ? CircleXmarkIcon : CATEGORY_ICON[category]
 	const target = spanTarget(span, category)
-	// Only a model id is a provider path — a tool's target is usually a file path,
-	// whose last segment is not the part worth keeping.
-	const targetLabel = target === undefined ? "—" : category === "tool" ? target : shortTarget(target)
+	// A model gets the name the catalog knows it by; a tool's target is a file
+	// path or a query, which nothing but itself can spell. Either way the value
+	// the span carried stays in the row's `title`.
+	const targetLabel = target === undefined ? "—" : category === "tool" ? target : detect(target).displayName
 
 	return (
 		<button

--- a/apps/web/src/hooks/use-detected-models.ts
+++ b/apps/web/src/hooks/use-detected-models.ts
@@ -1,0 +1,72 @@
+import { useMemo } from "react"
+
+import { DetectAiModelsRequest, type DetectAiModelResponse } from "@maple/domain/http"
+import { Atom, Result, useAtomValue } from "@/lib/effect-atom"
+import { shortTarget } from "@/lib/agent-sessions/span-filters"
+import { MapleInternalAtomClient } from "@/lib/services/common/internal-atom-client"
+
+/**
+ * What a model string resolved to, as the UI needs it. The same shape whether
+ * the catalog answered or not: an unresolved model still has a name to print
+ * (its last path segment, the best the client can do alone) and nulls that
+ * `modelVendorIcon` reads as "no mark", so nothing branches on loading state.
+ */
+export interface DetectedModel {
+	readonly model: string
+	readonly displayName: string
+	readonly vendorSlug: string | null
+	readonly vendorName: string | null
+	readonly family: string | null
+}
+
+const unresolved = (model: string): DetectedModel => ({
+	model,
+	displayName: shortTarget(model),
+	vendorSlug: null,
+	vendorName: null,
+	family: null,
+})
+
+/**
+ * Detection is a pure catalog lookup — no org, no time window — that only
+ * changes when the catalog is regenerated on a deploy, so the batch is keyed
+ * by its models alone and the answer is held well past a navigation away.
+ */
+const detectionAtom = Atom.family((key: string) =>
+	Atom.setIdleTTL(
+		MapleInternalAtomClient.query("aiModelsInternal", "detectMany", {
+			// Constructed, not a plain object: the payload is a `Schema.Class`, and
+			// a structurally identical literal typechecks but fails to encode at
+			// runtime — the request is never sent and the failure only shows up as
+			// every model falling back to its raw id.
+			// SAFETY: the key is this module's own `JSON.stringify` of a string
+			// array, and the family is not reachable with any other key.
+			payload: new DetectAiModelsRequest({ models: JSON.parse(key) as ReadonlyArray<string> }),
+		}),
+		"10 minutes",
+	),
+)
+
+/** The endpoint's cap, mirrored so a long page degrades to unresolved names instead of a 400. */
+const MAX_MODELS = 200
+
+/**
+ * Resolve a page's model strings to their vendor and display name in one
+ * request. Returns a lookup rather than an array so callers can ask about a
+ * model wherever they render it, in whatever order.
+ */
+export function useDetectedModels(models: ReadonlyArray<string>): (model: string) => DetectedModel {
+	// One request per distinct set, so the sessions list re-asks only when
+	// paging brings a model it has not seen. Sorted so two orders of the same
+	// models share the key.
+	const key = useMemo(() => JSON.stringify([...new Set(models)].sort().slice(0, MAX_MODELS)), [models])
+	const result = useAtomValue(detectionAtom(key))
+
+	return useMemo(() => {
+		const detected = Result.builder(result)
+			.onSuccess((value: ReadonlyArray<DetectAiModelResponse>) => value)
+			.orElse(() => [] as ReadonlyArray<DetectAiModelResponse>)
+		const byModel = new Map(detected.map((entry) => [entry.model, entry]))
+		return (model: string) => byModel.get(model.trim()) ?? unresolved(model)
+	}, [result])
+}

--- a/packages/domain/src/http/ai-models.ts
+++ b/packages/domain/src/http/ai-models.ts
@@ -8,9 +8,20 @@ import { SessionAuthorization } from "./current-tenant"
 // is the dashboard's to pick from `vendorSlug` / `family`, so it never
 // crosses the wire.
 
+/** Trimmed, then bounded: matched against a catalog, never stored — nothing legitimate is longer. */
+const ModelString = Schema.Trim.check(Schema.isMinLength(1), Schema.isMaxLength(500))
+
 export class DetectAiModelRequest extends Schema.Class<DetectAiModelRequest>("DetectAiModelRequest")({
-	/** Trimmed, then bounded: matched against a catalog, never stored — nothing legitimate is longer. */
-	model: Schema.Trim.check(Schema.isMinLength(1), Schema.isMaxLength(500)),
+	model: ModelString,
+}) {}
+
+export class DetectAiModelsRequest extends Schema.Class<DetectAiModelsRequest>("DetectAiModelsRequest")({
+	/**
+	 * The distinct model strings a page needs to render, deduped by the caller.
+	 * Bounded because a page that needs more than this many marks has stopped
+	 * being a page; the sessions list pages 50 rows at a time.
+	 */
+	models: Schema.Array(ModelString).check(Schema.isMaxLength(200)),
 }) {}
 
 export const AiModelDetectionSource = Schema.Literals(["openrouter", "heuristic", "unknown"])
@@ -41,6 +52,15 @@ export class AiModelsInternalApiGroup extends HttpApiGroup.make("aiModelsInterna
 		HttpApiEndpoint.post("detect", "/detect", {
 			payload: DetectAiModelRequest,
 			success: DetectAiModelResponse,
+		}),
+	)
+	.add(
+		// One request per page rather than one per model: the sessions list would
+		// otherwise open a connection per distinct model in the viewport.
+		// Results come back in request order, so the caller can zip them.
+		HttpApiEndpoint.post("detectMany", "/detect-many", {
+			payload: DetectAiModelsRequest,
+			success: Schema.Array(DetectAiModelResponse),
 		}),
 	)
 	.prefix("/internal/ai-models")


### PR DESCRIPTION
Consumes the AI model detect contract from #776 on the Agent Sessions surfaces. Four places printed whatever id an instrumentation reported, truncated to its last path segment; they now read the model's name beside its vendor's mark, with the raw id one hover away.

| Surface | Before | After |
| --- | --- | --- |
| List model lane | `claude-opus-5 +4` | `✳ Claude Opus 5 +4` |
| Detail header, Model | `claude-opus-5 +4` | `✳ Claude Opus 5 +4` |
| Cost by model rail | `gpt-5-mini` | OpenAI mark · `GPT-5 Mini` |
| Waterfall MODEL / TARGET | `claude-haiku-4-5` | `Claude Haiku 4.5` |

Tool rows in the waterfall are untouched — a tool's target is a file path or a query, which nothing but itself can spell.

## Batch, not one call per model

`detectMany` sits beside `detect` in the `aiModelsInternal` group: a list page would otherwise open a connection per distinct model in the viewport. One request per distinct model set, capped at 200, answered in request order. The span carries `maple.ai_model.count` and `.unknown_count` rather than per-model attributes — an unresolved count climbing is the same signal `source: unknown` is on the single endpoint, and it stays one attribute however long the batch is.

`useDetectedModels` keys an `Atom.family` by the sorted distinct set — detection is a pure catalog lookup, no org and no time window, so it never goes stale within a session — and returns a lookup rather than an array, so a caller asks about a model wherever it renders one. The header, the rail and the waterfall pass the same set and share one batch.

## The fallback hides a real failure, so it is written down

An unresolved model keeps exactly the shape it had before: last path segment, generic mark, same size. Nothing reflows when the batch lands, and a page whose models the catalog does not know looks as it always did.

That degradation is also indistinguishable from the endpoint never being called, which is how the first cut of this shipped green: the payload was a plain object literal, the request is a `Schema.Class`, and a structurally identical literal typechecks but fails to encode at runtime. No request went out; every model sat on its fallback; the tests passed because they exercise that path. Caught by screenshotting it. Fixed with `new DetectAiModelsRequest({ models })` and a comment at the call site — `detect` has the same trap and no callers.

## Bundle: +27.6 KB gzip of startup, and it is brand art

Needs a decision, not just a rubber stamp. The 33 vendor marks added with the contract cost nothing while nothing rendered them; the mark table now retains all forty in the `icons` chunk startup already loads. Budget goes 653 → 682 KB.

Splitting them out was tried twice and does not work: a lazy `React.lazy` chunk, then deep imports bypassing the barrel. `@/components/icons` re-exports the marks, so the barrel's own chunk keeps a static edge to them however they are reached — both attempts moved the bytes between chunks that startup already pulls. Dropping the marks from the model lanes is what buys the 27 KB back, and the naming win survives that. Say the word and I will.

## Verification

Typecheck (turbo, 41 tasks), lint, 340 web + 8 api tests, bundle check at 680.3 against 682.

Browser verification needed a stand-in: `bun dev` wants `alchemy login`, so `apps/api` could not run. Ran vite alone against a scratchpad stub of the two detect routes backed by the real `@maple/ai-model-catalog`, signed in with the Clerk test account, and confirmed the resolved names and marks on the lab session route. The stub is not in the repo. Nothing exercised the list page — it needs the warehouse.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791388205&installation_model_id=427786&pr_number=784&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F784&signature=1542a037bd5153052f5707c58fdff8facbd5ba1eab64cd18a14b28e594923675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->