### PR TITLE
refactor(web): fold ChatEvent through Schema.TaggedUnion.matchOrElse

### DIFF
--- a/apps/web/src/hooks/use-maple-chat.ts
+++ b/apps/web/src/hooks/use-maple-chat.ts
@@ -3,10 +3,11 @@ import { Schema } from "effect"
 import {
 	ChatHistoryResponse,
 	ChatSendResponse,
+	ChatEvent,
 	decodeChatEvent,
 	makeChatSessionId,
-	type ChatEvent,
 	type ChatMessage as ChatSessionMessage,
+	type ChatTaskRef,
 	type ChatToolCall,
 } from "@maple/domain/chat-session"
 import type { ChatStatus, UIMessage, UIMessagePart } from "@/components/ai-elements/types"
@@ -257,14 +258,11 @@ function addToolCall(message: UIMessage, event: Extract<ChatEvent, { type: "tool
  * Deny by default, matching the server's fold: an event whose parent message or task part is
  * missing is dropped rather than materialising a stray top-level message.
  */
-function applyTaskEvent(
-	messages: UIMessage[],
-	event: ChatEvent & { task: NonNullable<Extract<ChatEvent, { type: "text-delta" }>["task"]> },
-): UIMessage[] {
-	return updateMessage(messages, event.task.parentMessageId, (message) => ({
+function applyTaskEvent(messages: UIMessage[], event: ChatEvent, task: ChatTaskRef): UIMessage[] {
+	return updateMessage(messages, task.parentMessageId, (message) => ({
 		...message,
 		parts: message.parts.map((part) => {
-			if (part.type !== "task" || part.toolCallId !== event.task.id) return part
+			if (part.type !== "task" || part.toolCallId !== task.id) return part
 			return {
 				...part,
 				status:
@@ -324,42 +322,55 @@ function settleToolCall(message: UIMessage, event: Extract<ChatEvent, { type: "t
 }
 
 /**
+ * The sub-agent task an event belongs to, if any. `user-message` and `compaction` are the two
+ * members that never carry one; every other event is task-scoped exactly when `task` is set.
+ */
+const taskOf = ChatEvent.matchOrElse(
+	{ "user-message": () => undefined, compaction: () => undefined },
+	(event) => event.task,
+)
+
+/**
  * Fold one live `ChatEvent` into the transcript. `user-message` is a no-op: the
  * optimistic send already rendered it under the same id the server assigns (see
  * `sendMessage`), so replaying it here would either duplicate it or land on a
  * message that's already there — either way there's nothing new to show.
  */
 function applyChatEvent(messages: UIMessage[], event: ChatEvent): UIMessage[] {
-	// A sub-agent's event belongs to the `task` part that started it, never to this transcript.
-	if (event.type !== "user-message" && event.type !== "compaction" && event.task !== undefined) {
-		return applyTaskEvent(messages, event as Parameters<typeof applyTaskEvent>[1])
-	}
-	switch (event.type) {
-		case "user-message":
-			return messages
-		case "turn-start":
-			return ensureAssistantMessage(messages, event.messageId)
-		case "text-delta": {
-			const withMessage = ensureAssistantMessage(messages, event.messageId)
-			return updateMessage(withMessage, event.messageId, (m) => appendTextDelta(m, event.text))
-		}
-		case "tool-call": {
-			const withMessage = ensureAssistantMessage(messages, event.messageId)
-			return updateMessage(withMessage, event.messageId, (m) => addToolCall(m, event))
-		}
-		case "tool-result":
-			return updateMessage(settleTaskResult(messages, event), event.messageId, (m) =>
-				settleToolCall(m, event),
-			)
-		case "turn-retry":
-			return updateMessage(messages, event.messageId, (m) => retractText(m, event.retractChars))
-		// Model-facing bookkeeping. Only the server's `toLlmMessages` reads a compaction; the
-		// transcript the user scrolls back through is deliberately left intact.
-		case "compaction":
-			return messages
-		case "turn-end":
-			return updateMessage(messages, event.messageId, finalizeStreamingText)
-	}
+	return ChatEvent.matchOrElse(
+		event,
+		{
+			"user-message": () => messages,
+			// Model-facing bookkeeping. Only the server's `toLlmMessages` reads a compaction; the
+			// transcript the user scrolls back through is deliberately left intact.
+			compaction: () => messages,
+		},
+		(event) => {
+			// A sub-agent's event belongs to the `task` part that started it, never to this transcript.
+			const task = event.task
+			if (task !== undefined) return applyTaskEvent(messages, event, task)
+			switch (event.type) {
+				case "turn-start":
+					return ensureAssistantMessage(messages, event.messageId)
+				case "text-delta": {
+					const withMessage = ensureAssistantMessage(messages, event.messageId)
+					return updateMessage(withMessage, event.messageId, (m) => appendTextDelta(m, event.text))
+				}
+				case "tool-call": {
+					const withMessage = ensureAssistantMessage(messages, event.messageId)
+					return updateMessage(withMessage, event.messageId, (m) => addToolCall(m, event))
+				}
+				case "tool-result":
+					return updateMessage(settleTaskResult(messages, event), event.messageId, (m) =>
+						settleToolCall(m, event),
+					)
+				case "turn-retry":
+					return updateMessage(messages, event.messageId, (m) => retractText(m, event.retractChars))
+				case "turn-end":
+					return updateMessage(messages, event.messageId, finalizeStreamingText)
+			}
+		},
+	)
 }
 
 /** Consecutive-failure budget for a dropped `events` stream before surfacing an error. */
@@ -534,13 +545,7 @@ export function useMapleChat({ tabId, context }: UseMapleChatOptions): UseMapleC
 							// task card, not the stream. Without this guard the first sub-agent to
 							// finish ended the parent's read loop, so the rest of the parent's answer
 							// only appeared on the next reconnect.
-							if (
-								event.type !== "user-message" &&
-								event.type !== "compaction" &&
-								event.task !== undefined
-							) {
-								continue
-							}
+							if (taskOf(event) !== undefined) continue
 							if (event.type === "turn-start") setStatus("streaming")
 							if (event.type === "turn-end") {
 								sawTurnEnd = true


### PR DESCRIPTION
## What

Effect rc.112 (#792) added `matchOrElse` to `Schema.TaggedUnion` / `toTaggedUnion`: partial case matching with a typed `orElse` that receives the union minus the handled members.

This PR applies it to the one site in scope where it removes a real cast: the chat transcript fold in `apps/web/src/hooks/use-maple-chat.ts`.

- `applyChatEvent` matched all eight `ChatEvent` members, but first had to reach the optional `task` ref through a hand-written `type !== "user-message" && type !== "compaction"` chain, then cast with `Parameters<typeof applyTaskEvent>[1]`. It now handles the two task-less members as cases and reads `task` off the narrowed remainder in `orElse`. `applyTaskEvent` takes the ref as its own argument, so the cast is gone.
- The SSE read loop repeated the same guard; a `taskOf` helper built with the data-last `matchOrElse` replaces it.
- The remaining six-way `switch` stays inside `orElse` and is still exhaustive.

## Survey

`grep -rn 'Schema.TaggedUnion(\|toTaggedUnion('` finds four declarations in scope: `ChatEvent` and `ChatEventPayload` in `packages/domain/src/chat-session.ts`, and the `Machine.events` / `emittedEvents` unions in `apps/api/src/services/alerts/incident-hysteresis.ts`. The hysteresis unions are consumed by `effect-machine` handlers, and `countersOf` is an exhaustive switch over machine states. Every other `switch (x._tag|kind|type|status)` and `Match.orElse` in `packages/domain`, `apps/api/src/services/{alerts,errors}` and `apps/web/src` is over a plain TS union or string literals, or is exhaustive with a `never` arm that should stay. None were converted.

## Verification

- `bun run --filter=@maple/web typecheck` clean
- `vitest run src/hooks/use-maple-chat.test.tsx` 9/9
- Not run (after 22:00 local): repo-wide typecheck, full suite.

Rebased onto `main` now that the rc.112 bump has landed there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791413375&installation_model_id=427786&pr_number=796&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F796&signature=accfe4740dd223aab431de7422f87d75e99a439fee7e0fee17141868408b8089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
