### PR TITLE
feat(agent-sessions): make the Traces view rows scannable

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -834,17 +834,21 @@ describe("SessionWaterfall", () => {
 		expect(onToggleTurn).toHaveBeenCalledWith(turns[0]!.id)
 	})
 
-	it("names the model in MODEL even when the span name already says it", () => {
+	// The span name conventionally repeats the model ("chat gpt-5"), and MODEL is
+	// already the column for it: a row that says it twice is a row where neither
+	// copy is the one being read.
+	it("leaves the model to MODEL when the span name already says it", () => {
 		render(<Waterfall turns={targetTurns} summary={targetSummary} />)
 
-		const named = screen.getByText("chat gpt-5").closest("button")!
-		expect(within(named).getByText("gpt-5")).toBeTruthy()
+		expect(screen.queryByText("chat gpt-5")).toBeNull()
+		expect(screen.getAllByText("chat")).toHaveLength(2)
+		expect(screen.getAllByText("gpt-5")).toHaveLength(1)
 	})
 
 	it("shortens a gateway model id in MODEL, with the full id in the title", () => {
 		render(<Waterfall turns={targetTurns} summary={targetSummary} />)
 
-		const modelCell = within(screen.getByText("chat").closest("button")!).getByText("gpt-4o-mini")
+		const modelCell = screen.getByText("gpt-4o-mini").closest("[title]")!
 		expect(modelCell.getAttribute("title")).toBe("openrouter/openai/gpt-4o-mini")
 	})
 
@@ -864,12 +868,14 @@ describe("SessionWaterfall", () => {
 		expect(within(toolRow).getAllByText("read_file")).toHaveLength(1)
 	})
 
-	it("splits a call's tokens into the same halves the header totals", () => {
+	it("breaks a call's tokens into the same buckets the header totals", () => {
 		render(<Waterfall />)
 
-		// 40,000 in and 600 out, cache buckets included in the prompt half exactly
-		// as the session total counts them.
-		expect(screen.getByText("40.0K → 600")).toBeTruthy()
+		// 40,000 input and 600 output: one bar segment each, and their sum is the
+		// figure beside the bar — the same total the session header reaches. The
+		// title's newlines come back normalised, so the query reads them as spaces.
+		const cell = screen.getAllByTitle("40.6K tokens Input: 40,000 Output: 600")[0]!
+		expect(within(cell).getByText("40.6K")).toBeTruthy()
 	})
 
 	// Regression: assignment is by start time, so a span reporting for the whole

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -16,9 +16,11 @@ import {
 	spanTokenBuckets,
 	type IdleGap,
 	type SessionSummary,
+	type SessionTokenTotals,
 } from "@/lib/agent-sessions/session-summary"
 import {
 	classifyAiSpan,
+	GEN_AI_OPERATIONS,
 	isLlmCall,
 	spanEndMs,
 	spanFailed,
@@ -30,6 +32,8 @@ import {
 } from "@/lib/agent-sessions/session-turns"
 import { filterSpans, isDelegation } from "@/lib/agent-sessions/span-filters"
 import { useDetectedModels, type DetectedModel } from "@/hooks/use-detected-models"
+import { TOKEN_BUCKETS } from "@/lib/agent-sessions/token-buckets"
+import { ModelLabel } from "../model-label"
 import { Pill } from "./pill"
 import type { SpanDetailTab } from "./span-expansion"
 import { SpanPopover } from "./span-popover"
@@ -53,6 +57,8 @@ const COL_MODEL = "hidden w-[150px] shrink-0 truncate px-2 text-muted-foreground
 /** Rows are fixed-height, so the cell truncates rather than wrapping into the row below. */
 const COL_TOKENS =
 	"hidden w-[132px] shrink-0 truncate px-2 text-right tabular-nums text-muted-foreground @3xl:block"
+/** The same cell as a flex row, for the breakdown bar and the figure beside it. */
+const COL_TOKENS_SPLIT = "hidden w-[132px] shrink-0 items-center gap-1.5 px-2 @3xl:flex"
 /** A margin, not padding: the bars inside position in percent, which resolves
  *  against the padding box and would ignore padding entirely. */
 const COL_AXIS = "relative ml-3 min-w-0 flex-1 self-stretch"
@@ -228,7 +234,7 @@ export function SessionWaterfall({
 				<div className="flex h-7 items-center border-border border-b px-2.5 font-medium text-[11px] text-muted-foreground uppercase tracking-wider">
 					<span className={COL_SPAN}>Span</span>
 					<span className={COL_MODEL}>Model / target</span>
-					<span className={COL_TOKENS}>Tokens In / Out</span>
+					<span className={COL_TOKENS}>Tokens</span>
 					<span className={cn(COL_AXIS, "flex items-center")}>
 						{ticks.map((tick, index) => (
 							<span
@@ -505,7 +511,7 @@ function TurnHeader({
 				)}
 			</span>
 			<span className={COL_MODEL}>{turn.agentName ?? "—"}</span>
-			<span className={COL_TOKENS}>{tokens.total > 0 ? formatNumber(tokens.total) : "—"}</span>
+			<TokenCell tokens={tokens} />
 			<span className={COL_AXIS}>
 				<AxisGrid ticks={axis.ticks} />
 				<span
@@ -565,11 +571,12 @@ function SpanRow({
 	// The same glyph vocabulary as the Flow view's nodes: the kind of work reads
 	// by shape, and a failure takes the glyph over outright.
 	const Glyph = errored ? CircleXmarkIcon : CATEGORY_ICON[category]
+	const heading = spanHeading(span, category)
 	const target = spanTarget(span, category)
-	// A model gets the name the catalog knows it by; a tool's target is a file
-	// path or a query, which nothing but itself can spell. Either way the value
-	// the span carried stays in the row's `title`.
-	const targetLabel = target === undefined ? "—" : category === "tool" ? target : detect(target).displayName
+	// A model is drawn with its vendor's mark and the name the catalog knows it
+	// by; a tool's target is a file path or a query, which nothing but itself can
+	// spell. Either way the value the span carried stays in the cell's `title`.
+	const model = category === "tool" ? undefined : spanModel(span)
 
 	return (
 		<button
@@ -604,15 +611,36 @@ function SpanRow({
 					size={13}
 					className={cn("shrink-0", errored ? "text-destructive" : CATEGORY_TEXT[category])}
 				/>
-				<span className="truncate font-medium">{span.spanName}</span>
-				<span className="min-w-0 truncate text-muted-foreground">{spanMeta(span, category)}</span>
+				{heading.operation !== undefined && (
+					// Chrome, not the label: which operation ran is already the row's
+					// glyph and its hue, so the name it acted on is what carries weight.
+					<span className="shrink-0 text-muted-foreground/70">{heading.operation}</span>
+				)}
+				{heading.subject !== undefined && (
+					// Holds its width against the status message beside it: the tool a
+					// row ran is what the reader is scanning for, so a long error string
+					// yields the space rather than sharing it.
+					<span className="max-w-[60%] shrink-0 truncate font-medium">{heading.subject}</span>
+				)}
+				{span.statusMessage !== "" && (
+					<span className="min-w-0 truncate text-muted-foreground">{span.statusMessage}</span>
+				)}
 				{errored && <Pill tone="error">{span.genAi.errorType ?? "Error"}</Pill>}
 				{isDelegation(span, spansById) && <Pill tone="outline">Subagent</Pill>}
 			</span>
-			<span className={cn(COL_MODEL, errored && "text-destructive")} title={target}>
-				{targetLabel}
+			<span
+				className={cn(COL_MODEL, errored && "text-destructive")}
+				// The raw value the span carried, whichever way the cell draws it —
+				// `ModelLabel` fills the cell, so it is the one that has to hold it.
+				title={model === undefined ? target : undefined}
+			>
+				{model !== undefined ? (
+					<ModelLabel detected={detect(model)} size={12} title={target} />
+				) : (
+					(target ?? "—")
+				)}
 			</span>
-			<span className={cn(COL_TOKENS, errored && "text-destructive")}>{spanTokens(span)}</span>
+			<TokenCell tokens={isLlmCall(span) ? spanTokenBuckets(span) : undefined} errored={errored} />
 			<span className={COL_AXIS}>
 				<AxisGrid ticks={axis.ticks} />
 				<SpanBar span={span} axis={axis} category={category} errored={errored} />
@@ -685,19 +713,49 @@ function GapRow({ gap }: { gap: IdleGap }) {
 /* Cell content                                                               */
 /* -------------------------------------------------------------------------- */
 
-/** Inline meta beside the span name. */
-function spanMeta(span: AiSessionSpan, category: AiSpanCategory): string {
-	const parts: string[] = []
-	const agentName = span.genAi.agentName
-	if (category === "agent" && agentName !== undefined) parts.push(agentName)
-	const toolName = span.genAi.toolName
-	if (category === "tool" && toolName !== undefined) parts.push(toolName)
-	const ttftMs = spanTtftMs(span)
-	if (ttftMs !== undefined) parts.push(`ttft ${formatDuration(ttftMs)}`)
-	const reasoning = span.genAi.usageReasoningOutputTokens
-	if (reasoning !== undefined && reasoning > 0) parts.push(`${formatNumber(reasoning)} reasoning`)
-	if (span.statusMessage !== "") parts.push(span.statusMessage)
-	return parts.join(" · ")
+/**
+ * How the SPAN cell reads: the operation as chrome, and the one thing the row
+ * is about as its label.
+ *
+ * A span name conventionally leads with its operation — `execute_tool
+ * read_file`, `chat gpt-5` — so the two are split back apart rather than set as
+ * one string. What follows the operation is the subject, and where the name
+ * carries only the operation the subject comes from the attribute that names
+ * it. A model call has no subject here at all: naming the model is the MODEL
+ * column's job, and one row should say a thing once.
+ */
+function spanHeading(
+	span: AiSessionSpan,
+	category: AiSpanCategory,
+): { operation: string | undefined; subject: string | undefined } {
+	const name = span.spanName.trim()
+	const operation = leadingOperation(span, name)
+	const rest = operation === undefined ? name : name.slice(operation.length).trim()
+	const subject = rest === "" ? undefined : rest
+
+	if (category === "tool") return { operation, subject: subject ?? span.genAi.toolName }
+	if (category === "agent") return { operation, subject: subject ?? span.genAi.agentName }
+	if (category === "inference" && subject !== undefined && namesTheModel(span, subject)) {
+		return { operation, subject: undefined }
+	}
+	return { operation, subject }
+}
+
+/** The operation the span name leads with, when it leads with one at all. The
+ *  reported `gen_ai.operation.name` is trusted first; reporters that skip it
+ *  still spell a known operation into the name. */
+function leadingOperation(span: AiSessionSpan, name: string): string | undefined {
+	const reported = span.genAi.operationName
+	if (reported !== undefined && (name === reported || name.startsWith(`${reported} `))) return reported
+	const head = name.split(" ")[0] ?? ""
+	return GEN_AI_OPERATIONS.has(head) ? head : undefined
+}
+
+function namesTheModel(span: AiSessionSpan, subject: string): boolean {
+	const lower = subject.toLowerCase()
+	return (
+		span.genAi.responseModel?.toLowerCase() === lower || span.genAi.requestModel?.toLowerCase() === lower
+	)
 }
 
 /** The MODEL / TARGET cell: the model that ran, or what the tool acted on. The
@@ -737,15 +795,43 @@ function clipTarget(value: string): string | undefined {
 }
 
 /**
- * `in → out`, taken from the same buckets the header sums, so a row and the
- * session total can never tell different stories. The in half is everything the
- * model read — fresh input plus both cache buckets — and the out half is what
- * it wrote, reasoning included.
+ * The TOKENS cell: the five disjoint buckets as a bar, with their sum beside
+ * it. The same fills as the Overview's Tokens rail and the list row's bar, so
+ * cache-heavy against fresh against generated reads the same everywhere — and
+ * the same buckets the session total sums, so a row and the header can never
+ * tell different stories.
+ *
+ * A bar rather than a prompt/completion pair: the thing a reader wants from a
+ * column of model calls is which of them re-read a cached prompt and which paid
+ * for a fresh one, and that is a shape question rather than two figures.
  */
-function spanTokens(span: AiSessionSpan): string {
-	if (!isLlmCall(span)) return "—"
-	const buckets = spanTokenBuckets(span)
-	if (buckets === undefined || buckets.total === 0) return "—"
-	const completion = buckets.output + buckets.reasoning
-	return `${formatNumber(buckets.total - completion)} → ${formatNumber(completion)}`
+function TokenCell({ tokens, errored }: { tokens: SessionTokenTotals | undefined; errored?: boolean }) {
+	const drawn = tokens === undefined ? [] : TOKEN_BUCKETS.filter((bucket) => tokens[bucket.key] > 0)
+	if (tokens === undefined || tokens.total === 0 || drawn.length === 0) {
+		return <span className={cn(COL_TOKENS, errored && "text-destructive")}>—</span>
+	}
+
+	const title = [
+		`${formatNumber(tokens.total)} tokens`,
+		...drawn.map((bucket) => `${bucket.label}: ${tokens[bucket.key].toLocaleString()}`),
+	].join("\n")
+
+	return (
+		<span className={COL_TOKENS_SPLIT} title={title}>
+			<span aria-hidden className="flex h-1.5 flex-1 gap-px overflow-hidden rounded-xs bg-muted">
+				{drawn.map((bucket) => (
+					<span
+						key={bucket.key}
+						className={bucket.fill}
+						style={{ width: `${(tokens[bucket.key] / tokens.total) * 100}%` }}
+					/>
+				))}
+			</span>
+			<span
+				className={cn("shrink-0 tabular-nums text-muted-foreground", errored && "text-destructive")}
+			>
+				{formatNumber(tokens.total)}
+			</span>
+		</span>
+	)
 }

--- a/apps/web/src/lib/agent-sessions/session-turns.ts
+++ b/apps/web/src/lib/agent-sessions/session-turns.ts
@@ -32,6 +32,17 @@ const RETRIEVAL_OPS = new Set(["embeddings", "retrieval"])
 const TOOL_OPS = new Set(["execute_tool"])
 const AGENT_OPS = new Set(["invoke_agent", "create_agent", "invoke_workflow", "plan", "agent_step"])
 
+/** Every operation name the four sets above recognise. A span name conventionally
+ *  leads with one ("execute_tool read_file", "chat gpt-5"), so a view that wants
+ *  to set the operation apart from its subject needs to know which words are
+ *  operations — including for the reporters that skip `gen_ai.operation.name`. */
+export const GEN_AI_OPERATIONS: ReadonlySet<string> = new Set([
+	...INFERENCE_OPS,
+	...RETRIEVAL_OPS,
+	...TOOL_OPS,
+	...AGENT_OPS,
+])
+
 export function spanStartMs(span: AiSessionSpan): number {
 	return toEpochMs(span.timestamp)
 }


### PR DESCRIPTION
Each row of the session Traces view now says one thing once, and says it in the column that owns it.

### TOKENS
The five disjoint usage buckets as a bar, with their sum beside it, in place of `in → out`. Same fills as the Overview's Tokens rail and the list row's bar, and the same buckets the session total sums — so a row, the header and the list can't tell different stories. One bar answers what two figures could not: which calls re-read a cached prompt and which paid for a fresh one. Per-bucket counts are in the cell's title.

### SPAN
The span name is split at the operation it conventionally leads with (`execute_tool read_file`, `chat gpt-5`). The operation is set as muted chrome — the row's glyph and hue already say which kind of work ran — and what it acted on is the label. A tool is named once per row rather than twice.

`GEN_AI_OPERATIONS` is exported from `session-turns.ts` so the split also works for reporters that skip `gen_ai.operation.name` and only spell the operation into the name.

### Chat rows
A model call's model belongs to MODEL, so it comes off the SPAN cell, and TTFT and the reasoning-token count go with it. The bar still splits at TTFT, and the span popover carries both.

### MODEL / TARGET
A model is drawn with its vendor's mark via the same `ModelLabel` the list rows and the Overview rail use. The raw id stays in the title. Tool targets and service names are unchanged.

---

**Verification**

- 338 agent-sessions tests pass; three rewritten for the new rendering.
- Full `@maple/web` suite: 16 failures, identical to `main` (pre-existing, unrelated).
- `bun typecheck` and oxlint clean.
- Checked visually at `/lab/agent-session?view=trace`, including an errored tool row and deep subagent indentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791463146&installation_model_id=427786&pr_number=804&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F804&signature=f11569d74f9290208549edbe8728bd8620a4dfb546128fa25b65bad5baa63fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->