### PR TITLE
Say why a fan-out start failed

### DIFF
--- a/apps/api/src/services/errors/investigation-fanout-error.ts
+++ b/apps/api/src/services/errors/investigation-fanout-error.ts
@@ -1,5 +1,10 @@
 import { Schema } from "effect"
 
+import { describeCause } from "@/platform/describe-cause"
+
+/** How much of the underlying reason survives into the message. */
+const MAX_REASON_CHARS = 300
+
 /** Internal workflow-start failure shared by both investigation entry points. */
 export class FanoutStartError extends Schema.TaggedError<FanoutStartError>()(
 	"@maple/api/errors/FanoutStartError",
@@ -8,9 +13,19 @@ export class FanoutStartError extends Schema.TaggedError<FanoutStartError>()(
 		cause: Schema.Defect(),
 	},
 ) {
+	/**
+	 * The reason lands in the MESSAGE, not only in `cause`: every caller renders
+	 * this through `summarizeCause`, which reads a reason's tag and message and
+	 * stops there — so a Workflows error left in `cause` reaches no log line and
+	 * no span, which is how three days of failing fan-out starts said only that
+	 * they had failed.
+	 */
 	static fromCause(cause: unknown): FanoutStartError {
+		const reason = describeCause(cause)?.split("\n")[0]?.trim().slice(0, MAX_REASON_CHARS)
 		return new FanoutStartError({
-			message: "Investigation fanout failed to start",
+			message: reason
+				? `Investigation fanout failed to start: ${reason}`
+				: "Investigation fanout failed to start",
 			cause,
 		})
 	}


### PR DESCRIPTION
Investigation fan-out starts have failed in prod since **2026-09-08 00:01 UTC** — roughly 100 a day from the alerting tick, plus 503s from `POST /v2/investigations/:id/restart` — and no fan-out has run since (`maple-investigations` reported 437k spans between 09-05 and 09-07 20:00 UTC, then nothing). That window is the deploy of #787, which moved the Workflows to alchemy's class form.

The reason each start fails has never left the isolate. `FanoutStartError` keeps the Cloudflare Workflows error in a `Schema.Defect()` cause, and `summarizeCause` — which all three call sites use for the log annotation and the span — renders a reason's tag and message and stops there. So every failure reads `@maple/api/errors/FanoutStartError: Investigation fanout failed to start`, which does not distinguish "the workflow is not registered at Cloudflare" from "an instance with this id already exists".

`fromCause` now folds the cause's first line into the message, capped at 300 characters, which `summarizeCause`'s own 500-character cap bounds again. One change covers all three sites, since they share the constructor.

Public failures are unchanged: this error is internal, and the route still answers with `InvestigationStartFailedError`'s fixed wording.

**Why this first:** the root cause is still open. The two candidates are a workflow that alchemy's state believes exists (every plan since prints both workflows as `noop`) but Cloudflare never provisioned, and a class/script mismatch on the registered workflow. The physical names are NOT split between the two Workers — both derive `maple-api-investigationfanoutworkflow-eced6125` — so the next diagnostic step is either `wrangler workflows list` or `alchemy sync --dry-run`. With this deployed, the failures name themselves within minutes instead.

**Verified:** `tsc --noEmit` clean for `apps/api`; `InvestigationService.test.ts` and `ai-triage-enqueue.test.ts` pass (29 tests); oxfmt and oxlint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791656966&installation_model_id=427786&pr_number=827&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F827&signature=e48f66f959f1ba3b1a2ee70d5686288e5a13e4f156f031ac864059e9117c1ba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Investigation fanout startup errors now provide a clearer message based on the underlying cause when available.
  - Error details are trimmed to a concise length, with a fallback message shown when no useful cause information can be provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->