### PR TITLE
fix(deps): patch OpenRouter usage that reports reasoning tokens outside the completion total

### DIFF
--- a/apps/api/src/platform/Llm.test.ts
+++ b/apps/api/src/platform/Llm.test.ts
@@ -10,7 +10,7 @@
  * The fake responds 400, which the provider classifies as a non-retryable invalid request. That
  * keeps the run to a single request with no backoff; the resulting failure is expected and ignored.
  */
-import { Effect } from "effect"
+import { Effect, Layer, Stream } from "effect"
 import { LanguageModel } from "effect/unstable/ai"
 import { FetchHttpClient } from "effect/unstable/http"
 import { describe, it } from "@effect/vitest"
@@ -283,4 +283,114 @@ describe("resolveTriageModel — context limits", () => {
 			expect(model.limits.context).toBe(1_050_000)
 		}
 	})
+})
+
+/**
+ * The usage block of a streamed completion, as an upstream that keeps reasoning tokens *outside*
+ * `completion_tokens` reports it. Numbers are from a real failing chat turn.
+ */
+const disjointReasoningUsage = {
+	prompt_tokens: 21_435,
+	completion_tokens: 293,
+	total_tokens: 21_728,
+	prompt_tokens_details: { cached_tokens: 16_128, cache_write_tokens: 0 },
+	completion_tokens_details: { reasoning_tokens: 321 },
+}
+
+const sseBody = (usage: Record<string, unknown>): string =>
+	[
+		`data: ${JSON.stringify({
+			id: "gen-1",
+			object: "chat.completion.chunk",
+			created: 1_789_056_870,
+			model: "z-ai/glm-5.3-flash",
+			choices: [{ index: 0, delta: { role: "assistant", content: "hi" } }],
+		})}`,
+		"",
+		`data: ${JSON.stringify({
+			id: "gen-1",
+			object: "chat.completion.chunk",
+			created: 1_789_056_870,
+			model: "z-ai/glm-5.3-flash",
+			choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			usage,
+		})}`,
+		"",
+		"data: [DONE]",
+		"",
+	].join("\n")
+
+/** Stream one completion off a fake transport and return the run's `finish` part. */
+const streamFinishPart = (usage: Record<string, unknown>) =>
+	Effect.gen(function* () {
+		const fakeFetch: typeof globalThis.fetch = async () =>
+			new Response(sseBody(usage), {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			})
+
+		const model = resolveTriageModel(openRouterEnv)
+		const parts = yield* LanguageModel.streamText({ prompt: "hi" }).pipe(
+			Stream.runCollect,
+			// One provide, not a chain: the model layer needs the clients the LLM stack builds, so
+			// they go in as a single merged layer rather than two lifecycles stacked on each other.
+			Effect.provide(Layer.provide(model.layer, layerLlm(openRouterEnv))),
+			Effect.provideService(FetchHttpClient.Fetch, fakeFetch),
+		)
+
+		const finish = parts.find((part) => part.type === "finish")
+		if (finish === undefined) return yield* Effect.die("the stream carried no finish part")
+		return finish
+	})
+
+/**
+ * Guards the `@effect/ai-openrouter` patch in `patches/`.
+ *
+ * The package derives the output text component as `completion_tokens - reasoning_tokens`, which
+ * assumes reasoning tokens are counted inside the completion total. Some OpenRouter upstreams
+ * report them side by side, so the derived component goes negative and the agent engine — which
+ * decodes every usage field as a natural number — throws away a response the model already
+ * produced. The patch folds the two together when they are disjoint; this is what proves it is
+ * still applied, since a `bun install` that dropped it would leave the numbers below negative.
+ */
+describe("streamed usage — reasoning tokens reported outside the completion total", () => {
+	it.live("folds them back into the completion total", () =>
+		Effect.gen(function* () {
+			// Unpatched, this is what fails the turn: text would be 293 - 321.
+			const finish = yield* streamFinishPart(disjointReasoningUsage)
+
+			expect(finish.usage.outputTokens.text).toBe(293)
+			expect(finish.usage.outputTokens.reasoning).toBe(321)
+			expect(finish.usage.outputTokens.total).toBe(614)
+			// The input side is already coherent and must come through unchanged.
+			expect(finish.usage.inputTokens.total).toBe(21_435)
+			expect(finish.usage.inputTokens.cacheRead).toBe(16_128)
+		}),
+	)
+
+	it.live("does the same for cached tokens reported outside the prompt total", () =>
+		Effect.gen(function* () {
+			const finish = yield* streamFinishPart({
+				...disjointReasoningUsage,
+				prompt_tokens: 5_000,
+				prompt_tokens_details: { cached_tokens: 16_128, cache_write_tokens: 0 },
+			})
+
+			expect(finish.usage.inputTokens.total).toBe(21_128)
+			expect(finish.usage.inputTokens.uncached).toBe(5_000)
+		}),
+	)
+
+	it.live("leaves a provider that already nests reasoning inside the completion untouched", () =>
+		Effect.gen(function* () {
+			const finish = yield* streamFinishPart({
+				...disjointReasoningUsage,
+				completion_tokens: 614,
+				completion_tokens_details: { reasoning_tokens: 321 },
+			})
+
+			expect(finish.usage.outputTokens.total).toBe(614)
+			expect(finish.usage.outputTokens.text).toBe(293)
+		}),
+	)
 })

--- a/bun.lock
+++ b/bun.lock
@@ -786,6 +786,7 @@
     },
   },
   "patchedDependencies": {
+    "@effect/ai-openrouter@4.0.0-rc.112": "patches/@effect%2Fai-openrouter@4.0.0-rc.112.patch",
     "@effect/vitest@4.0.0-rc.112": "patches/@effect%2Fvitest@4.0.0-rc.112.patch",
     "effect@4.0.0-rc.112": "patches/effect@4.0.0-rc.112.patch",
   },

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
 		}
 	},
 	"patchedDependencies": {
+		"@effect/ai-openrouter@4.0.0-rc.112": "patches/@effect%2Fai-openrouter@4.0.0-rc.112.patch",
 		"@effect/vitest@4.0.0-rc.112": "patches/@effect%2Fvitest@4.0.0-rc.112.patch",
 		"effect@4.0.0-rc.112": "patches/effect@4.0.0-rc.112.patch"
 	}

--- a/patches/@effect%2Fai-openrouter@4.0.0-rc.112.patch
+++ b/patches/@effect%2Fai-openrouter@4.0.0-rc.112.patch
@@ -1,0 +1,41 @@
+diff --git a/dist/OpenRouterLanguageModel.js b/dist/OpenRouterLanguageModel.js
+index 371be3d891c1c3f901cac2622b08a34de8f25338..9fa9a806fc65125f35212de458b788566eeb465f 100644
+--- a/dist/OpenRouterLanguageModel.js
++++ b/dist/OpenRouterLanguageModel.js
+@@ -1317,16 +1317,32 @@ const getUsage = usage => {
+   const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
+   const cacheWriteTokens = usage.prompt_tokens_details?.cache_write_tokens ?? 0;
+   const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens ?? 0;
++  // Patched (maple): mirrors Effect-TS/effect#8170 — drop once it ships.
++  //
++  // OpenRouter documents `cached_tokens` and `reasoning_tokens` as subsets of
++  // `prompt_tokens` and `completion_tokens` respectively, but some upstream
++  // providers report them as disjoint counts (i.e. `reasoning_tokens` exceeds
++  // `completion_tokens`). When a detail exceeds its parent count, treat the
++  // two as disjoint so the derived components never go negative.
++  //
++  // This only catches the provable case. A provider that reports disjoint
++  // counts where the detail is less than or equal to its parent is
++  // indistinguishable from the documented subset accounting: nothing on the
++  // usage block indicates which convention applies (`total_tokens` is just
++  // `prompt_tokens + completion_tokens`), so those responses still use the
++  // subset derivation and will under-report `total` by the detail count.
++  const inputTotal = cacheReadTokens > promptTokens ? promptTokens + cacheReadTokens : promptTokens;
++  const outputTotal = reasoningTokens > completionTokens ? completionTokens + reasoningTokens : completionTokens;
+   return {
+     inputTokens: {
+-      uncached: promptTokens - cacheReadTokens,
+-      total: promptTokens,
++      uncached: inputTotal - cacheReadTokens,
++      total: inputTotal,
+       cacheRead: cacheReadTokens,
+       cacheWrite: cacheWriteTokens
+     },
+     outputTokens: {
+-      total: completionTokens,
+-      text: completionTokens - reasoningTokens,
++      total: outputTotal,
++      text: outputTotal - reasoningTokens,
+       reasoning: reasoningTokens
+     }
+   };


### PR DESCRIPTION
Maple chat has been unusable in production: every turn fails with

> Response failed — Model response usage fields and derived totals must be non-negative safe integers

after the model has already answered (HTTP 200, `finish_reason: tool_calls`).

## Cause

`@effect/ai-openrouter`'s `getUsage` derives `outputTokens.text` as
`completion_tokens - reasoning_tokens` and `inputTokens.uncached` as `prompt_tokens - cached_tokens`,
taking each detail for a subset of its parent total — which is how OpenRouter documents them. Some
upstream providers report them disjoint instead.

OpenRouter's own generation records for the three failing turns:

| completion | reasoning | derived `text` |
| --- | --- | --- |
| 293 | 321 | -28 |
| 445 | 518 | -73 |
| 277 | 323 | -46 |

The agent engine decodes every usage field as a natural number, so a completed response is thrown
away as a protocol error.

## Fix

A patch on the package, alongside the two `effect` patches already in `patches/`, so the repair sits
where the arithmetic is wrong instead of in a wire rewrite on Maple's side. When a detail exceeds its
parent count the two are disjoint, so their sum is the total; the documented subset case is
untouched, on both the output and the input side.

The patch is the diff of https://github.com/Effect-TS/effect/pull/8170 line for line. It drops out
once that ships and the dependency is bumped — and a bump makes bun demand the patch be re-cut,
which is the prompt to check.

## Tests

Three tests drive the real client over a fake SSE transport with the production numbers: the
disjoint reasoning case, the documented subset case, and the disjoint cached case. They also fail if
an install ever leaves the patch behind — without it the first fails with `expected -28 to be 293`,
the exact production defect.