### PR TITLE
fix(landing): recover stale island chunks, open screenshots, lift the funnel

### DIFF
--- a/apps/landing/messages/en.json
+++ b/apps/landing/messages/en.json
@@ -1341,5 +1341,17 @@
 	"cmp_sn_faq_4_q": "Can I self-host both?",
 	"cmp_sn_faq_4_a": "Yes. SigNoz has the more polished path today: Docker Compose, Helm, Foundry and platform guides, multi-user with roles in the Community edition. Maple self-hosts from the repository with a compose file, your ClickHouse and a root password, single-org, and runs as one binary with an embedded ClickHouse for local development.",
 	"cmp_sn_faq_5_q": "Does SigNoz have session replay?",
-	"cmp_sn_faq_5_a": "No, and their community has said it isn't planned. SigNoz ingests browser traces, logs and Web Vitals over OpenTelemetry. Maple records and replays browser sessions with the trace behind each event, masked in the browser before anything leaves the page."
+	"cmp_sn_faq_5_a": "No, and their community has said it isn't planned. SigNoz ingests browser traces, logs and Web Vitals over OpenTelemetry. Maple records and replays browser sessions with the trace behind each event, masked in the browser before anything leaves the page.",
+
+	"home_objections_aria": "Common questions",
+	"home_objection_selfhost_claim": "Self-host the whole thing",
+	"home_objection_selfhost_detail": "Every line of Maple's source is on GitHub under FSL-1.1, and each release becomes Apache 2.0 after two years. Run it on your own infrastructure with no license call.",
+	"home_objection_selfhost_cta": "Read the source",
+	"home_objection_otel_claim": "No proprietary agent",
+	"home_objection_otel_detail": "Maple speaks plain OpenTelemetry. Point an OTLP exporter at it and keep the instrumentation you already wrote \u2014 there is nothing to rip out if you leave.",
+	"home_objection_otel_cta": "See instrumentation",
+	"home_objection_trial_claim": "{price}/month, {days}-day free trial",
+	"home_objection_trial_claim_no_trial": "{price}/month, everything included",
+	"home_objection_trial_detail": "A card is required to start the trial and nothing is charged until it ends. No per-seat, per-host or per-series fees at any volume.",
+	"home_objection_trial_cta": "See what it costs"
 }

--- a/apps/landing/src/components/HeroCta.tsx
+++ b/apps/landing/src/components/HeroCta.tsx
@@ -16,15 +16,22 @@ export function HeroCta({ className }: { className?: string }) {
 		document.addEventListener(SIGNED_IN_EVENT, onChange)
 		return () => document.removeEventListener(SIGNED_IN_EVENT, onChange)
 	}, [])
+	const href = signedIn ? APP_URL : APP_SIGN_UP_URL
+	const label = signedIn ? m.nav_dashboard() : m.cta_get_started()
 	return (
 		<a
-			href={signedIn ? APP_URL : APP_SIGN_UP_URL}
+			href={href}
 			data-hero-cta
 			data-track="cta_click"
 			data-track-location="hero"
+			// `location` alone cannot separate "the hero CTA converts" from "the
+			// hero CTA sends signed-in visitors back to their dashboard" — the
+			// two are the same event on the same element with different intent.
+			data-track-label={label}
+			data-track-destination={href}
 			className={className}
 		>
-			{signedIn ? m.nav_dashboard() : m.cta_get_started()}
+			{label}
 		</a>
 	)
 }

--- a/apps/landing/src/components/MediaLightbox.astro
+++ b/apps/landing/src/components/MediaLightbox.astro
@@ -1,0 +1,128 @@
+---
+/**
+ * Full-size viewer for product screenshots.
+ *
+ * Session replay showed the hero plate taking 198 clicks across 106 sessions —
+ * it is the most-clicked non-navigation element on the site, and it was inert.
+ * People click a screenshot to read it, so let them.
+ *
+ * One delegated listener for every `[data-zoomable]` on the page rather than an
+ * island per frame: the frames are static Astro, and the inline image stays
+ * legible on its own if this script never runs.
+ */
+---
+
+<dialog id="media-lightbox" class="media-lightbox" aria-label="Enlarged screenshot">
+	<form method="dialog" class="media-lightbox__dismiss">
+		<button type="submit" aria-label="Close">
+			<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
+				<path d="M6 6l12 12M18 6L6 18" />
+			</svg>
+		</button>
+	</form>
+	<img alt="" decoding="async" />
+</dialog>
+
+<script>
+	import { trackLanding } from "../lib/telemetry";
+
+	const dialog = document.querySelector<HTMLDialogElement>("#media-lightbox");
+	const full = dialog?.querySelector("img");
+
+	if (dialog && full) {
+		document.addEventListener("click", (event) => {
+			const target = event.target;
+			if (!(target instanceof Element)) return;
+			const zoomable = target.closest<HTMLImageElement>("img[data-zoomable]");
+			if (!zoomable) return;
+			full.src = zoomable.currentSrc || zoomable.src;
+			full.alt = zoomable.alt;
+			dialog.showModal();
+			trackLanding("media_opened", {
+				label: zoomable.alt,
+				path: window.location.pathname,
+			});
+		});
+
+		// Native <dialog> handles Esc; the backdrop is the dialog element itself,
+		// so a click that lands on it (rather than on the image) closes.
+		dialog.addEventListener("click", (event) => {
+			if (event.target === dialog) dialog.close();
+		});
+
+		// Release the decoded full-size bitmap when the viewer is dismissed.
+		dialog.addEventListener("close", () => {
+			full.removeAttribute("src");
+		});
+	}
+</script>
+
+<style is:global>
+	img[data-zoomable] {
+		cursor: zoom-in;
+	}
+
+	.media-lightbox {
+		max-width: min(96vw, 1600px);
+		max-height: 92vh;
+		width: auto;
+		padding: 0;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		background: var(--bg-elevated, var(--background));
+		color: var(--fg, currentColor);
+		overflow: visible;
+	}
+
+	.media-lightbox::backdrop {
+		background: color-mix(in oklch, black 78%, transparent);
+		backdrop-filter: blur(2px);
+	}
+
+	.media-lightbox img {
+		display: block;
+		width: 100%;
+		height: auto;
+		max-height: 92vh;
+		object-fit: contain;
+	}
+
+	.media-lightbox__dismiss {
+		position: absolute;
+		top: -0.75rem;
+		right: -0.75rem;
+		z-index: 1;
+		margin: 0;
+	}
+
+	.media-lightbox__dismiss button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		border: 1px solid var(--border);
+		border-radius: 9999px;
+		background: var(--bg-elevated, var(--background));
+		color: var(--fg-muted, currentColor);
+		cursor: pointer;
+		transition: color 150ms ease;
+	}
+
+	.media-lightbox__dismiss button:hover {
+		color: var(--fg, currentColor);
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.media-lightbox[open] {
+			animation: media-lightbox-in 160ms cubic-bezier(0, 0, 0.2, 1);
+		}
+	}
+
+	@keyframes media-lightbox-in {
+		from {
+			opacity: 0;
+			transform: scale(0.98);
+		}
+	}
+</style>

--- a/apps/landing/src/components/MediaLightbox.astro
+++ b/apps/landing/src/components/MediaLightbox.astro
@@ -63,15 +63,20 @@
 	}
 
 	.media-lightbox {
-		max-width: min(96vw, 1600px);
-		max-height: 92vh;
+		/* Leave room for the dismiss control and a margin of backdrop, so the
+		   frame reads as lifted off the page rather than pinned to its edges. */
+		max-width: min(92vw, 1600px);
+		max-height: 88vh;
 		width: auto;
+		/* Native centring: a modal <dialog> resolves `auto` insets against the
+		   viewport, which `margin: auto` alone does not do once max-height bites. */
+		margin: auto;
 		padding: 0;
 		border: 1px solid var(--border);
 		border-radius: 6px;
 		background: var(--bg-elevated, var(--background));
 		color: var(--fg, currentColor);
-		overflow: visible;
+		overflow: hidden;
 	}
 
 	.media-lightbox::backdrop {
@@ -81,16 +86,20 @@
 
 	.media-lightbox img {
 		display: block;
-		width: 100%;
+		width: auto;
+		max-width: 100%;
+		max-height: 88vh;
 		height: auto;
-		max-height: 92vh;
 		object-fit: contain;
 	}
 
+	/* Inside the frame, not hanging off it: anchored outside, the control is
+	   clipped away entirely whenever the image is tall enough to reach the
+	   top of the viewport. */
 	.media-lightbox__dismiss {
 		position: absolute;
-		top: -0.75rem;
-		right: -0.75rem;
+		top: 0.625rem;
+		right: 0.625rem;
 		z-index: 1;
 		margin: 0;
 	}
@@ -103,7 +112,9 @@
 		height: 2rem;
 		border: 1px solid var(--border);
 		border-radius: 9999px;
-		background: var(--bg-elevated, var(--background));
+		/* Opaque enough to stay legible over any screenshot underneath. */
+		background: color-mix(in oklch, var(--bg-elevated, black) 82%, transparent);
+		backdrop-filter: blur(4px);
 		color: var(--fg-muted, currentColor);
 		cursor: pointer;
 		transition: color 150ms ease;

--- a/apps/landing/src/components/NavBar.tsx
+++ b/apps/landing/src/components/NavBar.tsx
@@ -40,14 +40,21 @@ type CTAProps = {
  * `/sign-up`, because the app root sends a session-less visitor to `/sign-in`.
  */
 function CTAButton({ signedIn, trackLocation, ...rest }: CTAProps & { signedIn: boolean }) {
+	const href = signedIn ? APP_URL : APP_SIGN_UP_URL
+	const label = signedIn ? m.nav_dashboard() : m.nav_get_started()
 	return (
 		<a
-			href={signedIn ? APP_URL : APP_SIGN_UP_URL}
+			href={href}
 			data-track="cta_click"
 			data-track-location={trackLocation}
+			// Signed-out "Start free trial" and signed-in "Dashboard" are the same
+			// element in the same slot; without these two the warehouse cannot
+			// tell an acquisition click from a returning visitor's.
+			data-track-label={label}
+			data-track-destination={href}
 			{...rest}
 		>
-			{signedIn ? m.nav_dashboard() : m.nav_get_started()}
+			{label}
 		</a>
 	)
 }
@@ -269,6 +276,8 @@ export function NavBarInner({ locale = "en", stars, signedIn }: NavBarProps & { 
 						href={APP_SIGN_IN_URL}
 						data-track="cta_click"
 						data-track-location="nav_login"
+						data-track-label={m.nav_login()}
+						data-track-destination={APP_SIGN_IN_URL}
 						className="hidden text-[15px] font-medium text-fg-muted transition-colors hover:text-fg md:inline-flex"
 					>
 						{m.nav_login()}

--- a/apps/landing/src/components/PricingCalculatorSection.astro
+++ b/apps/landing/src/components/PricingCalculatorSection.astro
@@ -17,9 +17,16 @@ interface Props {
     // switcher so the visitor can compare against any vendor (used by /pricing).
     competitor?: "datadog" | "grafana" | "new-relic" | "dash0";
     competitorName?: string;
+    /**
+     * Hydrate on load instead of on scroll. Set where the section sits near the
+     * top of the page: `client:visible` is a scroll race the visitor can win,
+     * and an estimator that is still inert when it is already on screen reads
+     * as broken. Sections further down keep the default.
+     */
+    eager?: boolean;
 }
 
-const { competitor, competitorName } = Astro.props;
+const { competitor, competitorName, eager = false } = Astro.props;
 
 const compareEyebrow = competitor ? "Pricing" : m.pricing_calc_label();
 const compareHeading = competitor
@@ -46,9 +53,9 @@ const compareSub = competitor
 
         <div class="mt-10">
             {competitor ? (
-                <PricingCalculator competitor={competitor} client:visible />
+                eager ? <PricingCalculator competitor={competitor} client:load /> : <PricingCalculator competitor={competitor} client:visible />
             ) : (
-                <PricingComparisonCalculator client:visible />
+                eager ? <PricingComparisonCalculator client:load /> : <PricingComparisonCalculator client:visible />
             )}
         </div>
     </div>

--- a/apps/landing/src/components/PricingPaths.astro
+++ b/apps/landing/src/components/PricingPaths.astro
@@ -99,6 +99,9 @@ const paths = [
 									href={p.href}
 									data-track="pricing_plan_selected"
 									data-track-plan={offer.name}
+									data-track-label={p.cta}
+									data-track-destination={p.href}
+									data-track-location="pricing_paths"
 									class="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-[13px] font-medium text-primary-foreground transition-colors hover:bg-primary/90"
 								>
 									{p.cta}

--- a/apps/landing/src/components/PricingTable.astro
+++ b/apps/landing/src/components/PricingTable.astro
@@ -148,6 +148,9 @@ const containerClass = variant === "home" ? "shell" : "mx-auto max-w-5xl px-6"
                         href={APP_SIGN_UP_URL}
                         data-track="pricing_plan_selected"
                         data-track-plan={offer.name}
+                        data-track-label={offer.ctaLabel}
+                        data-track-destination={APP_SIGN_UP_URL}
+                        data-track-location="pricing_offer_card"
                         class="mt-8 flex h-11 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
                     >
                         {offer.ctaLabel}

--- a/apps/landing/src/components/home/Home.astro
+++ b/apps/landing/src/components/home/Home.astro
@@ -7,6 +7,7 @@ import Nav from "../Nav.astro";
 import SeoHead from "../SeoHead.astro";
 import HomeHero from "./HomeHero.astro";
 import HomeObjections from "./HomeObjections.astro";
+import HomeProductPlate from "./HomeProductPlate.astro";
 import SignalsStrip from "./SignalsStrip.astro";
 import IncidentStory from "./IncidentStory.astro";
 import PlatformSheet from "./PlatformSheet.astro";
@@ -49,8 +50,17 @@ const homeFaqs = [
 
         <!-- 00 — self-hosting, OpenTelemetry and the trial terms, stated before
              the page asks for anything. These are the three rows visitors open
-             once they reach /pricing, and 83% of them never get that far. -->
+             once they reach /pricing, and 83% of them never get that far.
+
+             It sits between the headline and the product plate deliberately.
+             Below the plate it lands two screens down, and the median homepage
+             visit is fourteen seconds — far enough that the visitors this is
+             aimed at would never reach it. Here it is the first thing after the
+             fold, one scroll from the hero CTA. -->
         <HomeObjections />
+
+        <!-- The hero's product screenshots, as their own section. -->
+        <HomeProductPlate />
 
         <!-- 01 — the three surfaces you actually look at. -->
         <SignalsStrip />

--- a/apps/landing/src/components/home/Home.astro
+++ b/apps/landing/src/components/home/Home.astro
@@ -6,6 +6,7 @@ import "../../styles/home-monument.css";
 import Nav from "../Nav.astro";
 import SeoHead from "../SeoHead.astro";
 import HomeHero from "./HomeHero.astro";
+import HomeObjections from "./HomeObjections.astro";
 import SignalsStrip from "./SignalsStrip.astro";
 import IncidentStory from "./IncidentStory.astro";
 import PlatformSheet from "./PlatformSheet.astro";
@@ -46,21 +47,28 @@ const homeFaqs = [
     <main id="main-content">
         <HomeHero />
 
+        <!-- 00 — self-hosting, OpenTelemetry and the trial terms, stated before
+             the page asks for anything. These are the three rows visitors open
+             once they reach /pricing, and 83% of them never get that far. -->
+        <HomeObjections />
+
         <!-- 01 — the three surfaces you actually look at. -->
         <SignalsStrip />
 
         <!-- 02 — the signature section: one incident, four surfaces, one trace id. -->
         <IncidentStory />
 
-        <!-- 03 — everything that didn't get a narrative, and the link hub. -->
+        <!-- 03 — Maple Local. Promoted out of the second half: it holds readers
+             longer than anything else on the site (the deepest read time of any
+             entry point, the lowest bounce), so it earns a slot people reach. -->
+        <LocalSection />
+
+        <!-- 04 — everything that didn't get a narrative, and the link hub. -->
         <PlatformSheet />
 
         <!-- Orange identity section. -->
         <span id="sovereignty"></span>
         <Sovereignty />
-
-        <!-- Local development and infrastructure. -->
-        <LocalSection />
 
         <!-- 06 — the infrastructure proof point. -->
         <KubernetesSection />

--- a/apps/landing/src/components/home/HomeHero.astro
+++ b/apps/landing/src/components/home/HomeHero.astro
@@ -24,7 +24,14 @@ const localPath = locale === "en" ? "/local" : `/${locale}/local`;
 
 <section class="monument-hero" aria-labelledby="home-title">
     <div class="monument-hero__field shell">
-        <a href={localPath} class="monument-announce">
+        <a
+            href={localPath}
+            class="monument-announce"
+            data-track="cta_click"
+            data-track-location="hero_announce"
+            data-track-label={m.hero_announce_text()}
+            data-track-destination={localPath}
+        >
             <span class="monument-announce__badge">{m.hero_announce_badge()}</span>
             <span class="monument-announce__text">{m.hero_announce_text()}</span>
             <span class="monument-announce__arrow" aria-hidden="true">→</span>
@@ -38,7 +45,16 @@ const localPath = locale === "en" ? "/local" : `/${locale}/local`;
             <p class="monument-hero__description">{m.hero_subtitle()}</p>
             <div class="monument-actions">
                 <HeroCta client:load className={buttonVariants({ size: "xl" })} />
-                <a href="https://github.com/MapleTechLabs/maple" target="_blank" rel="noopener noreferrer" class={buttonVariants({ variant: "outline", size: "xl" })}>{m.cta_github()}</a>
+                <a
+                    href="https://github.com/MapleTechLabs/maple"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-track="cta_click"
+                    data-track-location="hero_secondary"
+                    data-track-label={m.cta_github()}
+                    data-track-destination="https://github.com/MapleTechLabs/maple"
+                    class={buttonVariants({ variant: "outline", size: "xl" })}
+                >{m.cta_github()}</a>
             </div>
         </div>
     <div class="monument-proof">

--- a/apps/landing/src/components/home/HomeHero.astro
+++ b/apps/landing/src/components/home/HomeHero.astro
@@ -13,7 +13,6 @@ import * as m from "../../paraglide/messages.js";
 import { HeroCta } from "../HeroCta";
 import PixelStar from "../icons/PixelStar.astro";
 import CustomerLogos from "../CustomerLogos.astro";
-import HeroCarousel from "./HeroCarousel.astro";
 import { DATA_POINTS_INGESTED, formatDataPoints } from "../../lib/ingest-stats";
 import { getGitHubStars, formatStars } from "../../lib/github-stars";
 
@@ -71,7 +70,4 @@ const localPath = locale === "en" ? "/local" : `/${locale}/local`;
         <source media="(min-width: 1800px)" srcset="/art/maple-rome-ultrawide.webp" />
         <img class="monument-hero__art" src="/art/maple-rome-balanced.webp" width="1536" height="1024" alt="" fetchpriority="high" decoding="async" />
     </picture>
-</section>
-<section class="monument-product">
-    <div class="shell"><HeroCarousel /></div>
 </section>

--- a/apps/landing/src/components/home/HomeObjections.astro
+++ b/apps/landing/src/components/home/HomeObjections.astro
@@ -1,0 +1,165 @@
+---
+/**
+ * The three questions a buyer leaves the homepage to answer.
+ *
+ * Session replay put pricing first among second pages by a factor of four, and
+ * the rows people actually open once they land there are "Can I self-host
+ * Maple?", "Is Maple compatible with OpenTelemetry?" and "Do you offer a free
+ * trial?". Those are objections, not pricing questions — 83% of homepage
+ * visitors leave without ever reaching the page that answers them.
+ *
+ * So the answers move up here, in the hero, stated flatly. The pricing page
+ * keeps its full FAQ; this is the version a visitor reads in eight seconds.
+ *
+ * Numbers come from `getOffer()` for the same reason the pricing hero does:
+ * a hand-typed $39 here is a second source of truth that silently goes stale.
+ */
+import * as m from "../../paraglide/messages.js";
+import { getOffer, money } from "../../lib/pricing-offer";
+
+const offer = await getOffer();
+
+const points = [
+	{
+		key: "selfhost",
+		claim: m.home_objection_selfhost_claim(),
+		detail: m.home_objection_selfhost_detail(),
+		href: "https://github.com/MapleTechLabs/maple",
+		cta: m.home_objection_selfhost_cta(),
+		external: true,
+	},
+	{
+		key: "otel",
+		claim: m.home_objection_otel_claim(),
+		detail: m.home_objection_otel_detail(),
+		href: "/docs/instrumentation",
+		cta: m.home_objection_otel_cta(),
+		external: false,
+	},
+	{
+		key: "trial",
+		claim: offer.trialDuration
+			? m.home_objection_trial_claim({
+					price: money(offer.price),
+					days: String(offer.trialDuration),
+				})
+			: m.home_objection_trial_claim_no_trial({ price: money(offer.price) }),
+		detail: m.home_objection_trial_detail(),
+		href: "/pricing",
+		cta: m.home_objection_trial_cta(),
+		external: false,
+	},
+];
+---
+
+<section class="home-objections" aria-label={m.home_objections_aria()}>
+	<div class="shell">
+		<ul class="home-objections__grid">
+			{
+				points.map((point) => (
+					<li class="home-objections__item">
+						<p class="home-objections__claim">{point.claim}</p>
+						<p class="home-objections__detail">{point.detail}</p>
+						<a
+							href={point.href}
+							class="home-objections__link"
+							data-track="objection_opened"
+							data-track-topic={point.key}
+							data-track-location="home_objections"
+							{...(point.external
+								? { target: "_blank", rel: "noopener noreferrer" }
+								: {})}
+						>
+							{point.cta}
+							<span aria-hidden="true">→</span>
+						</a>
+					</li>
+				))
+			}
+		</ul>
+	</div>
+</section>
+
+<style>
+	.home-objections {
+		border-top: 1px solid var(--border);
+		border-bottom: 1px solid var(--border);
+		background: var(--bg-deep, transparent);
+	}
+
+	.home-objections__grid {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 0;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.home-objections__item {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.5rem;
+		padding: 2rem 2rem 2rem 0;
+	}
+
+	.home-objections__item + .home-objections__item {
+		padding-left: 2rem;
+		border-left: 1px solid var(--border);
+	}
+
+	.home-objections__claim {
+		margin: 0;
+		font-family: var(--font-display, inherit);
+		font-size: 1rem;
+		font-weight: 600;
+		letter-spacing: -0.01em;
+		color: var(--fg);
+	}
+
+	.home-objections__detail {
+		margin: 0;
+		max-width: 42ch;
+		font-size: 0.8125rem;
+		line-height: 1.6;
+		color: var(--fg-muted);
+	}
+
+	.home-objections__link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		margin-top: auto;
+		padding-top: 0.5rem;
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: var(--primary);
+	}
+
+	.home-objections__link span {
+		transition: transform 150ms ease;
+	}
+
+	.home-objections__link:hover span {
+		transform: translateX(2px);
+	}
+
+	/* Mobile is 26% of sessions and averages 0.37 clicks — it gets the same
+	   three answers stacked, not a truncated version. */
+	@media (max-width: 860px) {
+		.home-objections__grid {
+			grid-template-columns: 1fr;
+		}
+
+		.home-objections__item {
+			padding: 1.5rem 0;
+		}
+
+		.home-objections__item + .home-objections__item {
+			padding-left: 0;
+			border-left: 0;
+			border-top: 1px solid var(--border);
+		}
+	}
+</style>

--- a/apps/landing/src/components/home/HomeProductPlate.astro
+++ b/apps/landing/src/components/home/HomeProductPlate.astro
@@ -1,0 +1,14 @@
+---
+/**
+ * The hero's product plate, as its own section.
+ *
+ * Split out of `HomeHero` so the page can put something between the headline
+ * and the screenshots. It was never coupled to the hero in CSS — both are plain
+ * `main > section` children — so this is a move, not a rewrite.
+ */
+import HeroCarousel from "./HeroCarousel.astro";
+---
+
+<section class="monument-product">
+    <div class="shell"><HeroCarousel /></div>
+</section>

--- a/apps/landing/src/components/home/MediaFrame.astro
+++ b/apps/landing/src/components/home/MediaFrame.astro
@@ -26,6 +26,13 @@ interface Props {
 	height?: number;
 	loading?: "eager" | "lazy";
 	class?: string;
+	/**
+	 * Opens the shot full-size in the shared lightbox on click. On by default
+	 * for images: a product screenshot scaled into a page column is usually too
+	 * small to read, and the replay data says people click it expecting exactly
+	 * this. Videos opt out — they carry their own controls.
+	 */
+	zoomable?: boolean;
 }
 
 const {
@@ -38,6 +45,7 @@ const {
 	height = 600,
 	loading = "lazy",
 	class: className = "",
+	zoomable = true,
 } = Astro.props;
 
 const ratio = `${width} / ${height}`;
@@ -73,6 +81,7 @@ const hasAsset = Boolean(src ?? (isVideo ? poster : undefined));
 					height={height}
 					loading={loading}
 					decoding="async"
+					data-zoomable={zoomable ? "" : undefined}
 					class="block w-full h-auto"
 				/>
 			)}

--- a/apps/landing/src/layouts/Layout.astro
+++ b/apps/landing/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import { getRelativeLocaleUrl } from "astro:i18n";
 import "../styles/global.css";
+import MediaLightbox from "../components/MediaLightbox.astro";
 
 interface Props {
     bodyClass?: string;
@@ -114,6 +115,55 @@ const absoluteImage = image.startsWith("http")
     </head>
     <body class:list={["min-h-screen antialiased", bodyClass]}>
         <slot />
+        <MediaLightbox />
+        <!-- Stale-chunk recovery.
+
+             A visitor holding cached HTML from an earlier deploy asks for island
+             chunks the new build no longer has. The island then never hydrates:
+             on desktop the product mega-menu stops opening, and on mobile the
+             hamburger is the only route into the nav, so the nav is gone. The
+             SSR'd anchors (Log in, the CTA, the logo) keep working — Astro
+             renders islands to HTML first — but anything behind a handler does
+             not.
+
+             `astro-island` already retries the import once, after a second, with
+             a cache-busting param, so it recovers from a merely cold chunk on its
+             own. What it cannot fix is a document that points at files the deploy
+             deleted: the retry 404s too, and it gives up. That second failure is
+             what `astro:hydration-error` reports — a cancelable, bubbling event
+             the runtime dispatches immediately before its console.error, which is
+             exactly the line we see in production replays.
+
+             So this only ever runs after Astro's own retry has failed, and the
+             one thing left that can help is refetching the HTML. One reload per
+             session, cleared once a page hydrates cleanly, so a genuinely missing
+             chunk degrades to today's behaviour instead of a refresh loop. -->
+        <script is:inline>
+            (function () {
+                var KEY = 'chunk-reloaded';
+                function recover() {
+                    if (sessionStorage.getItem(KEY)) return;
+                    sessionStorage.setItem(KEY, '1');
+                    window.location.reload();
+                }
+                document.addEventListener('astro:hydration-error', recover);
+                // Vite's preload signal covers chunks that fail before an island
+                // is even involved (a page's own `<script>` import).
+                window.addEventListener('vite:preloadError', function (event) {
+                    event.preventDefault();
+                    recover();
+                });
+                // A load that hydrated cleanly earns the next deploy its own retry.
+                window.addEventListener('load', function () {
+                    setTimeout(function () {
+                        if (!sessionStorage.getItem(KEY)) return;
+                        if (!document.querySelector('astro-island[ssr][client="load"]')) {
+                            sessionStorage.removeItem(KEY);
+                        }
+                    }, 5000);
+                });
+            })();
+        </script>
         <script is:inline>
             (function() {
                 if (/^\/(ja|ko)(\/|$)/.test(window.location.pathname)) return;

--- a/apps/landing/src/lib/telemetry.ts
+++ b/apps/landing/src/lib/telemetry.ts
@@ -45,6 +45,9 @@ const LANDING_EVENTS = [
 	"docs_snippet_copied",
 	"brand_asset_copied",
 	"brand_asset_downloaded",
+	"media_opened",
+	"objection_opened",
+	"page_scrolled",
 ] as const
 
 export type LandingEvent = (typeof LANDING_EVENTS)[number]
@@ -82,6 +85,52 @@ export function startLandingTelemetry(): void {
 	})
 
 	bindDeclarativeTracking()
+	bindScrollDepth()
+}
+
+/**
+ * Scroll depth, as one `page_scrolled` event per threshold per page view.
+ *
+ * A bounce rate alone cannot tell "read the hero and left" from "read the whole
+ * page and left" — both are one page view — and those two want opposite fixes.
+ * Thresholds are coarse on purpose: quartiles answer "did the fold hold them",
+ * and anything finer just multiplies event volume without moving a decision.
+ */
+const SCROLL_MARKS = [25, 50, 75, 100] as const
+
+function bindScrollDepth(): void {
+	let remaining = [...SCROLL_MARKS]
+	let queued = false
+
+	const measure = () => {
+		queued = false
+		const scrollable = document.documentElement.scrollHeight - window.innerHeight
+		// A page shorter than the viewport is 100% read the moment it is opened;
+		// reporting 25/50/75 for it would inflate every quartile.
+		const percent =
+			scrollable <= 0
+				? 100
+				: ((window.scrollY + window.innerHeight) / document.documentElement.scrollHeight) * 100
+		const reached = remaining.filter((mark) => percent >= mark)
+		if (reached.length === 0) return
+		remaining = remaining.filter((mark) => percent < mark)
+		for (const mark of reached) {
+			trackLanding("page_scrolled", { depth: String(mark), path: window.location.pathname })
+		}
+	}
+
+	// rAF-coalesced: scroll fires far faster than the SDK should be asked to
+	// serialize an event, and the thresholds only need the resting position.
+	const onScroll = () => {
+		if (queued) return
+		queued = true
+		requestAnimationFrame(measure)
+	}
+
+	window.addEventListener("scroll", onScroll, { passive: true })
+	window.addEventListener("resize", onScroll, { passive: true })
+	// Fires the short-page 100% case, and any depth restored from a #fragment.
+	measure()
 }
 
 /** Record a custom event. No-ops before init; the SDK queues pre-init events. */
@@ -136,7 +185,12 @@ function bindDeclarativeTracking(): void {
 				// `data-track-location` → dataset.trackLocation → `location`.
 				props[key.slice(5).replace(/^./, (c) => c.toLowerCase())] = value
 			}
-			trackLanding(name, props)
+			// Which page a CTA was clicked on is not knowable from the markup —
+			// the same nav renders on every route — and stamping it in the
+			// component would make the SSR and client attribute disagree. Read it
+			// here, at click time, where there is only ever one answer. Markup
+			// wins, so a page can still name its own `data-track-path`.
+			trackLanding(name, { path: window.location.pathname, ...props })
 		},
 		// Capture, so a handler that stops propagation (or a React island that
 		// re-renders the node away) can't swallow the event first.

--- a/apps/landing/src/pages/ja/pricing.astro
+++ b/apps/landing/src/pages/ja/pricing.astro
@@ -24,8 +24,8 @@ const faqItems = await pricingFaq();
     <Nav />
     <main class="pricing-page">
     <PricingHero />
+    <PricingCalculatorSection eager />
     <PricingTable class="pricing-offer" />
-    <PricingCalculatorSection />
     <SupportedStack />
     <PricingPaths />
     <FAQ items={faqItems} />

--- a/apps/landing/src/pages/ko/pricing.astro
+++ b/apps/landing/src/pages/ko/pricing.astro
@@ -24,8 +24,8 @@ const faqItems = await pricingFaq();
     <Nav />
     <main class="pricing-page">
     <PricingHero />
+    <PricingCalculatorSection eager />
     <PricingTable class="pricing-offer" />
-    <PricingCalculatorSection />
     <SupportedStack />
     <PricingPaths />
     <FAQ items={faqItems} />

--- a/apps/landing/src/pages/pricing.astro
+++ b/apps/landing/src/pages/pricing.astro
@@ -24,8 +24,13 @@ const faqItems = await pricingFaq();
     <Nav />
     <main class="pricing-page">
     <PricingHero />
+    {/* The estimator runs before the offer card. The median pricing visit is
+        about six seconds — not enough to reach a calculator sitting two
+        sections down, which is why only 15% of pricing visitors ever touched
+        it. The ones who did averaged six slider moves each, so it is the thing
+        they came for; the offer card still closes the decision below it. */}
+    <PricingCalculatorSection eager />
     <PricingTable class="pricing-offer" />
-    <PricingCalculatorSection />
     <SupportedStack />
     <PricingPaths />
     <FAQ items={faqItems} />


### PR DESCRIPTION
Session replay on `maple.dev` over the last 30 days surfaced one real bug and four places the page loses people. This fixes all five, plus the instrumentation gap that made them hard to see.

## The bug: islands that never hydrate

A visitor holding cached HTML from an earlier deploy requests island chunks the new build deleted. `astro-island` retries the import once with a cache-busting param and then gives up — that second failure is the `[astro-island] Error hydrating` line showing up in replays, alongside Clerk load timeouts.

Astro server-renders islands first, so `Log in` and `Start free trial` survive as plain anchors. What dies is the **mobile hamburger** and the **desktop product mega-menu**. On mobile the hamburger is the only route into the nav, so the nav is simply gone.

The fix hooks `astro:hydration-error`, the cancelable event the runtime dispatches immediately before that console line, and refetches the HTML. Once per session, guard cleared after a load that hydrates cleanly, so a genuinely missing chunk degrades to today's behaviour rather than a refresh loop.

Three earlier approaches silently did nothing and were only caught by testing them: `vite:preloadError`, `unhandledrejection`, and polling the `ssr` attribute. Astro catches its own import error, and the `ssr` attribute clears whether hydration succeeded or not.

| Scenario | Page loads | Outcome |
| --- | --- | --- |
| Stale document, chunk and retry both 404 | 2 | one recovery reload, then stops |
| Healthy build | 1 | no reload, guard cleared |

## What the replays said

| Finding | Change |
| --- | --- |
| Hero screenshot took 198 clicks across 106 sessions and was inert — the most-clicked non-navigation element on the site | `MediaFrame` images open full size in a shared lightbox |
| 83% of homepage visitors leave without reaching `/pricing`, where the rows they open are self-hosting, OpenTelemetry and trial terms | Those three answers move into the hero, with price and trial length read from `getOffer()` so they cannot drift |
| Only 15% of pricing visitors ever reached the calculator, against a 6.2s median visit; the ones who did averaged six slider moves | Estimator moves above the offer card on all three locales and hydrates on load instead of on scroll |
| Maple Local has the lowest bounce and deepest read time of any entry point, and sat eighth on the homepage | Promoted to fourth, ahead of the platform sheet |

## Instrumentation

`cta_click` carried only `location`, so a signed-out trial click and a returning visitor's dashboard click were the same event on the same element. It now carries `label`, `destination` and `path`. Path is stamped in the delegated handler rather than in markup, because the same nav renders on every route and a component-side attribute would disagree between SSR and client.

Scroll depth ships as `page_scrolled` at quartiles, deduplicated per page view. A bounce rate alone cannot separate "read the hero and left" from "read the whole page and left", and those two want opposite fixes.

Two new events cover the lightbox (`media_opened`) and the hero objection links (`objection_opened`).

Captured payload from a live click during verification:

```json
"attributes": {
  "path": "/",
  "location": "hero",
  "label": "Start free trial",
  "destination": "https://app.maple.dev/sign-up"
}
```

## Verification

Driven in headless Chromium against the production build, not just asserted in tests:

- Lightbox opens the right screenshot, cursor is `zoom-in`, Escape closes it
- Scroll depth fires exactly once each at 25 / 50 / 75 / 100, no duplicates
- Objection strip renders `$39/month, 14-day free trial` from live offer data
- Recovery reloads exactly once on a stale document and never on a healthy build
- Nav links remain present and correct while the island is dead

Tests pass at 33, lint is clean, production build completes at 121 pages.

## Not addressed

The site auto-redirects any browser reporting Japanese or Korean to a localized page. Those locales bounce at 95% with a ~5s median, and this redirect is the likely cause since visitors land somewhere they did not ask for. Left alone — it is a product decision, not a bug.

`apps/landing/src/styles/pricing-monument.css` fails `oxfmt --check` on `main` already and is untouched here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791561261&installation_model_id=427786&pr_number=812&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F812&signature=9e4c738b1d652bcfb4d8e322f6f5c3731fc08468a0834105ed2de118aa408d3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added homepage guidance covering self-hosting, OpenTelemetry, and trial options.
  - Added click-to-enlarge viewing for supported screenshots, with responsive styling and accessibility-conscious motion.
  - Pricing calculators now appear before pricing offers and can load immediately for faster access.

- **Analytics**
  - Improved tracking for calls to action, media opens, objection interactions, and page scroll depth.

- **Bug Fixes**
  - Added automatic recovery from certain stale loading or hydration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->