### PR TITLE
fix(charts): align the linked cursor on first move (and revert #816)

### DIFF
--- a/apps/web/src/hooks/use-linked-cursor.tsx
+++ b/apps/web/src/hooks/use-linked-cursor.tsx
@@ -1,20 +1,14 @@
-import type { MouseEvent, PointerEvent } from "react"
+import type { CSSProperties, MouseEvent, PointerEvent, RefObject } from "react"
 import { useRef } from "react"
 
 /**
- * Linked cursor for every plot on screen, under either renderer.
+ * Linked cursor for a container of independent plots, under either renderer.
  *
  * Recharts' own `syncId` synchronizes charts through its event bus: every
  * pointer move re-renders every synced chart's tooltip store (a render storm on
  * grids of 4+ charts). This hook keeps each chart fully independent and instead
  * paints a lightweight CSS-variable-driven cursor line across the sibling
  * plots — pointer moves only touch DOM style properties, never React state.
- *
- * The cursor position is GLOBAL: the ratio and visibility live in CSS variables
- * on the document element, so charts in separate containers — a metrics grid and
- * a correlation strip on the same page — track one pointer together. Each
- * container still opts in by spreading `containerProps`; that is what makes its
- * charts a pointer SOURCE, and what an unlinked chart omits.
  *
  * Usage:
  * - Spread `containerProps` on the element that wraps all linked charts.
@@ -47,22 +41,22 @@ const OVERLAY_SELECTOR = "[data-linked-cursor-overlay]"
 const PLOT_SELECTOR = "[data-chart-plot], .recharts-cartesian-grid"
 const TOOLTIP_UPDATE_INTERVAL_MS = 1000 / 30
 
-/**
- * The chart currently under the pointer, shared across every hook instance:
- * moving from a chart in one linked container to a chart in another has to
- * un-hide the first one's overlay, and the two containers are different hooks.
- */
-const activeChartRef = { current: null as HTMLElement | null }
+interface LinkedCursorStyle extends CSSProperties {
+	"--linked-cursor-ratio": number
+	"--linked-cursor-visible": number
+}
 
-function cursorRoot(): HTMLElement {
-	return document.documentElement
+const LINKED_CURSOR_STYLE: LinkedCursorStyle = {
+	"--linked-cursor-ratio": 0,
+	"--linked-cursor-visible": 0,
 }
 
 export interface LinkedCursorContainerProps {
-	onPointerEnter: () => void
+	style: CSSProperties | undefined
+	onPointerEnter: (event: PointerEvent<HTMLElement>) => void
 	onMouseMoveCapture: (event: MouseEvent<HTMLElement>) => void
 	onPointerMove: (event: PointerEvent<HTMLElement>) => void
-	onPointerLeave: () => void
+	onPointerLeave: (event: PointerEvent<HTMLElement>) => void
 }
 
 /** Marks a chart wrapper as a linked-cursor participant. Pass `undefined` to opt out. */
@@ -70,7 +64,7 @@ export function linkedCursorChartProps(chartId: string | undefined): Record<stri
 	return chartId == null ? {} : { [LINKED_CURSOR_CHART_ATTR]: chartId }
 }
 
-function setCursorSource(nextChart: HTMLElement | null) {
+function setCursorSource(activeChartRef: RefObject<HTMLElement | null>, nextChart: HTMLElement | null) {
 	if (activeChartRef.current === nextChart) return
 
 	activeChartRef.current?.querySelector<HTMLElement>(OVERLAY_SELECTOR)?.removeAttribute("hidden")
@@ -81,19 +75,17 @@ function setCursorSource(nextChart: HTMLElement | null) {
 	nextChart?.querySelector<HTMLElement>(OVERLAY_SELECTOR)?.setAttribute("hidden", "")
 }
 
-function hideLinkedCursor() {
-	cursorRoot().style.setProperty("--linked-cursor-visible", "0")
-	setCursorSource(null)
+function hideLinkedCursor(container: HTMLElement, activeChartRef: RefObject<HTMLElement | null>) {
+	container.style.setProperty("--linked-cursor-visible", "0")
+	setCursorSource(activeChartRef, null)
 }
 
 /**
- * Snap every overlay on the page onto its chart's plot rect. Runs on container
- * pointer enter — the cursor is only visible while hovering, so that is the only
+ * Snap every overlay onto its chart's plot rect. Runs on container pointer
+ * enter — the cursor is only visible while hovering, so that is the only
  * moment alignment matters, and it keeps per-pointer-move work at zero reads.
- * It sweeps the whole document rather than the entered container because the
- * cursor is painted on every linked chart on screen, not just that container's.
  */
-function alignOverlays() {
+function alignOverlays(container: HTMLElement) {
 	const placements: Array<{
 		overlay: HTMLElement
 		left: number
@@ -101,7 +93,7 @@ function alignOverlays() {
 		width: number
 		height: number
 	}> = []
-	for (const chart of document.querySelectorAll<HTMLElement>(CHART_SELECTOR)) {
+	for (const chart of container.querySelectorAll<HTMLElement>(CHART_SELECTOR)) {
 		const overlay = chart.querySelector<HTMLElement>(OVERLAY_SELECTOR)
 		const plot = chart.querySelector<Element>(PLOT_SELECTOR)
 		const host = overlay?.offsetParent
@@ -126,11 +118,12 @@ function alignOverlays() {
 }
 
 export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCursorContainerProps } {
+	const activeChartRef = useRef<HTMLElement | null>(null)
 	const lastTooltipUpdateRef = useRef(0)
 
-	const handlePointerEnter = () => {
+	const handlePointerEnter = (event: PointerEvent<HTMLElement>) => {
 		if (!enabled) return
-		alignOverlays()
+		alignOverlays(event.currentTarget)
 	}
 
 	const handleMouseMoveCapture = (event: MouseEvent<HTMLElement>) => {
@@ -165,7 +158,7 @@ export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCurso
 		const chart = target instanceof Element ? target.closest<HTMLElement>(CHART_SELECTOR) : null
 		const plot = chart?.querySelector<Element>(PLOT_SELECTOR)
 		if (!chart || !plot || !event.currentTarget.contains(chart)) {
-			hideLinkedCursor()
+			hideLinkedCursor(event.currentTarget, activeChartRef)
 			return
 		}
 
@@ -176,25 +169,25 @@ export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCurso
 			event.clientY >= bounds.top &&
 			event.clientY <= bounds.bottom
 		if (!insidePlot || bounds.width === 0) {
-			hideLinkedCursor()
+			hideLinkedCursor(event.currentTarget, activeChartRef)
 			return
 		}
 
 		const ratio = Math.min(1, Math.max(0, (event.clientX - bounds.left) / bounds.width))
-		setCursorSource(chart)
-		const root = cursorRoot().style
-		root.setProperty("--linked-cursor-ratio", String(ratio))
-		root.setProperty("--linked-cursor-visible", "1")
+		setCursorSource(activeChartRef, chart)
+		event.currentTarget.style.setProperty("--linked-cursor-ratio", String(ratio))
+		event.currentTarget.style.setProperty("--linked-cursor-visible", "1")
 	}
 
-	const handlePointerLeave = () => {
+	const handlePointerLeave = (event: PointerEvent<HTMLElement>) => {
 		if (!enabled) return
 		lastTooltipUpdateRef.current = 0
-		hideLinkedCursor()
+		hideLinkedCursor(event.currentTarget, activeChartRef)
 	}
 
 	return {
 		containerProps: {
+			style: enabled ? LINKED_CURSOR_STYLE : undefined,
 			onPointerEnter: handlePointerEnter,
 			onMouseMoveCapture: handleMouseMoveCapture,
 			onPointerMove: handlePointerMove,
@@ -216,13 +209,13 @@ export function LinkedCursorOverlay({ chartId }: { chartId: string }) {
 			className="pointer-events-none absolute"
 			style={{
 				containerType: "inline-size",
-				opacity: "var(--linked-cursor-visible, 0)",
+				opacity: "var(--linked-cursor-visible)",
 			}}
 		>
 			<div
-				className="absolute inset-y-0 left-0 w-px bg-muted-foreground/45 will-change-transform"
+				className="absolute inset-y-0 left-0 w-px bg-border will-change-transform"
 				style={{
-					transform: "translateX(calc(var(--linked-cursor-ratio, 0) * (100cqw - 1px)))",
+					transform: "translateX(calc(var(--linked-cursor-ratio) * (100cqw - 1px)))",
 				}}
 			/>
 		</div>

--- a/apps/web/src/hooks/use-linked-cursor.tsx
+++ b/apps/web/src/hooks/use-linked-cursor.tsx
@@ -16,8 +16,8 @@ import { useRef } from "react"
  *   {@link linkedCursorChartProps} and render a {@link LinkedCursorOverlay}
  *   inside it, absolutely positioned against it.
  *
- * The overlay is aligned to each chart's own plot rect when the pointer enters
- * the container, so charts with different y-axis widths and margins all show
+ * The overlay is aligned to each chart's own plot rect on the first pointer move
+ * of a hover session, so charts with different y-axis widths and margins all show
  * the cursor at the same time-bucket ratio — no chart has to be told what width
  * its neighbours resolved to. The hovered chart keeps its own native
  * cursor+tooltip (its overlay is hidden via the `data-linked-cursor-source`
@@ -53,7 +53,6 @@ const LINKED_CURSOR_STYLE: LinkedCursorStyle = {
 
 export interface LinkedCursorContainerProps {
 	style: CSSProperties | undefined
-	onPointerEnter: (event: PointerEvent<HTMLElement>) => void
 	onMouseMoveCapture: (event: MouseEvent<HTMLElement>) => void
 	onPointerMove: (event: PointerEvent<HTMLElement>) => void
 	onPointerLeave: (event: PointerEvent<HTMLElement>) => void
@@ -81,9 +80,18 @@ function hideLinkedCursor(container: HTMLElement, activeChartRef: RefObject<HTML
 }
 
 /**
- * Snap every overlay onto its chart's plot rect. Runs on container pointer
- * enter — the cursor is only visible while hovering, so that is the only
- * moment alignment matters, and it keeps per-pointer-move work at zero reads.
+ * Snap every overlay onto its chart's plot rect. Runs once per hover session, on
+ * the first pointer move over a plot — the cursor is only visible while
+ * hovering, so that is the only moment alignment matters, and every later move
+ * in the session does zero layout reads.
+ *
+ * Deliberately NOT driven by `pointerenter`. That fires before the plots have
+ * laid out whenever the pointer is already inside the container as the charts
+ * mount (a route change or late data under a resting cursor), and every
+ * zero-width plot is skipped below — leaving the overlays at their unsized 0x0
+ * default with no second chance to align, because moving the pointer around
+ * inside the container never re-enters it. The cursor then turned "on" but
+ * painted nothing until you left the window and came back.
  */
 function alignOverlays(container: HTMLElement) {
 	const placements: Array<{
@@ -120,11 +128,8 @@ function alignOverlays(container: HTMLElement) {
 export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCursorContainerProps } {
 	const activeChartRef = useRef<HTMLElement | null>(null)
 	const lastTooltipUpdateRef = useRef(0)
-
-	const handlePointerEnter = (event: PointerEvent<HTMLElement>) => {
-		if (!enabled) return
-		alignOverlays(event.currentTarget)
-	}
+	/** Cleared whenever the cursor hides, so each hover session aligns exactly once. */
+	const alignedRef = useRef(false)
 
 	const handleMouseMoveCapture = (event: MouseEvent<HTMLElement>) => {
 		if (!enabled) return
@@ -158,6 +163,7 @@ export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCurso
 		const chart = target instanceof Element ? target.closest<HTMLElement>(CHART_SELECTOR) : null
 		const plot = chart?.querySelector<Element>(PLOT_SELECTOR)
 		if (!chart || !plot || !event.currentTarget.contains(chart)) {
+			alignedRef.current = false
 			hideLinkedCursor(event.currentTarget, activeChartRef)
 			return
 		}
@@ -169,8 +175,14 @@ export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCurso
 			event.clientY >= bounds.top &&
 			event.clientY <= bounds.bottom
 		if (!insidePlot || bounds.width === 0) {
+			alignedRef.current = false
 			hideLinkedCursor(event.currentTarget, activeChartRef)
 			return
+		}
+
+		if (!alignedRef.current) {
+			alignedRef.current = true
+			alignOverlays(event.currentTarget)
 		}
 
 		const ratio = Math.min(1, Math.max(0, (event.clientX - bounds.left) / bounds.width))
@@ -182,13 +194,13 @@ export function useLinkedCursor(enabled: boolean): { containerProps: LinkedCurso
 	const handlePointerLeave = (event: PointerEvent<HTMLElement>) => {
 		if (!enabled) return
 		lastTooltipUpdateRef.current = 0
+		alignedRef.current = false
 		hideLinkedCursor(event.currentTarget, activeChartRef)
 	}
 
 	return {
 		containerProps: {
 			style: enabled ? LINKED_CURSOR_STYLE : undefined,
-			onPointerEnter: handlePointerEnter,
 			onMouseMoveCapture: handleMouseMoveCapture,
 			onPointerMove: handlePointerMove,
 			onPointerLeave: handlePointerLeave,
@@ -213,7 +225,7 @@ export function LinkedCursorOverlay({ chartId }: { chartId: string }) {
 			}}
 		>
 			<div
-				className="absolute inset-y-0 left-0 w-px bg-border will-change-transform"
+				className="absolute inset-y-0 left-0 w-px bg-muted-foreground/45 will-change-transform"
 				style={{
 					transform: "translateX(calc(var(--linked-cursor-ratio) * (100cqw - 1px)))",
 				}}


### PR DESCRIPTION
The linked cursor looked broken until you left the browser window and came back. #816 blamed the wrong thing and shipped a change that was not needed; this reverts it and fixes the actual bug.

## The bug

`alignOverlays` sizes each overlay from its chart's plot rect, and skips any plot still measuring zero. It ran only on the container's `pointerenter`. Whenever the pointer was already inside the container as the charts mounted — a route change or late data under a resting cursor — that single run found nothing but zero-width plots, and it never ran again: moving around inside a container does not re-enter it.

Meanwhile `--linked-cursor-ratio` / `--linked-cursor-visible` were set on every move, so the cursor was "on" the whole time, painting into overlays still at their unsized 0×0 default. Leaving the window and returning fired `pointerenter` again, by which point the plots had laid out — hence the tab-out-and-back-in.

## The fix

Align on the first pointer move over a plot in each hover session, resetting the flag wherever the cursor hides. Same one sweep per session, zero layout reads on every subsequent move, and no dependence on an event that may have fired before there was anything to measure.

Verified on `/lab/bench/infra` by dispatching a `pointermove` with **no** preceding `pointerenter`:

| | overlay widths | cursor visible |
|---|---|---|
| before | unsized (0×0) ×4 | `1` — on, but painting nothing |
| after | `500px, 500px, 466px, 466px` | `1` |

## Revert of #816

#816 moved the cursor variables to `document.documentElement` and the active-chart marker to a module singleton, linking charts across containers. That was written for this bug and does not fix it — alignment was always the problem, and container scoping was never in the way. No route renders two linked containers at once (`host-detail-chart.tsx` only mentions the hook in comments), so it bought nothing while widening every chart hover to the document element. Reverted to container scope.

Kept from #816: the line goes from `bg-border` to `bg-muted-foreground/45`, which was a separate request — it was easy to lose against the grid.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791633428&installation_model_id=427786&pr_number=818&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F818&signature=4090285f2f2afe29cf6df7f960276bac5be3fc7bed020c6c661a9f0c9367ca38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Linked cursors now remain correctly scoped to their individual chart or container.
  - Multiple chart areas can display independent cursor positions without interfering with one another.
  - Cursor overlays align reliably when pointer movement begins, improving hover behavior.
  - Cursor visibility and positioning no longer affect unrelated areas of the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->