### PR TITLE
ci(deploy): re-key the api's Durable Object tag before deploying past #787

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -106,6 +106,17 @@ jobs:
             # including the ingest gateway, which reaches Postgres through PSBouncer as
             # a role that does NOT inherit `postgres`.
 
+            # One-shot for #787 (2026-09-07): the api's chat Durable Object moved
+            # from the `CHAT_SESSION` binding to alchemy's class form, which keys
+            # the class by its own name. The script tag alchemy reads on upload
+            # still says `CHAT_SESSION=ChatSession`, so the deploy planned a
+            # delete AND a create of the same class — rejected by Cloudflare
+            # ("cannot be the target of more than one migration"), and it would
+            # have destroyed the namespace. Re-key the tag once; a no-op after.
+            # Delete this step and the script once stg and prd have deployed past it.
+            - name: Retag the api Worker's Durable Object logical ids (one-shot, #787)
+              run: bun scripts/retag-durable-object-logical-ids.ts maple-api
+
             # alchemy's env-credential path (CI=true) otherwise discovers the account
             # with an STS GetCallerIdentity issued while its own AWSEnvironment is
             # still being built, and that call waits on the half-built environment

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -102,6 +102,17 @@ jobs:
             - name: Run database migrations
               run: DATABASE_URL="$MAPLE_PG_URL" bun run --cwd packages/db db:migrate
 
+            # One-shot for #787 (2026-09-07): the api's chat Durable Object moved
+            # from the `CHAT_SESSION` binding to alchemy's class form, which keys
+            # the class by its own name. The script tag alchemy reads on upload
+            # still says `CHAT_SESSION=ChatSession`, so the deploy planned a
+            # delete AND a create of the same class — rejected by Cloudflare
+            # ("cannot be the target of more than one migration"), and it would
+            # have destroyed the namespace. Re-key the tag once; a no-op after.
+            # Delete this step and the script once stg and prd have deployed past it.
+            - name: Retag the api Worker's Durable Object logical ids (one-shot, #787)
+              run: bun scripts/retag-durable-object-logical-ids.ts maple-api-stg
+
             # AWS_ACCOUNT_ID: see the note in deploy-prd.yml.
             #
             # One pass, no retry. A stage's first deploy used to fail here — its

--- a/scripts/retag-durable-object-logical-ids.ts
+++ b/scripts/retag-durable-object-logical-ids.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+/**
+ * One-shot migration for #787: rewrite the api Worker's `alchemy:dos:` script
+ * tag so its Durable Object classes are keyed by their own class name.
+ *
+ *   bun scripts/retag-durable-object-logical-ids.ts <script-name>
+ *
+ * Alchemy tracks which logical id hosts which Durable Object class in a
+ * script tag (`alchemy:dos:<logicalId>=<className>;…`), written on upload and
+ * read back on the next deploy to decide the class migrations. The chat
+ * Durable Object used to be the `CHAT_SESSION` binding, so the deployed tag
+ * says `CHAT_SESSION=ChatSession`; the class form registers the same class
+ * under the logical id `ChatSession`. Alchemy therefore plans BOTH a delete of
+ * `ChatSession` (its old logical id is gone) and a fresh create of `ChatSession`
+ * (its new logical id is unknown) — Cloudflare rejects that upload with
+ * "class 'ChatSession' cannot be the target of more than one migration", and
+ * had it accepted it the namespace's data would have been destroyed.
+ *
+ * Re-keying the pair to `ChatSession` (elided form, logical id == class name)
+ * makes the next deploy a no-op migration on a class that already exists.
+ * Idempotent: a tag that already has the elided form is left alone and no
+ * PATCH is sent. Remove the workflow step and this script once stg and prd
+ * have deployed past #787.
+ *
+ * Auth: CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID (the deploy workflow's
+ * own credentials).
+ */
+
+const PACKED_DO_TAG_PREFIX = "alchemy:dos:"
+
+/** Classes whose logical id must equal the class name after #787. */
+const CLASS_FORM_CLASSES: ReadonlySet<string> = new Set(["ChatSession"])
+
+const FAILURE = 1
+
+const fail = (message: string): never => {
+	console.error(`✗ ${message}`)
+	process.exit(FAILURE)
+}
+
+const requireEnv = (key: string): string => {
+	const value = process.env[key]?.trim()
+	if (!value) return fail(`Missing required env: ${key}`)
+	return value
+}
+
+/** Re-key every `<logicalId>=<className>` pair whose class is class-form now. Pure; exported for a dry check. */
+export const rewriteDurableObjectTags = (tags: ReadonlyArray<string>): string[] =>
+	tags.map((tag) => {
+		if (!tag.startsWith(PACKED_DO_TAG_PREFIX)) return tag
+		const pairs = tag
+			.slice(PACKED_DO_TAG_PREFIX.length)
+			.split(";")
+			.filter((pair) => pair !== "")
+			.map((pair) => {
+				const eq = pair.indexOf("=")
+				const logicalId = decodeURIComponent(eq === -1 ? pair : pair.slice(0, eq))
+				const className = decodeURIComponent(eq === -1 ? pair : pair.slice(eq + 1))
+				return CLASS_FORM_CLASSES.has(className)
+					? { logicalId: className, className }
+					: { logicalId, className }
+			})
+			.sort((a, b) => a.logicalId.localeCompare(b.logicalId))
+			.map(({ logicalId, className }) =>
+				logicalId === className
+					? encodeURIComponent(className)
+					: `${encodeURIComponent(logicalId)}=${encodeURIComponent(className)}`,
+			)
+		return `${PACKED_DO_TAG_PREFIX}${pairs.join(";")}`
+	})
+
+const main = async () => {
+	const scriptName = process.argv[2]?.trim()
+	if (!scriptName) return fail("Usage: bun scripts/retag-durable-object-logical-ids.ts <script-name>")
+	const token = requireEnv("CLOUDFLARE_API_TOKEN")
+	const accountId = requireEnv("CLOUDFLARE_ACCOUNT_ID")
+	const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/scripts/${scriptName}/script-settings`
+	const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }
+
+	const current = await fetch(url, { headers })
+	if (current.status === 404) {
+		console.log(`ℹ ${scriptName} does not exist yet — nothing to retag`)
+		return
+	}
+	if (!current.ok) return fail(`GET script-settings for ${scriptName}: HTTP ${current.status}`)
+	const settings = (await current.json()) as { result?: { tags?: string[] | null } }
+	const tags = settings.result?.tags ?? []
+	const rewritten = rewriteDurableObjectTags(tags)
+	if (rewritten.join("\n") === tags.join("\n")) {
+		console.log(`✓ ${scriptName}: Durable Object tags already keyed by class name — no change`)
+		return
+	}
+	console.log(`${scriptName}: rewriting Durable Object tags`)
+	console.log(`  before: ${JSON.stringify(tags)}`)
+	console.log(`  after:  ${JSON.stringify(rewritten)}`)
+	const patched = await fetch(url, { method: "PATCH", headers, body: JSON.stringify({ tags: rewritten }) })
+	if (!patched.ok)
+		return fail(`PATCH script-settings for ${scriptName}: HTTP ${patched.status} ${await patched.text()}`)
+	console.log(`✓ ${scriptName}: tags updated`)
+}
+
+if (import.meta.main) await main()


### PR DESCRIPTION
The prod deploy of #787 ([run 34162300043](https://github.com/MapleTechLabs/maple/actions/runs/34162300043)) failed uploading the api Worker with `ScriptStartupError: class 'ChatSession' cannot be the target of more than one migration`. Prod is still serving the previous api; every other Worker and the ECS services shipped, so prod is on two commits until this lands.

## Cause

Alchemy records which logical id hosts which Durable Object class in the script tag `alchemy:dos:<logicalId>=<className>` and reads it back on the next upload to derive class migrations. Before #787 the chat object was the `CHAT_SESSION` binding, so the deployed tag says `CHAT_SESSION=ChatSession`. The class form (`Cloudflare.DurableObject<Self>()("ChatSession", …)`) registers the same class under the logical id `ChatSession`, and the class form ties logical id, binding name and class name to that one string, so there is no way to declare the old id. Alchemy then plans both a delete of `ChatSession` (its old logical id disappeared) and a fresh create of `ChatSession` (its new logical id is unknown). Cloudflare rejects the upload — and had it accepted it, the namespace's data would have gone with the delete. Neither beta.74 nor beta.76 has a rename path for the logical id.

## Fix

`scripts/retag-durable-object-logical-ids.ts` re-keys the pair to `ChatSession` through the script-settings API (a `tags` PATCH), and both deploy workflows run it right before `alchemy deploy`. With the tag re-keyed the reconcile finds the class under its own id and emits no migration, so the namespace carries over untouched. The step is idempotent and a no-op once applied; delete it and the script after stg and prd have deployed past #787.

## Verification

- The transform is checked against the prod-shaped tag list: `alchemy:dos:CHAT_SESSION=ChatSession` becomes `alchemy:dos:ChatSession`, other pairs are left alone, and a second pass is the identity.
- No staging rehearsal: `deploy-stg.yml` is disabled in the repository (stg shares prod's Hyperdrive config, so a stg deploy is not a safe dry run anyway). The first live run of the retag is the prod deploy this merge triggers; the step logs the tag list before and after, and the deploy's own `Verify the deployed api serves this commit` step confirms the api Worker updated.
