### PR TITLE
Stop a missing sandbox token from failing the whole deploy

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -35,7 +35,7 @@ import {
 	resolveMapleDomains,
 } from "@maple/infra/cloudflare"
 import * as Acm from "@maple/infra/acm"
-import { optionalPlain, plainWithDefault } from "@maple/infra/env"
+import { optionalPlain, plainWithDefault, secretIsSet } from "@maple/infra/env"
 import * as Portless from "@maple/alchemy-portless"
 import { DEV_PROCESS_APPS, selectedDevApps, type DevApp } from "@maple/infra/dev-urls"
 import Alerting from "./apps/alerting/src/worker.ts"
@@ -217,7 +217,20 @@ export default Alchemy.Stack(
 		// Object, and the api binds it as `SANDBOX`. Yielded first so the binding
 		// sees a Worker this deploy created rather than stored state, and only on
 		// the stages that run it — see `stageDeploysSandbox`.
-		const sandbox = stageDeploysSandbox(stage) ? yield* MapleSandbox : undefined
+		//
+		// The token is checked here rather than required inside the Worker's own
+		// props. Both refuse to deploy a sandbox that would answer 401 to every
+		// call, but a `requiredSecret` in the props fails the whole `alchemy deploy`
+		// at config load, before any resource is touched — so a token nobody had
+		// provisioned yet stopped every Worker in the stage from updating. Deciding
+		// it here keeps the blast radius at the feature: no token, no sandbox, and
+		// the api logs that it is unavailable.
+		const sandboxTokenSet = yield* secretIsSet("SANDBOX_INTERNAL_SERVICE_TOKEN")
+		if (stageDeploysSandbox(stage) && !sandboxTokenSet)
+			yield* Effect.logWarning(
+				"skipping the repository sandbox: SANDBOX_INTERNAL_SERVICE_TOKEN is not set for this stage",
+			)
+		const sandbox = stageDeploysSandbox(stage) && sandboxTokenSet ? yield* MapleSandbox : undefined
 		const api = yield* sandbox === undefined
 			? MapleApi
 			: Effect.provideService(MapleApi, SandboxWorker, sandbox)

--- a/packages/infra/src/env.test.ts
+++ b/packages/infra/src/env.test.ts
@@ -12,6 +12,8 @@ import {
 	ingestKeyCryptoEnv,
 	optionalPlain,
 	optionalSecret,
+	requireSecretEntry,
+	secretIsSet,
 	planetScaleOAuthEnv,
 	plainWithDefault,
 	PRD_LOCKSTEP_REVISION_SERVICES,
@@ -121,6 +123,28 @@ describe("primitives", () => {
 		expect(run(derived("MAPLE_ENVIRONMENT", "pr-42"), { MAPLE_ENVIRONMENT: "production" })).toEqual({
 			MAPLE_ENVIRONMENT: "pr-42",
 		})
+	})
+})
+
+describe("secretIsSet", () => {
+	// Gates whether a resource is declared at all, so it must agree with
+	// `requiredSecret` on what counts as present: a blank value is not.
+	it("is false when the key is missing or blank, true only for a real value", () => {
+		expect(run(secretIsSet("SANDBOX_INTERNAL_SERVICE_TOKEN"), {})).toBe(false)
+		expect(
+			run(secretIsSet("SANDBOX_INTERNAL_SERVICE_TOKEN"), { SANDBOX_INTERNAL_SERVICE_TOKEN: "" }),
+		).toBe(false)
+		expect(
+			run(secretIsSet("SANDBOX_INTERNAL_SERVICE_TOKEN"), { SANDBOX_INTERNAL_SERVICE_TOKEN: "   " }),
+		).toBe(false)
+		expect(
+			run(secretIsSet("SANDBOX_INTERNAL_SERVICE_TOKEN"), { SANDBOX_INTERNAL_SERVICE_TOKEN: "tok" }),
+		).toBe(true)
+	})
+
+	it("never fails, so a missing secret cannot abort the deploy before any resource is touched", () => {
+		expect(runExit(secretIsSet("SANDBOX_INTERNAL_SERVICE_TOKEN"), {})._tag).toBe("Success")
+		expect(runExit(requireSecretEntry("SANDBOX_INTERNAL_SERVICE_TOKEN"), {})._tag).toBe("Failure")
 	})
 })
 

--- a/packages/infra/src/env.ts
+++ b/packages/infra/src/env.ts
@@ -106,6 +106,18 @@ export const optionalPlain = (key: string, fallback?: string): Config.Config<Pla
 export const optionalSecret = (key: string): Config.Config<SecretEnv> =>
 	trimmedOption(key).pipe(Config.map((value) => entry(key, Option.map(value, Redacted.make))))
 
+/**
+ * Whether a secret is set, without reading it.
+ *
+ * For deciding at the stack level whether a resource that *requires* a secret
+ * should be declared at all. `requiredSecret` inside a resource's props is the
+ * right shape once the resource exists, but it fails the whole `alchemy deploy`
+ * before any resource is touched — so a secret nobody provisioned takes down
+ * every Worker in the stage rather than the one feature that needed it.
+ */
+export const secretIsSet = (key: string): Config.Config<boolean> =>
+	trimmedOption(key).pipe(Config.map(Option.isSome))
+
 /** The first present-and-non-blank of `keys`, else `fallback`. For build vars with a `VITE_` twin. */
 export const plainFrom = (keys: ReadonlyArray<string>, fallback: string): Config.Config<string> =>
 	Config.all(keys.map(trimmedOption)).pipe(


### PR DESCRIPTION
The production deploy of #819 failed at config load, before any resource was touched, so nothing deployed:

```
ConfigError: SchemaError(Expected string
  at ["SANDBOX_INTERNAL_SERVICE_TOKEN"])
```

`requireSecretEntry` in the sandbox Worker's props was meant to refuse a sandbox that would answer 401 to every call. That intent is right. The effect was wrong: it failed `alchemy deploy` for the entire stage on a secret nobody had provisioned yet, so every other Worker was blocked from updating too.

The decision moves up to the stack, where it can be made without failing. `secretIsSet` reports presence without reading the value, and the sandbox Worker is declared only when the stage runs one **and** the token is set. Without it the rest of the stage deploys normally, no sandbox is provisioned, and the api logs that the repository sandbox is unavailable — which it already did for exactly this case. The Worker's own props still require the token; that path is now unreachable while it is absent.

Setting `SANDBOX_INTERNAL_SERVICE_TOKEN` for prd and stg is what turns the feature on.

Verified: typecheck and lint clean, infra tests pass including two new cases pinning that `secretIsSet` treats blank as absent and never fails where `requireSecretEntry` does, and a dev-stage plan is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791663533&installation_model_id=427786&pr_number=830&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F830&signature=9f590f2ca008fd572300a4a69556b2ba1ca00c392a78335aa25329d8e6a2b533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sandbox-enabled deployments now continue deploying the API and other services when the sandbox token is missing.
  - A warning is displayed when the sandbox is skipped due to a missing or blank token.
  - When the token is available, sandbox deployment continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->