### PR TITLE
fix(landing): let the docs page description span the full content width

### DIFF
--- a/apps/landing/src/pages/docs/[...slug].astro
+++ b/apps/landing/src/pages/docs/[...slug].astro
@@ -25,7 +25,7 @@ const { Content, headings } = await render(doc);
     <article class="docs-content max-w-none">
         <Breadcrumb group={doc.data.group} title={doc.data.title} />
         <h1 class="font-display text-2xl md:text-3xl font-medium tracking-[-0.02em] text-fg mb-2">{doc.data.title}</h1>
-        <p class="text-sm text-fg-muted mb-8 leading-relaxed max-w-[64ch]">{doc.data.description}</p>
+        <p class="text-sm text-fg-muted mb-8 leading-relaxed">{doc.data.description}</p>
         <div class="border-t border-border pt-8">
             <Content />
         </div>


### PR DESCRIPTION
The docs page description was capped at `max-w-[64ch]`, narrower than the `max-w-3xl` body, so it wrapped early relative to the copy below it. Drops the cap so the description matches the body width.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791638394&installation_model_id=427786&pr_number=820&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F820&signature=782ec5e25d0b7615b38534b90102e9cc6fcfa8a5bdbeabd13f6147a8d3edaef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated documentation page descriptions to use the full available article width instead of limiting text to 64 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->