### PR TITLE
feat(web): remember the selected time range for the tab

### DIFF
--- a/apps/web/src/atoms/session-time-range-atoms.ts
+++ b/apps/web/src/atoms/session-time-range-atoms.ts
@@ -1,0 +1,33 @@
+import { Schema } from "effect"
+
+import { Atom } from "@/lib/effect-atom"
+import { sessionStorageRuntime } from "@/lib/services/common/storage-runtime"
+
+/**
+ * The time window the user last chose on any time-filtered page, kept for the
+ * life of the tab so the next page opens on the same window instead of its own
+ * default. Mirrors `TimeRangeSearchFields`: a preset, or an absolute pair.
+ */
+export const SessionTimeRangeSchema = Schema.Struct({
+	startTime: Schema.optionalKey(Schema.String),
+	endTime: Schema.optionalKey(Schema.String),
+	timePreset: Schema.optionalKey(Schema.String),
+})
+
+export type SessionTimeRange = Schema.Schema.Type<typeof SessionTimeRangeSchema>
+
+const sessionTimeRangeAtomFamily = Atom.family((orgId: string) =>
+	Atom.kvs({
+		runtime: sessionStorageRuntime,
+		key: `maple.time-range.session.${orgId}`,
+		schema: SessionTimeRangeSchema,
+		defaultValue: (): SessionTimeRange => ({}),
+	}),
+)
+
+// Inert while there is no org: mounting a kvs atom for a placeholder key would
+// write its default into sessionStorage under that placeholder.
+const noOrgSessionTimeRangeAtom = Atom.make<SessionTimeRange>({})
+
+export const sessionTimeRangeAtomFor = (orgId: string | null | undefined) =>
+	orgId ? sessionTimeRangeAtomFamily(orgId) : noOrgSessionTimeRangeAtom

--- a/apps/web/src/atoms/session-time-range-atoms.ts
+++ b/apps/web/src/atoms/session-time-range-atoms.ts
@@ -6,7 +6,9 @@ import { sessionStorageRuntime } from "@/lib/services/common/storage-runtime"
 /**
  * The time window the user last chose on any time-filtered page, kept for the
  * life of the tab so the next page opens on the same window instead of its own
- * default. Mirrors `TimeRangeSearchFields`: a preset, or an absolute pair.
+ * default. Mirrors `TimeRangeSearchFields` with `optionalKey` instead of
+ * `optional`: this is a JSON value we write ourselves, so a key is either there
+ * or absent, whereas the router hands search params present-but-undefined.
  */
 export const SessionTimeRangeSchema = Schema.Struct({
 	startTime: Schema.optionalKey(Schema.String),
@@ -25,8 +27,9 @@ const sessionTimeRangeAtomFamily = Atom.family((orgId: string) =>
 	}),
 )
 
-// Inert while there is no org: mounting a kvs atom for a placeholder key would
-// write its default into sessionStorage under that placeholder.
+// A kvs atom writes its default into storage on the first read of a missing
+// key — fine for a real org (`{}` reads back as "nothing remembered"), but with
+// no org that would mint a placeholder entry, so that case gets an inert atom.
 const noOrgSessionTimeRangeAtom = Atom.make<SessionTimeRange>({})
 
 export const sessionTimeRangeAtomFor = (orgId: string | null | undefined) =>

--- a/apps/web/src/components/time-range-picker/session-time-range.test.ts
+++ b/apps/web/src/components/time-range-picker/session-time-range.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { sessionTimeRangeAtomFor } from "@/atoms/session-time-range-atoms"
+import { appRegistry } from "@/lib/registry"
+import { setActiveOrgId } from "@/lib/services/common/auth-headers"
+
+import { persistSessionTimeRange, sessionTimeRangeSearchMiddleware } from "./session-time-range"
+
+const next = <T>(search: T) => search
+// TanStack hands middlewares present-but-undefined keys; mirror that here.
+const pageSearch = { services: ["api"], timePreset: undefined }
+
+describe("sessionTimeRangeSearchMiddleware", () => {
+	beforeEach(() => {
+		sessionStorage.clear()
+		setActiveOrgId("org_1")
+	})
+
+	afterEach(() => {
+		setActiveOrgId(null)
+	})
+
+	it("fills a navigation that names no window with the remembered one", () => {
+		appRegistry.set(sessionTimeRangeAtomFor("org_1"), { timePreset: "7d" })
+
+		expect(sessionTimeRangeSearchMiddleware({ search: pageSearch, next })).toEqual({
+			services: ["api"],
+			timePreset: "7d",
+		})
+		expect(sessionStorage.getItem("maple.time-range.session.org_1")).toContain('"7d"')
+	})
+
+	it("keeps a window the navigation names itself", () => {
+		appRegistry.set(sessionTimeRangeAtomFor("org_1"), { timePreset: "7d" })
+		const search = { startTime: "2026-09-01T00:00:00Z", endTime: "2026-09-02T00:00:00Z" }
+
+		expect(sessionTimeRangeSearchMiddleware({ search, next })).toEqual(search)
+	})
+
+	it("passes through when nothing is remembered or there is no org", () => {
+		setActiveOrgId("org_untouched")
+		expect(sessionTimeRangeSearchMiddleware({ search: pageSearch, next })).toEqual({
+			services: ["api"],
+		})
+
+		appRegistry.set(sessionTimeRangeAtomFor("org_1"), { timePreset: "7d" })
+		setActiveOrgId(null)
+		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toEqual({})
+	})
+
+	it("scopes the remembered window to the org", () => {
+		appRegistry.set(sessionTimeRangeAtomFor("org_1"), { timePreset: "7d" })
+		setActiveOrgId("org_2")
+
+		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toEqual({})
+	})
+})
+
+describe("persistSessionTimeRange", () => {
+	afterEach(() => {
+		setActiveOrgId(null)
+	})
+
+	it("remembers a preset, then an absolute window, and ignores locations without one", () => {
+		setActiveOrgId("org_persist")
+		const atom = sessionTimeRangeAtomFor("org_persist")
+
+		persistSessionTimeRange({ timePreset: "24h" })
+		expect(appRegistry.get(atom)).toEqual({ timePreset: "24h" })
+
+		persistSessionTimeRange({ startTime: "2026-09-01T00:00:00Z", endTime: "2026-09-02T00:00:00Z" })
+		expect(appRegistry.get(atom)).toEqual({
+			startTime: "2026-09-01T00:00:00Z",
+			endTime: "2026-09-02T00:00:00Z",
+		})
+
+		persistSessionTimeRange({})
+		expect(appRegistry.get(atom).startTime).toBe("2026-09-01T00:00:00Z")
+	})
+
+	it("does nothing without an org", () => {
+		setActiveOrgId(null)
+		persistSessionTimeRange({ timePreset: "24h" })
+		expect(sessionStorage.getItem("maple.time-range.session.null")).toBeNull()
+	})
+})

--- a/apps/web/src/components/time-range-picker/session-time-range.test.ts
+++ b/apps/web/src/components/time-range-picker/session-time-range.test.ts
@@ -1,88 +1,125 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { sessionTimeRangeAtomFor } from "@/atoms/session-time-range-atoms"
 import { appRegistry } from "@/lib/registry"
 import { setActiveOrgId } from "@/lib/services/common/auth-headers"
 
-import { persistSessionTimeRange, sessionTimeRangeSearchMiddleware } from "./session-time-range"
+import {
+	persistSessionTimeRange,
+	sessionTimeRangeSearchMiddleware,
+	subscribeSessionTimeRange,
+} from "./session-time-range"
 
 const next = <T>(search: T) => search
 // TanStack hands middlewares present-but-undefined keys; mirror that here.
 const pageSearch = { services: ["api"], timePreset: undefined }
+const absolute = { startTime: "2026-09-01T00:00:00Z", endTime: "2026-09-02T00:00:00Z" }
+
+// Each test gets its own org: an `Atom.family` member lives for the process
+// once read, so clearing sessionStorage would not reset a reused key.
+afterEach(() => {
+	setActiveOrgId(null)
+})
 
 describe("sessionTimeRangeSearchMiddleware", () => {
-	beforeEach(() => {
-		sessionStorage.clear()
-		setActiveOrgId("org_1")
-	})
-
-	afterEach(() => {
-		setActiveOrgId(null)
-	})
-
 	it("fills a navigation that names no window with the remembered one", () => {
-		appRegistry.set(sessionTimeRangeAtomFor("org_1"), { timePreset: "7d" })
+		setActiveOrgId("org_fill")
+		appRegistry.set(sessionTimeRangeAtomFor("org_fill"), { timePreset: "7d" })
 
-		expect(sessionTimeRangeSearchMiddleware({ search: pageSearch, next })).toEqual({
+		expect(sessionTimeRangeSearchMiddleware({ search: pageSearch, next })).toStrictEqual({
 			services: ["api"],
 			timePreset: "7d",
 		})
-		expect(sessionStorage.getItem("maple.time-range.session.org_1")).toContain('"7d"')
-	})
-
-	it("keeps a window the navigation names itself", () => {
-		appRegistry.set(sessionTimeRangeAtomFor("org_1"), { timePreset: "7d" })
-		const search = { startTime: "2026-09-01T00:00:00Z", endTime: "2026-09-02T00:00:00Z" }
-
-		expect(sessionTimeRangeSearchMiddleware({ search, next })).toEqual(search)
-	})
-
-	it("passes through when nothing is remembered or there is no org", () => {
-		setActiveOrgId("org_untouched")
-		expect(sessionTimeRangeSearchMiddleware({ search: pageSearch, next })).toEqual({
-			services: ["api"],
+		expect(JSON.parse(sessionStorage.getItem("maple.time-range.session.org_fill")!)).toEqual({
+			timePreset: "7d",
 		})
-
-		appRegistry.set(sessionTimeRangeAtomFor("org_1"), { timePreset: "7d" })
-		setActiveOrgId(null)
-		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toEqual({})
 	})
 
-	it("scopes the remembered window to the org", () => {
-		appRegistry.set(sessionTimeRangeAtomFor("org_1"), { timePreset: "7d" })
-		setActiveOrgId("org_2")
+	it("reads a window written by an earlier page load straight from storage", () => {
+		setActiveOrgId("org_cold")
+		sessionStorage.setItem("maple.time-range.session.org_cold", JSON.stringify(absolute))
 
-		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toEqual({})
+		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toEqual(absolute)
+	})
+
+	it("keeps a window the navigation names itself, even a partial one", () => {
+		setActiveOrgId("org_keep")
+		appRegistry.set(sessionTimeRangeAtomFor("org_keep"), { timePreset: "7d" })
+
+		expect(sessionTimeRangeSearchMiddleware({ search: absolute, next })).toStrictEqual(absolute)
+		const half = { startTime: absolute.startTime }
+		expect(sessionTimeRangeSearchMiddleware({ search: half, next })).toStrictEqual(half)
+	})
+
+	it("passes through when nothing is remembered, the value is malformed, or there is no org", () => {
+		setActiveOrgId("org_untouched")
+		expect(sessionTimeRangeSearchMiddleware({ search: pageSearch, next })).toStrictEqual(pageSearch)
+
+		setActiveOrgId("org_garbage")
+		sessionStorage.setItem("maple.time-range.session.org_garbage", "{not json")
+		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({})
+
+		setActiveOrgId("org_number")
+		sessionStorage.setItem("maple.time-range.session.org_number", JSON.stringify({ timePreset: 123 }))
+		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({})
+
+		setActiveOrgId("org_signed_out")
+		appRegistry.set(sessionTimeRangeAtomFor("org_signed_out"), { timePreset: "7d" })
+		setActiveOrgId(null)
+		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({})
+	})
+
+	it("scopes the remembered window to the org and keeps it across a switch", () => {
+		setActiveOrgId("org_a")
+		appRegistry.set(sessionTimeRangeAtomFor("org_a"), { timePreset: "7d" })
+
+		setActiveOrgId("org_b")
+		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({})
+
+		setActiveOrgId("org_a")
+		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({ timePreset: "7d" })
 	})
 })
 
 describe("persistSessionTimeRange", () => {
-	afterEach(() => {
-		setActiveOrgId(null)
-	})
-
 	it("remembers a preset, then an absolute window, and ignores locations without one", () => {
 		setActiveOrgId("org_persist")
 		const atom = sessionTimeRangeAtomFor("org_persist")
 
 		persistSessionTimeRange({ timePreset: "24h" })
-		expect(appRegistry.get(atom)).toEqual({ timePreset: "24h" })
+		expect(appRegistry.get(atom)).toStrictEqual({ timePreset: "24h" })
 
-		persistSessionTimeRange({ startTime: "2026-09-01T00:00:00Z", endTime: "2026-09-02T00:00:00Z" })
-		expect(appRegistry.get(atom)).toEqual({
-			startTime: "2026-09-01T00:00:00Z",
-			endTime: "2026-09-02T00:00:00Z",
-		})
+		persistSessionTimeRange(absolute)
+		expect(appRegistry.get(atom)).toStrictEqual(absolute)
 
 		persistSessionTimeRange({})
-		expect(appRegistry.get(atom).startTime).toBe("2026-09-01T00:00:00Z")
+		persistSessionTimeRange({ startTime: absolute.startTime })
+		expect(appRegistry.get(atom)).toStrictEqual(absolute)
 	})
 
 	it("does nothing without an org", () => {
-		setActiveOrgId(null)
+		const before = sessionStorage.length
 		persistSessionTimeRange({ timePreset: "24h" })
-		expect(sessionStorage.getItem("maple.time-range.session.null")).toBeNull()
+		expect(appRegistry.get(sessionTimeRangeAtomFor(null))).toStrictEqual({})
+		expect(sessionStorage.length).toBe(before)
+	})
+})
+
+describe("subscribeSessionTimeRange", () => {
+	it("persists the resolved location's window", () => {
+		setActiveOrgId("org_router")
+		const subscribe = vi.fn(
+			(_event: string, handler: (event: { toLocation: { search: unknown } }) => void) => {
+				handler({ toLocation: { search: { timePreset: "3d" } } })
+				return () => {}
+			},
+		)
+
+		subscribeSessionTimeRange({ subscribe } as never)
+
+		expect(subscribe).toHaveBeenCalledWith("onResolved", expect.any(Function))
+		expect(appRegistry.get(sessionTimeRangeAtomFor("org_router"))).toStrictEqual({ timePreset: "3d" })
 	})
 })

--- a/apps/web/src/components/time-range-picker/session-time-range.test.ts
+++ b/apps/web/src/components/time-range-picker/session-time-range.test.ts
@@ -101,6 +101,8 @@ describe("persistSessionTimeRange", () => {
 
 		persistSessionTimeRange({})
 		persistSessionTimeRange({ startTime: absolute.startTime })
+		persistSessionTimeRange({ startTime: "not a time", endTime: "nor this" })
+		persistSessionTimeRange({ startTime: absolute.endTime, endTime: absolute.startTime })
 		expect(appRegistry.get(atom)).toStrictEqual(absolute)
 	})
 

--- a/apps/web/src/components/time-range-picker/session-time-range.test.ts
+++ b/apps/web/src/components/time-range-picker/session-time-range.test.ts
@@ -15,7 +15,10 @@ import {
 const next = <T>(search: T) => search
 // TanStack hands middlewares present-but-undefined keys; mirror that here.
 const pageSearch = { services: ["api"], timePreset: undefined }
-const absolute = { startTime: "2026-09-01T00:00:00Z", endTime: "2026-09-02T00:00:00Z" }
+const absolute = {
+	startTime: "2026-09-01T00:00:00Z",
+	endTime: "2026-09-02T00:00:00Z",
+}
 
 // Each test gets its own org: an `Atom.family` member lives for the process
 // once read, so clearing sessionStorage would not reset a reused key.
@@ -28,7 +31,7 @@ describe("sessionTimeRangeSearchMiddleware", () => {
 		setActiveOrgId("org_fill")
 		appRegistry.set(sessionTimeRangeAtomFor("org_fill"), { timePreset: "7d" })
 
-		expect(sessionTimeRangeSearchMiddleware({ search: pageSearch, next })).toStrictEqual({
+		expect(sessionTimeRangeSearchMiddleware()({ search: pageSearch, next })).toStrictEqual({
 			services: ["api"],
 			timePreset: "7d",
 		})
@@ -41,34 +44,36 @@ describe("sessionTimeRangeSearchMiddleware", () => {
 		setActiveOrgId("org_cold")
 		sessionStorage.setItem("maple.time-range.session.org_cold", JSON.stringify(absolute))
 
-		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toEqual(absolute)
+		expect(sessionTimeRangeSearchMiddleware()({ search: {}, next })).toEqual(absolute)
 	})
 
 	it("keeps a window the navigation names itself, even a partial one", () => {
 		setActiveOrgId("org_keep")
 		appRegistry.set(sessionTimeRangeAtomFor("org_keep"), { timePreset: "7d" })
 
-		expect(sessionTimeRangeSearchMiddleware({ search: absolute, next })).toStrictEqual(absolute)
+		expect(sessionTimeRangeSearchMiddleware()({ search: absolute, next })).toStrictEqual(absolute)
 		const half = { startTime: absolute.startTime }
-		expect(sessionTimeRangeSearchMiddleware({ search: half, next })).toStrictEqual(half)
+		expect(sessionTimeRangeSearchMiddleware()({ search: half, next })).toStrictEqual(half)
 	})
 
 	it("passes through when nothing is remembered, the value is malformed, or there is no org", () => {
 		setActiveOrgId("org_untouched")
-		expect(sessionTimeRangeSearchMiddleware({ search: pageSearch, next })).toStrictEqual(pageSearch)
+		expect(sessionTimeRangeSearchMiddleware()({ search: pageSearch, next })).toStrictEqual(pageSearch)
 
 		setActiveOrgId("org_garbage")
 		sessionStorage.setItem("maple.time-range.session.org_garbage", "{not json")
-		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({})
+		expect(sessionTimeRangeSearchMiddleware()({ search: {}, next })).toStrictEqual({})
 
 		setActiveOrgId("org_number")
 		sessionStorage.setItem("maple.time-range.session.org_number", JSON.stringify({ timePreset: 123 }))
-		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({})
+		expect(sessionTimeRangeSearchMiddleware()({ search: {}, next })).toStrictEqual({})
 
 		setActiveOrgId("org_signed_out")
-		appRegistry.set(sessionTimeRangeAtomFor("org_signed_out"), { timePreset: "7d" })
+		appRegistry.set(sessionTimeRangeAtomFor("org_signed_out"), {
+			timePreset: "7d",
+		})
 		setActiveOrgId(null)
-		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({})
+		expect(sessionTimeRangeSearchMiddleware()({ search: {}, next })).toStrictEqual({})
 	})
 
 	it("scopes the remembered window to the org and keeps it across a switch", () => {
@@ -76,10 +81,10 @@ describe("sessionTimeRangeSearchMiddleware", () => {
 		appRegistry.set(sessionTimeRangeAtomFor("org_a"), { timePreset: "7d" })
 
 		setActiveOrgId("org_b")
-		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({})
+		expect(sessionTimeRangeSearchMiddleware()({ search: {}, next })).toStrictEqual({})
 
 		setActiveOrgId("org_a")
-		expect(sessionTimeRangeSearchMiddleware({ search: {}, next })).toStrictEqual({ timePreset: "7d" })
+		expect(sessionTimeRangeSearchMiddleware()({ search: {}, next })).toStrictEqual({ timePreset: "7d" })
 	})
 })
 
@@ -121,5 +126,45 @@ describe("subscribeSessionTimeRange", () => {
 
 		expect(subscribe).toHaveBeenCalledWith("onResolved", expect.any(Function))
 		expect(appRegistry.get(sessionTimeRangeAtomFor("org_router"))).toStrictEqual({ timePreset: "3d" })
+	})
+})
+
+describe("sessionTimeRangeSearchMiddleware ceiling", () => {
+	const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60
+
+	it("ignores a remembered window wider than the page supports", () => {
+		setActiveOrgId("org_ceiling")
+		appRegistry.set(sessionTimeRangeAtomFor("org_ceiling"), {
+			timePreset: "12mo",
+		})
+
+		expect(sessionTimeRangeSearchMiddleware()({ search: {}, next })).toStrictEqual({})
+		expect(
+			sessionTimeRangeSearchMiddleware({ maxRangeSeconds: ONE_YEAR_SECONDS })({
+				search: {},
+				next,
+			}),
+		).toStrictEqual({ timePreset: "12mo" })
+
+		const wide = {
+			startTime: "2026-01-01T00:00:00Z",
+			endTime: "2026-03-01T00:00:00Z",
+		}
+		appRegistry.set(sessionTimeRangeAtomFor("org_ceiling"), wide)
+		expect(sessionTimeRangeSearchMiddleware()({ search: {}, next })).toStrictEqual({})
+		expect(
+			sessionTimeRangeSearchMiddleware({ maxRangeSeconds: ONE_YEAR_SECONDS })({
+				search: {},
+				next,
+			}),
+		).toStrictEqual(wide)
+	})
+
+	it("lets a month-wide preset through everywhere", () => {
+		setActiveOrgId("org_month")
+		appRegistry.set(sessionTimeRangeAtomFor("org_month"), {
+			timePreset: "1mo",
+		})
+		expect(sessionTimeRangeSearchMiddleware()({ search: {}, next })).toStrictEqual({ timePreset: "1mo" })
 	})
 })

--- a/apps/web/src/components/time-range-picker/session-time-range.ts
+++ b/apps/web/src/components/time-range-picker/session-time-range.ts
@@ -72,6 +72,9 @@ export function sessionTimeRangeSearchMiddleware<T extends TimeRangeSearch>(opti
 export function persistSessionTimeRange(search: TimeRangeSearch) {
 	const orgId = getActiveOrgId()
 	if (!orgId || !isCompleteTimeRange(search)) return
+	// A hand-edited pair — a bad timestamp, an end before its start — must not
+	// replace a good window with one the middleware will only reject.
+	if (!isWithin(search, Number.POSITIVE_INFINITY)) return
 	const value: SessionTimeRange =
 		"timePreset" in search
 			? { timePreset: search.timePreset }

--- a/apps/web/src/components/time-range-picker/session-time-range.ts
+++ b/apps/web/src/components/time-range-picker/session-time-range.ts
@@ -6,8 +6,21 @@ import { getActiveOrgId } from "@/lib/services/common/auth-headers"
 
 import type { TimeRangeSearch } from "./search"
 
-function hasTimeRangeSearch(search: TimeRangeSearch): boolean {
-	return Boolean(search.timePreset || (search.startTime && search.endTime))
+// `typeof` rather than truthiness: a history pop or a hand-edited URL reaches
+// here unvalidated, and TanStack JSON-parses values, so `?timePreset=123` is a
+// number that must neither be remembered nor re-injected elsewhere.
+const isSet = (value: unknown): value is string => typeof value === "string" && value !== ""
+
+/** The search names a window, or part of one — nothing should be added to it. */
+function namesTimeRange(search: TimeRangeSearch): boolean {
+	return isSet(search.timePreset) || isSet(search.startTime) || isSet(search.endTime)
+}
+
+/** A complete window: a preset, or both absolute bounds. Only these are remembered. */
+function isCompleteTimeRange(
+	search: TimeRangeSearch,
+): search is { timePreset: string } | { startTime: string; endTime: string } {
+	return isSet(search.timePreset) || (isSet(search.startTime) && isSet(search.endTime))
 }
 
 /**
@@ -18,16 +31,19 @@ function hasTimeRangeSearch(search: TimeRangeSearch): boolean {
  * becomes the remembered window once it lands.
  *
  * Runs on `buildLocation`, so links and preloads see the same URL the
- * navigation will produce; the loader's `deps` are right the first time.
+ * navigation will produce; the loader's `deps` are right the first time. The
+ * read is a bare, synchronous `registry.get`: `Atom.kvs` in sync mode settles
+ * inline because the storage layer is synchronous, and falls back to `{}` if
+ * that ever stops being true — the window would then silently stop sticking.
  */
 export function sessionTimeRangeSearchMiddleware<T extends TimeRangeSearch>({
 	search,
 	next,
 }: Parameters<SearchMiddleware<T>>[0]): T {
 	const result = next(search)
-	if (hasTimeRangeSearch(result)) return result
+	if (namesTimeRange(result)) return result
 	const stored = appRegistry.get(sessionTimeRangeAtomFor(getActiveOrgId()))
-	if (!hasTimeRangeSearch(stored)) return result
+	if (!isCompleteTimeRange(stored)) return result
 	return { ...result, ...stored }
 }
 
@@ -38,10 +54,11 @@ export function sessionTimeRangeSearchMiddleware<T extends TimeRangeSearch>({
  */
 export function persistSessionTimeRange(search: TimeRangeSearch) {
 	const orgId = getActiveOrgId()
-	if (!orgId || !hasTimeRangeSearch(search)) return
-	const value: SessionTimeRange = search.timePreset
-		? { timePreset: search.timePreset }
-		: { startTime: search.startTime!, endTime: search.endTime! }
+	if (!orgId || !isCompleteTimeRange(search)) return
+	const value: SessionTimeRange =
+		"timePreset" in search
+			? { timePreset: search.timePreset }
+			: { startTime: search.startTime, endTime: search.endTime }
 	appRegistry.set(sessionTimeRangeAtomFor(orgId), value)
 }
 

--- a/apps/web/src/components/time-range-picker/session-time-range.ts
+++ b/apps/web/src/components/time-range-picker/session-time-range.ts
@@ -1,0 +1,53 @@
+import type { AnyRouter, SearchMiddleware } from "@tanstack/react-router"
+
+import { sessionTimeRangeAtomFor, type SessionTimeRange } from "@/atoms/session-time-range-atoms"
+import { appRegistry } from "@/lib/registry"
+import { getActiveOrgId } from "@/lib/services/common/auth-headers"
+
+import type { TimeRangeSearch } from "./search"
+
+function hasTimeRangeSearch(search: TimeRangeSearch): boolean {
+	return Boolean(search.timePreset || (search.startTime && search.endTime))
+}
+
+/**
+ * Search middleware for every route that spreads `TimeRangeSearchFields`: a
+ * navigation that names no window gets the one the user last chose in this
+ * tab (see `persistSessionTimeRange`). A navigation that does name one — the
+ * picker, a chart brush, a "view logs for this trace" link — wins, and then
+ * becomes the remembered window once it lands.
+ *
+ * Runs on `buildLocation`, so links and preloads see the same URL the
+ * navigation will produce; the loader's `deps` are right the first time.
+ */
+export function sessionTimeRangeSearchMiddleware<T extends TimeRangeSearch>({
+	search,
+	next,
+}: Parameters<SearchMiddleware<T>>[0]): T {
+	const result = next(search)
+	if (hasTimeRangeSearch(result)) return result
+	const stored = appRegistry.get(sessionTimeRangeAtomFor(getActiveOrgId()))
+	if (!hasTimeRangeSearch(stored)) return result
+	return { ...result, ...stored }
+}
+
+/**
+ * Records the window a resolved location carries into the per-org session
+ * atom. A location without one — a dashboard, a settings page — leaves the
+ * memory as it was, so the next time-filtered page still opens on it.
+ */
+export function persistSessionTimeRange(search: TimeRangeSearch) {
+	const orgId = getActiveOrgId()
+	if (!orgId || !hasTimeRangeSearch(search)) return
+	const value: SessionTimeRange = search.timePreset
+		? { timePreset: search.timePreset }
+		: { startTime: search.startTime!, endTime: search.endTime! }
+	appRegistry.set(sessionTimeRangeAtomFor(orgId), value)
+}
+
+/** Persist after every navigation settles, including the first load. */
+export function subscribeSessionTimeRange(router: AnyRouter) {
+	return router.subscribe("onResolved", ({ toLocation }) => {
+		persistSessionTimeRange(toLocation.search as TimeRangeSearch)
+	})
+}

--- a/apps/web/src/components/time-range-picker/session-time-range.ts
+++ b/apps/web/src/components/time-range-picker/session-time-range.ts
@@ -3,6 +3,7 @@ import type { AnyRouter, SearchMiddleware } from "@tanstack/react-router"
 import { sessionTimeRangeAtomFor, type SessionTimeRange } from "@/atoms/session-time-range-atoms"
 import { appRegistry } from "@/lib/registry"
 import { getActiveOrgId } from "@/lib/services/common/auth-headers"
+import { isTimeRangeWithin, relativeToAbsolute } from "@/lib/time-utils"
 
 import type { TimeRangeSearch } from "./search"
 
@@ -23,12 +24,26 @@ function isCompleteTimeRange(
 	return isSet(search.timePreset) || (isSet(search.startTime) && isSet(search.endTime))
 }
 
+// The widest standard preset is "1mo"; 32 days covers any calendar month.
+const DEFAULT_MAX_RANGE_SECONDS = 32 * 24 * 60 * 60
+
+function isWithin(
+	stored: { timePreset: string } | { startTime: string; endTime: string },
+	maxRangeSeconds: number,
+) {
+	const range = "timePreset" in stored ? relativeToAbsolute(stored.timePreset) : stored
+	return range !== null && isTimeRangeWithin(range, maxRangeSeconds)
+}
+
 /**
  * Search middleware for every route that spreads `TimeRangeSearchFields`: a
  * navigation that names no window gets the one the user last chose in this
  * tab (see `persistSessionTimeRange`). A navigation that does name one — the
  * picker, a chart brush, a "view logs for this trace" link — wins, and then
- * becomes the remembered window once it lands.
+ * becomes the remembered window once it lands. A remembered window wider than
+ * `maxRangeSeconds` — a year picked on Services, then a visit to Logs — is
+ * ignored so the page opens on its own default; pass the same ceiling the
+ * page hands its picker.
  *
  * Runs on `buildLocation`, so links and preloads see the same URL the
  * navigation will produce; the loader's `deps` are right the first time. The
@@ -36,15 +51,17 @@ function isCompleteTimeRange(
  * inline because the storage layer is synchronous, and falls back to `{}` if
  * that ever stops being true — the window would then silently stop sticking.
  */
-export function sessionTimeRangeSearchMiddleware<T extends TimeRangeSearch>({
-	search,
-	next,
-}: Parameters<SearchMiddleware<T>>[0]): T {
-	const result = next(search)
-	if (namesTimeRange(result)) return result
-	const stored = appRegistry.get(sessionTimeRangeAtomFor(getActiveOrgId()))
-	if (!isCompleteTimeRange(stored)) return result
-	return { ...result, ...stored }
+export function sessionTimeRangeSearchMiddleware<T extends TimeRangeSearch>(options?: {
+	maxRangeSeconds?: number
+}): SearchMiddleware<T> {
+	const maxRangeSeconds = options?.maxRangeSeconds ?? DEFAULT_MAX_RANGE_SECONDS
+	return ({ search, next }) => {
+		const result = next(search)
+		if (namesTimeRange(result)) return result
+		const stored = appRegistry.get(sessionTimeRangeAtomFor(getActiveOrgId()))
+		if (!isCompleteTimeRange(stored) || !isWithin(stored, maxRangeSeconds)) return result
+		return { ...result, ...stored }
+	}
 }
 
 /**

--- a/apps/web/src/lib/services/common/storage-runtime.ts
+++ b/apps/web/src/lib/services/common/storage-runtime.ts
@@ -2,3 +2,6 @@ import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore"
 import { Atom } from "effect/unstable/reactivity"
 
 export const localStorageRuntime = Atom.runtime(KeyValueStore.layerStorage(() => localStorage))
+
+/** For state that should outlive navigation but not the tab. */
+export const sessionStorageRuntime = Atom.runtime(KeyValueStore.layerStorage(() => sessionStorage))

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -3,6 +3,7 @@ import { createEffectRouter } from "@effect-router/core"
 import { NotFoundError, RouteError, recordRouteErrorInfo } from "./components/route-error"
 import { appRegistry, sharedAtomRuntime } from "./lib/registry"
 import { runtime } from "./lib/services/common/runtime"
+import { subscribeSessionTimeRange } from "./components/time-range-picker/session-time-range"
 import { routeTree } from "./routeTree.gen"
 
 export interface RouterAuthContext {
@@ -29,6 +30,8 @@ export const router = createEffectRouter({
 		auth: undefined!,
 	},
 })
+
+subscribeSessionTimeRange(router)
 
 declare module "@tanstack/react-router" {
 	interface Register {

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -12,6 +12,7 @@ import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { LONG_RANGE_PRESET_OPTIONS, presetLabel, formatTimeRangeDisplay } from "@/lib/time-utils"
 import { normalizeTimestampInput } from "@/lib/timezone-format"
 import { AlertRuleChart } from "@/components/alerts/alert-rule-chart"
@@ -113,6 +114,7 @@ const RuleDetailSearch = Schema.Struct({
 export const Route = createFileRoute("/alerts/$ruleId")({
 	component: RuleDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(RuleDetailSearch),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function RuleDetailPage() {

--- a/apps/web/src/routes/alerts/$ruleId.tsx
+++ b/apps/web/src/routes/alerts/$ruleId.tsx
@@ -114,7 +114,7 @@ const RuleDetailSearch = Schema.Struct({
 export const Route = createFileRoute("/alerts/$ruleId")({
 	component: RuleDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(RuleDetailSearch),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware({ maxRangeSeconds: ONE_YEAR_SECONDS })] },
 })
 
 function RuleDetailPage() {

--- a/apps/web/src/routes/analytics/index.tsx
+++ b/apps/web/src/routes/analytics/index.tsx
@@ -56,6 +56,7 @@ import {
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 
@@ -72,6 +73,7 @@ const BREAKDOWN_LIMIT = 50
 export const Route = createFileRoute("/analytics/")({
 	component: WebAnalyticsPage,
 	validateSearch: Schema.toStandardSchemaV1(analyticsSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function WebAnalyticsPage() {

--- a/apps/web/src/routes/analytics/index.tsx
+++ b/apps/web/src/routes/analytics/index.tsx
@@ -73,7 +73,7 @@ const BREAKDOWN_LIMIT = 50
 export const Route = createFileRoute("/analytics/")({
 	component: WebAnalyticsPage,
 	validateSearch: Schema.toStandardSchemaV1(analyticsSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 function WebAnalyticsPage() {

--- a/apps/web/src/routes/errors/issues/$issueId.tsx
+++ b/apps/web/src/routes/errors/issues/$issueId.tsx
@@ -39,6 +39,7 @@ import { LinkedInvestigationPanel } from "@/components/errors/linked-investigati
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { MapleApiAtomClient, retainedQuery } from "@/lib/services/common/atom-client"
 import { MapleApiV2AtomClient, retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
@@ -93,6 +94,7 @@ const issueSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/errors/issues/$issueId")({
 	component: IssueDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(issueSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function IssueDetailPage() {

--- a/apps/web/src/routes/errors/issues/$issueId.tsx
+++ b/apps/web/src/routes/errors/issues/$issueId.tsx
@@ -94,7 +94,7 @@ const issueSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/errors/issues/$issueId")({
 	component: IssueDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(issueSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 function IssueDetailPage() {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -42,7 +42,7 @@ const dashboardSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/")({
 	component: DashboardPage,
 	validateSearch: Schema.toStandardSchemaV1(dashboardSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 interface OverviewChartConfig {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -28,6 +28,7 @@ import { mergeExactThroughput, type CustomChartTimeSeriesResponse } from "@/api/
 import type { ServiceDetailTimeSeriesPoint, ServicesFacetsResponse } from "@/api/warehouse/services"
 import { disabledResultAtom } from "@/lib/services/atoms/disabled-result-atom"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { isClerkAuthEnabled } from "@/lib/services/common/auth-mode"
 
 import { formatWarehouseDateTime } from "@maple/query-engine"
@@ -41,6 +42,7 @@ const dashboardSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/")({
 	component: DashboardPage,
 	validateSearch: Schema.toStandardSchemaV1(dashboardSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 interface OverviewChartConfig {

--- a/apps/web/src/routes/infra/cloudflare/$zoneName.tsx
+++ b/apps/web/src/routes/infra/cloudflare/$zoneName.tsx
@@ -47,6 +47,7 @@ import { formatNumber } from "@maple/ui/lib/format"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 
@@ -58,6 +59,7 @@ const zoneDetailSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/cloudflare/$zoneName")({
 	component: ZoneDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(zoneDetailSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 const ZONE_SERVICE_PREFIX = "cloudflare/"

--- a/apps/web/src/routes/infra/cloudflare/$zoneName.tsx
+++ b/apps/web/src/routes/infra/cloudflare/$zoneName.tsx
@@ -59,7 +59,7 @@ const zoneDetailSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/cloudflare/$zoneName")({
 	component: ZoneDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(zoneDetailSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 const ZONE_SERVICE_PREFIX = "cloudflare/"

--- a/apps/web/src/routes/infra/cloudflare/index.tsx
+++ b/apps/web/src/routes/infra/cloudflare/index.tsx
@@ -43,6 +43,7 @@ import type { CloudflareIngestPhase } from "@/components/infra/cloudflare/ingest
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 
@@ -53,6 +54,7 @@ const cloudflareSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/cloudflare/")({
 	component: CloudflarePage,
 	validateSearch: Schema.toStandardSchemaV1(cloudflareSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function CloudflarePage() {

--- a/apps/web/src/routes/infra/cloudflare/index.tsx
+++ b/apps/web/src/routes/infra/cloudflare/index.tsx
@@ -54,7 +54,7 @@ const cloudflareSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/cloudflare/")({
 	component: CloudflarePage,
 	validateSearch: Schema.toStandardSchemaV1(cloudflareSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 function CloudflarePage() {

--- a/apps/web/src/routes/infra/containers/index.tsx
+++ b/apps/web/src/routes/infra/containers/index.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/lib/services/atoms/warehouse-query-atoms"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { useDebouncedValue } from "@maple/ui/hooks/use-debounced-value"
@@ -75,6 +76,7 @@ export type ContainersSearchParams = Schema.Schema.Type<typeof containersSearchS
 export const Route = createFileRoute("/infra/containers/")({
 	component: ContainersPage,
 	validateSearch: Schema.toStandardSchemaV1(containersSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 const SCOPE_LABEL: Record<ContainerScope, string> = {

--- a/apps/web/src/routes/infra/containers/index.tsx
+++ b/apps/web/src/routes/infra/containers/index.tsx
@@ -76,7 +76,7 @@ export type ContainersSearchParams = Schema.Schema.Type<typeof containersSearchS
 export const Route = createFileRoute("/infra/containers/")({
 	component: ContainersPage,
 	validateSearch: Schema.toStandardSchemaV1(containersSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 const SCOPE_LABEL: Record<ContainerScope, string> = {

--- a/apps/web/src/routes/infra/kubernetes/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router"
 import { Schema } from "effect"
 
 import { TimeRangeSearchFields } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 
 /**
  * The section root. The sidebar's single Kubernetes row points here, and the
@@ -16,6 +17,7 @@ const searchSchema = Schema.Struct(TimeRangeSearchFields)
 
 export const Route = createFileRoute("/infra/kubernetes/")({
 	validateSearch: Schema.toStandardSchemaV1(searchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 	beforeLoad: ({ search }) => {
 		throw redirect({ to: "/infra/kubernetes/pods", search, replace: true })
 	},

--- a/apps/web/src/routes/infra/kubernetes/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/index.tsx
@@ -17,7 +17,7 @@ const searchSchema = Schema.Struct(TimeRangeSearchFields)
 
 export const Route = createFileRoute("/infra/kubernetes/")({
 	validateSearch: Schema.toStandardSchemaV1(searchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 	beforeLoad: ({ search }) => {
 		throw redirect({ to: "/infra/kubernetes/pods", search, replace: true })
 	},

--- a/apps/web/src/routes/infra/kubernetes/nodes/$nodeName.tsx
+++ b/apps/web/src/routes/infra/kubernetes/nodes/$nodeName.tsx
@@ -21,6 +21,7 @@ import {
 	applyTimeRangeSearch,
 	pickTimeRangeSearch,
 } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { listPodsResultAtom, nodeDetailSummaryResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 
@@ -31,6 +32,7 @@ const nodeDetailSearchSchema = Schema.Struct(TimeRangeSearchFields)
 export const Route = createFileRoute("/infra/kubernetes/nodes/$nodeName")({
 	component: NodeDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(nodeDetailSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 const METRIC_OPTIONS = [

--- a/apps/web/src/routes/infra/kubernetes/nodes/$nodeName.tsx
+++ b/apps/web/src/routes/infra/kubernetes/nodes/$nodeName.tsx
@@ -32,7 +32,7 @@ const nodeDetailSearchSchema = Schema.Struct(TimeRangeSearchFields)
 export const Route = createFileRoute("/infra/kubernetes/nodes/$nodeName")({
 	component: NodeDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(nodeDetailSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 const METRIC_OPTIONS = [

--- a/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
@@ -21,6 +21,7 @@ import {
 	applyTimeRangeSearch,
 	pickTimeRangeSearch,
 } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 
 const DEFAULT_PRESET = "12h"
 
@@ -40,6 +41,7 @@ export type NodesSearchParams = Schema.Schema.Type<typeof nodesSearchSchema>
 export const Route = createFileRoute("/infra/kubernetes/nodes/")({
 	component: NodesPage,
 	validateSearch: Schema.toStandardSchemaV1(nodesSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 /**

--- a/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/nodes/index.tsx
@@ -41,7 +41,7 @@ export type NodesSearchParams = Schema.Schema.Type<typeof nodesSearchSchema>
 export const Route = createFileRoute("/infra/kubernetes/nodes/")({
 	component: NodesPage,
 	validateSearch: Schema.toStandardSchemaV1(nodesSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 /**

--- a/apps/web/src/routes/infra/kubernetes/pods/$podName.tsx
+++ b/apps/web/src/routes/infra/kubernetes/pods/$podName.tsx
@@ -33,7 +33,7 @@ const podDetailSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/kubernetes/pods/$podName")({
 	component: PodDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(podDetailSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 const METRIC_OPTIONS = [

--- a/apps/web/src/routes/infra/kubernetes/pods/$podName.tsx
+++ b/apps/web/src/routes/infra/kubernetes/pods/$podName.tsx
@@ -19,6 +19,7 @@ import { PageHero, HeroChip } from "@/components/infra/primitives/page-hero"
 import { SegmentPivot } from "@/components/infra/primitives/segment-pivot"
 import { StatRail, StatRailItem } from "@/components/infra/primitives/stat-rail"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { podDetailSummaryResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 
@@ -32,6 +33,7 @@ const podDetailSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/kubernetes/pods/$podName")({
 	component: PodDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(podDetailSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 const METRIC_OPTIONS = [

--- a/apps/web/src/routes/infra/kubernetes/pods/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/pods/index.tsx
@@ -29,6 +29,7 @@ import {
 	applyTimeRangeSearch,
 	pickTimeRangeSearch,
 } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 
 const PAGE_SIZE = 50
 const DEFAULT_PRESET = "12h"
@@ -82,6 +83,7 @@ export type PodsSearchParams = Schema.Schema.Type<typeof podsSearchSchema>
 export const Route = createFileRoute("/infra/kubernetes/pods/")({
 	component: PodsPage,
 	validateSearch: Schema.toStandardSchemaV1(podsSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 const SCOPE_LABEL: Record<PodScope, string> = {

--- a/apps/web/src/routes/infra/kubernetes/pods/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/pods/index.tsx
@@ -83,7 +83,7 @@ export type PodsSearchParams = Schema.Schema.Type<typeof podsSearchSchema>
 export const Route = createFileRoute("/infra/kubernetes/pods/")({
 	component: PodsPage,
 	validateSearch: Schema.toStandardSchemaV1(podsSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 const SCOPE_LABEL: Record<PodScope, string> = {

--- a/apps/web/src/routes/infra/kubernetes/services/$serviceName.tsx
+++ b/apps/web/src/routes/infra/kubernetes/services/$serviceName.tsx
@@ -30,6 +30,7 @@ import {
 import type { WorkloadKind } from "@/api/warehouse/infra"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 
 /**
  * Kubernetes, read through one service.
@@ -46,6 +47,7 @@ const searchSchema = Schema.Struct(TimeRangeSearchFields)
 export const Route = createFileRoute("/infra/kubernetes/services/$serviceName")({
 	component: ServiceLensPage,
 	validateSearch: Schema.toStandardSchemaV1(searchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 /** Matches the pod table's own page size on the browse route. */

--- a/apps/web/src/routes/infra/kubernetes/services/$serviceName.tsx
+++ b/apps/web/src/routes/infra/kubernetes/services/$serviceName.tsx
@@ -47,7 +47,7 @@ const searchSchema = Schema.Struct(TimeRangeSearchFields)
 export const Route = createFileRoute("/infra/kubernetes/services/$serviceName")({
 	component: ServiceLensPage,
 	validateSearch: Schema.toStandardSchemaV1(searchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 /** Matches the pod table's own page size on the browse route. */

--- a/apps/web/src/routes/infra/kubernetes/services/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/services/index.tsx
@@ -22,7 +22,7 @@ const searchSchema = Schema.Struct(TimeRangeSearchFields)
 export const Route = createFileRoute("/infra/kubernetes/services/")({
 	component: ServiceLensIndexPage,
 	validateSearch: Schema.toStandardSchemaV1(searchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 function ServiceLensIndexPage() {

--- a/apps/web/src/routes/infra/kubernetes/services/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/services/index.tsx
@@ -7,6 +7,7 @@ import { KubernetesIcon } from "@/components/icons"
 import { ServiceLensShell } from "@/components/infra/service-lens/service-lens-shell"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 
 /**
  * The lens with nothing selected.
@@ -21,6 +22,7 @@ const searchSchema = Schema.Struct(TimeRangeSearchFields)
 export const Route = createFileRoute("/infra/kubernetes/services/")({
 	component: ServiceLensIndexPage,
 	validateSearch: Schema.toStandardSchemaV1(searchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function ServiceLensIndexPage() {

--- a/apps/web/src/routes/infra/kubernetes/workloads/$kind/$workloadName.tsx
+++ b/apps/web/src/routes/infra/kubernetes/workloads/$kind/$workloadName.tsx
@@ -48,7 +48,7 @@ const paramsSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/kubernetes/workloads/$kind/$workloadName")({
 	component: WorkloadDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(workloadDetailSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 	params: {
 		parse: (raw) => Schema.decodeUnknownSync(paramsSchema)(raw),
 		stringify: (p) => ({ kind: p.kind, workloadName: p.workloadName }),

--- a/apps/web/src/routes/infra/kubernetes/workloads/$kind/$workloadName.tsx
+++ b/apps/web/src/routes/infra/kubernetes/workloads/$kind/$workloadName.tsx
@@ -47,12 +47,12 @@ const paramsSchema = Schema.Struct({
 
 export const Route = createFileRoute("/infra/kubernetes/workloads/$kind/$workloadName")({
 	component: WorkloadDetailPage,
-	validateSearch: Schema.toStandardSchemaV1(workloadDetailSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 	params: {
 		parse: (raw) => Schema.decodeUnknownSync(paramsSchema)(raw),
 		stringify: (p) => ({ kind: p.kind, workloadName: p.workloadName }),
 	},
+	validateSearch: Schema.toStandardSchemaV1(workloadDetailSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 const METRIC_OPTIONS = [

--- a/apps/web/src/routes/infra/kubernetes/workloads/$kind/$workloadName.tsx
+++ b/apps/web/src/routes/infra/kubernetes/workloads/$kind/$workloadName.tsx
@@ -24,6 +24,7 @@ import {
 	applyTimeRangeSearch,
 	pickTimeRangeSearch,
 } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import {
 	listPodsResultAtom,
 	workloadDetailSummaryResultAtom,
@@ -47,6 +48,7 @@ const paramsSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/kubernetes/workloads/$kind/$workloadName")({
 	component: WorkloadDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(workloadDetailSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 	params: {
 		parse: (raw) => Schema.decodeUnknownSync(paramsSchema)(raw),
 		stringify: (p) => ({ kind: p.kind, workloadName: p.workloadName }),

--- a/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
@@ -22,6 +22,7 @@ import {
 	applyTimeRangeSearch,
 	pickTimeRangeSearch,
 } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 
 const DEFAULT_PRESET = "12h"
 
@@ -49,6 +50,7 @@ export type WorkloadsSearchParams = Schema.Schema.Type<typeof workloadsSearchSch
 export const Route = createFileRoute("/infra/kubernetes/workloads/")({
 	component: WorkloadsPage,
 	validateSearch: Schema.toStandardSchemaV1(workloadsSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 const KIND_OPTIONS = [

--- a/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
+++ b/apps/web/src/routes/infra/kubernetes/workloads/index.tsx
@@ -50,7 +50,7 @@ export type WorkloadsSearchParams = Schema.Schema.Type<typeof workloadsSearchSch
 export const Route = createFileRoute("/infra/kubernetes/workloads/")({
 	component: WorkloadsPage,
 	validateSearch: Schema.toStandardSchemaV1(workloadsSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 const KIND_OPTIONS = [

--- a/apps/web/src/routes/infra/planetscale/$dbName.tsx
+++ b/apps/web/src/routes/infra/planetscale/$dbName.tsx
@@ -74,6 +74,7 @@ import {
 import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import type { PlanetScaleInfraTimeseriesRow } from "@/api/warehouse/planetscale-infra"
@@ -95,6 +96,7 @@ const planetscaleDbSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/planetscale/$dbName")({
 	component: PlanetScaleDatabasePage,
 	validateSearch: Schema.toStandardSchemaV1(planetscaleDbSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 /** Stable empty fallbacks — a fresh `[]` per render busts every downstream memo. */

--- a/apps/web/src/routes/infra/planetscale/$dbName.tsx
+++ b/apps/web/src/routes/infra/planetscale/$dbName.tsx
@@ -96,7 +96,7 @@ const planetscaleDbSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/planetscale/$dbName")({
 	component: PlanetScaleDatabasePage,
 	validateSearch: Schema.toStandardSchemaV1(planetscaleDbSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 /** Stable empty fallbacks — a fresh `[]` per render busts every downstream memo. */

--- a/apps/web/src/routes/infra/planetscale/index.tsx
+++ b/apps/web/src/routes/infra/planetscale/index.tsx
@@ -52,7 +52,7 @@ const planetscaleSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/planetscale/")({
 	component: PlanetScalePage,
 	validateSearch: Schema.toStandardSchemaV1(planetscaleSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 function PlanetScalePage() {

--- a/apps/web/src/routes/infra/planetscale/index.tsx
+++ b/apps/web/src/routes/infra/planetscale/index.tsx
@@ -41,6 +41,7 @@ import { retainedQueryV2 } from "@/lib/services/common/v2-atom-client"
 import { formatNumber } from "@maple/ui/lib/format"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 
@@ -51,6 +52,7 @@ const planetscaleSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/infra/planetscale/")({
 	component: PlanetScalePage,
 	validateSearch: Schema.toStandardSchemaV1(planetscaleSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function PlanetScalePage() {

--- a/apps/web/src/routes/lab/query-builder.tsx
+++ b/apps/web/src/routes/lab/query-builder.tsx
@@ -16,7 +16,7 @@ const queryBuilderLabSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/lab/query-builder")({
 	component: QueryBuilderLabPage,
 	validateSearch: Schema.toStandardSchemaV1(queryBuilderLabSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 function QueryBuilderLabPage() {

--- a/apps/web/src/routes/lab/query-builder.tsx
+++ b/apps/web/src/routes/lab/query-builder.tsx
@@ -5,6 +5,7 @@ import { QueryBuilderLab } from "@/lab/query-builder-lab"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 
@@ -15,6 +16,7 @@ const queryBuilderLabSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/lab/query-builder")({
 	component: QueryBuilderLabPage,
 	validateSearch: Schema.toStandardSchemaV1(queryBuilderLabSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function QueryBuilderLabPage() {

--- a/apps/web/src/routes/logs/index.tsx
+++ b/apps/web/src/routes/logs/index.tsx
@@ -39,7 +39,7 @@ export type LogsSearchParams = Schema.Schema.Type<typeof logsSearchSchema>
 export const Route = createFileRoute("/logs/")({
 	component: LogsPage,
 	validateSearch: Schema.toStandardSchemaV1(logsSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 function LogsPage() {

--- a/apps/web/src/routes/logs/index.tsx
+++ b/apps/web/src/routes/logs/index.tsx
@@ -7,6 +7,7 @@ import { LogsTable } from "@/components/logs/logs-table"
 import { LogsVolumeChart } from "@/components/logs/logs-volume-chart"
 import { LogsFilterSidebar } from "@/components/logs/logs-filter-sidebar"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { ActiveFilterChips } from "@maple/ui/components/filters/active-filter-chips"
@@ -38,6 +39,7 @@ export type LogsSearchParams = Schema.Schema.Type<typeof logsSearchSchema>
 export const Route = createFileRoute("/logs/")({
 	component: LogsPage,
 	validateSearch: Schema.toStandardSchemaV1(logsSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function LogsPage() {

--- a/apps/web/src/routes/metrics/$metricName.tsx
+++ b/apps/web/src/routes/metrics/$metricName.tsx
@@ -37,7 +37,7 @@ function buildBackToMetricsHref(searchStr: string): string {
 export const Route = createFileRoute("/metrics/$metricName")({
 	component: MetricDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(metricDetailSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 function MetricDetailPage() {

--- a/apps/web/src/routes/metrics/$metricName.tsx
+++ b/apps/web/src/routes/metrics/$metricName.tsx
@@ -5,6 +5,7 @@ import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { MetricDetail } from "@/components/metrics/metric-detail"
 import type { MetricQueryPatch } from "@/components/metrics/metric-query-controls"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { AutocompleteValuesProvider } from "@/hooks/use-autocomplete-values"
@@ -36,6 +37,7 @@ function buildBackToMetricsHref(searchStr: string): string {
 export const Route = createFileRoute("/metrics/$metricName")({
 	component: MetricDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(metricDetailSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function MetricDetailPage() {

--- a/apps/web/src/routes/metrics/index.tsx
+++ b/apps/web/src/routes/metrics/index.tsx
@@ -4,6 +4,7 @@ import { Schema } from "effect"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { MetricsBrowse, type MetricsBrowsePatch } from "@/components/metrics/metrics-browse"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import {
@@ -28,6 +29,7 @@ export type MetricsSearchParams = Schema.Schema.Type<typeof metricsSearchSchema>
 export const Route = createFileRoute("/metrics/")({
 	component: MetricsPage,
 	validateSearch: Schema.toStandardSchemaV1(metricsSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function MetricsPage() {

--- a/apps/web/src/routes/metrics/index.tsx
+++ b/apps/web/src/routes/metrics/index.tsx
@@ -29,7 +29,7 @@ export type MetricsSearchParams = Schema.Schema.Type<typeof metricsSearchSchema>
 export const Route = createFileRoute("/metrics/")({
 	component: MetricsPage,
 	validateSearch: Schema.toStandardSchemaV1(metricsSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 })
 
 function MetricsPage() {

--- a/apps/web/src/routes/releases/$commitSha.tsx
+++ b/apps/web/src/routes/releases/$commitSha.tsx
@@ -22,6 +22,7 @@ import {
 	applyTimeRangeSearch,
 	pickTimeRangeSearch,
 } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { LONG_RANGE_PRESET_OPTIONS } from "@/lib/time-utils"
@@ -53,6 +54,7 @@ const releaseDetailSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/releases/$commitSha")({
 	component: ReleaseDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(releaseDetailSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 interface ReleaseChartConfig {

--- a/apps/web/src/routes/releases/$commitSha.tsx
+++ b/apps/web/src/routes/releases/$commitSha.tsx
@@ -54,7 +54,7 @@ const releaseDetailSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/releases/$commitSha")({
 	component: ReleaseDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(releaseDetailSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware({ maxRangeSeconds: ONE_YEAR_SECONDS })] },
 })
 
 interface ReleaseChartConfig {

--- a/apps/web/src/routes/releases/index.tsx
+++ b/apps/web/src/routes/releases/index.tsx
@@ -55,7 +55,7 @@ export type ReleasesSearchParams = Schema.Schema.Type<typeof releasesSearchSchem
 export const Route = createFileRoute("/releases/")({
 	component: ReleasesPage,
 	validateSearch: Schema.toStandardSchemaV1(releasesSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware({ maxRangeSeconds: ONE_YEAR_SECONDS })] },
 })
 
 function ReleasesPage() {

--- a/apps/web/src/routes/releases/index.tsx
+++ b/apps/web/src/routes/releases/index.tsx
@@ -17,6 +17,7 @@ import {
 	applyTimeRangeSearch,
 	pickTimeRangeSearch,
 } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { LONG_RANGE_PRESET_OPTIONS } from "@/lib/time-utils"
@@ -54,6 +55,7 @@ export type ReleasesSearchParams = Schema.Schema.Type<typeof releasesSearchSchem
 export const Route = createFileRoute("/releases/")({
 	component: ReleasesPage,
 	validateSearch: Schema.toStandardSchemaV1(releasesSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function ReleasesPage() {

--- a/apps/web/src/routes/replays/index.tsx
+++ b/apps/web/src/routes/replays/index.tsx
@@ -54,7 +54,7 @@ const replaysSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/replays/")({
 	component: ReplaysPage,
 	validateSearch: Schema.toStandardSchemaV1(replaysSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 	loaderDeps: ({ search }) => search,
 	// Both queries are on the critical path and neither is cached server-side, so
 	// starting them here rather than on mount is worth real time: the router runs

--- a/apps/web/src/routes/replays/index.tsx
+++ b/apps/web/src/routes/replays/index.tsx
@@ -15,6 +15,7 @@ import { Result } from "@/lib/effect-atom"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
 import { listReplaysResultAtom, replaysFacetsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import type { TimeRange } from "@/components/time-range-picker/types"
@@ -53,6 +54,7 @@ const replaysSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/replays/")({
 	component: ReplaysPage,
 	validateSearch: Schema.toStandardSchemaV1(replaysSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 	loaderDeps: ({ search }) => search,
 	// Both queries are on the critical path and neither is cached server-side, so
 	// starting them here rather than on mount is worth real time: the router runs

--- a/apps/web/src/routes/service-map.tsx
+++ b/apps/web/src/routes/service-map.tsx
@@ -39,7 +39,7 @@ const serviceMapSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/service-map")({
 	component: ServiceMapPage,
 	validateSearch: Schema.toStandardSchemaV1(serviceMapSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware({ maxRangeSeconds: ONE_YEAR_SECONDS })] },
 })
 
 function ServiceMapPage() {

--- a/apps/web/src/routes/service-map.tsx
+++ b/apps/web/src/routes/service-map.tsx
@@ -12,6 +12,7 @@ import { ServiceMapView } from "@/components/service-map/service-map-view"
 import type { DeclutterFocus } from "@/components/service-map/service-map-declutter"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { QueryErrorState } from "@/components/common/query-error-state"
@@ -38,6 +39,7 @@ const serviceMapSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/service-map")({
 	component: ServiceMapPage,
 	validateSearch: Schema.toStandardSchemaV1(serviceMapSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 function ServiceMapPage() {

--- a/apps/web/src/routes/services/$serviceName.tsx
+++ b/apps/web/src/routes/services/$serviceName.tsx
@@ -66,7 +66,7 @@ const serviceDetailSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/services/$serviceName")({
 	component: ServiceDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(serviceDetailSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware({ maxRangeSeconds: ONE_YEAR_SECONDS })] },
 })
 
 interface ServiceChartConfig {

--- a/apps/web/src/routes/services/$serviceName.tsx
+++ b/apps/web/src/routes/services/$serviceName.tsx
@@ -20,6 +20,7 @@ import type { ServiceDetailTimeSeriesPoint } from "@/api/warehouse/services"
 import { useCommitMarkers } from "@/components/vcs/commit-markers/use-commit-markers"
 import type { ReleasePoint } from "@/components/vcs/commit-markers/marker-layout"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { Button } from "@maple/ui/components/ui/button"
@@ -65,6 +66,7 @@ const serviceDetailSearchSchema = Schema.Struct({
 export const Route = createFileRoute("/services/$serviceName")({
 	component: ServiceDetailPage,
 	validateSearch: Schema.toStandardSchemaV1(serviceDetailSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 })
 
 interface ServiceChartConfig {

--- a/apps/web/src/routes/services/index.tsx
+++ b/apps/web/src/routes/services/index.tsx
@@ -80,7 +80,7 @@ export function servicesRouteAtoms(search: ServicesSearchParams) {
 export const Route = createFileRoute("/services/")({
 	component: ServicesPage,
 	validateSearch: Schema.toStandardSchemaV1(servicesSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware({ maxRangeSeconds: ONE_YEAR_SECONDS })] },
 	loaderDeps: ({ search }) => search,
 	// A plain `loader`, not the `effectRoute` wrapper: TanStack's route
 	// code-splitting extracts `component` by statically matching

--- a/apps/web/src/routes/services/index.tsx
+++ b/apps/web/src/routes/services/index.tsx
@@ -16,6 +16,7 @@ import { serviceFilterChips } from "@/lib/services-list/service-filter-chips"
 import { useGlobalNamespace } from "@/hooks/use-global-namespace"
 import { ServicesFilterSidebar } from "@/components/services/services-filter-sidebar"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
@@ -79,6 +80,7 @@ export function servicesRouteAtoms(search: ServicesSearchParams) {
 export const Route = createFileRoute("/services/")({
 	component: ServicesPage,
 	validateSearch: Schema.toStandardSchemaV1(servicesSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 	loaderDeps: ({ search }) => search,
 	// A plain `loader`, not the `effectRoute` wrapper: TanStack's route
 	// code-splitting extracts `component` by statically matching

--- a/apps/web/src/routes/traces/index.tsx
+++ b/apps/web/src/routes/traces/index.tsx
@@ -76,7 +76,7 @@ export type TracesSearchParams = Schema.Schema.Type<typeof tracesSearchSchema>
 export const Route = createFileRoute("/traces/")({
 	component: TracesPage,
 	validateSearch: Schema.toStandardSchemaV1(tracesSearchSchema),
-	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
+	search: { middlewares: [sessionTimeRangeSearchMiddleware()] },
 	loaderDeps: ({ search }) => search,
 	// Only the facet sidebar is warmed. The trace list is paginated and sorted
 	// from state the route does not own, so rebuilding its input here would risk

--- a/apps/web/src/routes/traces/index.tsx
+++ b/apps/web/src/routes/traces/index.tsx
@@ -15,6 +15,7 @@ import { useAtomValue } from "@/lib/effect-atom"
 import { applyWhereClause } from "@/lib/traces/advanced-filter-sync"
 import { getTracesFacetsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { TimeRangeSearchFields, applyTimeRangeSearch } from "@/components/time-range-picker/search"
+import { sessionTimeRangeSearchMiddleware } from "@/components/time-range-picker/session-time-range"
 import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
 import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import { AutocompleteValuesProvider } from "@/hooks/use-autocomplete-values"
@@ -75,6 +76,7 @@ export type TracesSearchParams = Schema.Schema.Type<typeof tracesSearchSchema>
 export const Route = createFileRoute("/traces/")({
 	component: TracesPage,
 	validateSearch: Schema.toStandardSchemaV1(tracesSearchSchema),
+	search: { middlewares: [sessionTimeRangeSearchMiddleware] },
 	loaderDeps: ({ search }) => search,
 	// Only the facet sidebar is warmed. The trace list is paginated and sorted
 	// from state the route does not own, so rebuilding its input here would risk


### PR DESCRIPTION
## Summary

Every time-filtered page used to open on its own default window, so a range picked on Logs was gone by the time Traces rendered. The window the URL carries is now remembered for the life of the tab and applied to the next page that names none.

- `sessionStorage`-backed, per-org `Atom.kvs` (`apps/web/src/atoms/session-time-range-atoms.ts`), on a new `sessionStorageRuntime`. Tab-scoped by design: the window should outlive navigation, not the browser.
- A router `onResolved` subscription (`router.tsx`) writes the landed location's window into the atom. No React involved.
- A TanStack search middleware on every route that spreads `TimeRangeSearchFields` fills a navigation that names no window with the remembered one. It runs in `buildLocation`, so links, preloads and loader `deps` all see the final URL.
- A navigation that names its own window (picker, chart brush, deep link, the reset ✕) still wins, and then becomes the remembered one.
- Per-route ceiling: `sessionTimeRangeSearchMiddleware({ maxRangeSeconds })` takes the same limit the page hands its picker. Default is one month (the widest standard preset); the six long-range pages pass a year. A wider remembered window falls back to the page default instead of following the user onto Logs as a 365-day scan.
- Only well-formed windows are remembered: values must be strings (history pops arrive unvalidated and JSON-parsed), and a half absolute pair is neither stored nor merged onto.

## Known limits

- Storage failures (blocked `sessionStorage`, quota) degrade silently to "not remembered".
- A cold load of a bare time-filtered URL loads once on the default, then once more on the injected window.

## Test plan

- [x] `bun turbo typecheck --filter=@maple/web`
- [x] `session-time-range.test.ts` (13 cases: cold read from storage, malformed entries, org round trip, half windows, ceilings, router wiring) plus the logs/traces/services route tests
- [x] oxlint / oxfmt clean on all touched files
- [ ] Manual: pick 7d on Logs, open Traces via sidebar → URL carries `timePreset=7d`; pick 12mo on Services, open Logs → Logs opens on its 12h default

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791638894&installation_model_id=427786&pr_number=821&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F821&signature=f524df4775dcf8b4a63b6e99c4db280a73d2938a382dff5c713794327f3c334a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time-range selections are now remembered per organization during a browser session.
  * Returning to supported dashboards and detail pages restores the previously selected time range automatically.
  * Explicit time ranges in links and navigation continue to take priority.
  * Stored ranges are validated and limited to appropriate maximum durations, including one-year limits on selected pages.
* **Bug Fixes**
  * Invalid, incomplete, or overly broad saved time ranges are ignored instead of being applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->