### PR TITLE
fix(api): name 5xx responses where they are rendered

### DIFF
--- a/apps/api/src/routes/rendered-failure.ts
+++ b/apps/api/src/routes/rendered-failure.ts
@@ -35,17 +35,9 @@ const recordException = (failure: RenderedFailure) =>
 	}).pipe(Effect.ignore)
 
 /**
- * Record a failure where it becomes a response — the one seam every renderer goes through.
- *
- * The API renders a failure in four places: an endpoint's declared 5xx, a route defect, a response
- * that failed its own schema, and a cause escaping the route graph. Each conversion is individually
- * correct and each one used to destroy what the next needed, so a crash reached the wire unnamed.
- *
- * The diagnosis goes on the span as a real `exception` event, not only into a log. Spans from a
- * request reach the warehouse when that request's logs do not, and error tracking fingerprints on
- * `exception.type` — so a 500 arrives under its own name instead of as one anonymous bucket. A 5xx
- * span carrying no exception event of its own was rendered below this seam, and the tracer labels
- * exactly those `HttpServerErrorResponse`.
+ * The one seam every renderer goes through. The diagnosis rides the span, not only the log: spans
+ * reach the warehouse when a request's logs do not, and error tracking fingerprints on
+ * `exception.type`. A 5xx span with no exception event was therefore rendered below this seam.
  */
 export const recordRenderedFailure = (failure: RenderedFailure): Effect.Effect<void> =>
 	Effect.gen(function* () {

--- a/apps/api/src/routes/rendered-failure.ts
+++ b/apps/api/src/routes/rendered-failure.ts
@@ -1,0 +1,68 @@
+import { Clock, Effect } from "effect"
+
+/** A failure at the moment the API turns it into a response. */
+export interface RenderedFailure {
+	readonly group: string
+	readonly operation: string
+	/** What error tracking groups this under — a domain `_tag`, or a defect's constructor name. */
+	readonly errorType: string
+	/** The log line: which of the four renderings this was. */
+	readonly summary: string
+	/** The failure's own message. */
+	readonly message: string
+	readonly status: number
+	readonly stack?: string | undefined
+	readonly detail?: ReadonlyArray<string> | undefined
+	readonly cause: unknown
+}
+
+/** A defect's identity: an `Error` subclass by name, anything else by its `typeof`. */
+export const failureTypeOf = (value: unknown): string => (value instanceof Error ? value.name : typeof value)
+
+export const failureStackOf = (value: unknown): string | undefined =>
+	value instanceof Error ? value.stack : undefined
+
+/** The live span carries the diagnosis; no-ops on an untraced fiber. */
+const recordException = (failure: RenderedFailure) =>
+	Effect.gen(function* () {
+		const at = yield* Clock.currentTimeNanos
+		const span = yield* Effect.currentSpan
+		span.event("exception", at, {
+			"exception.type": failure.errorType,
+			"exception.message": failure.message,
+			...(failure.stack === undefined ? undefined : { "exception.stacktrace": failure.stack }),
+		})
+	}).pipe(Effect.ignore)
+
+/**
+ * Record a failure where it becomes a response — the one seam every renderer goes through.
+ *
+ * The API renders a failure in four places: an endpoint's declared 5xx, a route defect, a response
+ * that failed its own schema, and a cause escaping the route graph. Each conversion is individually
+ * correct and each one used to destroy what the next needed, so a crash reached the wire unnamed.
+ *
+ * The diagnosis goes on the span as a real `exception` event, not only into a log. Spans from a
+ * request reach the warehouse when that request's logs do not, and error tracking fingerprints on
+ * `exception.type` — so a 500 arrives under its own name instead of as one anonymous bucket. A 5xx
+ * span carrying no exception event of its own was rendered below this seam, and the tracer labels
+ * exactly those `HttpServerErrorResponse`.
+ */
+export const recordRenderedFailure = (failure: RenderedFailure): Effect.Effect<void> =>
+	Effect.gen(function* () {
+		yield* Effect.annotateCurrentSpan({
+			"error.type": failure.errorType,
+			"http.response.status_code": failure.status,
+		})
+		yield* recordException(failure)
+		yield* Effect.logError(failure.summary).pipe(
+			Effect.annotateLogs({
+				errorTag: failure.errorType,
+				status: failure.status,
+				group: failure.group,
+				operation: failure.operation,
+				message: failure.message,
+				cause: failure.cause,
+				...(failure.detail === undefined ? undefined : { details: failure.detail }),
+			}),
+		)
+	})

--- a/apps/api/src/routes/server-error-observability.ts
+++ b/apps/api/src/routes/server-error-observability.ts
@@ -1,5 +1,6 @@
 import { Effect, Schema, SchemaAST } from "effect"
 import type { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
+import { failureStackOf, recordRenderedFailure } from "@/routes/rendered-failure"
 
 /** The `HttpApiSchema.status` annotation, the one the response encoder resolves. */
 const httpApiStatus = SchemaAST.resolveAt<number>("httpApiStatus")
@@ -39,22 +40,14 @@ export const observeServerError =
 	(error: unknown): Effect.Effect<void> => {
 		const status = declaredStatus(endpoint, error)
 		if (status === undefined || status < 500) return Effect.void
-		const tag = tagOf(error)
-		return Effect.annotateCurrentSpan({
-			"error.type": tag,
-			"http.response.status_code": status,
-		}).pipe(
-			Effect.andThen(
-				Effect.logError("Route answered with a server error").pipe(
-					Effect.annotateLogs({
-						errorTag: tag,
-						status,
-						group: group.identifier,
-						operation: endpoint.identifier,
-						message: messageOf(error),
-						cause: error,
-					}),
-				),
-			),
-		)
+		return recordRenderedFailure({
+			group: group.identifier,
+			operation: endpoint.identifier,
+			errorType: tagOf(error),
+			summary: "Route answered with a server error",
+			message: messageOf(error) ?? "",
+			status,
+			stack: failureStackOf(error),
+			cause: error,
+		})
 	}

--- a/apps/api/src/routes/v1/error-boundary.ts
+++ b/apps/api/src/routes/v1/error-boundary.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Layer } from "effect"
 import { HttpApiMiddleware } from "effect/unstable/httpapi"
 import {
 	V1RequestValidationError,
@@ -6,30 +6,11 @@ import {
 	V1UnexpectedError,
 	V1UnexpectedErrors,
 } from "@maple/domain/http"
+import { failureStackOf, failureTypeOf, recordRenderedFailure } from "@/routes/rendered-failure"
 import { describeSchemaIssue, summarizeSchemaError } from "@/routes/schema-error-detail"
 import { observeServerError } from "@/routes/server-error-observability"
 
-class V1RouteExecutionDefect extends Schema.TaggedError<V1RouteExecutionDefect>()(
-	"@maple/api/routes/v1/V1RouteExecutionDefect",
-	{
-		group: Schema.String,
-		operation: Schema.String,
-		message: Schema.String,
-		cause: Schema.Defect(),
-	},
-) {}
-
-class V1ResponseSchemaError extends Schema.TaggedError<V1ResponseSchemaError>()(
-	"@maple/api/routes/v1/V1ResponseSchemaError",
-	{
-		group: Schema.String,
-		operation: Schema.String,
-		component: Schema.Literals(["Body", "ResponseHeaders"]),
-		message: Schema.String,
-		details: Schema.Array(Schema.String),
-		cause: Schema.Defect(),
-	},
-) {}
+const sanitized = () => new V1UnexpectedError({ message: "An unexpected error occurred on our end." })
 
 const V1SchemaErrorTransformLive = HttpApiMiddleware.layerSchemaErrorTransform(
 	V1SchemaErrors,
@@ -37,31 +18,16 @@ const V1SchemaErrorTransformLive = HttpApiMiddleware.layerSchemaErrorTransform(
 		Effect.suspend((): Effect.Effect<never, V1RequestValidationError | V1UnexpectedError> => {
 			const details = describeSchemaIssue(schemaError.cause.issue)
 			if (schemaError.kind === "Body" || schemaError.kind === "ResponseHeaders") {
-				const error = new V1ResponseSchemaError({
+				return recordRenderedFailure({
 					group: group.identifier,
 					operation: endpoint.identifier,
-					component: schemaError.kind,
-					message: "V1 response failed its declared HTTP schema",
-					details: details.map(({ line }) => line),
+					errorType: `@maple/api/routes/v1/V1ResponseSchemaError/${schemaError.kind}`,
+					summary: "V1 response failed its declared HTTP schema",
+					message: details.map(({ line }) => line).join("; "),
+					status: 500,
+					detail: details.map(({ line }) => line),
 					cause: schemaError.cause,
-				})
-				return Effect.logError(error.message).pipe(
-					Effect.annotateLogs({
-						errorTag: error._tag,
-						group: error.group,
-						operation: error.operation,
-						component: error.component,
-						details: error.details,
-						cause: error.cause,
-					}),
-					Effect.andThen(
-						Effect.fail(
-							new V1UnexpectedError({
-								message: "An unexpected error occurred on our end.",
-							}),
-						),
-					),
-				)
+				}).pipe(Effect.andThen(Effect.fail(sanitized())))
 			}
 			const first = details[0]
 			return Effect.fail(
@@ -79,31 +45,18 @@ const V1UnexpectedErrorsLive = Layer.succeed(
 	V1UnexpectedErrors.of((httpEffect, { endpoint, group }) =>
 		httpEffect.pipe(
 			Effect.tapError(observeServerError(endpoint, group)),
-			Effect.catchDefect((cause) => {
-				const defectType = cause instanceof Error ? cause.name : typeof cause
-				const error = new V1RouteExecutionDefect({
+			Effect.catchDefect((cause) =>
+				recordRenderedFailure({
 					group: group.identifier,
 					operation: endpoint.identifier,
-					message: "Unexpected v1 route execution defect",
+					errorType: failureTypeOf(cause),
+					summary: "Unexpected v1 route execution defect",
+					message: cause instanceof Error ? cause.message : String(cause),
+					status: 500,
+					stack: failureStackOf(cause),
 					cause,
-				})
-				return Effect.logError(error.message).pipe(
-					Effect.annotateLogs({
-						errorTag: error._tag,
-						group: error.group,
-						operation: error.operation,
-						defectType,
-						cause: error.cause,
-					}),
-					Effect.andThen(
-						Effect.fail(
-							new V1UnexpectedError({
-								message: "An unexpected error occurred on our end.",
-							}),
-						),
-					),
-				)
-			}),
+				}).pipe(Effect.andThen(Effect.fail(sanitized()))),
+			),
 		),
 	),
 )

--- a/apps/api/src/routes/v2/error-envelope.ts
+++ b/apps/api/src/routes/v2/error-envelope.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Layer } from "effect"
 import { HttpApiMiddleware } from "effect/unstable/httpapi"
 import { HttpEffect, HttpServerResponse } from "effect/unstable/http"
 import {
@@ -8,30 +8,9 @@ import {
 	V2UnexpectedFailure,
 	V2UnexpectedErrors,
 } from "@maple/domain/http/v2"
+import { failureStackOf, failureTypeOf, recordRenderedFailure } from "@/routes/rendered-failure"
 import { describeSchemaIssue } from "@/routes/schema-error-detail"
 import { observeServerError } from "@/routes/server-error-observability"
-
-class V2RouteExecutionDefect extends Schema.TaggedError<V2RouteExecutionDefect>()(
-	"@maple/api/routes/v2/V2RouteExecutionDefect",
-	{
-		group: Schema.String,
-		operation: Schema.String,
-		message: Schema.String,
-		cause: Schema.Defect(),
-	},
-) {}
-
-class V2ResponseSchemaError extends Schema.TaggedError<V2ResponseSchemaError>()(
-	"@maple/api/routes/v2/V2ResponseSchemaError",
-	{
-		group: Schema.String,
-		operation: Schema.String,
-		component: Schema.Literals(["Body", "ResponseHeaders"]),
-		message: Schema.String,
-		details: Schema.Array(Schema.String),
-		cause: Schema.Defect(),
-	},
-) {}
 
 type V2SchemaBoundaryError =
 	| ReturnType<typeof V2InvalidRequest.make>
@@ -54,25 +33,16 @@ const V2SchemaErrorTransformLive = HttpApiMiddleware.layerSchemaErrorTransform(
 		Effect.suspend((): Effect.Effect<never, V2SchemaBoundaryError> => {
 			const details = describeSchemaIssue(schemaError.cause.issue)
 			if (schemaError.kind === "Body" || schemaError.kind === "ResponseHeaders") {
-				const error = new V2ResponseSchemaError({
+				return recordRenderedFailure({
 					group: group.identifier,
 					operation: endpoint.identifier,
-					component: schemaError.kind,
-					message: "V2 response failed its declared HTTP schema",
-					details: details.map(({ line }) => line),
+					errorType: `@maple/api/routes/v2/V2ResponseSchemaError/${schemaError.kind}`,
+					summary: "V2 response failed its declared HTTP schema",
+					message: details.map(({ line }) => line).join("; "),
+					status: 500,
+					detail: details.map(({ line }) => line),
 					cause: schemaError.cause,
-				})
-				return Effect.logError(error.message).pipe(
-					Effect.annotateLogs({
-						errorTag: error._tag,
-						group: error.group,
-						operation: error.operation,
-						component: error.component,
-						details: error.details,
-						cause: error.cause,
-					}),
-					Effect.andThen(Effect.fail(V2ResponseSchemaFailure.make())),
-				)
+				}).pipe(Effect.andThen(Effect.fail(V2ResponseSchemaFailure.make())))
 			}
 			const first = details[0]
 			if (first === undefined) {
@@ -121,25 +91,18 @@ export const V2UnexpectedErrorsLive = Layer.succeed(
 		httpEffect.pipe(
 			Effect.tapError(appendRetryAfter),
 			Effect.tapError(observeServerError(endpoint, group)),
-			Effect.catchDefect((cause) => {
-				const defectType = cause instanceof Error ? cause.name : typeof cause
-				const error = new V2RouteExecutionDefect({
+			Effect.catchDefect((cause) =>
+				recordRenderedFailure({
 					group: group.identifier,
 					operation: endpoint.identifier,
-					message: "Unexpected v2 route execution defect",
+					errorType: failureTypeOf(cause),
+					summary: "Unexpected v2 route execution defect",
+					message: cause instanceof Error ? cause.message : String(cause),
+					status: 500,
+					stack: failureStackOf(cause),
 					cause,
-				})
-				return Effect.logError(error.message).pipe(
-					Effect.annotateLogs({
-						errorTag: error._tag,
-						group: error.group,
-						operation: error.operation,
-						defectType,
-						cause: error.cause,
-					}),
-					Effect.andThen(Effect.fail(V2UnexpectedFailure.make())),
-				)
-			}),
+				}).pipe(Effect.andThen(Effect.fail(V2UnexpectedFailure.make()))),
+			),
 		),
 	),
 )

--- a/apps/api/src/worker-bridge.test.ts
+++ b/apps/api/src/worker-bridge.test.ts
@@ -19,11 +19,16 @@ import { buildIsolateHandler, makeFetch, WorkerPlatformLive } from "./worker/htt
  * on the route graph (liveness, preflights, the graph failing to build) and
  * that a routed answer exports as a server span.
  */
+const ExportedAttribute = Schema.Struct({
+	key: Schema.String,
+	value: Schema.Record(Schema.String, Schema.Unknown),
+})
 const ExportedSpan = Schema.Struct({
 	name: Schema.String,
 	status: Schema.Struct({ code: Schema.optionalKey(Schema.Finite) }),
-	attributes: Schema.Array(
-		Schema.Struct({ key: Schema.String, value: Schema.Record(Schema.String, Schema.Unknown) }),
+	attributes: Schema.Array(ExportedAttribute),
+	events: Schema.optionalKey(
+		Schema.Array(Schema.Struct({ name: Schema.String, attributes: Schema.Array(ExportedAttribute) })),
 	),
 })
 type ExportedSpan = typeof ExportedSpan.Type
@@ -79,9 +84,24 @@ const logBodies = (recorded: ReadonlyArray<RecordedRequest>): Array<string> =>
 		.flatMap((resource) => resource.scopeLogs.flatMap((scope) => scope.logRecords))
 		.flatMap((record) => (record.body?.stringValue === undefined ? [] : [record.body.stringValue]))
 
+/** One attribute as its rendered value — OTLP JSON carries ints as strings anyway. */
+const attributeOf = (span: ExportedSpan | undefined, key: string): string | undefined => {
+	const value = span?.attributes.find((attribute) => attribute.key === key)?.value
+	const rendered = value === undefined ? undefined : Object.values(value)[0]
+	return rendered === undefined ? undefined : String(rendered)
+}
+
 const statusCodeOf = (span: ExportedSpan | undefined): number | undefined => {
-	const value = span?.attributes.find((attribute) => attribute.key === "http.response.status_code")?.value
-	return value === undefined ? undefined : Number(Object.values(value)[0])
+	const value = attributeOf(span, "http.response.status_code")
+	return value === undefined ? undefined : Number(value)
+}
+
+/** What error tracking will group this span's failure under. */
+const exceptionTypeOf = (span: ExportedSpan | undefined): string | undefined => {
+	const event = span?.events?.find((candidate) => candidate.name === "exception")
+	const value = event?.attributes.find((attribute) => attribute.key === "exception.type")?.value
+	const rendered = value === undefined ? undefined : Object.values(value)[0]
+	return rendered === undefined ? undefined : String(rendered)
 }
 
 /** No stage database exists in these requests, so the port is never reached. */
@@ -101,6 +121,14 @@ class GraphBuildFailure extends Schema.TaggedError<GraphBuildFailure>()("GraphBu
 const notFoundApp: Effect.Effect<HttpEffect, never> = Effect.succeed(
 	Effect.succeed(HttpServerResponse.text("Not Found", { status: 404 })),
 )
+
+/** A graph that renders its own 500, the shape the unattributed prod 500s arrive in. */
+const renderedServerErrorApp: Effect.Effect<HttpEffect, never> = Effect.succeed(
+	Effect.succeed(HttpServerResponse.text("", { status: 500 })),
+)
+
+/** A graph whose handler dies, so the cause is still live when it leaves the router. */
+const dyingApp: Effect.Effect<HttpEffect, never> = Effect.succeed(Effect.die(new Error("handler exploded")))
 
 /** One route that answers with the bearer it was called with — the header a leaked request would get wrong. */
 const EchoGroup = HttpApiGroup.make("echo").add(
@@ -260,6 +288,31 @@ describe("the api Worker through alchemy's bridge", () => {
 			const { response, logs } = yield* event("GET", "/logging", app)
 			assert.strictEqual(response.status, 200)
 			assert.include(logs, "boundary answered with a server error")
+		}),
+	)
+
+	it.effect("a 5xx no seam recorded stays anonymous and carries the isolate shape", () =>
+		Effect.gen(function* () {
+			const { response, server, logs } = yield* event("GET", "/boom", renderedServerErrorApp)
+			assert.strictEqual(response.status, 500)
+			// The exit is a success, so the tracer flags the span from the status alone.
+			assert.strictEqual(server[0]?.status.code, 2 /* Error */)
+			// Nothing named it, which is exactly what the generic type means.
+			assert.strictEqual(exceptionTypeOf(server[0]), "HttpServerErrorResponse")
+			assert.include(logs, "Route graph answered with a server error nothing recorded")
+			assert.strictEqual(Number(attributeOf(server[0], "maple.isolate.age_ms")), 0)
+			assert.strictEqual(Number(attributeOf(server[0], "maple.isolate.request_ordinal")), 1)
+		}),
+	)
+
+	it.effect("a cause escaping the route graph reaches error tracking under its own name", () =>
+		Effect.gen(function* () {
+			const { response, server, logs } = yield* event("GET", "/boom", dyingApp)
+			assert.strictEqual(response.status, 500)
+			assert.include(logs, "Cause escaped the route graph")
+			assert.strictEqual(attributeOf(server[0], "error.type"), "Error")
+			// The real exception survives instead of being relabelled by the tracer.
+			assert.strictEqual(exceptionTypeOf(server[0]), "Error")
 		}),
 	)
 

--- a/apps/api/src/worker-bridge.test.ts
+++ b/apps/api/src/worker-bridge.test.ts
@@ -9,6 +9,7 @@ import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
 import { MapleDbConnection } from "./platform/bindings"
 import { cachedRecoverable } from "@maple/infra/cached-recoverable"
+import { recordRenderedFailure } from "./routes/rendered-failure"
 import { buildIsolateHandler, makeFetch, WorkerPlatformLive } from "./worker/http"
 
 /**
@@ -168,6 +169,27 @@ const LoggingHandlersLive = HttpApiBuilder.group(LoggingApi, "logging", (handler
 	),
 )
 
+/** One route that records a rendered failure the way the boundaries do, to pin which span it lands on. */
+const RecordingGroup = HttpApiGroup.make("recording").add(
+	HttpApiEndpoint.get("recording", "/recording", { success: Schema.String }),
+)
+class RecordingApi extends HttpApi.make("RecordingApi").add(RecordingGroup) {}
+const RecordingHandlersLive = HttpApiBuilder.group(RecordingApi, "recording", (handlers) =>
+	Effect.succeed(
+		handlers.handle("recording", () =>
+			recordRenderedFailure({
+				group: "recording",
+				operation: "recording",
+				errorType: "WarehouseQueryError",
+				summary: "Route answered with a server error",
+				message: "memory limit exceeded",
+				status: 502,
+				cause: new Error("memory limit exceeded"),
+			}).pipe(Effect.as("recorded")),
+		),
+	),
+)
+
 const event = (
 	method: string,
 	path: string,
@@ -293,13 +315,12 @@ describe("the api Worker through alchemy's bridge", () => {
 
 	it.effect("a 5xx no seam recorded stays anonymous and carries the isolate shape", () =>
 		Effect.gen(function* () {
-			const { response, server, logs } = yield* event("GET", "/boom", renderedServerErrorApp)
+			const { response, server } = yield* event("GET", "/boom", renderedServerErrorApp)
 			assert.strictEqual(response.status, 500)
 			// The exit is a success, so the tracer flags the span from the status alone.
 			assert.strictEqual(server[0]?.status.code, 2 /* Error */)
 			// Nothing named it, which is exactly what the generic type means.
 			assert.strictEqual(exceptionTypeOf(server[0]), "HttpServerErrorResponse")
-			assert.include(logs, "Route graph answered with a server error nothing recorded")
 			assert.strictEqual(Number(attributeOf(server[0], "maple.isolate.age_ms")), 0)
 			assert.strictEqual(Number(attributeOf(server[0], "maple.isolate.request_ordinal")), 1)
 		}),
@@ -313,6 +334,22 @@ describe("the api Worker through alchemy's bridge", () => {
 			assert.strictEqual(attributeOf(server[0], "error.type"), "Error")
 			// The real exception survives instead of being relabelled by the tracer.
 			assert.strictEqual(exceptionTypeOf(server[0]), "Error")
+		}),
+	)
+
+	it.effect("a failure recorded inside an HttpApi handler lands on the server span", () =>
+		Effect.gen(function* () {
+			const app = yield* cachedRecoverable(
+				buildIsolateHandler(
+					Context.empty(),
+					HttpApiBuilder.layer(RecordingApi).pipe(
+						Layer.provide(RecordingHandlersLive),
+						Layer.provide(WorkerPlatformLive),
+					),
+				),
+			)
+			const { server } = yield* event("GET", "/recording", app)
+			assert.strictEqual(exceptionTypeOf(server[0]), "WarehouseQueryError")
 		}),
 	)
 

--- a/apps/api/src/worker/http.ts
+++ b/apps/api/src/worker/http.ts
@@ -125,10 +125,8 @@ const unavailableResponse = (path: string) =>
 	)
 
 /**
- * A cause escaping the route graph, recorded at the last point it still exists.
- * Alchemy's `safeHttpEffect` renders it as a response and logs nothing whenever
- * every reason is `ErrorReporter.isIgnored`, which is how a 500 reaches the wire
- * with no cause anywhere. Interrupts are client aborts and stay silent.
+ * The last point the cause still exists: the bridge's `safeHttpEffect` renders it and logs nothing
+ * when every reason is `ErrorReporter.isIgnored`. Interrupts are client aborts and stay silent.
  */
 const recordEscapedCause = (method: string, path: string, cause: Cause.Cause<unknown>) => {
 	if (Cause.hasInterruptsOnly(cause)) return Effect.void
@@ -146,10 +144,8 @@ const recordEscapedCause = (method: string, path: string, cause: Cause.Cause<unk
 }
 
 /**
- * A 5xx the graph already turned into a response, so no seam recorded it and the
- * cause is gone. Everything the API renders leaves an `exception` event behind,
- * which is what makes this the leftover: a response no owned layer produced. The
- * isolate fields carry the cold-start shape these cluster in.
+ * A 5xx no seam recorded, so the cause is already gone. The isolate fields carry the cold-start
+ * shape these cluster in.
  */
 const recordUnownedServerError = (
 	method: string,
@@ -190,9 +186,8 @@ const recordUnownedServerError = (
  * background events get them.
  */
 export const makeFetch = (app: Effect.Effect<HttpEffect, unknown>, ports: Layer.Layer<MapleDbConnection>) => {
-	// Isolate-scoped: the Worker's init calls `makeFetch` once. The unattributed
-	// 500s all landed within ~60ms of an isolate's first request, so the span has
-	// to carry that shape for the next one to confirm or kill it.
+	// Isolate-scoped: the Worker's init calls `makeFetch` once. The unattributed 500s all landed
+	// within ~60ms of an isolate's first request, so the span has to carry that shape.
 	let firstRequestAt: number | undefined
 	let served = 0
 	return Effect.gen(function* () {

--- a/apps/api/src/worker/http.ts
+++ b/apps/api/src/worker/http.ts
@@ -4,7 +4,7 @@
  */
 import * as Cloudflare from "alchemy/Cloudflare"
 import type { HttpEffect } from "alchemy/Http"
-import { Clock, type Context, Effect, Exit, FileSystem, Layer, Path, Scope } from "effect"
+import { Cause, Clock, type Context, Effect, Exit, FileSystem, Layer, Path, Scope } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import * as Etag from "effect/unstable/http/Etag"
 import * as HttpPlatform from "effect/unstable/http/HttpPlatform"
@@ -12,6 +12,7 @@ import { API_CORS_RESPONSE_HEADERS, apiCorsPreflightResponse } from "../http/api
 import { v2WorkerUnavailableResponse } from "../http/v2-worker-unavailable"
 import type { MapleDbConnection } from "../platform/bindings"
 import { layerPg } from "../platform/DatabasePgLive"
+import { recordRenderedFailure } from "../routes/rendered-failure"
 import { withPgConnectionScope } from "../platform/pg-connection-scope"
 import type { ApiPortsLayer } from "./bindings"
 
@@ -124,6 +125,58 @@ const unavailableResponse = (path: string) =>
 	)
 
 /**
+ * A cause escaping the route graph, recorded at the last point it still exists.
+ * Alchemy's `safeHttpEffect` renders it as a response and logs nothing whenever
+ * every reason is `ErrorReporter.isIgnored`, which is how a 500 reaches the wire
+ * with no cause anywhere. Interrupts are client aborts and stay silent.
+ */
+const recordEscapedCause = (method: string, path: string, cause: Cause.Cause<unknown>) => {
+	if (Cause.hasInterruptsOnly(cause)) return Effect.void
+	const first = Cause.prettyErrors(cause)[0]
+	return recordRenderedFailure({
+		group: "route-graph",
+		operation: `${method} ${path}`,
+		errorType: first?.name ?? "Unknown",
+		summary: "Cause escaped the route graph",
+		message: first?.message ?? "",
+		status: 500,
+		stack: first?.stack,
+		cause,
+	})
+}
+
+/**
+ * A 5xx the graph already turned into a response, so no seam recorded it and the
+ * cause is gone. Everything the API renders leaves an `exception` event behind,
+ * which is what makes this the leftover: a response no owned layer produced. The
+ * isolate fields carry the cold-start shape these cluster in.
+ */
+const recordUnownedServerError = (
+	method: string,
+	path: string,
+	response: HttpServerResponse.HttpServerResponse,
+	isolate: { readonly ageMs: number; readonly ordinal: number },
+) =>
+	Effect.annotateCurrentSpan({
+		"maple.isolate.age_ms": isolate.ageMs,
+		"maple.isolate.request_ordinal": isolate.ordinal,
+		"maple.http.response_content_length": response.headers["content-length"] ?? "",
+	}).pipe(
+		Effect.andThen(
+			Effect.logError("Route graph answered with a server error nothing recorded").pipe(
+				Effect.annotateLogs({
+					method,
+					path,
+					status: response.status,
+					isolateAgeMs: isolate.ageMs,
+					requestOrdinal: isolate.ordinal,
+					contentLength: response.headers["content-length"] ?? "",
+				}),
+			),
+		),
+	)
+
+/**
  * The request handler the bridge serves. Liveness and preflights answer before
  * the route graph exists: neither needs the domain graph, authentication, the
  * database scope or the route codecs, and a cold isolate can report health
@@ -136,8 +189,13 @@ const unavailableResponse = (path: string) =>
  * issued. The ports are provided around the whole request, the same way the
  * background events get them.
  */
-export const makeFetch = (app: Effect.Effect<HttpEffect, unknown>, ports: Layer.Layer<MapleDbConnection>) =>
-	Effect.gen(function* () {
+export const makeFetch = (app: Effect.Effect<HttpEffect, unknown>, ports: Layer.Layer<MapleDbConnection>) => {
+	// Isolate-scoped: the Worker's init calls `makeFetch` once. The unattributed
+	// 500s all landed within ~60ms of an isolate's first request, so the span has
+	// to carry that shape for the next one to confirm or kill it.
+	let firstRequestAt: number | undefined
+	let served = 0
+	return Effect.gen(function* () {
 		const request = yield* HttpServerRequest.HttpServerRequest
 		const path = pathOf(request.url)
 		if (request.method === "GET" && path === "/health") {
@@ -157,6 +215,8 @@ export const makeFetch = (app: Effect.Effect<HttpEffect, unknown>, ports: Layer.
 
 		const isMcp = request.method === "POST" && path === "/mcp"
 		const startedAt = yield* Clock.currentTimeMillis
+		firstRequestAt ??= startedAt
+		const ordinal = ++served
 
 		const built = yield* Effect.exit(app)
 		if (Exit.isFailure(built)) {
@@ -166,7 +226,16 @@ export const makeFetch = (app: Effect.Effect<HttpEffect, unknown>, ports: Layer.
 			return unavailableResponse(path)
 		}
 
-		const response = yield* withPgConnectionScope(built.value)
+		const response = yield* withPgConnectionScope(built.value).pipe(
+			Effect.tapCause((cause) => recordEscapedCause(request.method, path, cause)),
+		)
+
+		if (response.status >= 500) {
+			yield* recordUnownedServerError(request.method, path, response, {
+				ageMs: startedAt - firstRequestAt,
+				ordinal,
+			})
+		}
 
 		if (isMcp) {
 			// The transport is stateless, so there is no session to carry across
@@ -184,3 +253,4 @@ export const makeFetch = (app: Effect.Effect<HttpEffect, unknown>, ports: Layer.
 		// oxlint-disable-next-line effecttsgo/strict-effect-provide -- the request IS the boundary the ports belong to.
 		Effect.provide(ports),
 	)
+}

--- a/apps/api/src/worker/http.ts
+++ b/apps/api/src/worker/http.ts
@@ -144,33 +144,14 @@ const recordEscapedCause = (method: string, path: string, cause: Cause.Cause<unk
 }
 
 /**
- * A 5xx no seam recorded, so the cause is already gone. The isolate fields carry the cold-start
- * shape these cluster in.
+ * How cold the isolate was when this 5xx arrived. Which layer rendered it is already on the span: a seam
+ * that named the failure left an `exception` event, and the tracer labels the rest generically.
  */
-const recordUnownedServerError = (
-	method: string,
-	path: string,
-	response: HttpServerResponse.HttpServerResponse,
-	isolate: { readonly ageMs: number; readonly ordinal: number },
-) =>
+const recordIsolateAge = (isolate: { readonly ageMs: number; readonly ordinal: number }) =>
 	Effect.annotateCurrentSpan({
 		"maple.isolate.age_ms": isolate.ageMs,
 		"maple.isolate.request_ordinal": isolate.ordinal,
-		"maple.http.response_content_length": response.headers["content-length"] ?? "",
-	}).pipe(
-		Effect.andThen(
-			Effect.logError("Route graph answered with a server error nothing recorded").pipe(
-				Effect.annotateLogs({
-					method,
-					path,
-					status: response.status,
-					isolateAgeMs: isolate.ageMs,
-					requestOrdinal: isolate.ordinal,
-					contentLength: response.headers["content-length"] ?? "",
-				}),
-			),
-		),
-	)
+	})
 
 /**
  * The request handler the bridge serves. Liveness and preflights answer before
@@ -226,10 +207,7 @@ export const makeFetch = (app: Effect.Effect<HttpEffect, unknown>, ports: Layer.
 		)
 
 		if (response.status >= 500) {
-			yield* recordUnownedServerError(request.method, path, response, {
-				ageMs: startedAt - firstRequestAt,
-				ordinal,
-			})
+			yield* recordIsolateAge({ ageMs: startedAt - firstRequestAt, ordinal })
 		}
 
 		if (isMcp) {

--- a/packages/effect-sdk/src/shared/flushable-tracer.test.ts
+++ b/packages/effect-sdk/src/shared/flushable-tracer.test.ts
@@ -236,6 +236,41 @@ describe("makeSpanBuffer rendered 5xx responses", () => {
 		}),
 	)
 
+	it.effect("keeps an exception the handler recorded itself instead of relabelling it", () =>
+		Effect.gen(function* () {
+			const buffer = makeSpanBuffer()
+			// A service that names the failure where it renders the response: the
+			// generic type would collapse every such 5xx into one bucket.
+			yield* Effect.currentSpan.pipe(
+				Effect.flatMap((span) =>
+					Effect.sync(() =>
+						span.event("exception", 1n, {
+							"exception.type": "WarehouseQueryError",
+							"exception.message": "Memory limit exceeded",
+						}),
+					),
+				),
+				Effect.andThen(
+					Effect.annotateCurrentSpan({
+						"http.request.method": "GET",
+						"url.path": "/api/sync/shape",
+						"http.response.status_code": 500,
+					}),
+				),
+				Effect.withSpan("http.server GET", { kind: "server" }),
+				Effect.provide(buffer.tracerLayer),
+			)
+			const [span] = buffer.drain()
+			assert.strictEqual(span!.status.code, 2 /* Error */)
+			const exceptions = span!.events.filter((event) => event.name === "exception")
+			assert.strictEqual(exceptions.length, 1)
+			assert.deepStrictEqual(
+				exceptions[0]!.attributes.find((attribute) => attribute.key === "exception.type")?.value,
+				{ stringValue: "WarehouseQueryError" },
+			)
+		}),
+	)
+
 	it.effect("leaves a 4xx server span Ok", () =>
 		Effect.gen(function* () {
 			const buffer = makeSpanBuffer()

--- a/packages/effect-sdk/src/shared/flushable-tracer.ts
+++ b/packages/effect-sdk/src/shared/flushable-tracer.ts
@@ -275,15 +275,22 @@ const makeOtlpSpan = (self: SpanImpl, anticipatedErrorIdentifiers?: ReadonlySet<
 				? `HTTP ${serverError} (${method} ${path})`
 				: `HTTP ${serverError}`
 		otelStatus = { code: StatusCode.Error, message }
-		events.push({
-			name: "exception",
-			timeUnixNano: String(status.endTime),
-			droppedAttributesCount: 0,
-			attributes: [
-				{ key: ATTR_EXCEPTION_TYPE, value: { stringValue: "HttpServerErrorResponse" } },
-				{ key: ATTR_EXCEPTION_MESSAGE, value: { stringValue: message } },
-			],
-		})
+		// Only when nothing named the failure itself. A service that records its own
+		// exception where it renders the response knows the type, message and stack;
+		// replacing that with the status line would collapse every such 5xx into one
+		// anonymous bucket in error tracking. The generic event is the fallback for a
+		// 5xx no one claimed, not a relabelling of one someone did.
+		if (!events.some((event) => event.name === "exception")) {
+			events.push({
+				name: "exception",
+				timeUnixNano: String(status.endTime),
+				droppedAttributesCount: 0,
+				attributes: [
+					{ key: ATTR_EXCEPTION_TYPE, value: { stringValue: "HttpServerErrorResponse" } },
+					{ key: ATTR_EXCEPTION_MESSAGE, value: { stringValue: message } },
+				],
+			})
+		}
 	} else if (status.exit._tag === "Success") {
 		otelStatus = constOtelStatusSuccess
 	} else if (Cause.hasInterruptsOnly(status.exit.cause)) {

--- a/packages/effect-sdk/src/shared/flushable-tracer.ts
+++ b/packages/effect-sdk/src/shared/flushable-tracer.ts
@@ -275,11 +275,8 @@ const makeOtlpSpan = (self: SpanImpl, anticipatedErrorIdentifiers?: ReadonlySet<
 				? `HTTP ${serverError} (${method} ${path})`
 				: `HTTP ${serverError}`
 		otelStatus = { code: StatusCode.Error, message }
-		// Only when nothing named the failure itself. A service that records its own
-		// exception where it renders the response knows the type, message and stack;
-		// replacing that with the status line would collapse every such 5xx into one
-		// anonymous bucket in error tracking. The generic event is the fallback for a
-		// 5xx no one claimed, not a relabelling of one someone did.
+		// Only when nothing named the failure itself — relabelling a recorded exception would
+		// collapse every such 5xx into one anonymous bucket in error tracking.
 		if (!events.some((event) => event.name === "exception")) {
 			events.push({
 				name: "exception",


### PR DESCRIPTION
## What

Collapses the API's failure-to-response recording onto one seam, `apps/api/src/routes/rendered-failure.ts`, and makes a rendered 5xx carry the identity of the failure that caused it.

## Why

A defect on its way out of the API is converted into a Response by up to three layers: the v1/v2 `HttpApiMiddleware` boundaries, the router, and the bridge's outermost catch. Each conversion is individually correct and defensible, and each one destroys information the next one needed. Defense in depth turned into information loss in depth.

The result in production is roughly 11 unattributed 500s a day, on `/v2/*/timeseries` and several `/internal/query-engine/*` routes. They carry no `error.type`, no stack trace, no child span and no log line, and they all fingerprint into a single anonymous `HttpServerErrorResponse` bucket in error tracking. They are not new: the same shape appears across 09-07, 09-08 and 09-09.

## What changed

- **One recorder.** `recordRenderedFailure` is called by every layer that renders a failure: an endpoint's declared 5xx, a route defect, a response that failed its own schema, and a cause escaping the route graph. Five hand-written annotate-and-log blocks became five calls, so a new boundary cannot implement half of the contract.
- **The diagnosis rides the span, not just the log.** It is recorded as a real `exception` event with the failure's type, message and stack. Spans from a given request reach the warehouse when that request's logs do not, and error tracking fingerprints on `exception.type`, so these 500s will now group under their own names.
- **The tracer stops relabelling.** `flushable-tracer.ts` only synthesizes the generic `HttpServerErrorResponse` event when nothing named the failure first. This also benefits SDK consumers, not only this API.
- **The leftover case is now self-identifying.** Because everything we own leaves an exception event behind, a 5xx still labelled `HttpServerErrorResponse` is by construction one no owned layer rendered. No marker attribute is needed. The bridge records those with `maple.isolate.age_ms` and `maple.isolate.request_ordinal`, since prior analysis put them on cold isolates serving several concurrent first requests.
- **Deletes four `Schema.TaggedError` classes** that were constructed, read for their fields, and thrown away without ever entering an error channel. They existed only to shape a log line.

## Reviewer notes

- `packages/effect-sdk` ships to customers. The tracer change is additive and covered by a new test; `dist` is gitignored and rebuilt at deploy.
- Existing boundary tests were not modified. They assert the log message and annotations for the declared-5xx path, and the recorder preserves both.
- This does not answer whether the API's logs are being dropped on cold isolates. It routes around that question by putting the diagnosis on the channel that demonstrably survives. If logs are dropping, that hole still sits under every log line in the API and is worth a separate look.

## Verification

- `bun typecheck` — 41/41 packages
- `bun run lint` — clean
- `bun run --cwd apps/api vitest run src/routes src/mcp src/worker-bridge.test.ts` — 737 passed
- `bun run --cwd packages/effect-sdk vitest run` — 131 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791574286&installation_model_id=427786&pr_number=814&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F814&signature=df360e29667db195de42f30376aa4c3ea882dfba634d2fa8b1991faa317d407c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved original error types, messages, stack traces, causes, and diagnostic details in server error reporting.
  * Prevented generic HTTP 500 errors from replacing more specific recorded exceptions.
  * Improved handling and tracking of unexpected route failures and server errors.

* **Observability**
  * Added consistent telemetry for rendered API failures, including response status and diagnostic details.

* **Tests**
  * Added coverage for anonymous 500 responses, escaped causes, and preservation of specific exception details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->