### PR TITLE
feat(agent-sessions): leaner detail header, legible time legend

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -1259,34 +1259,41 @@ describe("SessionViews", () => {
 
 describe("SessionHeader", () => {
 	it("names the session after its agent, with the framework as a fact beside it", () => {
-		const { turns: vendorTurns, summary: vendorSummary } = sessionOf([
+		const { summary: vendorSummary } = sessionOf([
 			agentSpan({ spanId: "v-agent", startMs: 0, durationMs: SECOND, vendorId: "langchain" }),
 		])
-		render(<SessionHeader sessionId="sess-1" summary={vendorSummary} turns={vendorTurns} />)
+		render(<SessionHeader sessionId="sess-1" summary={vendorSummary} />)
 		expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("billing-agent")
 		expect(screen.getByText("Framework").nextElementSibling?.textContent).toBe("LangChain")
 	})
 
 	it("demotes the opening prompt to a quoted line rather than making it the title", () => {
-		render(<SessionHeader sessionId="sess-1" summary={summary} turns={turns} />)
+		render(<SessionHeader sessionId="sess-1" summary={summary} />)
 		expect(screen.getByText("“fix the webhook retry backoff”")).toBeTruthy()
 		expect(screen.getByRole("heading", { level: 1 }).textContent).not.toContain("webhook")
 	})
 
 	it("shows the full session id as a copyable fact, never as the heading", () => {
-		render(<SessionHeader sessionId="0f3c9a1e-long-session-id" summary={summary} turns={turns} />)
+		render(<SessionHeader sessionId="0f3c9a1e-long-session-id" summary={summary} />)
 		const copy = screen.getByRole("button", { name: "Copy Session ID" })
-		expect(copy.textContent).toBe("0f3c9a1e-long-session-id")
+		expect(copy.textContent).toContain("0f3c9a1e-long-session-id")
 		expect(screen.getByRole("heading", { level: 1 }).textContent).not.toContain("0f3c9a1e")
 	})
 
-	it("counts turns and names the model beside the duration", () => {
-		render(<SessionHeader sessionId="sess-1" summary={summary} turns={turns} />)
-		expect(screen.getByText("Turns").nextElementSibling?.textContent).toBe("2")
-		expect(screen.getByText("Model").nextElementSibling?.textContent).toBe("claude-sonnet-4-5")
+	it("shows the duration, and neither the model nor a turn count", () => {
+		render(<SessionHeader sessionId="sess-1" summary={summary} />)
 		expect(screen.getByText("Duration").nextElementSibling?.textContent).toBe(
 			formatSessionDuration(summary.wallClockMs),
 		)
+		expect(screen.queryByText("Turns")).toBeNull()
+		expect(screen.queryByText("Model")).toBeNull()
+	})
+
+	it("copies the trace id, under its own label, for a trace-synthesized session", () => {
+		render(<SessionHeader sessionId="trace:0f3c9a1e2b7d4c5e6f708192a3b4c5d6" summary={summary} />)
+		const copy = screen.getByRole("button", { name: "Copy Trace ID" })
+		expect(copy.textContent).toContain("0f3c9a1e2b7d4c5e6f708192a3b4c5d6")
+		expect(copy.textContent).not.toContain("trace:")
 	})
 
 	it("falls back to the framework, then to a generic name, when no agent is named", () => {

--- a/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
@@ -4,15 +4,14 @@ import { Badge } from "@maple/ui/components/ui/badge"
 import { formatSessionDuration } from "@maple/ui/lib/replay-format"
 import { formatRelativeTimeOrDate } from "@maple/ui/lib/time-format"
 
+import { traceSessionTraceId } from "@maple/domain/gen-ai"
+
 import { CopyableValue } from "@/components/attributes"
-import { UserIcon } from "@/components/icons"
+import { CopyIcon, UserIcon } from "@/components/icons"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import type { SessionSummary } from "@/lib/agent-sessions/session-summary"
-import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
-import { useDetectedModels } from "@/hooks/use-detected-models"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
 import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
-import { ModelLabel } from "../model-label"
 
 /**
  * The page's heading: what ran, when, on what — the facts a reader needs to
@@ -25,21 +24,12 @@ import { ModelLabel } from "../model-label"
  * place — the prompt as a quoted line under the heading, the id as the last
  * fact, in full, one click from the clipboard.
  */
-export function SessionHeader({
-	sessionId,
-	summary,
-	turns,
-}: {
-	sessionId: string
-	summary: SessionSummary
-	turns: readonly SessionTurn[]
-}) {
+export function SessionHeader({ sessionId, summary }: { sessionId: string; summary: SessionSummary }) {
 	const identity = sessionIdentity(summary)
-	// The same model set the rail resolves, so both share one batch.
-	const detect = useDetectedModels(summary.models.map((model) => model.model))
 	const VendorIcon = vendorIcon(summary.vendorIds[0] ?? "")
-	const turnWord = turns[0]?.anchorKind === "trace" ? "segment" : "turn"
-	const firstModel = summary.models[0]
+	// A `trace:<id>` session is one Maple synthesized from a single trace: the
+	// id a reader wants in their clipboard is the trace id, not the prefix.
+	const traceId = traceSessionTraceId(sessionId)
 
 	return (
 		<div className="flex min-w-0 flex-col gap-2">
@@ -67,27 +57,19 @@ export function SessionHeader({
 					{formatRelativeTimeOrDate(summary.startMs)}
 				</Fact>
 				<Fact label="Duration">{formatSessionDuration(summary.wallClockMs)}</Fact>
-				<Fact label={turns.length === 1 ? capitalize(turnWord) : `${capitalize(turnWord)}s`}>
-					{turns.length}
-				</Fact>
-				{firstModel !== undefined && (
-					<Fact label="Model" title={summary.models.map((model) => model.model).join(", ")}>
-						<ModelLabel
-							detected={detect(firstModel.model)}
-							moreCount={summary.models.length - 1}
-							size={12}
-							title={summary.models.map((model) => model.model).join(", ")}
-						/>
-					</Fact>
-				)}
 				{summary.serviceNames.length > 0 && (
 					<Fact label="Service" title={summary.serviceNames.join(", ")} mono>
 						{firstPlusRest(summary.serviceNames)}
 					</Fact>
 				)}
-				<Fact label="Session ID">
-					<CopyableValue value={sessionId} label="Session ID" className="font-mono">
-						{sessionId}
+				<Fact label={traceId === undefined ? "Session ID" : "Trace ID"}>
+					<CopyableValue
+						value={traceId ?? sessionId}
+						label={traceId === undefined ? "Session ID" : "Trace ID"}
+						className="inline-flex min-w-0 max-w-full items-center gap-1 font-mono"
+					>
+						<span className="min-w-0 truncate">{traceId ?? sessionId}</span>
+						<CopyIcon size={11} className="shrink-0 text-muted-foreground" aria-hidden />
 					</CopyableValue>
 				</Fact>
 			</dl>
@@ -142,8 +124,4 @@ function firstPlusRest(names: readonly string[]): string {
 	const [first, ...rest] = names
 	if (first === undefined) return ""
 	return rest.length > 0 ? `${first} +${rest.length}` : first
-}
-
-function capitalize(word: string): string {
-	return word[0]!.toUpperCase() + word.slice(1)
 }

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -27,7 +27,7 @@ import { useDetectedModels } from "@/hooks/use-detected-models"
 import { ModelLabel } from "../model-label"
 import type { SpanDetailTab } from "./span-expansion"
 import { SpanPopover } from "./span-popover"
-import { OCCUPANCY_DOT_FILL, OCCUPANCY_FILL, OCCUPANCY_LABEL } from "./span-visuals"
+import { OCCUPANCY_FILL, OCCUPANCY_ICON, OCCUPANCY_LABEL, OCCUPANCY_TEXT } from "./span-visuals"
 
 const SEVERITY_DOT = {
 	failure: "bg-destructive",
@@ -386,18 +386,18 @@ function TimeComposition({ summary, turns }: { summary: SessionSummary; turns: r
 			</div>
 
 			<div className="mt-3.5 flex flex-wrap gap-x-6 gap-y-2">
-				{legend.map((segment) => (
+				{legend.map((segment) => {
+					const Icon = OCCUPANCY_ICON[segment.kind]
+					return (
 					<span key={segment.kind} className="flex items-center gap-2 text-[13px]">
-						<span
-							aria-hidden
-							className={cn("size-2 rounded-xs", OCCUPANCY_DOT_FILL[segment.kind])}
-						/>
+						<Icon size={14} aria-hidden className={cn("shrink-0", OCCUPANCY_TEXT[segment.kind])} />
 						<span>{OCCUPANCY_LABEL[segment.kind]}</span>
 						<span className="font-mono text-muted-foreground text-xs tabular-nums">
 							{formatSessionDuration(segment.ms)} · {formatPercent(segment.percent / 100)}
 						</span>
 					</span>
-				))}
+					)
+				})}
 			</div>
 		</section>
 	)

--- a/apps/web/src/components/agent-sessions/session-detail/span-visuals.ts
+++ b/apps/web/src/components/agent-sessions/session-detail/span-visuals.ts
@@ -1,11 +1,21 @@
 // The session page's shared color vocabulary: one token per kind of work, read
 // identically by the header's breakdown bar, the waterfall's dots and bars and
 // the flow view's nodes. The tokens are the app's existing chart tokens rather
-// than new ones, and time-to-first-token is a lighter value of the inference
-// token rather than a fifth hue — chart-5 and chart-2 are two near-identical
-// cyans in the light palette (ΔL 0.04, Δh 25°).
+// than new ones. Time-to-first-token gets its own hue (chart-3) rather than a
+// lighter value of the inference token: side by side in the occupancy bar the
+// two values of chart-2 read as one band. chart-5 stays unused here — it and
+// chart-2 are two near-identical cyans in the light palette (ΔL 0.04, Δh 25°).
 
-import { DotsIcon, FaceRobotIcon, GearIcon, PixelSparkleIcon, type IconComponent } from "@/components/icons"
+import {
+	BoltIcon,
+	CircleQuestionIcon,
+	DotsIcon,
+	FaceRobotIcon,
+	GearIcon,
+	MediaPauseIcon,
+	PixelSparkleIcon,
+	type IconComponent,
+} from "@/components/icons"
 
 import type { AiSpanCategory } from "@/lib/agent-sessions/session-turns"
 import type { OccupancyKind } from "@/lib/agent-sessions/session-summary"
@@ -45,19 +55,30 @@ export const CATEGORY_TEXT = {
 /** Segment background in the header's occupancy bar. */
 export const OCCUPANCY_FILL = {
 	idle: NO_WORK_FILL,
-	ttft: "bg-chart-2/45",
+	ttft: "bg-chart-3",
 	inference: "bg-chart-2",
 	tool: "bg-chart-4",
 	unaccounted: UNACCOUNTED_FILL,
 } satisfies Record<OccupancyKind, string>
 
-/** The same vocabulary at 6px, where the 45% ttft fill washes out. */
-export const OCCUPANCY_DOT_FILL = {
-	idle: NO_WORK_FILL,
-	ttft: "bg-chart-2/70",
-	inference: "bg-chart-2",
-	tool: "bg-chart-4",
-	unaccounted: UNACCOUNTED_FILL,
+/** Legend glyph for an occupancy segment: the kind of time reads by shape
+ *  first, with the bar's hue as reinforcement — the same rule the flow view's
+ *  nodes follow. */
+export const OCCUPANCY_ICON = {
+	idle: MediaPauseIcon,
+	ttft: BoltIcon,
+	inference: PixelSparkleIcon,
+	tool: GearIcon,
+	unaccounted: CircleQuestionIcon,
+} satisfies Record<OccupancyKind, IconComponent>
+
+/** The bar's tokens as text color, for the legend glyphs. */
+export const OCCUPANCY_TEXT = {
+	idle: "text-muted-foreground/70",
+	ttft: "text-chart-3",
+	inference: "text-chart-2",
+	tool: "text-chart-4",
+	unaccounted: "text-muted-foreground",
 } satisfies Record<OccupancyKind, string>
 
 /** Legend text for an occupancy segment. */

--- a/apps/web/src/lab/agent-session-lab.tsx
+++ b/apps/web/src/lab/agent-session-lab.tsx
@@ -40,7 +40,7 @@ export function AgentSessionLab({ initialView }: { initialView?: SessionView }) 
 			{/* The page's own header, over the fixture — the one place to eyeball it. */}
 			<div className="flex shrink-0 items-start gap-4 border-border border-b px-4 py-3">
 				<div className="min-w-0 flex-1">
-					<SessionHeader sessionId="lab-session-0f3c9a1e2b7d" summary={summary} turns={turns} />
+					<SessionHeader sessionId="lab-session-0f3c9a1e2b7d" summary={summary} />
 					{selectedSpanId !== undefined && (
 						<p className="mt-1 text-muted-foreground text-xs">selected {selectedSpanId}</p>
 					)}

--- a/apps/web/src/routes/agent-sessions/$sessionId.tsx
+++ b/apps/web/src/routes/agent-sessions/$sessionId.tsx
@@ -224,7 +224,7 @@ function SessionDetailBody({
 			<DashboardLayout.Content>
 				<DashboardLayout.Sticky>
 					<DashboardLayout.Header
-						titleContent={<SessionHeader sessionId={sessionId} summary={summary} turns={turns} />}
+						titleContent={<SessionHeader sessionId={sessionId} summary={summary} />}
 					/>
 				</DashboardLayout.Sticky>
 				{/* `py-0` (the content blocks carry the padding instead) so the views'


### PR DESCRIPTION
- Header drops the Model and turn-count facts — both read better inside the page's views than as facts under the heading.
- The id fact is labelled **Trace ID** and copies the bare trace id for the `trace:<id>` sessions Maple synthesizes; **Session ID** otherwise. Both now carry a visible copy glyph.
- In "Where the time went", time-to-first-token was a 45% value of the inference token — side by side in the bar the two read as one band. It gets its own hue (`chart-3`).
- The legend's colored squares become glyphs (pause / bolt / sparkle / gear / question): the kind of time reads by shape first, hue as reinforcement.

Detail tests updated and passing (68); `@maple/web` typecheck clean.