### PR TITLE
fix(api): pin an isolate-wide memo to the context it was created in

### DIFF
--- a/apps/api/src/platform/cached-recoverable.ts
+++ b/apps/api/src/platform/cached-recoverable.ts
@@ -11,24 +11,35 @@ import { Deferred, Effect, Exit } from "effect"
  * Deferred and observe its exit, whatever it is — the failed generation is
  * evicted only after its Deferred is complete, so no waiter can find the slot
  * empty. The next caller after a failure starts a fresh run.
+ *
+ * The run is pinned to the context this memo is *created* in, not the context
+ * of whichever caller happens to trigger it. A memo made once per isolate is
+ * triggered by some event, and that event's fiber carries services belonging
+ * to it alone — an `HttpServerRequest`, its scope. Anything the run captures
+ * from them outlives the event and reaches every later caller: a route graph
+ * built this way pinned one request into every handler for the life of the
+ * isolate. `setContext` replaces the caller's context rather than merging into
+ * it, as `provideContext` would, which is what makes the caller unobservable.
+ * The requirement moves to creation time, so `R` leaves the memoized effect.
  */
 export const cachedRecoverable = <A, E, R>(
 	self: Effect.Effect<A, E, R>,
-): Effect.Effect<Effect.Effect<A, E, R>> =>
-	Effect.sync(() => {
+): Effect.Effect<Effect.Effect<A, E>, never, R> =>
+	Effect.map(Effect.context<R>(), (context) => {
+		const run = Effect.setContext(self, context)
 		let success: Exit.Exit<A, E> | undefined
 		let inFlight: Deferred.Deferred<A, E> | undefined
 		return Effect.gen(function* () {
 			if (success !== undefined) return yield* success
 			if (inFlight !== undefined) return yield* Deferred.await(inFlight)
-			const run = yield* Deferred.make<A, E>()
-			inFlight = run
-			return yield* self.pipe(
+			const generation = yield* Deferred.make<A, E>()
+			inFlight = generation
+			return yield* run.pipe(
 				Effect.onExit((exit) =>
 					Effect.sync(() => {
 						if (Exit.isSuccess(exit)) success = exit
 						inFlight = undefined
-					}).pipe(Effect.andThen(Deferred.done(run, exit))),
+					}).pipe(Effect.andThen(Deferred.done(generation, exit))),
 				),
 			)
 		})

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -699,6 +699,10 @@ export default class MapleApi extends Cloudflare.Worker<MapleApi>()(
 		// init also runs at plan time, where alchemy auto-binds every `Config` it
 		// sees read onto the Worker, and this Worker's env is declared in full by
 		// `props`.
+		// Both memos are pinned to this context, so neither build can observe the
+		// event that happens to trigger it — `HttpApiBuilder.handle` captures the
+		// ambient context at layer-build time, and a graph built under a live
+		// request serves that request's headers and body to every later one.
 		const app = yield* cachedRecoverable(buildApp)
 		const rpcServices = yield* cachedRecoverable(buildRpcServices)
 		const pgScope = yield* Effect.cached(pgScopeModule)


### PR DESCRIPTION
## The defect

#772 moved the api onto alchemy's class-form Worker, where the route graph is built lazily by whichever event asks for it first. `cachedRecoverable` ran that build on the **triggering caller's fiber**, and on a fetch event that fiber carries the `HttpServerRequest` the bridge installed for it.

`HttpApiBuilder.handle` captures the ambient context at layer-build time and re-provides it to every route handler. So the graph pinned the *building* request into every handler for the life of the isolate, and requests arriving during a cold build decoded that request's method, headers and body instead of their own.

The retired `HttpEffect.toWebHandlerLayerWith` entry built on a detached root fiber, so a request could never be in scope. This restores that invariant.

## What it did in production

Observed on `71b0f28e` before the rollback. Identical unauthenticated `GET /v2/dashboards`, no `Authorization` header:

- 3 requests returned **HTTP 200** with a list envelope — `{"object":"list","data":[],"has_more":false,"next_cursor":null}`
- 15/60 returned `InvalidCredentialsError` "This API key is only valid for the MCP server." — a branch reachable only when a key *was* resolved (`ApiAuthorizationV2Layer.ts:118`), impossible for a request that sent none (`ApiKeysService.ts:662` short-circuits on a falsy token)
- the rest returned the correct generic 401

One build served all of it (`x-maple-revision` identical on 25/25 `/health` probes), across two colos. That is one request's authenticated context answering another's call.

## The fix

The invariant belongs to the memo, not its call sites — a run memoized once per isolate must never observe the caller that happens to trigger it. `cachedRecoverable` now captures the context it is created in and pins the run to it.

`Effect.provideContext` merges into the ambient context (`internal/effect.ts:2195` — `updateContext(self, Context.merge(context))`) and so cannot scrub the caller; `Effect.setContext` replaces it. `R` moves to creation time and leaves the memoized effect, so the type states that the run is closed over its context.

Both `worker.ts` call sites are unchanged — the only edit there is a comment. This also covers `buildRpcServices`, which was memoized the same way and is run from the RPC path at `worker.ts:824`.

## Verification

Two concurrent *first* events, a GET and a POST, on a fresh instance, driven through `Cloudflare.Workers.makeRequestHandler(makeFetch(app))` — alchemy's real bridge path — with a build that records whichever `HttpServerRequest` is in scope while it runs:

```
PRE-FIX  -> GET saw: GET  | POST saw: GET
POST-FIX -> GET saw: none | POST saw: none
```

The pre-fix arm runs the previous algorithm verbatim, so it is a like-for-like comparison rather than a strawman.

`bun typecheck` green across all 41 tasks; `worker-bridge.test.ts` and `internal-rpc.test.ts` green (7 tests).

## Not in this PR

- `cached-recoverable.ts` still runs the build on the first caller's fiber for *interruption* purposes — a cancelled first request makes every waiter observe the interrupt exit.
- The in-flight build is not pinned to each waiting event's `waitUntil`, which alchemy's own isolate build does deliberately (`WorkerBridge.ts:358-373`, citing workerd's `handle_cross_request_promise_resolution`).
- The cast at `worker.ts:438-444` erases the request markers that would have made this a type error.
- A committed regression test for the two-concurrent-first-events case.
