### PR TITLE
fix(agent-sessions): agent-time breakdown, trimmed overview, model variants, work-kind hues

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -405,11 +405,18 @@ describe("SessionOverview", () => {
 		render(<Overview />)
 
 		expect(screen.getByText("Tool execution")).toBeTruthy()
-		expect(screen.getByText(/^23s · 56%$/)).toBeTruthy()
-		expect(screen.getByText(/41s agent time · up to 2 at once/)).toBeTruthy()
-		// The clock it is measured against stays under the bar, out of the bands.
-		expect(screen.getByText(/5m 12s wall clock/)).toBeTruthy()
-		expect(screen.queryByText("Idle")).toBeNull()
+		expect(screen.getByText("Agent time").nextElementSibling?.textContent).toBe("41s")
+		expect(screen.getByText("Wall clock").nextElementSibling?.textContent).toBe("5m 12s")
+		expect(screen.getByText("agents in parallel").previousElementSibling?.textContent).toBe("2×")
+	})
+
+	// Idle is not agent time, but nothing at all was running then — disjoint
+	// from every band, so it belongs in the same bar rather than a footnote.
+	it("keeps the idle the session spent waiting on a human in the breakdown", () => {
+		render(<Overview />)
+
+		expect(screen.getByText("Idle")).toBeTruthy()
+		expect(screen.getByText(/^4m 20s · 86%$/)).toBeTruthy()
 	})
 
 	// The five-second answer: the verdict names what killed the final turn and

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -1267,10 +1267,9 @@ describe("SessionHeader", () => {
 		expect(screen.getByText("Framework").nextElementSibling?.textContent).toBe("LangChain")
 	})
 
-	it("demotes the opening prompt to a quoted line rather than making it the title", () => {
+	it("leaves the opening prompt to the transcript, in the heading or anywhere else", () => {
 		render(<SessionHeader sessionId="sess-1" summary={summary} />)
-		expect(screen.getByText("“fix the webhook retry backoff”")).toBeTruthy()
-		expect(screen.getByRole("heading", { level: 1 }).textContent).not.toContain("webhook")
+		expect(screen.queryByText(/webhook/)).toBeNull()
 	})
 
 	it("shows the full session id as a copyable fact, never as the heading", () => {

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -399,12 +399,17 @@ describe("SessionOverview", () => {
 		)
 	}
 
-	it("splits the wall clock into where the time actually went", () => {
+	// Agent time, not the clock: 23s of tools and 18s of model calls inside a
+	// 5m 12s session, with two of those tools running at the same time.
+	it("splits agent time by class of work, and says how wide the fan-out got", () => {
 		render(<Overview />)
 
-		// 5m 12s wall clock, 4m 20s of it idle.
-		expect(screen.getByText("Idle")).toBeTruthy()
-		expect(screen.getByText(/4m 20s · 83%/)).toBeTruthy()
+		expect(screen.getByText("Tool execution")).toBeTruthy()
+		expect(screen.getByText(/^23s · 56%$/)).toBeTruthy()
+		expect(screen.getByText(/41s agent time · up to 2 at once/)).toBeTruthy()
+		// The clock it is measured against stays under the bar, out of the bands.
+		expect(screen.getByText(/5m 12s wall clock/)).toBeTruthy()
+		expect(screen.queryByText("Idle")).toBeNull()
 	})
 
 	// The five-second answer: the verdict names what killed the final turn and

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -302,7 +302,6 @@ function Waterfall(props: {
 	onToggleTurn?: (turnId: string) => void
 	selectedSpanId?: string
 	revealedSpanId?: string
-	revealedTurnId?: string
 	onSelectSpan?: (spanId: string | undefined) => void
 	spanTab?: SpanDetailTab
 }) {
@@ -317,7 +316,6 @@ function Waterfall(props: {
 			onToggleTurn={props.onToggleTurn ?? noop}
 			selectedSpanId={props.selectedSpanId}
 			revealedSpanId={props.revealedSpanId}
-			revealedTurnId={props.revealedTurnId}
 			onSelectSpan={props.onSelectSpan ?? noop}
 			spanTab={props.spanTab}
 			onSpanTabChange={noop}
@@ -383,7 +381,6 @@ describe("SessionOverview", () => {
 		initialSpanId?: string
 		onSelectSpan?: (spanId: string | undefined) => void
 		onOpenTraceView?: () => void
-		onOpenTurnInTraceView?: (turnId: string) => void
 	}) {
 		const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>(props.initialSpanId)
 		return (
@@ -398,7 +395,6 @@ describe("SessionOverview", () => {
 				spanTab={undefined}
 				onSpanTabChange={noop}
 				onOpenTraceView={props.onOpenTraceView ?? noop}
-				onOpenTurnInTraceView={props.onOpenTurnInTraceView ?? noop}
 			/>
 		)
 	}
@@ -485,20 +481,6 @@ describe("SessionOverview", () => {
 		expect(screen.getByText("No findings.")).toBeTruthy()
 	})
 
-	// The shape strip replaces the turn digest: one cell per turn, colored by
-	// what the findings attribute to it. A cell is a whole turn, so it crosses to
-	// Traces and lands on that turn — opening its root span in the overlay
-	// answered a question nobody asked of a strip of turns.
-	it("draws one cell per turn and sends a click to that turn in Traces", () => {
-		const onSelectSpan = vi.fn()
-		const onOpenTurnInTraceView = vi.fn()
-		render(<Overview onSelectSpan={onSelectSpan} onOpenTurnInTraceView={onOpenTurnInTraceView} />)
-
-		fireEvent.click(screen.getByRole("button", { name: "2" }))
-		expect(onOpenTurnInTraceView).toHaveBeenCalledWith(turns[1]!.id)
-		expect(onSelectSpan).not.toHaveBeenCalled()
-	})
-
 	// A tool called ten times and failing every time reads nothing like one that
 	// never failed; the rail used to draw both as the same bar.
 	it("separates a tool's failed calls from its successful ones", () => {
@@ -566,16 +548,6 @@ describe("SessionOverview", () => {
 })
 
 describe("SessionWaterfall", () => {
-	// The Overview's session shape sends the reader here by turn, not by span:
-	// the header is what they were sent to, so it wears the mark.
-	it("marks the turn header the reader was sent to", () => {
-		render(<Waterfall revealedTurnId={turns[1]!.id} />)
-
-		const marked = document.querySelectorAll("[data-revealed]")
-		expect(marked.length).toBe(1)
-		expect(marked[0]!.textContent).toContain("Turn 2")
-	})
-
 	it("groups spans under their turn and marks the idle between them", () => {
 		render(<Waterfall />)
 
@@ -1132,27 +1104,6 @@ describe("SessionViews", () => {
 		fireEvent.click(screen.getByRole("switch", { name: "Collapse idle" }))
 
 		expect(screen.queryByText(/of idle removed/)).toBeNull()
-	})
-
-	// The Overview has no filter box, so a query left behind in Traces is
-	// invisible from where a session-shape cell is clicked — and one matching
-	// nothing in that turn would drop the very row the reader was sent to.
-	it("clears a stale span filter when a session-shape cell crosses to Traces", () => {
-		render(<Views />)
-
-		fireEvent.change(screen.getByPlaceholderText("Filter spans"), {
-			target: { value: "no span says this" },
-		})
-		expect(screen.getByText("No spans match this filter.")).toBeTruthy()
-
-		fireEvent.click(screen.getByRole("tab", { name: /Overview/ }))
-		fireEvent.click(screen.getByRole("button", { name: "2" }))
-
-		// Back in Traces, on the turn that was clicked, with the filter gone.
-		expect(screen.getByPlaceholderText("Filter spans").getAttribute("value")).toBe("")
-		const marked = document.querySelectorAll("[data-revealed]")
-		expect(marked.length).toBe(1)
-		expect(marked[0]!.textContent).toContain("Turn 2")
 	})
 
 	// The state lives in SessionViews rather than the views precisely so a look

--- a/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
@@ -7,7 +7,7 @@ import { formatRelativeTimeOrDate } from "@maple/ui/lib/time-format"
 import { traceSessionTraceId } from "@maple/domain/gen-ai"
 
 import { CopyableValue } from "@/components/attributes"
-import { CopyIcon, UserIcon } from "@/components/icons"
+import { CopyIcon } from "@/components/icons"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import type { SessionSummary } from "@/lib/agent-sessions/session-summary"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
@@ -20,9 +20,9 @@ import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
  * The heading is the agent's name (or, unnamed, the framework's), never the
  * session id or the opening prompt: the id says nothing to a human, and the
  * first line of a prompt is usually a boilerplate instruction that reads as a
- * title the session doesn't deserve. Both stay on the page, each in its own
- * place — the prompt as a quoted line under the heading, the id as the last
- * fact, in full, one click from the clipboard.
+ * title the session doesn't deserve. The prompt is the transcript's own first
+ * line and is not repeated here; the id stays as the last fact, in full, one
+ * click from the clipboard.
  */
 export function SessionHeader({ sessionId, summary }: { sessionId: string; summary: SessionSummary }) {
 	const identity = sessionIdentity(summary)
@@ -38,18 +38,6 @@ export function SessionHeader({ sessionId, summary }: { sessionId: string; summa
 				<DashboardLayout.Title title={identity.heading}>{identity.heading}</DashboardLayout.Title>
 				{summary.failed && <Badge variant="error">Failed</Badge>}
 			</div>
-
-			{summary.title !== undefined && (
-				// Quoted and marked with the user glyph so it reads as what it is —
-				// the first thing the user said — and not as a name for the session.
-				<p className="flex min-w-0 items-center gap-1.5 text-muted-foreground text-sm">
-					<UserIcon size={13} className="shrink-0" aria-hidden />
-					<span className="sr-only">Opening prompt:</span>
-					<span className="min-w-0 truncate" title={summary.title}>
-						“{summary.title}”
-					</span>
-				</p>
-			)}
 
 			<dl className="flex flex-wrap items-baseline gap-x-4 gap-y-1 text-xs">
 				{identity.framework !== undefined && <Fact label="Framework">{identity.framework}</Fact>}

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -12,7 +12,6 @@ import {
 	type FindingSeverity,
 	type SessionFinding,
 	type SessionVerdict,
-	type TurnHealth,
 } from "@/lib/agent-sessions/session-findings"
 import {
 	formatCost,
@@ -53,7 +52,6 @@ export function SessionOverview({
 	onSpanTabChange,
 	toolResults,
 	onOpenTraceView,
-	onOpenTurnInTraceView,
 }: {
 	turns: readonly SessionTurn[]
 	summary: SessionSummary
@@ -68,8 +66,6 @@ export function SessionOverview({
 	toolResults?: SessionToolResults
 	/** The popover's "Open in Traces view": same span, sibling view. */
 	onOpenTraceView: () => void
-	/** A session-shape cell: cross to Traces and land on that whole turn. */
-	onOpenTurnInTraceView: (turnId: string) => void
 }) {
 	const report = useMemo(() => buildSessionFindings(turns, summary), [turns, summary])
 	const spansById = useMemo(
@@ -90,12 +86,6 @@ export function SessionOverview({
 						onOpenSpan={openSpan}
 					/>
 					<Findings findings={report.findings} onOpenSpan={openSpan} />
-					<TurnHealthStrip
-						turns={turns}
-						health={report.turnHealth}
-						summary={summary}
-						onOpenTurn={onOpenTurnInTraceView}
-					/>
 					<TimeComposition summary={summary} turns={turns} />
 				</div>
 				<Rail summary={summary} />
@@ -277,72 +267,6 @@ function FindingRow({ finding, onOpenSpan }: { finding: SessionFinding; onOpenSp
 }
 
 /* -------------------------------------------------------------------------- */
-/* Session shape                                                              */
-/* -------------------------------------------------------------------------- */
-
-const HEALTH_CELL = {
-	clean: "border-border bg-muted/40 text-muted-foreground hover:bg-accent",
-	anomaly: "border-severity-warn/40 bg-severity-warn/10 text-severity-warn hover:bg-severity-warn/20",
-	failure: "border-destructive/50 bg-destructive/10 text-destructive hover:bg-destructive/20",
-} satisfies Record<TurnHealth, string>
-
-function TurnHealthStrip({
-	turns,
-	health,
-	summary,
-	onOpenTurn,
-}: {
-	turns: readonly SessionTurn[]
-	health: readonly TurnHealth[]
-	summary: SessionSummary
-	/** A cell is a whole turn, so it opens the turn in Traces rather than one
-	 *  span in the overlay: the reader asking about turn 7 wants what it did. */
-	onOpenTurn: (turnId: string) => void
-}) {
-	// "with errors", not "failed": a red cell marks a turn something went wrong
-	// INSIDE — the turn itself may have closed cleanly, and calling it failed
-	// would contradict a Completed verdict two sections up.
-	const errored = health.filter((status) => status === "failure").length
-	const flagged = health.filter((status) => status === "anomaly").length
-	const caption = [
-		errored > 0 ? `${errored} with errors` : undefined,
-		flagged > 0 ? `${flagged} flagged` : undefined,
-		errored === 0 && flagged === 0 ? "none flagged" : undefined,
-		`${formatSessionDuration(summary.wallClockMs)} wall clock`,
-	]
-		.filter((part) => part !== undefined)
-		.join(" · ")
-
-	return (
-		<section>
-			<div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 pb-3.5">
-				<h3 className="font-semibold text-[11px] text-muted-foreground uppercase tracking-[0.09em]">
-					Session shape
-				</h3>
-				<span className="font-mono text-muted-foreground text-xs tabular-nums">{caption}</span>
-			</div>
-
-			<div className="flex flex-wrap gap-1.5">
-				{turns.map((turn, index) => (
-					<button
-						key={turn.id}
-						type="button"
-						onClick={() => onOpenTurn(turn.id)}
-						title={`${turnOrdinal(turn)}${turn.label === undefined ? "" : ` — ${turn.label}`} — open in Traces`}
-						className={cn(
-							"flex size-8 cursor-pointer items-center justify-center rounded-sm border font-mono text-[11px] tabular-nums",
-							HEALTH_CELL[health[index] ?? "clean"],
-						)}
-					>
-						{turn.index}
-					</button>
-				))}
-			</div>
-		</section>
-	)
-}
-
-/* -------------------------------------------------------------------------- */
 /* Where the time went                                                        */
 /* -------------------------------------------------------------------------- */
 
@@ -359,7 +283,12 @@ function TimeComposition({ summary, turns }: { summary: SessionSummary; turns: r
 	// wall clock, so a mid-session stall reads as a hole in the middle, not as
 	// an idle block pinned to the left.
 	const wallClockMs = Math.max(summary.wallClockMs, 1)
-	const caption = longestGapText(summary.idleGaps, turns)
+	// The section owns the session's wall clock now: it is the number every
+	// percentage below is a share of, so it belongs beside them rather than
+	// over a strip of turn cells.
+	const caption = [`${formatSessionDuration(summary.wallClockMs)} wall clock`, longestGapText(summary.idleGaps, turns)]
+		.filter((part) => part !== undefined)
+		.join(" · ")
 
 	return (
 		<section>
@@ -367,9 +296,7 @@ function TimeComposition({ summary, turns }: { summary: SessionSummary; turns: r
 				<h3 className="font-semibold text-[11px] text-muted-foreground uppercase tracking-[0.09em]">
 					Where the time went
 				</h3>
-				{caption !== undefined && (
-					<span className="font-mono text-muted-foreground text-xs tabular-nums">{caption}</span>
-				)}
+				<span className="font-mono text-muted-foreground text-xs tabular-nums">{caption}</span>
 			</div>
 
 			<div className="relative mt-3.5 h-4 w-full overflow-hidden rounded-sm bg-muted">

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactNode } from "react"
 
 import { ArrowRightIcon, ChevronRightIcon, CircleXmarkIcon } from "@/components/icons"
 import { Button } from "@maple/ui/components/ui/button"
+import { Separator } from "@maple/ui/components/ui/separator"
 import { formatNumber, formatPercent } from "@maple/ui/lib/format"
 import { formatSessionDuration } from "@maple/ui/lib/replay-format"
 import { cn } from "@maple/ui/lib/utils"
@@ -78,6 +79,10 @@ export function SessionOverview({
 	return (
 		<div className="@container flex grow flex-col pt-5 pb-10">
 			<div className="flex flex-col gap-8 @4xl:flex-row @4xl:gap-8">
+				{/* The verdict and its findings are one reading, so no rule divides
+				    them; each section below answers a different question, and the
+				    hairline is what keeps the verdict from reading as a header over
+				    all of them. */}
 				<div className="flex min-w-0 grow flex-col gap-7">
 					<Verdict
 						verdict={report.verdict}
@@ -86,6 +91,7 @@ export function SessionOverview({
 						onOpenSpan={openSpan}
 					/>
 					<Findings findings={report.findings} onOpenSpan={openSpan} />
+					<Separator />
 					<TimeComposition summary={summary} turns={turns} />
 				</div>
 				<Rail summary={summary} />

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -27,7 +27,7 @@ import { useDetectedModels } from "@/hooks/use-detected-models"
 import { ModelLabel } from "../model-label"
 import type { SpanDetailTab } from "./span-expansion"
 import { SpanPopover } from "./span-popover"
-import { OCCUPANCY_FILL, OCCUPANCY_ICON, OCCUPANCY_LABEL, OCCUPANCY_TEXT } from "./span-visuals"
+import { AGENT_TIME_FILL, AGENT_TIME_ICON, AGENT_TIME_LABEL, AGENT_TIME_TEXT } from "./span-visuals"
 
 const SEVERITY_DOT = {
 	failure: "bg-destructive",
@@ -277,22 +277,25 @@ function FindingRow({ finding, onOpenSpan }: { finding: SessionFinding; onOpenSp
 /* -------------------------------------------------------------------------- */
 
 function TimeComposition({ summary, turns }: { summary: SessionSummary; turns: readonly SessionTurn[] }) {
-	// Under half a percent a legend row reads "0%" and says nothing; the bar
-	// still draws the sliver in place, so nothing disappears from the timeline.
-	const legend = summary.occupancy
-		.map((segment) => ({
-			...segment,
-			percent: sharePercent(segment.ms, summary.wallClockMs),
-		}))
+	const { segments, totalMs, peakParallel } = summary.agentTime
+	// Agent time, not the clock: the bands are sorted by class and each one is
+	// the whole time that class of work ran, summed across every agent. Two
+	// subagents inferring at once are two seconds here per second of wall clock,
+	// which is the fan-out being visible rather than a double count. Where each
+	// piece of that time actually fell is the waterfall's question.
+	const total = Math.max(totalMs, 1)
+	const legend = segments
+		.map((segment) => ({ ...segment, percent: sharePercent(segment.ms, total) }))
+		// Under half a percent a legend row reads "0%" and says nothing; the band
+		// is still drawn, so nothing vanishes from the bar.
 		.filter((segment) => segment.percent >= 0.5)
-	// The bar is chronological — each interval sits where it happened on the
-	// wall clock, so a mid-session stall reads as a hole in the middle, not as
-	// an idle block pinned to the left.
-	const wallClockMs = Math.max(summary.wallClockMs, 1)
-	// The section owns the session's wall clock now: it is the number every
-	// percentage below is a share of, so it belongs beside them rather than
-	// over a strip of turn cells.
-	const caption = [`${formatSessionDuration(summary.wallClockMs)} wall clock`, longestGapText(summary.idleGaps, turns)]
+	const caption = [
+		`${formatSessionDuration(totalMs)} agent time`,
+		peakParallel > 1 ? `up to ${peakParallel} at once` : undefined,
+	]
+		.filter((part) => part !== undefined)
+		.join(" · ")
+	const footnote = [`${formatSessionDuration(summary.wallClockMs)} wall clock`, longestGapText(summary.idleGaps, turns)]
 		.filter((part) => part !== undefined)
 		.join(" · ")
 
@@ -305,33 +308,35 @@ function TimeComposition({ summary, turns }: { summary: SessionSummary; turns: r
 				<span className="font-mono text-muted-foreground text-xs tabular-nums">{caption}</span>
 			</div>
 
-			<div className="relative mt-3.5 h-4 w-full overflow-hidden rounded-sm bg-muted">
-				{summary.occupancyTimeline.map((interval) => (
+			<div className="mt-3.5 flex h-4 w-full overflow-hidden rounded-sm bg-muted">
+				{segments.map((segment) => (
 					<div
-						key={interval.startMs}
-						className={cn("absolute inset-y-0", OCCUPANCY_FILL[interval.kind])}
-						style={{
-							left: `${((interval.startMs - summary.startMs) / wallClockMs) * 100}%`,
-							width: `${((interval.endMs - interval.startMs) / wallClockMs) * 100}%`,
-						}}
+						key={segment.kind}
+						className={AGENT_TIME_FILL[segment.kind]}
+						style={{ width: `${(segment.ms / total) * 100}%` }}
 					/>
 				))}
 			</div>
 
 			<div className="mt-3.5 flex flex-wrap gap-x-6 gap-y-2">
 				{legend.map((segment) => {
-					const Icon = OCCUPANCY_ICON[segment.kind]
+					const Icon = AGENT_TIME_ICON[segment.kind]
 					return (
-					<span key={segment.kind} className="flex items-center gap-2 text-[13px]">
-						<Icon size={14} aria-hidden className={cn("shrink-0", OCCUPANCY_TEXT[segment.kind])} />
-						<span>{OCCUPANCY_LABEL[segment.kind]}</span>
-						<span className="font-mono text-muted-foreground text-xs tabular-nums">
-							{formatSessionDuration(segment.ms)} · {formatPercent(segment.percent / 100)}
+						<span key={segment.kind} className="flex items-center gap-2 text-[13px]">
+							<Icon size={14} aria-hidden className={cn("shrink-0", AGENT_TIME_TEXT[segment.kind])} />
+							<span>{AGENT_TIME_LABEL[segment.kind]}</span>
+							<span className="font-mono text-muted-foreground text-xs tabular-nums">
+								{formatSessionDuration(segment.ms)} · {formatPercent(segment.percent / 100)}
+							</span>
 						</span>
-					</span>
 					)
 				})}
 			</div>
+
+			{/* The clock the agent time is measured against — kept under the bar
+			    rather than in it, so no percentage above is a share of two
+			    different denominators. */}
+			<p className="mt-3 font-mono text-muted-foreground text-xs tabular-nums">{footnote}</p>
 		</section>
 	)
 }

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -9,14 +9,12 @@ import { cn } from "@maple/ui/lib/utils"
 
 import {
 	buildSessionFindings,
-	turnOrdinal,
 	type FindingSeverity,
 	type SessionFinding,
 	type SessionVerdict,
 } from "@/lib/agent-sessions/session-findings"
 import {
 	formatCost,
-	type IdleGap,
 	type SessionSummary,
 	type SessionToolUsage,
 } from "@/lib/agent-sessions/session-summary"
@@ -27,7 +25,13 @@ import { useDetectedModels } from "@/hooks/use-detected-models"
 import { ModelLabel } from "../model-label"
 import type { SpanDetailTab } from "./span-expansion"
 import { SpanPopover } from "./span-popover"
-import { AGENT_TIME_FILL, AGENT_TIME_ICON, AGENT_TIME_LABEL, AGENT_TIME_TEXT } from "./span-visuals"
+import {
+	AGENT_TIME_FILL,
+	AGENT_TIME_ICON,
+	AGENT_TIME_LABEL,
+	AGENT_TIME_TEXT,
+	type TimeBandKind,
+} from "./span-visuals"
 
 const SEVERITY_DOT = {
 	failure: "bg-destructive",
@@ -92,7 +96,7 @@ export function SessionOverview({
 					/>
 					<Findings findings={report.findings} onOpenSpan={openSpan} />
 					<Separator />
-					<TimeComposition summary={summary} turns={turns} />
+					<TimeComposition summary={summary} />
 				</div>
 				<Rail summary={summary} />
 			</div>
@@ -276,87 +280,91 @@ function FindingRow({ finding, onOpenSpan }: { finding: SessionFinding; onOpenSp
 /* Where the time went                                                        */
 /* -------------------------------------------------------------------------- */
 
-function TimeComposition({ summary, turns }: { summary: SessionSummary; turns: readonly SessionTurn[] }) {
+function TimeComposition({ summary }: { summary: SessionSummary }) {
 	const { segments, totalMs, peakParallel } = summary.agentTime
-	// Agent time, not the clock: the bands are sorted by class and each one is
-	// the whole time that class of work ran, summed across every agent. Two
-	// subagents inferring at once are two seconds here per second of wall clock,
-	// which is the fan-out being visible rather than a double count. Where each
-	// piece of that time actually fell is the waterfall's question.
-	const total = Math.max(totalMs, 1)
-	const legend = segments
-		.map((segment) => ({ ...segment, percent: sharePercent(segment.ms, total) }))
+	// Agent time, not the clock: each band is the whole time that class of work
+	// ran, summed across every agent, so two subagents inferring at once are two
+	// seconds here per second of wall clock — the fan-out made visible rather
+	// than a double count. Idle joins them because nothing at all was running
+	// then, which makes it disjoint from every band and honest to add. Where any
+	// of it fell chronologically is the waterfall's question.
+	const bands: readonly { kind: TimeBandKind; ms: number }[] = [
+		...segments,
+		...(summary.idleMs > 0 ? [{ kind: "idle" as const, ms: summary.idleMs }] : []),
+	]
+	const total = Math.max(
+		bands.reduce((sum, band) => sum + band.ms, 0),
+		1,
+	)
+	const legend = bands
+		.map((band) => ({ ...band, percent: sharePercent(band.ms, total) }))
 		// Under half a percent a legend row reads "0%" and says nothing; the band
 		// is still drawn, so nothing vanishes from the bar.
-		.filter((segment) => segment.percent >= 0.5)
-	const caption = [
-		`${formatSessionDuration(totalMs)} agent time`,
-		peakParallel > 1 ? `up to ${peakParallel} at once` : undefined,
-	]
-		.filter((part) => part !== undefined)
-		.join(" · ")
-	const footnote = [`${formatSessionDuration(summary.wallClockMs)} wall clock`, longestGapText(summary.idleGaps, turns)]
-		.filter((part) => part !== undefined)
-		.join(" · ")
+		.filter((band) => band.percent >= 0.5)
 
 	return (
 		<section>
-			<div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+			<div className="flex flex-wrap items-baseline justify-between gap-x-5 gap-y-2">
 				<h3 className="font-semibold text-[11px] text-muted-foreground uppercase tracking-[0.09em]">
 					Where the time went
 				</h3>
-				<span className="font-mono text-muted-foreground text-xs tabular-nums">{caption}</span>
+				{/* The two clocks the bands are read against, stated rather than left
+				    to be inferred from the bar — and the fan-out that makes them
+				    differ, which is the one number the bar itself cannot show. */}
+				<div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+					<Clock label="Agent time" value={formatSessionDuration(totalMs)} className="text-chart-ai-inference" />
+					<Clock label="Wall clock" value={formatSessionDuration(summary.wallClockMs)} />
+					{peakParallel > 1 && (
+						<span
+							className="flex items-baseline gap-1.5 rounded-sm bg-chart-ai-agent/12 px-1.5 py-0.5 text-chart-ai-agent"
+							title={`At its widest, ${peakParallel} model calls or tools were running at the same time.`}
+						>
+							<span className="font-mono font-semibold text-xs tabular-nums">{peakParallel}×</span>
+							<span className="text-[11px]">agents in parallel</span>
+						</span>
+					)}
+				</div>
 			</div>
 
 			<div className="mt-3.5 flex h-4 w-full overflow-hidden rounded-sm bg-muted">
-				{segments.map((segment) => (
+				{bands.map((band) => (
 					<div
-						key={segment.kind}
-						className={AGENT_TIME_FILL[segment.kind]}
-						style={{ width: `${(segment.ms / total) * 100}%` }}
+						key={band.kind}
+						className={AGENT_TIME_FILL[band.kind]}
+						style={{ width: `${(band.ms / total) * 100}%` }}
 					/>
 				))}
 			</div>
 
 			<div className="mt-3.5 flex flex-wrap gap-x-6 gap-y-2">
-				{legend.map((segment) => {
-					const Icon = AGENT_TIME_ICON[segment.kind]
+				{legend.map((band) => {
+					const Icon = AGENT_TIME_ICON[band.kind]
 					return (
-						<span key={segment.kind} className="flex items-center gap-2 text-[13px]">
-							<Icon size={14} aria-hidden className={cn("shrink-0", AGENT_TIME_TEXT[segment.kind])} />
-							<span>{AGENT_TIME_LABEL[segment.kind]}</span>
+						<span key={band.kind} className="flex items-center gap-2 text-[13px]">
+							<Icon size={14} aria-hidden className={cn("shrink-0", AGENT_TIME_TEXT[band.kind])} />
+							<span>{AGENT_TIME_LABEL[band.kind]}</span>
 							<span className="font-mono text-muted-foreground text-xs tabular-nums">
-								{formatSessionDuration(segment.ms)} · {formatPercent(segment.percent / 100)}
+								{formatSessionDuration(band.ms)} · {formatPercent(band.percent / 100)}
 							</span>
 						</span>
 					)
 				})}
 			</div>
-
-			{/* The clock the agent time is measured against — kept under the bar
-			    rather than in it, so no percentage above is a share of two
-			    different denominators. */}
-			<p className="mt-3 font-mono text-muted-foreground text-xs tabular-nums">{footnote}</p>
 		</section>
 	)
 }
 
-/** Where the session's longest hole sits — inside a turn it is a stall, between
- *  turns it is the user thinking, and the caption says which. */
-function longestGapText(gaps: readonly IdleGap[], turns: readonly SessionTurn[]): string | undefined {
-	const longest = [...gaps].sort((a, b) => b.durationMs - a.durationMs)[0]
-	if (longest === undefined) return undefined
-	const duration = formatSessionDuration(longest.durationMs)
-
-	const inside = turns.find((turn) => longest.startMs >= turn.startMs && longest.endMs <= turn.endMs)
-	if (inside !== undefined) return `longest stall ${duration}, inside ${turnOrdinal(inside).toLowerCase()}`
-
-	const before = [...turns].reverse().find((turn) => turn.endMs <= longest.startMs)
-	const after = turns.find((turn) => turn.startMs >= longest.endMs)
-	if (before !== undefined && after !== undefined) {
-		return `longest gap ${duration}, between ${turnOrdinal(before).toLowerCase()} and ${after.index}`
-	}
-	return `longest gap ${duration}`
+/** One of the section's two clocks: a micro label with the number carrying the
+ *  weight, so the pair reads as facts rather than a line of grey prose. */
+function Clock({ label, value, className }: { label: string; value: string; className?: string }) {
+	return (
+		<span className="flex items-baseline gap-1.5">
+			<span className="font-semibold text-[10px] text-muted-foreground uppercase tracking-[0.08em]">
+				{label}
+			</span>
+			<span className={cn("font-mono font-semibold text-xs tabular-nums", className)}>{value}</span>
+		</span>
+	)
 }
 
 /* -------------------------------------------------------------------------- */

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -93,24 +93,15 @@ export function SessionViews({
 	// reader lands at the top of six hundred of them. Component state rather
 	// than the URL: it is where the reader was just sent, not a place to link to.
 	const [revealedSpanId, setRevealedSpanId] = useState<string | undefined>(undefined)
-	// The same door, one level up: a cell of the Overview's session shape is a
-	// whole turn, so what the reader is sent to is the turn's header row rather
-	// than any one span inside it.
-	const [revealedTurnId, setRevealedTurnId] = useState<string | undefined>(undefined)
-
 	// Opening the panel on any span — or picking another view by hand — is the
 	// reader moving on, and the mark comes off the row they were sent to.
-	const clearRevealed = () => {
-		setRevealedSpanId(undefined)
-		setRevealedTurnId(undefined)
-	}
+	const clearRevealed = () => setRevealedSpanId(undefined)
 	// Stable, like the two toggles below: the transcript's rows are memoized
 	// on their props, and a callback minted per render would re-render every
 	// mounted block on every scroll.
 	const selectSpan = useCallback(
 		(spanId: string | undefined) => {
 			setRevealedSpanId(undefined)
-			setRevealedTurnId(undefined)
 			onSelectSpan(spanId)
 		},
 		[onSelectSpan],
@@ -129,26 +120,6 @@ export function SessionViews({
 	const openInTraceView = () => {
 		clearRevealed()
 		setRevealedSpanId(selectedSpanId)
-		onSelectSpan(undefined)
-		onViewChange("trace")
-	}
-
-	/** A session-shape cell: cross to Traces and land on that turn, expanded —
-	 *  a turn folded shut would put the reader on a header with nothing under it. */
-	const openTurnInTraceView = (turnId: string) => {
-		clearRevealed()
-		// The Overview never showed the filter box, so a query left behind by an
-		// earlier visit to Traces is invisible from where this click was made —
-		// and one that matches nothing in this turn would drop the very row the
-		// reader was sent to. Crossing from a view with no filter clears it.
-		setQuery("")
-		setRevealedTurnId(turnId)
-		setCollapsedTurns((previous) => {
-			if (!previous.has(turnId)) return previous
-			const next = new Set(previous)
-			next.delete(turnId)
-			return next
-		})
 		onSelectSpan(undefined)
 		onViewChange("trace")
 	}
@@ -299,7 +270,6 @@ export function SessionViews({
 						onSpanTabChange={setSpanTab}
 						toolResults={toolResults}
 						onOpenTraceView={openInTraceView}
-						onOpenTurnInTraceView={openTurnInTraceView}
 					/>
 				)}
 			</TabsContent>
@@ -315,7 +285,6 @@ export function SessionViews({
 						onToggleTurn={toggleTurn}
 						selectedSpanId={selectedSpanId}
 						revealedSpanId={revealedSpanId}
-						revealedTurnId={revealedTurnId}
 						onSelectSpan={selectSpan}
 						spanTab={spanTab}
 						onSpanTabChange={setSpanTab}

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -87,7 +87,6 @@ interface SessionWaterfallProps {
 	revealedSpanId: string | undefined
 	/** A turn sent here from the Overview's session shape: its header row is
 	 *  scrolled to and marked, and the spans under it read as its content. */
-	revealedTurnId: string | undefined
 	/** Raised with a span id to open it, `undefined` to close. */
 	onSelectSpan: (spanId: string | undefined) => void
 	/** The popover's tab, shared with the other views. */
@@ -107,7 +106,6 @@ export function SessionWaterfall({
 	onToggleTurn,
 	selectedSpanId,
 	revealedSpanId,
-	revealedTurnId,
 	onSelectSpan,
 	spanTab,
 	onSpanTabChange,
@@ -203,21 +201,6 @@ export function SessionWaterfall({
 		// effect, so on the render that mounts this view there is nothing to
 		// scroll and the link would silently land at the top.
 		if (getScrollElement() === null) return
-		// A revealed turn wins over a revealed span: it is the later of the two
-		// gestures, and its header is what the reader was sent to see.
-		if (revealedTurnId !== undefined) {
-			const turnIndex = rows.findIndex((row) => row.kind === "turn" && row.turn.id === revealedTurnId)
-			if (turnIndex === -1) return
-			didInitialScroll.current = true
-			virtualizer.scrollToIndex(turnIndex, { align: "center" })
-			correctionFrame.current = requestAnimationFrame(() => {
-				const header = [...document.querySelectorAll("[data-turn-row]")].find(
-					(candidate) => candidate.getAttribute("data-turn-row") === revealedTurnId,
-				)
-				header?.scrollIntoView({ block: "center" })
-			})
-			return
-		}
 		if (landingSpanId === undefined) return
 		// Nor before the row is in the list: a span the filter is hiding, or one
 		// inside a collapsed turn, has nowhere to land yet — leaving the landing
@@ -235,7 +218,7 @@ export function SessionWaterfall({
 			)
 			row?.scrollIntoView({ block: "center" })
 		})
-	}, [landingSpanId, revealedTurnId, rows, spanRowIndexById, setFocusedId, virtualizer, getScrollElement])
+	}, [landingSpanId, spanRowIndexById, setFocusedId, virtualizer, getScrollElement])
 
 	return (
 		<div className="@container flex grow flex-col">
@@ -310,7 +293,6 @@ export function SessionWaterfall({
 											turns={turns}
 											axis={axis}
 											collapsed={collapsedTurns.has(row.turn.id)}
-											revealed={revealedTurnId === row.turn.id}
 											onToggle={() => onToggleTurn(row.turn.id)}
 										/>
 									)}
@@ -457,7 +439,6 @@ function TurnHeader({
 	turns,
 	axis,
 	collapsed,
-	revealed,
 	onToggle,
 }: {
 	row: Extract<WaterfallRow, { kind: "turn" }>
@@ -465,8 +446,6 @@ function TurnHeader({
 	turns: readonly SessionTurn[]
 	axis: SessionAxis
 	collapsed: boolean
-	/** The turn the reader was sent here to see: marked until they move on. */
-	revealed: boolean
 	onToggle: () => void
 }) {
 	const { turn } = row
@@ -483,18 +462,7 @@ function TurnHeader({
 	const traceId = turn.traceIds[0]
 
 	return (
-		<div
-			// The row the landing correction below scrolls to, a frame after the
-			// virtualizer drew it.
-			data-turn-row={turn.id}
-			// The mark is a background colour; this is how the page's tests — and
-			// anything else looking for it — find the turn wearing it.
-			data-revealed={revealed || undefined}
-			className={cn(
-				"flex h-full w-full items-center rounded-md bg-card px-2.5 text-left text-xs hover:bg-accent/40",
-				revealed && "border-l-2 border-l-primary bg-primary/12",
-			)}
-		>
+		<div className="flex h-full w-full items-center rounded-md bg-card px-2.5 text-left text-xs hover:bg-accent/40">
 			<span className={COL_SPAN}>
 				<button
 					type="button"

--- a/apps/web/src/components/agent-sessions/session-detail/span-visuals.ts
+++ b/apps/web/src/components/agent-sessions/session-detail/span-visuals.ts
@@ -1,10 +1,11 @@
 // The session page's shared color vocabulary: one token per kind of work, read
 // identically by the header's breakdown bar, the waterfall's dots and bars and
-// the flow view's nodes. The tokens are the app's existing chart tokens rather
-// than new ones. Time-to-first-token gets its own hue (chart-3) rather than a
-// lighter value of the inference token: side by side in the occupancy bar the
-// two values of chart-2 read as one band. chart-5 stays unused here — it and
-// chart-2 are two near-identical cyans in the light palette (ΔL 0.04, Δh 25°).
+// the flow view's nodes. The four kinds have designated `chart-ai-*` hues
+// rather than chart-1..5 slots, for the reason the token buckets do: the
+// numbered slots are spaced per theme, and in dark they landed TTFT (chart-3)
+// and tool (chart-4) 0.08 apart in oklab — one band to the eye in a 16px bar,
+// with inference only 0.18 off the same pair. The designated hues sit ~85°
+// apart in both themes.
 
 import {
 	BoltIcon,
@@ -28,9 +29,9 @@ const UNACCOUNTED_FILL = "bg-muted-foreground/70"
 
 /** Bar and dot background, per span category. */
 export const CATEGORY_FILL = {
-	agent: "bg-chart-1",
-	inference: "bg-chart-2",
-	tool: "bg-chart-4",
+	agent: "bg-chart-ai-agent",
+	inference: "bg-chart-ai-inference",
+	tool: "bg-chart-ai-tool",
 	other: NO_WORK_FILL,
 } satisfies Record<AiSpanCategory, string>
 
@@ -44,20 +45,20 @@ export const CATEGORY_ICON = {
 	other: DotsIcon,
 } satisfies Record<AiSpanCategory, IconComponent>
 
-/** The same chart tokens as `CATEGORY_FILL`, as text color for the glyphs. */
+/** The same tokens as `CATEGORY_FILL`, as text color for the glyphs. */
 export const CATEGORY_TEXT = {
-	agent: "text-chart-1",
-	inference: "text-chart-2",
-	tool: "text-chart-4",
+	agent: "text-chart-ai-agent",
+	inference: "text-chart-ai-inference",
+	tool: "text-chart-ai-tool",
 	other: "text-muted-foreground",
 } satisfies Record<AiSpanCategory, string>
 
 /** Segment background in the header's occupancy bar. */
 export const OCCUPANCY_FILL = {
 	idle: NO_WORK_FILL,
-	ttft: "bg-chart-3",
-	inference: "bg-chart-2",
-	tool: "bg-chart-4",
+	ttft: "bg-chart-ai-ttft",
+	inference: "bg-chart-ai-inference",
+	tool: "bg-chart-ai-tool",
 	unaccounted: UNACCOUNTED_FILL,
 } satisfies Record<OccupancyKind, string>
 
@@ -75,9 +76,9 @@ export const OCCUPANCY_ICON = {
 /** The bar's tokens as text color, for the legend glyphs. */
 export const OCCUPANCY_TEXT = {
 	idle: "text-muted-foreground/70",
-	ttft: "text-chart-3",
-	inference: "text-chart-2",
-	tool: "text-chart-4",
+	ttft: "text-chart-ai-ttft",
+	inference: "text-chart-ai-inference",
+	tool: "text-chart-ai-tool",
 	unaccounted: "text-muted-foreground",
 } satisfies Record<OccupancyKind, string>
 

--- a/apps/web/src/components/agent-sessions/session-detail/span-visuals.ts
+++ b/apps/web/src/components/agent-sessions/session-detail/span-visuals.ts
@@ -12,6 +12,7 @@ import {
 	DotsIcon,
 	FaceRobotIcon,
 	GearIcon,
+	MediaPauseIcon,
 	PixelSparkleIcon,
 	type IconComponent,
 } from "@/components/icons"
@@ -49,12 +50,21 @@ export const CATEGORY_TEXT = {
 	other: "text-muted-foreground",
 } satisfies Record<AiSpanCategory, string>
 
-/** Band background in the agent-time breakdown. */
+/**
+ * The breakdown's bands: the classes of agent time, plus the idle the session
+ * spent waiting on a human. Idle is not agent time and gets the neutral rather
+ * than a hue, but it is disjoint from all the work — nothing at all was running
+ * — so the four sum honestly to the time the section accounts for.
+ */
+export type TimeBandKind = AgentTimeKind | "idle"
+
+/** Band background in the breakdown. */
 export const AGENT_TIME_FILL = {
 	ttft: "bg-chart-ai-ttft",
 	inference: "bg-chart-ai-inference",
 	tool: "bg-chart-ai-tool",
-} satisfies Record<AgentTimeKind, string>
+	idle: NO_WORK_FILL,
+} satisfies Record<TimeBandKind, string>
 
 /** Legend glyph for a class of agent time: the kind of work reads by shape
  *  first, with the band's hue as reinforcement — the same rule the flow view's
@@ -63,18 +73,21 @@ export const AGENT_TIME_ICON = {
 	ttft: BoltIcon,
 	inference: PixelSparkleIcon,
 	tool: GearIcon,
-} satisfies Record<AgentTimeKind, IconComponent>
+	idle: MediaPauseIcon,
+} satisfies Record<TimeBandKind, IconComponent>
 
 /** The bands' tokens as text color, for the legend glyphs. */
 export const AGENT_TIME_TEXT = {
 	ttft: "text-chart-ai-ttft",
 	inference: "text-chart-ai-inference",
 	tool: "text-chart-ai-tool",
-} satisfies Record<AgentTimeKind, string>
+	idle: "text-muted-foreground/70",
+} satisfies Record<TimeBandKind, string>
 
 /** Legend text for a class of agent time. */
 export const AGENT_TIME_LABEL = {
 	ttft: "Time to first token",
 	inference: "Inference",
 	tool: "Tool execution",
-} satisfies Record<AgentTimeKind, string>
+	idle: "Idle",
+} satisfies Record<TimeBandKind, string>

--- a/apps/web/src/components/agent-sessions/session-detail/span-visuals.ts
+++ b/apps/web/src/components/agent-sessions/session-detail/span-visuals.ts
@@ -9,23 +9,19 @@
 
 import {
 	BoltIcon,
-	CircleQuestionIcon,
 	DotsIcon,
 	FaceRobotIcon,
 	GearIcon,
-	MediaPauseIcon,
 	PixelSparkleIcon,
 	type IconComponent,
 } from "@/components/icons"
 
 import type { AiSpanCategory } from "@/lib/agent-sessions/session-turns"
-import type { OccupancyKind } from "@/lib/agent-sessions/session-summary"
+import type { AgentTimeKind } from "@/lib/agent-sessions/session-summary"
 
-// Idle and unaccounted are the absence of work, so they get the neutral rather
-// than a hue; unaccounted is denser because it is usually a percent or two of
-// the bar and washes out at that width.
+// A span that is neither a model call nor a tool is not a class of work, so it
+// gets the neutral rather than a hue of its own.
 const NO_WORK_FILL = "bg-muted-foreground/40"
-const UNACCOUNTED_FILL = "bg-muted-foreground/70"
 
 /** Bar and dot background, per span category. */
 export const CATEGORY_FILL = {
@@ -53,40 +49,32 @@ export const CATEGORY_TEXT = {
 	other: "text-muted-foreground",
 } satisfies Record<AiSpanCategory, string>
 
-/** Segment background in the header's occupancy bar. */
-export const OCCUPANCY_FILL = {
-	idle: NO_WORK_FILL,
+/** Band background in the agent-time breakdown. */
+export const AGENT_TIME_FILL = {
 	ttft: "bg-chart-ai-ttft",
 	inference: "bg-chart-ai-inference",
 	tool: "bg-chart-ai-tool",
-	unaccounted: UNACCOUNTED_FILL,
-} satisfies Record<OccupancyKind, string>
+} satisfies Record<AgentTimeKind, string>
 
-/** Legend glyph for an occupancy segment: the kind of time reads by shape
- *  first, with the bar's hue as reinforcement — the same rule the flow view's
+/** Legend glyph for a class of agent time: the kind of work reads by shape
+ *  first, with the band's hue as reinforcement — the same rule the flow view's
  *  nodes follow. */
-export const OCCUPANCY_ICON = {
-	idle: MediaPauseIcon,
+export const AGENT_TIME_ICON = {
 	ttft: BoltIcon,
 	inference: PixelSparkleIcon,
 	tool: GearIcon,
-	unaccounted: CircleQuestionIcon,
-} satisfies Record<OccupancyKind, IconComponent>
+} satisfies Record<AgentTimeKind, IconComponent>
 
-/** The bar's tokens as text color, for the legend glyphs. */
-export const OCCUPANCY_TEXT = {
-	idle: "text-muted-foreground/70",
+/** The bands' tokens as text color, for the legend glyphs. */
+export const AGENT_TIME_TEXT = {
 	ttft: "text-chart-ai-ttft",
 	inference: "text-chart-ai-inference",
 	tool: "text-chart-ai-tool",
-	unaccounted: "text-muted-foreground",
-} satisfies Record<OccupancyKind, string>
+} satisfies Record<AgentTimeKind, string>
 
-/** Legend text for an occupancy segment. */
-export const OCCUPANCY_LABEL = {
-	idle: "Idle",
+/** Legend text for a class of agent time. */
+export const AGENT_TIME_LABEL = {
 	ttft: "Time to first token",
 	inference: "Inference",
 	tool: "Tool execution",
-	unaccounted: "Unaccounted",
-} satisfies Record<OccupancyKind, string>
+} satisfies Record<AgentTimeKind, string>

--- a/apps/web/src/lib/agent-sessions/session-findings.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-findings.test.ts
@@ -44,7 +44,6 @@ describe("buildSessionFindings", () => {
 
 		expect(clean.verdict.status).toBe("clean")
 		expect(clean.findings).toEqual([])
-		expect(clean.turnHealth).toEqual(["clean", "clean"])
 	})
 
 	it("names the span the final turn died on, not the retry before it", () => {
@@ -93,7 +92,6 @@ describe("buildSessionFindings", () => {
 		expect(failed.findings[0]!.severity).toBe("failure")
 		expect(failed.findings[0]!.turnText).toBe("Turn 2 (final)")
 		expect(failed.findings.some((finding) => finding.label === "rate_limit")).toBe(true)
-		expect(failed.turnHealth).toEqual(["clean", "failure"])
 	})
 
 	it("tells the context story as prompt growth across the session's calls", () => {
@@ -265,7 +263,6 @@ describe("buildSessionFindings", () => {
 		expect(result.verdict.status).toBe("attention")
 		const finding = result.findings.find((entry) => entry.label === "rate_limit")!
 		expect(finding.severity).toBe("anomaly")
-		expect(result.turnHealth).toEqual(["clean", "anomaly"])
 	})
 
 	it("flags a cut-off reply once, at the deepest span that said so", () => {

--- a/apps/web/src/lib/agent-sessions/session-findings.ts
+++ b/apps/web/src/lib/agent-sessions/session-findings.ts
@@ -66,15 +66,10 @@ export interface SessionVerdict {
 	readonly spanId: string | undefined
 }
 
-/** Worst thing the findings attribute to a turn — the shape strip's cell color. */
-export type TurnHealth = "clean" | "anomaly" | "failure"
-
 export interface SessionFindingsReport {
 	readonly verdict: SessionVerdict
 	/** Failures first, the terminal one leading, then anomalies, each in time order. */
 	readonly findings: readonly SessionFinding[]
-	/** Aligned with `turns`. */
-	readonly turnHealth: readonly TurnHealth[]
 }
 
 /** A trace-anchored turn is the fallback partition — one turn per trace — so it
@@ -118,7 +113,7 @@ export function buildSessionFindings(
 		? { status: "failed", label: cause?.label, spanId: cause?.span.spanId }
 		: { status: findings.length > 0 ? "attention" : "clean", label: undefined, spanId: undefined }
 
-	return { verdict, findings, turnHealth: healthOf(turns, findings, turnIndexBySpan) }
+	return { verdict, findings }
 }
 
 function severityRank(severity: FindingSeverity): number {
@@ -373,21 +368,6 @@ function stallFindings(turns: readonly SessionTurn[]): SessionFinding[] {
 /* -------------------------------------------------------------------------- */
 /* Attribution                                                                */
 /* -------------------------------------------------------------------------- */
-
-function healthOf(
-	turns: readonly SessionTurn[],
-	findings: readonly SessionFinding[],
-	turnIndexBySpan: ReadonlyMap<string, number>,
-): readonly TurnHealth[] {
-	const health = turns.map((turn): TurnHealth => (turn.failed ? "failure" : "clean"))
-	for (const finding of findings) {
-		const index = turnIndexBySpan.get(finding.spanId)
-		if (index === undefined) continue
-		if (finding.severity === "failure") health[index] = "failure"
-		else if (health[index] === "clean") health[index] = "anomaly"
-	}
-	return health
-}
 
 /** `Turn 4 (final)`, `Turns 9, 11`, `Segments 1, 2`, `6 of 14 turns`. */
 function turnListText(indices: readonly number[], turns: readonly SessionTurn[], terminal: boolean): string {

--- a/apps/web/src/lib/agent-sessions/session-summary.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-summary.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { agentSpan, llmSpan, makeSpan, toolSpan } from "./span-test-support"
 import { buildSessionTurns } from "./session-turns"
-import { buildSessionSummary, countTurnTokens, findIdleGaps, type OccupancyKind } from "./session-summary"
+import { buildSessionSummary, countTurnTokens, findIdleGaps, type AgentTimeKind } from "./session-summary"
 
 const SECOND = 1000
 const MINUTE = 60 * SECOND
@@ -11,9 +11,9 @@ const summarize = (spans: Parameters<typeof buildSessionTurns>[0]) =>
 	buildSessionSummary({ spans, turns: buildSessionTurns(spans) })
 
 const segment = (
-	occupancy: readonly { readonly kind: OccupancyKind; readonly ms: number }[],
-	kind: OccupancyKind,
-) => occupancy.find((entry) => entry.kind === kind)?.ms
+	segments: readonly { readonly kind: AgentTimeKind; readonly ms: number }[],
+	kind: AgentTimeKind,
+) => segments.find((entry) => entry.kind === kind)?.ms
 
 describe("findIdleGaps", () => {
 	it("finds the stretches where nothing was running", () => {
@@ -59,10 +59,10 @@ describe("buildSessionSummary — time", () => {
 		expect(summary.activeMs).toBe(20 * SECOND)
 	})
 
-	it("measures occupancy, so parallel tools cannot exceed the wall clock", () => {
+	it("sums agent time, so parallel tools exceed the wall clock and say how wide", () => {
 		const summary = summarize([
 			agentSpan({ spanId: "agent", startMs: 0, durationMs: 10 * SECOND }),
-			// Four tools, ten seconds each, all at once: 40s of duration inside a
+			// Four tools, ten seconds each, all at once: 40s of agent time inside a
 			// 10s session.
 			toolSpan({ spanId: "t1", parentSpanId: "agent", startMs: 0, durationMs: 10 * SECOND }),
 			toolSpan({ spanId: "t2", parentSpanId: "agent", startMs: 0, durationMs: 10 * SECOND }),
@@ -70,19 +70,32 @@ describe("buildSessionSummary — time", () => {
 			toolSpan({ spanId: "t4", parentSpanId: "agent", startMs: 0, durationMs: 10 * SECOND }),
 		])
 
-		expect(segment(summary.occupancy, "tool")).toBe(10 * SECOND)
-		expect(summary.occupancy.reduce((total, entry) => total + entry.ms, 0)).toBe(summary.wallClockMs)
+		expect(segment(summary.agentTime.segments, "tool")).toBe(40 * SECOND)
+		expect(summary.agentTime.totalMs).toBe(40 * SECOND)
+		expect(summary.agentTime.peakParallel).toBe(4)
+		expect(summary.wallClockMs).toBe(10 * SECOND)
 	})
 
-	it("charges overlapping inference and tool time once, to inference", () => {
+	it("charges overlapping inference and tool time to both, in full", () => {
 		const summary = summarize([
 			llmSpan({ spanId: "llm", startMs: 0, durationMs: 10 * SECOND }),
 			// A tool that ran while the model was still streaming.
 			toolSpan({ spanId: "tool", startMs: 5 * SECOND, durationMs: 10 * SECOND }),
 		])
 
-		expect(segment(summary.occupancy, "inference")).toBe(10 * SECOND)
-		expect(segment(summary.occupancy, "tool")).toBe(5 * SECOND)
+		expect(segment(summary.agentTime.segments, "inference")).toBe(10 * SECOND)
+		expect(segment(summary.agentTime.segments, "tool")).toBe(10 * SECOND)
+		expect(summary.agentTime.peakParallel).toBe(2)
+	})
+
+	it("counts a span that starts as another ends as no overlap at all", () => {
+		const summary = summarize([
+			toolSpan({ spanId: "a", startMs: 0, durationMs: 5 * SECOND }),
+			toolSpan({ spanId: "b", startMs: 5 * SECOND, durationMs: 5 * SECOND }),
+		])
+
+		expect(summary.agentTime.peakParallel).toBe(1)
+		expect(segment(summary.agentTime.segments, "tool")).toBe(10 * SECOND)
 	})
 
 	it("splits a streaming call into time to first token and the rest", () => {
@@ -90,73 +103,28 @@ describe("buildSessionSummary — time", () => {
 			llmSpan({ spanId: "llm", startMs: 0, durationMs: 10 * SECOND, ttftSeconds: 4 }),
 		])
 
-		expect(segment(summary.occupancy, "ttft")).toBe(4 * SECOND)
-		expect(segment(summary.occupancy, "inference")).toBe(6 * SECOND)
+		expect(segment(summary.agentTime.segments, "ttft")).toBe(4 * SECOND)
+		expect(segment(summary.agentTime.segments, "inference")).toBe(6 * SECOND)
 	})
 
 	it("omits the time-to-first-token segment when no vendor reported one", () => {
 		const summary = summarize([llmSpan({ spanId: "llm", startMs: 0, durationMs: 10 * SECOND })])
 
-		expect(segment(summary.occupancy, "ttft")).toBeUndefined()
+		expect(segment(summary.agentTime.segments, "ttft")).toBeUndefined()
 	})
 
-	it("orders the timeline by the wall clock, not by class", () => {
+	it("orders the bands by class, and counts an agent span as neither", () => {
 		const summary = summarize([
-			// Work, then a mid-session stall, then more work: the stall must sit
-			// between the two inference stretches, not get pinned to the front.
-			llmSpan({ spanId: "a", startMs: 0, durationMs: 10 * SECOND, ttftSeconds: 4 }),
-			llmSpan({ spanId: "b", startMs: 70 * SECOND, durationMs: 10 * SECOND }),
-		])
-
-		expect(summary.occupancyTimeline.map((interval) => interval.kind)).toEqual([
-			"ttft",
-			"inference",
-			"idle",
-			"inference",
-		])
-		expect(summary.occupancyTimeline[2]).toMatchObject({
-			startMs: summary.startMs + 10 * SECOND,
-			endMs: summary.startMs + 70 * SECOND,
-		})
-	})
-
-	it("tiles the wall clock exactly, filling holes as unaccounted", () => {
-		const summary = summarize([
+			// The agent span covers both children, so charging it too would count
+			// the same work twice; the bands read tool-then-inference by class
+			// however the work fell on the clock.
 			agentSpan({ spanId: "agent", startMs: 0, durationMs: 12 * SECOND }),
-			llmSpan({ spanId: "llm", parentSpanId: "agent", startMs: 2 * SECOND, durationMs: 3 * SECOND }),
-			toolSpan({ spanId: "tool", parentSpanId: "agent", startMs: 6 * SECOND, durationMs: 4 * SECOND }),
+			toolSpan({ spanId: "tool", parentSpanId: "agent", startMs: SECOND, durationMs: 4 * SECOND }),
+			llmSpan({ spanId: "llm", parentSpanId: "agent", startMs: 6 * SECOND, durationMs: 3 * SECOND }),
 		])
 
-		expect(
-			summary.occupancyTimeline.map((interval) => [
-				interval.kind,
-				interval.startMs - summary.startMs,
-				interval.endMs - summary.startMs,
-			]),
-		).toEqual([
-			["unaccounted", 0, 2 * SECOND],
-			["inference", 2 * SECOND, 5 * SECOND],
-			["unaccounted", 5 * SECOND, 6 * SECOND],
-			["tool", 6 * SECOND, 10 * SECOND],
-			["unaccounted", 10 * SECOND, 12 * SECOND],
-		])
-		// The legend sums the same intervals, so bar and legend cannot disagree.
-		const timelineTotal = summary.occupancyTimeline.reduce(
-			(total, interval) => total + (interval.endMs - interval.startMs),
-			0,
-		)
-		expect(timelineTotal).toBe(summary.wallClockMs)
-		expect(summary.occupancy.reduce((total, entry) => total + entry.ms, 0)).toBe(summary.wallClockMs)
-	})
-
-	it("leaves the time no gen_ai span accounts for as the framework's own", () => {
-		const summary = summarize([
-			agentSpan({ spanId: "agent", startMs: 0, durationMs: 10 * SECOND }),
-			llmSpan({ spanId: "llm", parentSpanId: "agent", startMs: 2 * SECOND, durationMs: 3 * SECOND }),
-		])
-
-		expect(segment(summary.occupancy, "inference")).toBe(3 * SECOND)
-		expect(segment(summary.occupancy, "unaccounted")).toBe(7 * SECOND)
+		expect(summary.agentTime.segments.map((entry) => entry.kind)).toEqual(["inference", "tool"])
+		expect(summary.agentTime.totalMs).toBe(7 * SECOND)
 	})
 })
 

--- a/apps/web/src/lib/agent-sessions/session-summary.ts
+++ b/apps/web/src/lib/agent-sessions/session-summary.ts
@@ -40,21 +40,29 @@ export interface IdleGap {
 	readonly durationMs: number
 }
 
-/** Wall-clock occupancy classes, in the order the breakdown legend lists them. */
-export type OccupancyKind = "idle" | "ttft" | "inference" | "tool" | "unaccounted"
+/** Classes of agent time, in the order the breakdown stacks them. */
+export type AgentTimeKind = "ttft" | "inference" | "tool"
 
-const OCCUPANCY_KIND_ORDER: readonly OccupancyKind[] = ["idle", "ttft", "inference", "tool", "unaccounted"]
+const AGENT_TIME_KIND_ORDER: readonly AgentTimeKind[] = ["ttft", "inference", "tool"]
 
-export interface OccupancySegment {
-	readonly kind: OccupancyKind
+export interface AgentTimeSegment {
+	readonly kind: AgentTimeKind
 	readonly ms: number
 }
 
-/** One classified stretch of the wall clock — the chronological bar draws these. */
-export interface OccupancyInterval {
-	readonly kind: OccupancyKind
-	readonly startMs: number
-	readonly endMs: number
+/**
+ * What the agents spent, rather than what the clock did. Every work span
+ * contributes its whole duration, so two subagents inferring at once cost two
+ * seconds of agent time per second of wall clock — `totalMs` exceeding the wall
+ * clock is the fan-out, not an error, and `peakParallel` says how wide it got.
+ */
+export interface SessionAgentTime {
+	readonly totalMs: number
+	/** Non-zero segments only, stacked in `AGENT_TIME_KIND_ORDER`: an
+	 *  unavailable TTFT is absent, never a zero-width band. */
+	readonly segments: readonly AgentTimeSegment[]
+	/** Most work spans in flight at once — 1 when nothing ever overlapped. */
+	readonly peakParallel: number
 }
 
 export interface SessionTokenTotals {
@@ -141,11 +149,7 @@ export interface SessionSummary {
 	readonly activeMs: number
 	readonly idleMs: number
 	readonly idleGaps: readonly IdleGap[]
-	/** Non-zero segments only: an unavailable TTFT is absent, never a zero bar. */
-	readonly occupancy: readonly OccupancySegment[]
-	/** The same classes as chronological intervals tiling the wall clock — what
-	 *  the breakdown bar draws, while the legend sums `occupancy`. */
-	readonly occupancyTimeline: readonly OccupancyInterval[]
+	readonly agentTime: SessionAgentTime
 	/** The last turn did not close cleanly. */
 	readonly failed: boolean
 	/** The opening user message, when content was captured. */
@@ -207,7 +211,6 @@ export function buildSessionSummary({
 
 	const usage = countableUsageSpans(ordered, byId)
 	const calls = countedLlmCalls(ordered, byId, usage.bySpan, usage.costs)
-	const occupancyTimeline = computeOccupancyTimeline(ordered, startMs, endMs, idleGaps)
 
 	return {
 		startMs,
@@ -216,8 +219,7 @@ export function buildSessionSummary({
 		activeMs: wallClockMs - idleMs,
 		idleMs,
 		idleGaps,
-		occupancy: aggregateOccupancy(occupancyTimeline),
-		occupancyTimeline,
+		agentTime: computeAgentTime(ordered),
 		failed: turns[turns.length - 1]?.failed === true,
 		title: turns[0]?.label,
 		agentNames: distinctInOrder(ordered.map((span) => span.genAi.agentName)),
@@ -266,22 +268,6 @@ function union(intervals: readonly Interval[]): Interval[] {
 	return merged
 }
 
-/** `a` minus `b`; both are expected to be disjoint covers. */
-function subtract(a: readonly Interval[], b: readonly Interval[]): Interval[] {
-	const out: Interval[] = []
-	for (const interval of a) {
-		let cursor = interval.startMs
-		for (const hole of b) {
-			if (hole.endMs <= cursor) continue
-			if (hole.startMs >= interval.endMs) break
-			if (hole.startMs > cursor) out.push({ startMs: cursor, endMs: hole.startMs })
-			cursor = Math.max(cursor, hole.endMs)
-		}
-		if (cursor < interval.endMs) out.push({ startMs: cursor, endMs: interval.endMs })
-	}
-	return out
-}
-
 /**
  * The stretches where nothing at all was running, long enough to read as the
  * session waiting on a human. Short holes stay in active time — they are the
@@ -301,93 +287,71 @@ export function findIdleGaps(spans: readonly AiSessionSpan[]): readonly IdleGap[
 }
 
 /**
- * Classify the wall clock into a chronological cover of disjoint intervals.
+ * Sum what the agents spent, by class of work.
  *
- * Overlaps are resolved by a fixed priority — time to first token, then
- * inference, then tool — so the intervals always tile the wall clock exactly.
- * What neither idle nor a gen_ai span accounts for lands in `unaccounted`:
- * agent scaffolding, framework overhead, the app's own spans. That residual is
- * the point of the bar, so it is never folded into a neighbour.
+ * Every work span contributes its whole duration — nothing is unioned and
+ * nothing is resolved by priority, which is the difference from the wall-clock
+ * reading this replaced: a session running four subagents in parallel spent
+ * four seconds of agent time per second, and flattening that onto one clock
+ * hid the fan-out and quietly stole the overlap from whichever class lost the
+ * priority order. The waterfall is where time reads chronologically.
+ *
+ * A TTFT splits its own span: the wait is not inference, and a session whose
+ * time is mostly first-token latency is a different session from one that is
+ * mostly generation. Agent and non-AI spans contribute nothing — an agent span
+ * covers its children, and adding it would count the same work twice.
  */
-export function computeOccupancyTimeline(
-	spans: readonly AiSessionSpan[],
-	startMs: number,
-	endMs: number,
-	idleGaps: readonly IdleGap[],
-): readonly OccupancyInterval[] {
-	const ttftIntervals: Interval[] = []
-	const inferenceIntervals: Interval[] = []
-	const toolIntervals: Interval[] = []
+export function computeAgentTime(spans: readonly AiSessionSpan[]): SessionAgentTime {
+	const totals = new Map<AgentTimeKind, number>()
+	const add = (kind: AgentTimeKind, ms: number) => {
+		if (ms > 0) totals.set(kind, (totals.get(kind) ?? 0) + ms)
+	}
+	const work: Interval[] = []
 
 	for (const span of spans) {
 		const spanStart = spanStartMs(span)
 		const spanEnd = spanEndMs(span)
 		const category = classifyAiSpan(span)
+		if (category !== "tool" && category !== "inference") continue
+		work.push({ startMs: spanStart, endMs: spanEnd })
 		if (category === "tool") {
-			toolIntervals.push({ startMs: spanStart, endMs: spanEnd })
+			add("tool", spanEnd - spanStart)
 			continue
 		}
-		if (category !== "inference") continue
 		const ttftMs = spanTtftMs(span)
-		if (ttftMs === undefined) {
-			inferenceIntervals.push({ startMs: spanStart, endMs: spanEnd })
-		} else {
-			ttftIntervals.push({ startMs: spanStart, endMs: spanStart + ttftMs })
-			inferenceIntervals.push({ startMs: spanStart + ttftMs, endMs: spanEnd })
-		}
+		// A TTFT longer than the span itself is instrumentation disagreeing with
+		// itself; the span's own duration is the one both classes must fit in.
+		const ttft = ttftMs === undefined ? 0 : Math.min(ttftMs, spanEnd - spanStart)
+		add("ttft", ttft)
+		add("inference", spanEnd - spanStart - ttft)
 	}
 
-	const ttft = union(ttftIntervals)
-	const inference = subtract(union(inferenceIntervals), ttft)
-	const tool = subtract(
-		union(toolIntervals),
-		[...ttft, ...inference].sort((a, b) => a.startMs - b.startMs),
-	)
-
-	// Idle gaps are stretches where no span at all ran, and the three covers
-	// above live inside spans — so all four sets are mutually disjoint and a
-	// plain sort yields the timeline. Holes between them are the residual.
-	const classified: OccupancyInterval[] = [
-		...idleGaps.map(
-			(gap): OccupancyInterval => ({ kind: "idle", startMs: gap.startMs, endMs: gap.endMs }),
-		),
-		...ttft.map((i): OccupancyInterval => ({ kind: "ttft", ...i })),
-		...inference.map((i): OccupancyInterval => ({ kind: "inference", ...i })),
-		...tool.map((i): OccupancyInterval => ({ kind: "tool", ...i })),
-	].sort((a, b) => a.startMs - b.startMs)
-
-	const timeline: OccupancyInterval[] = []
-	const push = (interval: OccupancyInterval) => {
-		if (interval.endMs <= interval.startMs) return
-		const last = timeline[timeline.length - 1]
-		if (last !== undefined && last.kind === interval.kind && last.endMs === interval.startMs) {
-			timeline[timeline.length - 1] = { ...last, endMs: interval.endMs }
-		} else {
-			timeline.push(interval)
-		}
-	}
-
-	let cursor = startMs
-	for (const interval of classified) {
-		if (interval.startMs > cursor) push({ kind: "unaccounted", startMs: cursor, endMs: interval.startMs })
-		push(interval)
-		cursor = Math.max(cursor, interval.endMs)
-	}
-	if (cursor < endMs) push({ kind: "unaccounted", startMs: cursor, endMs })
-
-	return timeline
-}
-
-/** The legend's totals, summed from the same timeline the bar draws so the two
- *  can never disagree. Zero-total classes are absent, never a zero row. */
-function aggregateOccupancy(timeline: readonly OccupancyInterval[]): readonly OccupancySegment[] {
-	const totals = new Map<OccupancyKind, number>()
-	for (const interval of timeline) {
-		totals.set(interval.kind, (totals.get(interval.kind) ?? 0) + (interval.endMs - interval.startMs))
-	}
-	return OCCUPANCY_KIND_ORDER.map((kind) => ({ kind, ms: totals.get(kind) ?? 0 })).filter(
+	const segments = AGENT_TIME_KIND_ORDER.map((kind) => ({ kind, ms: totals.get(kind) ?? 0 })).filter(
 		(segment) => segment.ms > 0,
 	)
+	return {
+		totalMs: segments.reduce((total, segment) => total + segment.ms, 0),
+		segments,
+		peakParallel: peakParallel(work),
+	}
+}
+
+/** Most work spans open at once, by a sweep over their endpoints. Ends are
+ *  processed before starts, so a span beginning as another ends is not overlap. */
+function peakParallel(work: readonly Interval[]): number {
+	const events = work
+		.flatMap((interval) => [
+			{ atMs: interval.startMs, delta: 1 },
+			{ atMs: interval.endMs, delta: -1 },
+		])
+		.sort((a, b) => a.atMs - b.atMs || a.delta - b.delta)
+	let open = 0
+	let peak = 0
+	for (const event of events) {
+		open += event.delta
+		if (open > peak) peak = open
+	}
+	return Math.max(peak, 1)
 }
 
 /* -------------------------------------------------------------------------- */

--- a/lib/ai-model-catalog/src/detect.test.ts
+++ b/lib/ai-model-catalog/src/detect.test.ts
@@ -8,7 +8,7 @@ describe("detectAiModel", () => {
 			slug: "glm-5.3-flash:nitro",
 			normalizedSlug: "glm-5.3-flash",
 			openRouterId: "z-ai/glm-5.3-flash",
-			displayName: "GLM 5.3 Flash",
+			displayName: "GLM 5.3 Flash (nitro)",
 			vendorSlug: "z-ai",
 			vendorName: "Z.ai",
 			family: null,
@@ -89,9 +89,16 @@ describe("detectAiModel", () => {
 		})
 	})
 
-	it("names a variant after its plain listing", () => {
-		expect(detectAiModel("anthropic/claude-opus-5:batch").displayName).toBe("Claude Opus 5")
-		expect(detectAiModel("z-ai/glm-5.3-flash:free").displayName).toBe("GLM 5.3 Flash")
+	it("names a variant after its plain listing, and keeps the variant", () => {
+		expect(detectAiModel("anthropic/claude-opus-5:batch").displayName).toBe("Claude Opus 5 (batch)")
+		expect(detectAiModel("z-ai/glm-5.3-flash:free").displayName).toBe("GLM 5.3 Flash (free)")
+		// The plain listing keeps the plain name, so the two never collide.
+		expect(detectAiModel("z-ai/glm-5.3-flash").displayName).toBe("GLM 5.3 Flash")
+	})
+
+	it("keeps an Ollama size tag, and reads a Bedrock version as no tag at all", () => {
+		expect(detectAiModel("llama3.1:8b").displayName).toBe("Llama 3.1 (8b)")
+		expect(detectAiModel("us.anthropic.claude-opus-5-20250929-v1:0").displayName).toBe("Claude Opus 5")
 	})
 
 	it("places an unlisted model with its vendor by prefix", () => {

--- a/lib/ai-model-catalog/src/detect.ts
+++ b/lib/ai-model-catalog/src/detect.ts
@@ -20,7 +20,10 @@ export interface DetectedAiModel {
 	 * always one OpenRouter answers to; `vendorSlug` never carries it.
 	 */
 	readonly openRouterId: string | null
-	/** `GLM 5.3 Flash` — OpenRouter's name, or one derived from the slug. */
+	/**
+	 * `GLM 5.3 Flash` — OpenRouter's name, or one derived from the slug, with
+	 * any routing variant kept: `GLM 5.3 Flash (nitro)`.
+	 */
 	readonly displayName: string
 	/** `z-ai` — OpenRouter's author segment, the key an icon lookup uses. */
 	readonly vendorSlug: string | null
@@ -53,6 +56,29 @@ const stripVariant = (slug: string): string => {
 	const colon = slug.indexOf(":")
 	return colon === -1 ? slug : slug.slice(0, colon)
 }
+
+/**
+ * What follows a `:` — OpenRouter's routing variants (`:nitro`, `:free`) and
+ * Ollama's tags (`:8b`, `:instruct`) alike. A digits-only suffix is a Bedrock
+ * version (`…-v1:0`) and names nothing.
+ */
+const VARIANT = /^(?!\d+$)[a-z0-9][a-z0-9._-]*$/
+
+const variantOf = (slug: string): string | null => {
+	const colon = slug.indexOf(":")
+	if (colon === -1) return null
+	const variant = slug.slice(colon + 1)
+	return VARIANT.test(variant) ? variant : null
+}
+
+/**
+ * `GLM 5.3 Flash` + `nitro` → `GLM 5.3 Flash (nitro)`. The variant is part of
+ * the name because it is part of the identity: `glm-5.3-flash` and
+ * `glm-5.3-flash:nitro` differ in price and availability, and two rows sharing
+ * one name read as one model that was double-counted.
+ */
+const withVariant = (displayName: string, variant: string | null): string =>
+	variant === null ? displayName : `${displayName} (${variant})`
 
 /** Trailing date stamps and release numbers: `-20250929`, `-2025-08-07`, `-0125`, `-002`, `-05-06`. */
 const DATE_SUFFIX = /-(\d{8}|\d{4}-\d{2}-\d{2}|\d{2}-\d{2}|\d{3,4})$/
@@ -198,6 +224,7 @@ export const detectAiModel = (input: string): DetectedAiModel => {
 	// however the segment reads, so the lookup is vendor-qualified and an
 	// unlisted pairing falls through to the heuristic path with that vendor.
 	const base = stripVariant(slug)
+	const variant = variantOf(slug)
 	const spellings = candidates(base)
 	let entry: CatalogEntry | undefined
 	for (const candidate of spellings) {
@@ -211,7 +238,7 @@ export const detectAiModel = (input: string): DetectedAiModel => {
 			slug,
 			normalizedSlug: entry.modelSlug,
 			openRouterId: entry.openRouterId,
-			displayName: displayNameOf(entry.name),
+			displayName: withVariant(displayNameOf(entry.name), variant),
 			vendorSlug: entry.vendorSlug,
 			vendorName: vendorNameOf(entry.vendorSlug),
 			family: familyOf(entry.modelSlug),
@@ -222,13 +249,15 @@ export const detectAiModel = (input: string): DetectedAiModel => {
 	const normalizedSlug = spellings.at(-1) ?? base
 	const vendorSlug =
 		pathVendor ?? VENDOR_PREFIX_RULES.find(([pattern]) => pattern.test(normalizedSlug))?.[1] ?? null
+	// `titleCase` has nothing to say about a punctuation-only string; the raw
+	// input it falls back to already carries its variant.
+	const titled = titleCase(normalizedSlug)
 	return {
 		model,
 		slug,
 		normalizedSlug,
 		openRouterId: null,
-		// `titleCase` has nothing to say about a punctuation-only string.
-		displayName: titleCase(normalizedSlug) || model,
+		displayName: titled === "" ? model : withVariant(titled, variant),
 		vendorSlug,
 		vendorName: vendorSlug === null ? null : vendorNameOf(vendorSlug),
 		family: familyOf(normalizedSlug),

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -48,6 +48,16 @@
 	   reasoning at a distance the eye cannot resolve at that size. Warm for what
 	   the model produced, cool for what it was given, magenta for what it
 	   thought. Same hues in both themes; only lightness moves. */
+	/* The agent-session vocabulary: the four kinds of work the occupancy bar,
+	   the waterfall and the flow view all draw, usually side by side in a 16px
+	   bar. Designated hues ~85° apart, the same in both themes, for the reason
+	   the token buckets have them — the chart-1..5 slots are spaced per theme,
+	   and in dark they put TTFT (chart-3, green) next to tool (chart-4, teal)
+	   at ΔE 0.08, which is one band to the eye. Only lightness moves per theme. */
+	--chart-ai-ttft: oklch(0.64 0.16 65);
+	--chart-ai-tool: oklch(0.6 0.15 155);
+	--chart-ai-inference: oklch(0.6 0.15 250);
+	--chart-ai-agent: oklch(0.6 0.17 330);
 	--chart-tok-input: oklch(0.6 0.15 246);
 	--chart-tok-cache-read: oklch(0.62 0.13 174);
 	--chart-tok-cache-write: oklch(0.62 0.15 102);
@@ -197,6 +207,10 @@
 	   tuned slightly lighter for the dark canvas. */
 	--chart-throughput: oklch(0.66 0.14 290);
 	--chart-apdex: oklch(0.658 0.134 151);
+	--chart-ai-ttft: oklch(0.73 0.15 65);
+	--chart-ai-tool: oklch(0.7 0.14 155);
+	--chart-ai-inference: oklch(0.69 0.15 250);
+	--chart-ai-agent: oklch(0.7 0.16 330);
 	--chart-tok-input: oklch(0.69 0.15 246);
 	--chart-tok-cache-read: oklch(0.72 0.12 174);
 	--chart-tok-cache-write: oklch(0.73 0.15 102);
@@ -306,6 +320,10 @@
 	--color-chart-error: var(--chart-error);
 	--color-chart-throughput: var(--chart-throughput);
 	--color-chart-apdex: var(--chart-apdex);
+	--color-chart-ai-ttft: var(--chart-ai-ttft);
+	--color-chart-ai-tool: var(--chart-ai-tool);
+	--color-chart-ai-inference: var(--chart-ai-inference);
+	--color-chart-ai-agent: var(--chart-ai-agent);
 	--color-chart-tok-input: var(--chart-tok-input);
 	--color-chart-tok-cache-read: var(--chart-tok-cache-read);
 	--color-chart-tok-cache-write: var(--chart-tok-cache-write);

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -53,11 +53,15 @@
 	   bar. Designated hues ~85° apart, the same in both themes, for the reason
 	   the token buckets have them — the chart-1..5 slots are spaced per theme,
 	   and in dark they put TTFT (chart-3, green) next to tool (chart-4, teal)
-	   at ΔE 0.08, which is one band to the eye. Only lightness moves per theme. */
+	   at ΔE 0.08, which is one band to the eye. Only lightness moves per theme.
+	   Agent keeps the amber it has always worn in dark: it marks a span, and no
+	   view draws a span beside a class of agent time, so its closeness to TTFT
+	   costs nothing — while a purple agent read as the reasoning tokens, which
+	   wear the same glyph two sections away. */
 	--chart-ai-ttft: oklch(0.64 0.16 65);
 	--chart-ai-tool: oklch(0.6 0.15 155);
 	--chart-ai-inference: oklch(0.6 0.15 250);
-	--chart-ai-agent: oklch(0.6 0.17 330);
+	--chart-ai-agent: oklch(0.63 0.16 59);
 	--chart-tok-input: oklch(0.6 0.15 246);
 	--chart-tok-cache-read: oklch(0.62 0.13 174);
 	--chart-tok-cache-write: oklch(0.62 0.15 102);
@@ -210,7 +214,7 @@
 	--chart-ai-ttft: oklch(0.73 0.15 65);
 	--chart-ai-tool: oklch(0.7 0.14 155);
 	--chart-ai-inference: oklch(0.69 0.15 250);
-	--chart-ai-agent: oklch(0.7 0.16 330);
+	--chart-ai-agent: oklch(0.714 0.154 59);
 	--chart-tok-input: oklch(0.69 0.15 246);
 	--chart-tok-cache-read: oklch(0.72 0.12 174);
 	--chart-tok-cache-write: oklch(0.73 0.15 102);


### PR DESCRIPTION
Five changes to the agent-session pages.

### "Where the time went" is measured in agent time
The bar read the wall clock: each class of work was unioned into a disjoint cover, and overlaps were resolved by a fixed priority (TTFT → inference → tool). Parallel subagents were erased by that:

- four tools running at once for 10s read as **10s** of tool time, not 40s;
- a subagent streaming while another ran a tool had the tool's share handed to inference;
- two sessions with identical spans drew differently depending only on how much ran concurrently.

Now every work span contributes its **whole duration**, bands are stacked **by class** instead of laid out chronologically, and the total may exceed the wall clock — that excess is the fan-out, and a peak-parallel count says how wide it got (`41s agent time · up to 2 at once`). Agent spans contribute nothing: they cover their children, so charging them counts the same work twice.

Idle and Unaccounted leave the bar along with the clock they were measured on — neither is time an agent spent working, and keeping them would put two denominators under one set of percentages. Wall clock and longest gap move to a caption under the bar. Chronology is what the waterfall is for.

### The session shape strip is gone
The strip of turn cells said little the findings directly above it had not already said. Its cross-to-Traces door was the only reason the waterfall carried a turn-reveal path — state, a landing effect and a header highlight — so `revealedTurnId` and `turnHealth` go with it. The span-level reveal door (the panel's "Open in Traces view") is untouched.

### The overview's sections are ruled off
The verdict, its findings and the breakdown ran together as one column of evenly spaced blocks, so the verdict line read as a header over all of it. A hairline under the findings marks where that reading ends. Verdict and findings stay undivided, being one reading.

### The opening-prompt subtitle is gone
It duplicated the transcript's own first line and spent two header lines on what is usually a boilerplate instruction.

### Model variants are part of the name
`glm-5.3-flash` and `glm-5.3-flash:nitro` are separate entries that differ in price and availability, and both resolved to `GLM 5.3 Flash` — two filter rows reading as one model that had been double-counted.

| input | before | after |
| --- | --- | --- |
| `z-ai/glm-5.3-flash` | GLM 5.3 Flash | GLM 5.3 Flash |
| `z-ai/glm-5.3-flash:nitro` | GLM 5.3 Flash | GLM 5.3 Flash (nitro) |
| `llama3.1:8b` | Llama 3.1 | Llama 3.1 (8b) |
| `us.anthropic.claude-opus-5-20250929-v1:0` | Claude Opus 5 | Claude Opus 5 |

`displayName` is display-only, so this reaches the filter sidebar, the model labels and the waterfall without a schema change.

### Three colors in the breakdown read as one
In dark, TTFT was chart-3 (green 151) and tool execution chart-4 (teal 185) — **0.08 apart in oklab**, a single band in a 16px bar, with inference (chart-2) only 0.18 off the same pair. The numbered chart slots are spaced per theme, so no reshuffle fixes light and dark at once. The four session work kinds now have designated `--chart-ai-*` hues ~85° apart, same hues in both themes with only lightness moving — the rule `--chart-tok-*` already follows. Nearest pair is 0.20 in both themes; the waterfall and flow view read the same tokens.

### Verification
- `lib/ai-model-catalog`, `apps/web/src/components/agent-sessions` and `apps/web/src/lib/agent-sessions` tests pass; `apps/web` typechecks.
- The overview is not reachable in local dev (no `ai_trace_index` in the local Tinybird), so the palette was checked as swatches and by oklab distance rather than in the running page.