### PR TITLE
feat(llm): nest OpenRouter Broadcast traces under the calling span

### DIFF
--- a/apps/api/src/platform/Llm.test.ts
+++ b/apps/api/src/platform/Llm.test.ts
@@ -122,6 +122,22 @@ describe("resolveTriageModel — OpenRouter attribution", () => {
 		}),
 	)
 
+	it.live("stamps the calling span's ids on the trace field so Broadcast nests under it", () =>
+		Effect.gen(function* () {
+			const span = yield* Effect.currentSpan
+			const captured = yield* captureRequest(openRouterEnv, tags)
+
+			// OpenRouter's exporter uses these verbatim as the W3C ids of the trace it emits.
+			expect(captured.body.trace).toMatchObject({ trace_name: "chat", trace_id: span.traceId })
+			// The parent is whichever span is innermost at the transport — the model's, not ours —
+			// but it must be a real 16-hex span id that lives in our trace.
+			expect((captured.body.trace as { parent_span_id: string }).parent_span_id).toMatch(
+				/^[0-9a-f]{16}$/,
+			)
+			expect(captured.body.usage).toEqual({ include: true })
+		}).pipe(Effect.withSpan("chat")),
+	)
+
 	it.live("keeps the headers and tags off the Workers AI path", () =>
 		Effect.gen(function* () {
 			const captured = yield* captureRequest(

--- a/apps/api/src/platform/Llm.ts
+++ b/apps/api/src/platform/Llm.ts
@@ -12,7 +12,7 @@
  */
 import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai-compat"
 import { OpenRouterClient, OpenRouterLanguageModel } from "@effect/ai-openrouter"
-import { Effect, Layer, Redacted, Schema } from "effect"
+import { Effect, Layer, Option, Redacted, Schema } from "effect"
 import type * as LanguageModel from "effect/unstable/ai/LanguageModel"
 import type * as AiModel from "effect/unstable/ai/Model"
 import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest } from "effect/unstable/http"
@@ -187,7 +187,7 @@ export const resolveLlmProvider = (env: LlmEnv): LlmProvider =>
  *
  * `reasoning`, `user`, `session_id` and `trace` are all first-class fields on OpenRouter's chat
  * request, so they ride as model config rather than as a hand-built body. `usage` is the one
- * exception and is injected by {@link withUsageAccounting}.
+ * exception, spliced per call by {@link withPerCallFields} together with the span ids.
  */
 const openRouterConfig = (effort: ReasoningEffort | undefined, tags: LlmCallTags | undefined) => ({
 	...(effort === undefined || effort === "off" ? undefined : { reasoning: { effort } }),
@@ -280,21 +280,27 @@ export const resolveLensModel = (env: LlmEnv, tags?: LlmCallTags): ResolvedModel
 			)
 
 /**
- * Add OpenRouter's `usage: { include: true }` to every outgoing chat request.
+ * Splice the per-call fields into every outgoing OpenRouter chat request.
  *
- * It is the only field Maple needs that OpenRouter's generated request schema does not declare, and
- * a closed `Schema.Struct` drops what it does not know — so it is spliced into the encoded body
- * here instead. Without it the response carries no `cost`, and `gen_ai.usage.cost` is the only way
- * Maple ever reports spend: the provider's own bill, never a price table.
+ * `usage: { include: true }` is the one field Maple needs that OpenRouter's generated request
+ * schema does not declare, and a closed `Schema.Struct` drops what it does not know. Without it the
+ * response carries no `cost`, and `gen_ai.usage.cost` is the only way Maple ever reports spend: the
+ * provider's own bill, never a price table.
+ *
+ * `trace.trace_id` / `trace.parent_span_id` are the current span's W3C ids. OpenRouter's Broadcast
+ * exporter uses them verbatim, so the `LLM Generation` trace it emits (provider attempts, fallbacks,
+ * router latency) nests under the span that made the call instead of arriving as a twin trace that
+ * only shares a session id. The model config cannot carry them — it is built once per layer, and the
+ * ids are per call — which is why they ride here with `usage`.
  */
-const withUsageAccounting = (client: HttpClient.HttpClient): HttpClient.HttpClient =>
+const withPerCallFields = (client: HttpClient.HttpClient): HttpClient.HttpClient =>
 	HttpClient.mapRequestEffect(client, (request) =>
-		spliceUsageAccounting(request).pipe(Effect.orElseSucceed(() => request)),
+		splicePerCallFields(request).pipe(Effect.orElseSucceed(() => request)),
 	)
 
 const decodeJsonBody = Schema.decodeEffect(Schema.fromJsonString(Schema.Unknown))
 
-const spliceUsageAccounting = (
+const splicePerCallFields = (
 	request: HttpClientRequest.HttpClientRequest,
 ): Effect.Effect<HttpClientRequest.HttpClientRequest, Schema.SchemaError | HttpBody.HttpBodyError> =>
 	Effect.gen(function* () {
@@ -302,7 +308,18 @@ const spliceUsageAccounting = (
 		if (body._tag !== "Uint8Array") return request
 		const decoded = yield* decodeJsonBody(new TextDecoder().decode(body.body))
 		if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) return request
-		return yield* HttpClientRequest.bodyJson(request, { ...decoded, usage: { include: true } })
+		const span = yield* Effect.option(Effect.currentParentSpan)
+		const trace = {
+			...("trace" in decoded && typeof decoded.trace === "object" ? decoded.trace : undefined),
+			...(Option.isSome(span)
+				? { trace_id: span.value.traceId, parent_span_id: span.value.spanId }
+				: undefined),
+		}
+		return yield* HttpClientRequest.bodyJson(request, {
+			...decoded,
+			usage: { include: true },
+			...(Object.keys(trace).length === 0 ? undefined : { trace }),
+		})
 	})
 
 /**
@@ -320,7 +337,7 @@ export const layerLlm = (env: LlmEnv): Layer.Layer<LlmClients> => {
 	return Layer.mergeAll(
 		OpenRouterClient.layer({
 			apiKey: Redacted.make(readString(env, "OPENROUTER_API_KEY") ?? ""),
-			transformClient: withUsageAccounting,
+			transformClient: withPerCallFields,
 		}).pipe(
 			Layer.provide(
 				Layer.effect(HttpClient.HttpClient)(


### PR DESCRIPTION
## Summary
- OpenRouter Broadcast previously arrived as a separate `openrouter` trace per LLM call, linked to ours only by `session_id` (doubled session usage until #766's response-id dedupe).
- Verified against prod (2026-09-10): the Broadcast OTLP exporter uses the request's `trace.trace_id` / `trace.parent_span_id` **verbatim** as W3C ids.
- `withUsageAccounting` → `withPerCallFields`: the same HTTP-client body transform now also merges the current span's `traceId`/`spanId` into `trace`, keeping the per-layer `trace_name`. No span in scope → only `usage` is spliced.
- Result: OpenRouter's `LLM Generation` + `provider attempt N` spans nest under Maple's `chat` span, so the waterfall shows provider fallbacks and `deepestReporterSum` nets the usage within one trace.

## Test plan
- [x] `Llm.test.ts`: `trace_id` matches the enclosing span, `parent_span_id` is 16-hex, `usage.include` intact (21/21)
- [ ] After deploy: one real chat, `ServiceName='openrouter'` rows share the `chat` span's `TraceId`; Agent Sessions totals not doubled

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791661708&installation_model_id=427786&pr_number=829&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F829&signature=65c771f56cab1ceecdda4fe76e3d83d78310703f3a02c89cc10d5c86442fbdf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * OpenRouter requests now include usage accounting information.
  * Request traces now preserve existing trace details and include the current parent span context.
  * Requests remain unchanged if transformation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->