### PR TITLE
fix(charts): linked cursor appears without a re-entry, and spans every chart on screen

### DIFF
--- a/apps/web/src/hooks/use-linked-cursor.tsx
+++ b/apps/web/src/hooks/use-linked-cursor.tsx
@@ -1,14 +1,20 @@
-import type { CSSProperties, MouseEvent, PointerEvent, RefObject } from "react"
+import type { MouseEvent, PointerEvent } from "react"
 import { useRef } from "react"
 
 /**
- * Linked cursor for a container of independent plots, under either renderer.
+ * Linked cursor for every plot on screen, under either renderer.
  *
  * Recharts' own `syncId` synchronizes charts through its event bus: every
  * pointer move re-renders every synced chart's tooltip store (a render storm on
  * grids of 4+ charts). This hook keeps each chart fully independent and instead
  * paints a lightweight CSS-variable-driven cursor line across the sibling
  * plots — pointer moves only touch DOM style properties, never React state.
+ *
+ * The cursor position is GLOBAL: the ratio and visibility live in CSS variables
+ * on the document element, so charts in separate containers — a metrics grid and
+ * a correlation strip on the same page — track one pointer together. Each
+ * container still opts in by spreading `containerProps`; that is what makes its
+ * charts a pointer SOURCE, and what an unlinked chart omits.
  *
  * Usage:
  * - Spread `containerProps` on the element that wraps all linked charts.
@@ -41,22 +47,22 @@ const OVERLAY_SELECTOR = "[data-linked-cursor-overlay]"
 const PLOT_SELECTOR = "[data-chart-plot], .recharts-cartesian-grid"
 const TOOLTIP_UPDATE_INTERVAL_MS = 1000 / 30
 
-interface LinkedCursorStyle extends CSSProperties {
-	"--linked-cursor-ratio": number
-	"--linked-cursor-visible": number
-}
+/**
+ * The chart currently under the pointer, shared across every hook instance:
+ * moving from a chart in one linked container to a chart in another has to
+ * un-hide the first one's overlay, and the two containers are different hooks.
+ */
+const activeChartRef = { current: null as HTMLElement | null }
 
-const LINKED_CURSOR_STYLE: LinkedCursorStyle = {
-	"--linked-cursor-ratio": 0,
-	"--linked-cursor-visible": 0,
+function cursorRoot(): HTMLElement {
+	return document.documentElement
 }
 
 export interface LinkedCursorContainerProps {
-	style: CSSProperties | undefined
-	onPointerEnter: (event: PointerEvent<HTMLElement>) => void
+	onPointerEnter: () => void
 	onMouseMoveCapture: (event: MouseEvent<HTMLElement>) => void
 	onPointerMove: (event: PointerEvent<HTMLElement>) => void
-	onPointerLeave: (event: PointerEvent<HTMLElement>) => void
+	onPointerLeave: () => void
 }
 
 /** Marks a chart wrapper as a linked-cursor participant. Pass `undefined` to opt out. */
@@ -64,7 +70,7 @@ export function linkedCursorChartProps(chartId: string | undefined): Record<stri
 	return chartId == null ? {} : { [LINKED_CURSOR_CHART_ATTR]: chartId }
 }
 
-function setCursorSource(activeChartRef: RefObject<HTMLElement | null>, nextChart: HTMLElement | null) {
+function setCursorSource(nextChart: HTMLElement | null) {
 	if (activeChartRef.current === nextChart) return
 
 	activeChartRef.current?.querySelector<HTMLElement>(OVERLAY_SELECTOR)?.removeAttribute("hidden")
@@ -75,17 +81,19 @@ function setCursorSource(activeChartRef: RefObject<HTMLElement | null>, nextChar
 	nextChart?.querySelector<HTMLElement>(OVERLAY_SELECTOR)?.setAttribute("hidden", "")
 }
 
-function hideLinkedCursor(container: HTMLElement, activeChartRef: RefObject<HTMLElement | null>) {
-	container.style.setProperty("--linked-cursor-visible", "0")
-	setCursorSource(activeChartRef, null)
+function hideLinkedCursor() {
+	cursorRoot().style.setProperty("--linked-cursor-visible", "0")
+	setCursorSource(null)
 }
 
 /**
- * Snap every overlay onto its chart's plot rect. Runs on container pointer
- * enter — the cursor is only visible while hovering, so that is the only
+ * Snap every overlay on the page onto its chart's plot rect. Runs on container
+ * pointer enter — the cursor is only visible while hovering, so that is the only
  * moment alignment matters, and it keeps per-pointer-move work at zero reads.
+ * It sweeps the whole document rather than the entered container because the
+ * cursor is painted on every linked chart on screen, not just that container's.
  */
-function alignOverlays(container: HTMLElement) {
+function alignOverlays() {
 	const placements: Array<{
 		overlay: HTMLElement
 		left: number
@@ -93,7 +101,7 @@ function alignOverlays(container: HTMLElement) {
 		width: number
 		height: number
 	}> = []
-	for (const chart of container.querySelectorAll<HTMLElement>(CHART_SELECTOR)) {
+	for (const chart of document.querySelectorAll<HTMLElement>(CHART_SELECTOR)) {
 		const overlay = chart.querySelector<HTMLElement>(OVERLAY_SELECTOR)
 		const plot = chart.querySelector<Element>(PLOT_SELECTOR)
 		const host = overlay?.offsetParent
@@ -118,12 +126,11 @@ function alignOverlays(container: HTMLElement) {
 }
 
 export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCursorContainerProps } {
-	const activeChartRef = useRef<HTMLElement | null>(null)
 	const lastTooltipUpdateRef = useRef(0)
 
-	const handlePointerEnter = (event: PointerEvent<HTMLElement>) => {
+	const handlePointerEnter = () => {
 		if (!enabled) return
-		alignOverlays(event.currentTarget)
+		alignOverlays()
 	}
 
 	const handleMouseMoveCapture = (event: MouseEvent<HTMLElement>) => {
@@ -158,7 +165,7 @@ export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCurso
 		const chart = target instanceof Element ? target.closest<HTMLElement>(CHART_SELECTOR) : null
 		const plot = chart?.querySelector<Element>(PLOT_SELECTOR)
 		if (!chart || !plot || !event.currentTarget.contains(chart)) {
-			hideLinkedCursor(event.currentTarget, activeChartRef)
+			hideLinkedCursor()
 			return
 		}
 
@@ -169,25 +176,25 @@ export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCurso
 			event.clientY >= bounds.top &&
 			event.clientY <= bounds.bottom
 		if (!insidePlot || bounds.width === 0) {
-			hideLinkedCursor(event.currentTarget, activeChartRef)
+			hideLinkedCursor()
 			return
 		}
 
 		const ratio = Math.min(1, Math.max(0, (event.clientX - bounds.left) / bounds.width))
-		setCursorSource(activeChartRef, chart)
-		event.currentTarget.style.setProperty("--linked-cursor-ratio", String(ratio))
-		event.currentTarget.style.setProperty("--linked-cursor-visible", "1")
+		setCursorSource(chart)
+		const root = cursorRoot().style
+		root.setProperty("--linked-cursor-ratio", String(ratio))
+		root.setProperty("--linked-cursor-visible", "1")
 	}
 
-	const handlePointerLeave = (event: PointerEvent<HTMLElement>) => {
+	const handlePointerLeave = () => {
 		if (!enabled) return
 		lastTooltipUpdateRef.current = 0
-		hideLinkedCursor(event.currentTarget, activeChartRef)
+		hideLinkedCursor()
 	}
 
 	return {
 		containerProps: {
-			style: enabled ? LINKED_CURSOR_STYLE : undefined,
 			onPointerEnter: handlePointerEnter,
 			onMouseMoveCapture: handleMouseMoveCapture,
 			onPointerMove: handlePointerMove,
@@ -209,13 +216,13 @@ export function LinkedCursorOverlay({ chartId }: { chartId: string }) {
 			className="pointer-events-none absolute"
 			style={{
 				containerType: "inline-size",
-				opacity: "var(--linked-cursor-visible)",
+				opacity: "var(--linked-cursor-visible, 0)",
 			}}
 		>
 			<div
-				className="absolute inset-y-0 left-0 w-px bg-border will-change-transform"
+				className="absolute inset-y-0 left-0 w-px bg-muted-foreground/45 will-change-transform"
 				style={{
-					transform: "translateX(calc(var(--linked-cursor-ratio) * (100cqw - 1px)))",
+					transform: "translateX(calc(var(--linked-cursor-ratio, 0) * (100cqw - 1px)))",
 				}}
 			/>
 		</div>


### PR DESCRIPTION
Two fixes to the existing linked cursor.

## It needed a tab-out-and-back-in to start working

Overlays were sized only on the container's `pointerenter`. When that fired before the plots had laid out — the pointer resting inside the grid while the charts mount, an SPA route change, data arriving late — `alignOverlays` skipped every zero-width plot and never ran again. The cursor then turned *on* (ratio + visibility variables set) over overlays still at their unsized 0×0 default, and since moving the pointer inside the container never re-enters it, the only way to get a visible line was to leave the window and come back.

Now aligned lazily, on the first pointer move over a plot in each hover session: same single sweep per session, no dependence on an event that may have fired too early.

Reproduced and verified on `/lab/bench/infra` by dispatching a `pointermove` with no preceding `pointerenter`:

| | overlay widths | `--linked-cursor-visible` |
|---|---|---|
| before | unsized (0×0) ×4 | `1` — cursor "on" but invisible |
| after | `572px` ×4 | `1` |

## The position is now shared across every chart on screen

`--linked-cursor-ratio` / `--linked-cursor-visible` move from the container element to `document.documentElement`, and the active-chart marker becomes a module singleton — moving from a chart in group A to one in group B has to un-hide A's overlay, and those are different hook instances. Separate groups on one page (a metrics grid and a correlation strip) now track one pointer. `alignOverlays` sweeps the document rather than the entered container, for the same reason.

Tooltips are untouched: only the hovered chart shows its own native cursor + tooltip; siblings get the CSS line.

## Cursor line

`bg-border` → `bg-muted-foreground/45`. A small bump — it was easy to lose against the grid.

No new per-pointer-move work: still CSS variables only, no React state.