### PR TITLE
Repair prd drift from the deploy job's own environment

### DIFF
--- a/.github/workflows/sync-prd.yml
+++ b/.github/workflows/sync-prd.yml
@@ -1,0 +1,75 @@
+name: Sync PRD (Cloudflare via Alchemy)
+
+# Drift repair, by hand only. `alchemy sync` reads every resource back from its
+# provider and compares it to what state says was deployed: a resource that
+# diverged is reconciled, one that is GONE is recreated from the persisted
+# instance id, so deterministic physical names come back unchanged.
+#
+# It exists because a deploy cannot fix this class of failure on its own. When
+# state records a resource as created and the cloud never got it, every plan
+# reports `noop` forever — which is how production ran from 2026-09-08 with an
+# api Worker bound to `maple-api-investigationfanoutworkflow-eced6125`, a
+# Workflow that did not exist, and every investigation fan-out start failing.
+#
+# The job is deploy-prd's, step for step, so the environment is identical by
+# construction rather than by transcription: same composite, same Infisical
+# environment, same AWS role, same concurrency group (a sync never runs beside
+# a deploy).
+on:
+    workflow_dispatch:
+        inputs:
+            dry-run:
+                description: Report drift without repairing it
+                type: boolean
+                default: true
+
+concurrency:
+    group: deploy-prd
+    cancel-in-progress: false
+
+permissions:
+    contents: read
+    id-token: write # Infisical OIDC machine-identity auth
+
+jobs:
+    # The stack program reads the compiled binary at plan time, and sync plans
+    # the whole stack before it reads anything back.
+    ingest-binary:
+        uses: ./.github/workflows/build-ingest-binary.yml
+
+    sync-prd:
+        needs: ingest-binary
+        runs-on: ubuntu-latest
+        timeout-minutes: 45
+        environment: production
+        env:
+            INFISICAL_ENV_SLUG: prod
+            COMMIT_SHA: ${{ github.sha }}
+            VITE_COMMIT_SHA: ${{ github.sha }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+            - name: Deploy setup
+              id: setup
+              uses: ./.github/actions/deploy-setup
+              with:
+                  infisical-env-slug: ${{ env.INFISICAL_ENV_SLUG }}
+                  infisical-identity-id: ${{ secrets.INFISICAL_MACHINE_IDENTITY_ID }}
+                  infisical-project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
+                  aws-role-arn: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+
+            # `AWS_ACCOUNT_ID` for the same reason deploy-prd passes it: without
+            # it alchemy's env-credential path issues an STS call against its own
+            # half-built environment and deadlocks silently (#378).
+            - name: Report drift
+              if: ${{ inputs.dry-run }}
+              run: bun run alchemy:sync:prd:check
+              env:
+                  AWS_ACCOUNT_ID: ${{ steps.setup.outputs.aws-account-id }}
+
+            - name: Repair drift
+              if: ${{ !inputs.dry-run }}
+              run: bun run alchemy:sync:prd
+              env:
+                  AWS_ACCOUNT_ID: ${{ steps.setup.outputs.aws-account-id }}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
 		"alchemy:deploy": "bun run alchemy:build-deps && alchemy deploy --yes",
 		"alchemy:deploy:prd": "bun run alchemy:build-deps && alchemy deploy --yes --adopt --stage prd",
 		"alchemy:deploy:stg": "bun run alchemy:build-deps && alchemy deploy --yes --adopt --stage stg",
+		"alchemy:sync:prd": "bun run alchemy:build-deps && alchemy sync --yes --stage prd",
+		"alchemy:sync:prd:check": "bun run alchemy:build-deps && alchemy sync --yes --dry-run --stage prd",
 		"alchemy:deploy:pr": "bun run alchemy:build-deps && alchemy deploy --yes --adopt --stage pr-${PR_NUMBER}",
 		"alchemy:destroy": "alchemy destroy --yes",
 		"alchemy:destroy:stg": "alchemy destroy --yes --stage stg",


### PR DESCRIPTION
Confirmed against the live account today: the deployed `maple-api` Worker carries both Workflow bindings — `InvestigationFanoutWorkflow` → `maple-api-investigationfanoutworkflow-eced6125` and `ClickHouseSchemaApplyWorkflow` → `maple-api-clickhouseschemaapplyworkflow-41c1c85a` — and **neither workflow exists**. `wrangler workflows instances list` on the fan-out name returns `workflows.api.error.workflow.not_found [10200]`. `maple-alerting` binds the same missing name cross-script. The only workflows left on the prod script are the pre-rename `maple-ai-triage`, `maple-schema-apply` and `maple-tinybird-sync`, all orphaned.

State believes otherwise, so every plan since prints both as `noop` and no deploy will self-heal. `alchemy sync` is the tool for that: it reads each resource back from its provider, reconciles drift, and recreates what the cloud no longer has from the persisted instance id, so the physical names come back identical.

The point of running it as a workflow rather than by hand is the environment. A prd run needs the Infisical OIDC machine identity, the AWS role assumed over OIDC, `AWS_ACCOUNT_ID` set (or alchemy deadlocks on its own STS call, #378) and the mise toolchain — none of which a laptop reproduces faithfully. So this job is deploy-prd's, step for step, with the deploy swapped for a sync: the same `deploy-setup` composite, the same Infisical environment, the same role, and the same `deploy-prd` concurrency group so a sync never runs beside a deploy.

Dispatch only, and `dry-run` defaults to true — the first run reports what drifted, and repairing is opt-in per run.

Adds `alchemy:sync:prd` and `alchemy:sync:prd:check`, both mirroring `alchemy:deploy:prd`'s build-deps-first shape.

**Follow-ups this does not do:** the ~300 investigations parked in `start_failed` need a retry sweep once starts work, and the orphaned `maple-ai-triage` / `maple-schema-apply` workflows want deleting. #827 makes the next failure of this shape name itself.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791657495&installation_model_id=427786&pr_number=828&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F828&signature=281c0ba3061ce5da884787f59652ca095fccc54fcf1bb229cdde3ff405192462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added production configuration synchronization commands for standard updates and dry-run validation.
  - Added a manually triggered production synchronization workflow with options to detect configuration drift or apply repairs.
  - Production synchronization now includes the required build and deployment setup steps before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->