### PR TITLE
fix(api): hand raw routers their request services, log declared 5xx

### DIFF
--- a/apps/api/src/routes/server-error-observability.ts
+++ b/apps/api/src/routes/server-error-observability.ts
@@ -1,0 +1,60 @@
+import { Effect, Schema, SchemaAST } from "effect"
+import type { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
+
+/** The `HttpApiSchema.status` annotation, the one the response encoder resolves. */
+const httpApiStatus = SchemaAST.resolveAt<number>("httpApiStatus")
+
+/**
+ * The status an endpoint answers a typed failure with, read from the endpoint's declared error
+ * schemas — the same annotation the encoder uses, so this cannot disagree with the wire. An
+ * unannotated error schema encodes as 500, which is also what `HttpApi` does.
+ */
+const declaredStatus = (endpoint: HttpApiEndpoint.Top, error: unknown): number | undefined => {
+	for (const schema of endpoint.error) {
+		if (Schema.is(schema)(error)) return httpApiStatus(schema.ast) ?? 500
+	}
+	return undefined
+}
+
+const tagOf = (error: unknown): string =>
+	typeof error === "object" && error !== null && "_tag" in error && typeof error._tag === "string"
+		? error._tag
+		: typeof error
+
+const messageOf = (error: unknown): string | undefined =>
+	typeof error === "object" && error !== null && "message" in error && typeof error.message === "string"
+		? error.message
+		: undefined
+
+/**
+ * Record a typed failure the endpoint answers with a 5xx.
+ *
+ * Domain errors pass the boundaries as values and are encoded straight from their class, so a
+ * `WarehouseQueryError` becoming a 502 used to leave no log line, no span attribute and no
+ * exception event — every `/internal/query-engine/*` 500 was invisible. Defects are handled by the
+ * boundary's own `catchDefect`; this covers the failures it deliberately lets through.
+ */
+export const observeServerError =
+	(endpoint: HttpApiEndpoint.Top, group: HttpApiGroup.Top) =>
+	(error: unknown): Effect.Effect<void> => {
+		const status = declaredStatus(endpoint, error)
+		if (status === undefined || status < 500) return Effect.void
+		const tag = tagOf(error)
+		return Effect.annotateCurrentSpan({
+			"error.type": tag,
+			"http.response.status_code": status,
+		}).pipe(
+			Effect.andThen(
+				Effect.logError("Route answered with a server error").pipe(
+					Effect.annotateLogs({
+						errorTag: tag,
+						status,
+						group: group.identifier,
+						operation: endpoint.identifier,
+						message: messageOf(error),
+						cause: error,
+					}),
+				),
+			),
+		)
+	}

--- a/apps/api/src/routes/v1/chat-sessions.http.test.ts
+++ b/apps/api/src/routes/v1/chat-sessions.http.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, assert, describe, it } from "@effect/vitest"
+import { OrgId, UserId } from "@maple/domain/http"
+import { WorkerEnvironment } from "@maple/infra/worker-runtime"
+import { ConfigProvider, Effect, Layer, Schema } from "effect"
+import { HttpRouter } from "effect/unstable/http"
+import type { ChatSessionStub } from "@/chat/session"
+import { Env } from "@/platform/Env"
+import { cleanupTestDbs, createTestDb, type TestDb } from "@/platform/test-pglite"
+import { AuthService } from "@/services/auth/AuthService"
+import { ApiKeysService } from "@/services/org/ApiKeysService"
+import { ChatSessionsRouter } from "./chat-sessions.http"
+
+const trackedDbs: TestDb[] = []
+afterEach(() => cleanupTestDbs(trackedDbs))
+
+const ORG = Schema.decodeUnknownSync(OrgId)("org_chat")
+const USER = Schema.decodeUnknownSync(UserId)("user_chat")
+const INTERNAL_TOKEN = "chat-internal-service-token"
+const SESSION_PATH = `/api/chat/sessions/${encodeURIComponent(`${ORG}:quick`)}`
+
+const config = ConfigProvider.layer(
+	ConfigProvider.fromUnknown({
+		TINYBIRD_HOST: "https://api.tinybird.co",
+		TINYBIRD_TOKEN: "test-token",
+		MAPLE_AUTH_MODE: "self_hosted",
+		MAPLE_ROOT_PASSWORD: "test-root-password",
+		MAPLE_DEFAULT_ORG_ID: "default",
+		MAPLE_APP_BASE_URL: "https://app.example.com",
+		MAPLE_INGEST_KEY_ENCRYPTION_KEY: Buffer.alloc(32, 7).toString("base64"),
+		MAPLE_INGEST_KEY_LOOKUP_HMAC_KEY: "maple-test-lookup-secret",
+		INTERNAL_SERVICE_TOKEN: INTERNAL_TOKEN,
+	}),
+)
+
+type BeginTurnInput = Parameters<ChatSessionStub["beginTurn"]>[0]
+
+/** A `ChatSession` Durable Object that records the turns it is asked to start. */
+const makeStub = (turns: Array<BeginTurnInput>): ChatSessionStub => ({
+	cursor: () => Promise.resolve(0),
+	running: () => Promise.resolve(false),
+	history: () => Promise.resolve([]),
+	since: () => Promise.resolve([]),
+	subscribe: () => Promise.resolve(new ReadableStream<Uint8Array>()),
+	append: () => Promise.resolve(0),
+	beginTurn: (input) => {
+		turns.push(input)
+		return Promise.resolve({ cursor: turns.length, messageId: input.messageId })
+	},
+	holdsTurn: () => Promise.resolve(false),
+	endTurn: () => Promise.resolve(),
+	abort: () => Promise.resolve(),
+})
+
+/**
+ * The router over the services production gives it, and nothing else in the request context:
+ * every service a handler needs has to have been captured while the router was built. This is
+ * the shape that answered every chat request with "Service not found" until it was.
+ */
+const makeRouterLayer = (testDb: TestDb, turns: Array<BeginTurnInput>) => {
+	const base = Layer.mergeAll(testDb.layer, Env.layer.pipe(Layer.provide(config)))
+	const workerEnv = Layer.succeed(WorkerEnvironment, {
+		ChatSession: { idFromName: (name: string) => name, get: () => makeStub(turns) },
+	})
+	return ChatSessionsRouter.pipe(
+		Layer.provide(
+			Layer.mergeAll(
+				ApiKeysService.layer.pipe(Layer.provide(base)),
+				AuthService.layer.pipe(Layer.provide(base)),
+				base,
+				workerEnv,
+			),
+		),
+	)
+}
+
+const withHandler = (
+	testDb: TestDb,
+	turns: Array<BeginTurnInput>,
+	body: (handler: (request: Request) => Promise<Response>) => Effect.Effect<void>,
+) => {
+	const { handler, dispose } = HttpRouter.toWebHandler(makeRouterLayer(testDb, turns), {
+		disableLogger: true,
+	})
+	return body((request) => handler(request)).pipe(Effect.ensuring(Effect.promise(dispose)))
+}
+
+const send = (
+	handler: (request: Request) => Promise<Response>,
+	headers: Record<string, string>,
+	text = "hello",
+) =>
+	Effect.promise(() =>
+		handler(
+			new Request(`http://api.localhost${SESSION_PATH}/messages`, {
+				method: "POST",
+				headers: { "content-type": "application/json", ...headers },
+				body: JSON.stringify({ text }),
+			}),
+		),
+	)
+
+/** Mint a real key for the org so the API-key branch of the tenant resolver runs. */
+const mintApiKey = (testDb: TestDb) =>
+	Effect.gen(function* () {
+		const apiKeys = yield* ApiKeysService
+		const created = yield* apiKeys.create(ORG, USER, { name: "chat-test", kind: "standard" })
+		return created.secret
+	}).pipe(
+		Effect.provide(
+			ApiKeysService.layer.pipe(
+				Layer.provide(Layer.mergeAll(testDb.layer, Env.layer.pipe(Layer.provide(config)))),
+			),
+		),
+	)
+
+describe("ChatSessionsRouter", () => {
+	it.effect("starts a turn for an API-key caller of the session's own org", () => {
+		const testDb = createTestDb(trackedDbs)
+		const turns: Array<BeginTurnInput> = []
+		return Effect.gen(function* () {
+			const key = yield* mintApiKey(testDb)
+			yield* withHandler(
+				testDb,
+				turns,
+				Effect.fnUntraced(function* (handler) {
+					const response = yield* send(handler, { authorization: `Bearer ${key}` })
+					assert.strictEqual(response.status, 202)
+					const body = yield* Effect.promise(() => response.json())
+					assert.strictEqual(turns.length, 1)
+					assert.strictEqual(turns[0]?.tenant.orgId, ORG)
+					assert.strictEqual(turns[0]?.text, "hello")
+					assert.strictEqual(body.messageId, turns[0]?.messageId)
+				}),
+			)
+		})
+	})
+
+	it.effect("starts a turn for an internal-service caller", () => {
+		const testDb = createTestDb(trackedDbs)
+		const turns: Array<BeginTurnInput> = []
+		return withHandler(
+			testDb,
+			turns,
+			Effect.fnUntraced(function* (handler) {
+				const response = yield* send(handler, {
+					authorization: `Bearer maple_svc_${INTERNAL_TOKEN}`,
+					"x-org-id": ORG,
+				})
+				assert.strictEqual(response.status, 202)
+				assert.strictEqual(turns.length, 1)
+			}),
+		)
+	})
+
+	it.effect("answers 401, never 500, to a credential nobody issued", () => {
+		const testDb = createTestDb(trackedDbs)
+		const turns: Array<BeginTurnInput> = []
+		return withHandler(
+			testDb,
+			turns,
+			Effect.fnUntraced(function* (handler) {
+				const unknownKey = yield* send(handler, { authorization: "Bearer maple_ak_not_a_key" })
+				assert.strictEqual(unknownKey.status, 401)
+				const anonymous = yield* send(handler, {})
+				assert.strictEqual(anonymous.status, 401)
+				assert.strictEqual(turns.length, 0)
+			}),
+		)
+	})
+
+	it.effect("hides another org's session as 404", () => {
+		const testDb = createTestDb(trackedDbs)
+		const turns: Array<BeginTurnInput> = []
+		return withHandler(
+			testDb,
+			turns,
+			Effect.fnUntraced(function* (handler) {
+				const response = yield* send(handler, {
+					authorization: `Bearer maple_svc_${INTERNAL_TOKEN}`,
+					"x-org-id": "org_other",
+				})
+				assert.strictEqual(response.status, 404)
+				assert.strictEqual(turns.length, 0)
+			}),
+		)
+	})
+})

--- a/apps/api/src/routes/v1/chat-sessions.http.ts
+++ b/apps/api/src/routes/v1/chat-sessions.http.ts
@@ -31,10 +31,13 @@ import {
 	type ChatTurnTenantEncoded,
 } from "@maple/domain/chat-session"
 import { WorkerEnvironment } from "@maple/infra/worker-runtime"
-import { Effect, Option, Schema, Stream } from "effect"
+import { Effect, Layer, Option, Schema, Stream } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { chatSessionStub, type ChatSessionStub } from "@/chat/session"
+import { AuthService } from "@/services/auth/AuthService"
 import type { TenantContext } from "@/services/auth/tenant-context"
+import { ApiKeysService } from "@/services/org/ApiKeysService"
+import { Env } from "@/platform/Env"
 import { resolveHttpMcpTenant } from "@/mcp/lib/query-warehouse"
 
 const json = (body: unknown, status = 200) =>
@@ -264,4 +267,12 @@ export const ChatSessionsRouter = HttpRouter.use((router) =>
 			}),
 		)
 	}),
+).pipe(
+	// A raw router's handlers run in the request's own context; nothing carries the layer this
+	// router was built from into them. The tenant resolver and the Durable Object lookup read
+	// these per request, so hand them over from the build — reading them inside a handler
+	// answered every chat request with a 500 ("Service not found") until 2026-09-08.
+	HttpRouter.provideRequest(
+		Layer.effectContext(Effect.context<ApiKeysService | AuthService | Env | WorkerEnvironment>()),
+	),
 )

--- a/apps/api/src/routes/v1/error-boundary.test.ts
+++ b/apps/api/src/routes/v1/error-boundary.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from "@effect/vitest"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, Layer, Logger, References, Schema, Tracer } from "effect"
 import { HttpRouter } from "effect/unstable/http"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
 import { V1SchemaErrors, V1UnexpectedErrors } from "@maple/domain/http"
 import { V1ErrorBoundaryLive } from "./error-boundary"
+
+/** A declared failure the endpoint answers with a 502 — the shape every warehouse error takes. */
+class UpstreamError extends Schema.TaggedError<UpstreamError>()(
+	"@maple/test/UpstreamError",
+	{ message: Schema.String },
+	{ httpApiStatus: 502 },
+) {}
+
+/** A declared failure that is the caller's problem. */
+class ConflictError extends Schema.TaggedError<ConflictError>()(
+	"@maple/test/ConflictError",
+	{ message: Schema.String },
+	{ httpApiStatus: 409 },
+) {}
 
 const BoundaryGroup = HttpApiGroup.make("boundary")
 	.add(
@@ -14,6 +28,12 @@ const BoundaryGroup = HttpApiGroup.make("boundary")
 	)
 	.add(HttpApiEndpoint.get("invalidResponse", "/invalid-response", { success: Schema.String }))
 	.add(HttpApiEndpoint.get("defect", "/defect", { success: Schema.String }))
+	.add(
+		HttpApiEndpoint.get("declared", "/declared", {
+			success: Schema.String,
+			error: [UpstreamError, ConflictError],
+		}),
+	)
 
 class BoundaryApi extends HttpApi.make("BoundaryApi")
 	.add(BoundaryGroup)
@@ -25,9 +45,44 @@ const BoundaryHandlersLive = HttpApiBuilder.group(BoundaryApi, "boundary", (hand
 		handlers
 			.handle("validate", ({ payload }) => Effect.succeed(payload.name))
 			.handle("invalidResponse", () => Effect.succeed(42 as never))
-			.handle("defect", () => Effect.die(new Error("database password must not cross the wire"))),
+			.handle("defect", () => Effect.die(new Error("database password must not cross the wire")))
+			.handle("declared", ({ request }) =>
+				request.headers["x-fail-with"] === "conflict"
+					? Effect.fail(new ConflictError({ message: "already running" }))
+					: Effect.fail(new UpstreamError({ message: "SELECT failed: memory limit exceeded" })),
+			),
 	),
 )
+
+interface RecordedLog {
+	readonly level: string
+	readonly message: string
+	readonly annotations: Readonly<Record<string, unknown>>
+}
+
+/** A request context whose spans and log lines are kept, so the boundary's telemetry can be read. */
+const makeRecordingContext = () => {
+	const spans: Array<Tracer.NativeSpan> = []
+	const logs: Array<RecordedLog> = []
+	const tracer = Tracer.make({
+		span(options) {
+			const span = new Tracer.NativeSpan(options)
+			spans.push(span)
+			return span
+		},
+	})
+	const logger = Logger.make(({ fiber, logLevel, message }) => {
+		logs.push({
+			level: logLevel,
+			message: JSON.stringify(message),
+			annotations: fiber.getRef(References.CurrentLogAnnotations),
+		})
+	})
+	const context = Context.make(Tracer.Tracer, tracer).pipe(
+		Context.add(Logger.CurrentLoggers, new Set([logger])),
+	)
+	return { spans, logs, context }
+}
 
 const makeHarness = () => {
 	const routes = HttpApiBuilder.layer(BoundaryApi).pipe(
@@ -35,14 +90,22 @@ const makeHarness = () => {
 		Layer.provide(V1ErrorBoundaryLive),
 	)
 	const { handler, dispose } = HttpRouter.toWebHandler(routes, { disableLogger: true })
-	const request = async (method: string, path: string, body?: unknown) => {
+	const request = async (
+		method: string,
+		path: string,
+		body?: unknown,
+		options: { headers?: Record<string, string>; context?: Context.Context<never> } = {},
+	) => {
 		const response = await handler(
 			new Request(`http://maple.test${path}`, {
 				method,
-				headers: body === undefined ? undefined : { "content-type": "application/json" },
+				headers: {
+					...(body === undefined ? undefined : { "content-type": "application/json" }),
+					...options.headers,
+				},
 				body: body === undefined ? undefined : JSON.stringify(body),
 			}),
-			Context.empty() as never,
+			(options.context ?? Context.empty()) as never,
 		)
 		return { status: response.status, body: await response.json() }
 	}
@@ -75,6 +138,50 @@ describe("v1 HTTP error boundary", () => {
 				message: "An unexpected error occurred on our end.",
 			})
 			expect(JSON.stringify(response.body)).not.toContain("database password")
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	// A declared 5xx passes the boundary as a plain value and is encoded from its class, so it
+	// used to leave no log line and no span attribute: the api's query-engine 500s were invisible.
+	it("logs a declared 5xx and names it on the span", async () => {
+		const harness = makeHarness()
+		const { spans, logs, context } = makeRecordingContext()
+		try {
+			const response = await harness.request("GET", "/declared", undefined, { context })
+			expect(response.status).toBe(502)
+
+			const log = logs.find((entry) => entry.message.includes("Route answered with a server error"))
+			expect(log).toBeDefined()
+			expect(log?.level).toBe("Error")
+			expect(log?.annotations).toMatchObject({
+				errorTag: "@maple/test/UpstreamError",
+				status: 502,
+				group: "boundary",
+				operation: "declared",
+				message: "SELECT failed: memory limit exceeded",
+			})
+
+			const span = spans.find((s) => s.attributes.get("error.type") === "@maple/test/UpstreamError")
+			expect(span).toBeDefined()
+			expect(span?.attributes.get("http.response.status_code")).toBe(502)
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("stays quiet about a declared 4xx", async () => {
+		const harness = makeHarness()
+		const { spans, logs, context } = makeRecordingContext()
+		try {
+			const response = await harness.request("GET", "/declared", undefined, {
+				headers: { "x-fail-with": "conflict" },
+				context,
+			})
+			expect(response.status).toBe(409)
+			expect(logs.filter((entry) => entry.level === "Error")).toEqual([])
+			expect(spans.some((s) => s.attributes.has("error.type"))).toBe(false)
 		} finally {
 			await harness.dispose()
 		}

--- a/apps/api/src/routes/v1/error-boundary.ts
+++ b/apps/api/src/routes/v1/error-boundary.ts
@@ -7,6 +7,7 @@ import {
 	V1UnexpectedErrors,
 } from "@maple/domain/http"
 import { describeSchemaIssue, summarizeSchemaError } from "@/routes/schema-error-detail"
+import { observeServerError } from "@/routes/server-error-observability"
 
 class V1RouteExecutionDefect extends Schema.TaggedError<V1RouteExecutionDefect>()(
 	"@maple/api/routes/v1/V1RouteExecutionDefect",
@@ -77,6 +78,7 @@ const V1UnexpectedErrorsLive = Layer.succeed(
 	V1UnexpectedErrors,
 	V1UnexpectedErrors.of((httpEffect, { endpoint, group }) =>
 		httpEffect.pipe(
+			Effect.tapError(observeServerError(endpoint, group)),
 			Effect.catchDefect((cause) => {
 				const defectType = cause instanceof Error ? cause.name : typeof cause
 				const error = new V1RouteExecutionDefect({

--- a/apps/api/src/routes/v2/error-envelope.test.ts
+++ b/apps/api/src/routes/v2/error-envelope.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from "@effect/vitest"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, Layer, Logger, References, Schema, Tracer } from "effect"
 import { HttpRouter } from "effect/unstable/http"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
-import { V2SchemaErrors, V2UnexpectedErrors } from "@maple/domain/http/v2"
+import { WarehouseQueryError } from "@maple/domain/http"
+import { publicError, V2SchemaErrors, V2UnexpectedErrors } from "@maple/domain/http/v2"
 import { V2TransportErrorBoundaryLive } from "./error-envelope"
 
-const ResponseSchemaGroup = HttpApiGroup.make("responseSchema").add(
-	HttpApiEndpoint.get("invalidResponse", "/invalid-response", { success: Schema.String }),
-)
+const ResponseSchemaGroup = HttpApiGroup.make("responseSchema")
+	.add(HttpApiEndpoint.get("invalidResponse", "/invalid-response", { success: Schema.String }))
+	.add(
+		HttpApiEndpoint.get("declared", "/declared", {
+			success: Schema.String,
+			error: publicError(WarehouseQueryError),
+		}),
+	)
 
 class ResponseSchemaApi extends HttpApi.make("ResponseSchemaApi")
 	.add(ResponseSchemaGroup)
@@ -15,16 +21,91 @@ class ResponseSchemaApi extends HttpApi.make("ResponseSchemaApi")
 	.middleware(V2UnexpectedErrors) {}
 
 const ResponseSchemaHandlersLive = HttpApiBuilder.group(ResponseSchemaApi, "responseSchema", (handlers) =>
-	Effect.succeed(handlers.handle("invalidResponse", () => Effect.succeed(42 as never))),
+	Effect.succeed(
+		handlers
+			.handle("invalidResponse", () => Effect.succeed(42 as never))
+			.handle("declared", () =>
+				Effect.fail(
+					new WarehouseQueryError({
+						message: "Memory limit (for query) exceeded",
+						pipeName: "service_usage",
+					}),
+				),
+			),
+	),
 )
 
+const makeHarness = () => {
+	const routes = HttpApiBuilder.layer(ResponseSchemaApi).pipe(
+		Layer.provide(ResponseSchemaHandlersLive),
+		Layer.provide(V2TransportErrorBoundaryLive),
+	)
+	return HttpRouter.toWebHandler(routes, { disableLogger: true })
+}
+
+interface RecordedLog {
+	readonly level: string
+	readonly message: string
+	readonly annotations: Readonly<Record<string, unknown>>
+}
+
+/** A request context whose spans and log lines are kept, so the boundary's telemetry can be read. */
+const makeRecordingContext = () => {
+	const spans: Array<Tracer.NativeSpan> = []
+	const logs: Array<RecordedLog> = []
+	const tracer = Tracer.make({
+		span(options) {
+			const span = new Tracer.NativeSpan(options)
+			spans.push(span)
+			return span
+		},
+	})
+	const logger = Logger.make(({ fiber, logLevel, message }) => {
+		logs.push({
+			level: logLevel,
+			message: JSON.stringify(message),
+			annotations: fiber.getRef(References.CurrentLogAnnotations),
+		})
+	})
+	const context = Context.make(Tracer.Tracer, tracer).pipe(
+		Context.add(Logger.CurrentLoggers, new Set([logger])),
+	)
+	return { spans, logs, context }
+}
+
 describe("v2 response schema boundary", () => {
+	// A declared 5xx is encoded straight from its class and never touched the boundary's logging,
+	// so a warehouse failure behind a 502 left no log line and no span attribute.
+	it("logs a declared 5xx and names it on the span", async () => {
+		const { handler, dispose } = makeHarness()
+		const { spans, logs, context } = makeRecordingContext()
+		try {
+			const response = await handler(new Request("http://maple.test/declared"), context as never)
+			expect(response.status).toBe(502)
+
+			const log = logs.find((entry) => entry.message.includes("Route answered with a server error"))
+			expect(log).toBeDefined()
+			expect(log?.level).toBe("Error")
+			expect(log?.annotations).toMatchObject({
+				errorTag: "@maple/http/errors/WarehouseQueryError",
+				status: 502,
+				group: "responseSchema",
+				operation: "declared",
+				message: "Memory limit (for query) exceeded",
+			})
+
+			const span = spans.find(
+				(s) => s.attributes.get("error.type") === "@maple/http/errors/WarehouseQueryError",
+			)
+			expect(span).toBeDefined()
+			expect(span?.attributes.get("http.response.status_code")).toBe(502)
+		} finally {
+			await dispose()
+		}
+	})
+
 	it("logs response drift and returns a sanitized 500 envelope", async () => {
-		const routes = HttpApiBuilder.layer(ResponseSchemaApi).pipe(
-			Layer.provide(ResponseSchemaHandlersLive),
-			Layer.provide(V2TransportErrorBoundaryLive),
-		)
-		const { handler, dispose } = HttpRouter.toWebHandler(routes, { disableLogger: true })
+		const { handler, dispose } = makeHarness()
 		try {
 			const response = await handler(
 				new Request("http://maple.test/invalid-response"),

--- a/apps/api/src/routes/v2/error-envelope.ts
+++ b/apps/api/src/routes/v2/error-envelope.ts
@@ -9,6 +9,7 @@ import {
 	V2UnexpectedErrors,
 } from "@maple/domain/http/v2"
 import { describeSchemaIssue } from "@/routes/schema-error-detail"
+import { observeServerError } from "@/routes/server-error-observability"
 
 class V2RouteExecutionDefect extends Schema.TaggedError<V2RouteExecutionDefect>()(
 	"@maple/api/routes/v2/V2RouteExecutionDefect",
@@ -119,6 +120,7 @@ export const V2UnexpectedErrorsLive = Layer.succeed(
 	V2UnexpectedErrors.of((httpEffect, { endpoint, group }) =>
 		httpEffect.pipe(
 			Effect.tapError(appendRetryAfter),
+			Effect.tapError(observeServerError(endpoint, group)),
 			Effect.catchDefect((cause) => {
 				const defectType = cause instanceof Error ? cause.name : typeof cause
 				const error = new V2RouteExecutionDefect({

--- a/apps/api/src/runtime/http-graph.ts
+++ b/apps/api/src/runtime/http-graph.ts
@@ -72,6 +72,7 @@ import { McpToolRateLimiter } from "@/services/auth/McpToolRateLimiter"
 import { EdgeCacheServiceLive } from "@/platform/CacheBackendLive"
 import { OrgMembershipService } from "@/services/auth/OrgMembershipService"
 import { ApiKeysService } from "@/services/org/ApiKeysService"
+import type { ApiPortsLayer } from "@/worker/bindings"
 
 const HealthRouter = HttpRouter.use((router) => router.add("GET", "/health", HttpServerResponse.text("OK")))
 
@@ -160,29 +161,58 @@ const ApiV2Routes = HttpApiBuilder.layer(MapleApiV2).pipe(
 	Layer.provide(V2TransportErrorBoundaryLive),
 )
 
-export const AllRoutes = Layer.mergeAll(
-	ApiRoutes,
-	ApiInternalRoutes,
-	ApiV2Routes,
-	ChatSessionsRouter,
-	IntegrationsCallbackRouter,
-	SlackCallbackRouter,
-	SlackInternalRouter,
-	OAuthDiscoveryRouter,
-	PlanetScaleWebhookRouter,
-	ScraperInternalRouter,
-	VcsWebhookRouter,
-	ClerkWebhookRouter,
-	AutumnWebhookRouter,
-	McpLive,
-	HealthRouter,
-	DocsRoute,
-	DocsV2Route,
-	DiscoveryRouter,
-	// Last by convention only — find-my-way ranks the wildcard below every other
-	// route regardless of registration order.
-	NotFoundRouter,
-).pipe(Layer.provideMerge(HttpRouter.cors(API_CORS_OPTIONS)))
+/**
+ * Services a raw router's handlers still expect from the request context, beyond the Worker's
+ * ports, which every request carries. Each is a runtime "Service not found".
+ */
+type LeakedRequestServices<Routes extends Layer.Any> =
+	Layer.Services<Routes> extends infer Marker
+		? Marker extends HttpRouter.Request<"Requires", infer Service>
+			? Exclude<Service, Layer.Success<ApiPortsLayer>>
+			: never
+		: never
+
+/**
+ * A raw `HttpRouter` handler runs in the request's own context — unlike an `HttpApiBuilder`
+ * group, nothing carries the router's build context into it — so a service it reads per request
+ * has to arrive through `HttpRouter.provideRequest` (see `ChatSessionsRouter`). Read inside the
+ * handler instead, it compiles, because the isolate builder erases the marker, and fails every
+ * request with "Service not found", which is what took the chat routes down on 2026-09-08. This
+ * turns that into a build failure naming the leaked service.
+ */
+const rawRoutes = <Routes extends Layer.Any>(
+	routes: Routes &
+		([LeakedRequestServices<Routes>] extends [never]
+			? unknown
+			: { readonly leakedRequestServices: LeakedRequestServices<Routes> }),
+) => routes
+
+const RawRoutes = rawRoutes(
+	Layer.mergeAll(
+		ChatSessionsRouter,
+		IntegrationsCallbackRouter,
+		SlackCallbackRouter,
+		SlackInternalRouter,
+		OAuthDiscoveryRouter,
+		PlanetScaleWebhookRouter,
+		ScraperInternalRouter,
+		VcsWebhookRouter,
+		ClerkWebhookRouter,
+		AutumnWebhookRouter,
+		McpLive,
+		HealthRouter,
+		DocsRoute,
+		DocsV2Route,
+		DiscoveryRouter,
+		// Last by convention only — find-my-way ranks the wildcard below every other
+		// route regardless of registration order.
+		NotFoundRouter,
+	),
+)
+
+export const AllRoutes = Layer.mergeAll(ApiRoutes, ApiInternalRoutes, ApiV2Routes, RawRoutes).pipe(
+	Layer.provideMerge(HttpRouter.cors(API_CORS_OPTIONS)),
+)
 
 export const ApiAuthLive = Layer.mergeAll(
 	ApiAuthorizationLayer,


### PR DESCRIPTION
## What broke

Every `POST /api/chat/sessions/:id/messages` (and the history GET) in production answered 500 with `Service not found: @maple/api/services/ApiKeysService`, raised inside the chat route's tenant resolution (16:29–16:30 UTC, 2026-09-08; no successful chat traffic since at least 09-06).

A route handler runs in the request's own context. Nothing carries the layer the router was built from into it (an `HttpApiBuilder` group hands its handlers a captured copy at runtime; a raw `HttpRouter` hands them nothing), and `buildIsolateHandler` typed the graph with `Request<"Requires", unknown>`, so a handler that read `ApiKeysService` per request compiled and failed on every request.

## The structural fix

**A per-request service read is now a build failure at the one place every route's requirements are discharged.**

- `buildIsolateHandler` takes the Worker's ports and accepts a graph whose only per-request requirements are those ports (`IsolateRoutes<E, Ports>`). Any other `Request<"Requires", X>` fails typecheck naming `X`. Verified with a deliberately leaky router: `Layer<never, never, HttpRouter | Request<"Requires", AuditLogService>> is not assignable to IsolateRoutes<never, MapleDbConnection>`.
- The bridge-handler cast now widens only the error channel (the bridge's `safeHttpEffect` renders those); requirements stay typed through `makeFetch`, which provides the ports around the request.
- `provideRequestFromBuild(...keys)` is the one way to satisfy such a read: `HttpRouter.provideRequest` over exactly the named services, picked out of the router's build context. Never the whole context, which also carries the isolate's scope, its memo map and the build fiber's references. This is the same hand-over `HttpApiBuilder` does for its handlers at runtime, made explicit and typed.
- The chat router hands over `ApiKeysService | AuthService | Env | WorkerEnvironment`. The three HttpApi layers hand over `AuditLogService`, which `recordHttpAudit` reads inside handlers. The internal chat group resolves its tool executor and worker env where the group is built instead of inside the handler.

## Observability

Declared 5xx failures (warehouse 502s, query-engine 500s) passed the v1/v2 boundaries as plain values and were encoded from their class with no log line, span attribute or exception event — the api's sporadic `/internal/query-engine/*` 500s were invisible for exactly this reason. Both boundaries now log them at Error (`errorTag`, `status`, `group`, `operation`, `message`) and set `error.type` + `http.response.status_code` on the span. The status is read from the endpoint's declared error schema, the same annotation the encoder uses.

## Tests

- `chat-sessions.http.test.ts`: the router over exactly its production services — API key → 202 and the turn starts, internal-service token → 202, unknown/absent credential → 401 (never 500), another org's session → 404. The API-key case failed with a 500 before the fix.
- `error-boundary.test.ts` / `error-envelope.test.ts`: a declared 502 produces the Error log with the expected annotations and the span attributes; a declared 409 produces neither.
- `apps/api` typecheck clean; `src/routes/**`, the bridge and the MCP app suites pass (30 files, 350 tests).
