### PR TITLE
fix(clickhouse-builder-docs): keep the sidebar icon map's own key type

### DIFF
--- a/apps/clickhouse-builder-docs/src/sidebar-icons.tsx
+++ b/apps/clickhouse-builder-docs/src/sidebar-icons.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react"
 
 // Nucleo geometry from Maple’s existing icon set (apps/web/src/components/icons).
-const icons: Record<string, ReactNode> = {
+const icons = {
 	"branch-fork": (
 		<>
 			{" "}
@@ -297,10 +297,16 @@ const icons: Record<string, ReactNode> = {
 			))}{" "}
 		</>
 	),
+} satisfies Record<string, ReactNode>
+
+type SidebarIconName = keyof typeof icons
+
+function isSidebarIconName(name: string): name is SidebarIconName {
+	return name in icons
 }
 
 export function sidebarIcon(name: string | undefined) {
-	const icon = name ? icons[name] : undefined
+	const icon = name !== undefined && isSidebarIconName(name) ? icons[name] : undefined
 	if (!icon) return undefined
 	return (
 		<svg viewBox="0 0 24 24" width="16" height="16" fill="none" aria-hidden="true" focusable="false">


### PR DESCRIPTION
`main` has been red on `TypeScript (effect-lint)` since the docs app landed in `fcf492cc9`:

```
apps/clickhouse-builder-docs/src/sidebar-icons.tsx:4:42: The explicit open dictionary type on
binding `icons` discards known type evidence. Keep inference, validate with `satisfies`, or use
a named owner contract.
```

`Record<string, ReactNode>` on the literal threw away the one thing the map knows — which icons exist. Inference plus `satisfies` keeps the value check, and `sidebarIcon` narrows an arbitrary name to a key the map holds instead of indexing an open dictionary.

- `oxlint -c .oxlintrc.effect.json apps/clickhouse-builder-docs` clean.
- `tsc --noEmit` in that app clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791538778&installation_model_id=427786&pr_number=811&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F811&signature=e4501db30ed301017f338cb6f4c971f2fce8ba6d59a25f6a22921ca471291fef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar icon handling for missing or invalid icon names.
  * Sidebar icons now resolve more reliably without relying on truthiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->