### PR TITLE
feat(agent-sessions): order the session filters by how they're reached, mark the models

### DIFF
--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { getRouteApi } from "@tanstack/react-router"
 
 import { Result } from "@/lib/effect-atom"
@@ -16,9 +17,10 @@ import {
 } from "@/components/filters/filter-sidebar"
 import { RangeFilterSection, type RangePreset } from "@maple/ui/components/filters/range-filter-section"
 import { Separator } from "@maple/ui/components/ui/separator"
+import { modelVendorIcon } from "@/lib/agent-sessions/model-vendor-icon"
+import { useDetectedModels } from "@/hooks/use-detected-models"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
 import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
-import { shortTarget } from "@/lib/agent-sessions/span-filters"
 import {
 	AGENT_SESSIONS_FILTER_KEYS,
 	hasAgentSessionsFilters,
@@ -98,6 +100,17 @@ export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilter
 	const navigate = routeApi.useNavigate()
 	const search: AgentSessionsSearchState = routeApi.useSearch()
 
+	// Detection is a hook, so the model names have to be read out of the result
+	// here rather than inside the success branch below.
+	const modelNames = useMemo(
+		() =>
+			Result.builder(facetsResult)
+				.onSuccess((value) => value.models.map((option) => option.name))
+				.orElse(() => [] as ReadonlyArray<string>),
+		[facetsResult],
+	)
+	const detectModel = useDetectedModels(modelNames)
+
 	const setList = (key: ListKey, values: string[]) => {
 		navigate({ search: (prev) => ({ ...prev, [key]: values.length > 0 ? values : undefined }) })
 	}
@@ -140,44 +153,9 @@ export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilter
 						    toggle. "With errors" is deliberately absent: the toolbar chip is
 						    that filter, and two controls for one boolean read as a question
 						    about whether they agree. */}
-						<FilterSection
-							title="Framework"
-							options={vendors}
-							selected={search.vendors ?? []}
-							onChange={(vals) => setList("vendors", vals)}
-							getOptionLabel={vendorLabel}
-							getOptionIcon={vendorIcon}
-						/>
-
-						<SearchableFilterSection
-							title="Service"
-							options={services}
-							selected={search.services ?? []}
-							onChange={(vals) => setList("services", vals)}
-						/>
-
 						{/* Sections with nothing to offer hide themselves: most orgs never
 						    set an environment, and a framework that names no agents or tools
 						    would leave an empty list that reads as broken. */}
-						{environments.length > 0 && (
-							<FilterSection
-								title="Environment"
-								options={environments}
-								selected={search.environments ?? []}
-								onChange={(vals) => setList("environments", vals)}
-							/>
-						)}
-
-						{models.length > 0 && (
-							<SearchableFilterSection
-								title="Model"
-								options={models}
-								selected={search.models ?? []}
-								onChange={(vals) => setList("models", vals)}
-								getOptionLabel={shortTarget}
-							/>
-						)}
-
 						{agents.length > 0 && (
 							<SearchableFilterSection
 								title="Agent"
@@ -193,6 +171,42 @@ export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilter
 								options={tools}
 								selected={search.tools ?? []}
 								onChange={(vals) => setList("tools", vals)}
+							/>
+						)}
+
+						<SearchableFilterSection
+							title="Service"
+							options={services}
+							selected={search.services ?? []}
+							onChange={(vals) => setList("services", vals)}
+						/>
+
+						<FilterSection
+							title="Framework"
+							options={vendors}
+							selected={search.vendors ?? []}
+							onChange={(vals) => setList("vendors", vals)}
+							getOptionLabel={vendorLabel}
+							getOptionIcon={vendorIcon}
+						/>
+
+						{models.length > 0 && (
+							<SearchableFilterSection
+								title="Model"
+								options={models}
+								selected={search.models ?? []}
+								onChange={(vals) => setList("models", vals)}
+								getOptionLabel={(name) => detectModel(name).displayName}
+								getOptionIcon={(name) => modelVendorIcon(detectModel(name))}
+							/>
+						)}
+
+						{environments.length > 0 && (
+							<FilterSection
+								title="Environment"
+								options={environments}
+								selected={search.environments ?? []}
+								onChange={(vals) => setList("environments", vals)}
 							/>
 						)}
 


### PR DESCRIPTION
The sidebar's facet sections were ordered framework-first, which is the last thing you reach for when you already know what you're looking at.

- Sections now run Agent, Tool, Service, Framework, Model, with Environment last.
- Model options carry their vendor/family mark (`useDetectedModels` + `modelVendorIcon`), same detection the session header already uses, and take the detected display name instead of the raw `shortTarget`.

`bun --filter=@maple/web typecheck` and the agent-sessions web tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791456668&installation_model_id=427786&pr_number=801&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F801&signature=79641b763a7f1ea233c7f81484e6f1fed8d1fdb93c32287618623b54912025b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->