### PR TITLE
perf(agent-sessions): net usage once per session, read details one partition at a time

### DIFF
--- a/apps/api/src/routes/internal/ai-sessions.http.test.ts
+++ b/apps/api/src/routes/internal/ai-sessions.http.test.ts
@@ -543,11 +543,11 @@ describe("POST /internal/ai-sessions/details", () => {
 	})
 
 	it("fans out over the page's own extent, padded, and its ids under the page's filters", async () => {
-		let detailsSql: string | undefined
+		const detailsSql: Array<string> = []
 		const harness = makeHarness({
 			compiledQuery: (_tenant, compiled, options) => {
 				expect(options?.context).toBe("aiSessionsDetails")
-				detailsSql = compiledQueryOf(compiled).sql
+				detailsSql.push(compiledQueryOf(compiled).sql)
 				return compiledQueryOf(compiled)
 					.decodeRows(DETAILS_BODY.sessionIds.map(detailsRow))
 					.pipe(Effect.orDie)
@@ -557,18 +557,22 @@ describe("POST /internal/ai-sessions/details", () => {
 		try {
 			const response = await harness.post("/internal/ai-sessions/details", DETAILS_BODY)
 			expect(response.status).toBe(200)
-			// The fan-out reads `trace_detail_spans` over the page's extent, padded —
-			// the caller's window would be a week of partitions on the page the UI
-			// offers — and both `ai_trace_index` reads take the same bounds exactly.
-			expect(detailsSql).toContain("FROM trace_detail_spans")
-			expect(detailsSql).toContain("Timestamp >= '2026-08-19 09:50:00.000000000' - INTERVAL 3600 SECOND")
-			expect(detailsSql).toContain("Timestamp <= '2026-08-19 10:40:00.000000000' + INTERVAL 3600 SECOND")
-			expect(detailsSql?.split("Timestamp >= '2026-08-19 09:50:00.000000000'").length).toBe(4)
+			// The fan-out reads `trace_detail_spans` over the page's extent, padded
+			// by an hour — the caller's window would be a week of partitions on
+			// the page the UI offers — as one read, because the padded extent lies
+			// inside one day; both `ai_trace_index` reads take the page's bounds.
+			expect(detailsSql).toHaveLength(1)
+			const [sql] = detailsSql
+			expect(sql).toContain("FROM trace_detail_spans")
+			expect(sql).toContain("Timestamp >= '2026-08-19 08:50:00.000000000'")
+			expect(sql).toContain("Timestamp <= '2026-08-19 11:40:00.000000000'")
+			expect(sql).not.toContain("INTERVAL")
+			expect(sql?.split("Timestamp >= '2026-08-19 09:50:00.000000000'").length).toBe(3)
 			// Exactly the page's ids, and the page's counted filters, so a trace
 			// resolves to the session it was ranked into.
-			for (const sessionId of DETAILS_BODY.sessionIds) expect(detailsSql).toContain(`'${sessionId}'`)
-			expect(detailsSql).toContain("countIf(VendorId IN ('eve')) > 0")
-			expect(detailsSql).not.toContain("__PARAM_")
+			for (const sessionId of DETAILS_BODY.sessionIds) expect(sql).toContain(`'${sessionId}'`)
+			expect(sql).toContain("countIf(VendorId IN ('eve')) > 0")
+			expect(sql).not.toContain("__PARAM_")
 			// The rows as the fan-out returned them; the client merges by id.
 			expect(response.body).toEqual({
 				data: DETAILS_BODY.sessionIds.map((sessionId) => ({
@@ -580,6 +584,83 @@ describe("POST /internal/ai-sessions/details", () => {
 					endTime: "2026-08-19 10:45:00.000000000",
 					durationMs: 1_500_050,
 				})),
+			})
+		} finally {
+			await harness.dispose()
+		}
+	})
+
+	it("reads a page that straddles midnight one partition at a time, and folds the rows", async () => {
+		const spansBounds: Array<[string, string]> = []
+		const harness = makeHarness({
+			compiledQuery: (_tenant, compiled) => {
+				const { sql } = compiledQueryOf(compiled)
+				const start = /Timestamp >= '([^']+)'\n\s+AND Timestamp <= '([^']+)'\n\s+AND TraceId IN/.exec(sql)
+				spansBounds.push([start?.[1] ?? "", start?.[2] ?? ""])
+				// The first read (the earlier day) sees the session's first spans, the
+				// second its last; only one of them sees the `trace:` session at all.
+				const rows =
+					spansBounds.length === 1
+						? [
+								{
+									...detailsRow("wrun_beta"),
+									spanCount: "10",
+									errorSpanCount: "2",
+									serviceNames: ["agent-runner"],
+									startTime: "2026-08-19 23:59:58.000000000",
+									endTime: "2026-08-19 23:59:59.500000000",
+									durationMs: "1500",
+								},
+							]
+						: [
+								{
+									...detailsRow("wrun_beta"),
+									spanCount: "2",
+									errorSpanCount: "0",
+									serviceNames: ["web-service"],
+									startTime: "2026-08-20 00:00:00.250000000",
+									endTime: "2026-08-20 00:00:01.000000000",
+									durationMs: "750",
+								},
+								detailsRow(`trace:${TRACE_ID}`),
+							]
+				return compiledQueryOf(compiled).decodeRows(rows).pipe(Effect.orDie)
+			},
+		})
+
+		try {
+			const response = await harness.post("/internal/ai-sessions/details", {
+				...DETAILS_BODY,
+				startTime: "2026-08-19 23:30:00.000000000",
+				endTime: "2026-08-20 00:15:00.000000000",
+			})
+			expect(response.status).toBe(200)
+			// Two reads, cut at midnight, padded an hour on the outside only.
+			expect(spansBounds).toEqual([
+				["2026-08-19 22:30:00.000000000", "2026-08-19 23:59:59.999999999"],
+				["2026-08-20 00:00:00.000000000", "2026-08-20 01:15:00.000000000"],
+			])
+			expect(response.body).toEqual({
+				data: [
+					{
+						sessionId: "wrun_beta",
+						spanCount: 12,
+						errorSpanCount: 2,
+						serviceNames: ["agent-runner", "web-service"],
+						startTime: "2026-08-19 23:59:58.000000000",
+						endTime: "2026-08-20 00:00:01.000000000",
+						durationMs: 3_000,
+					},
+					{
+						sessionId: `trace:${TRACE_ID}`,
+						spanCount: 12,
+						errorSpanCount: 2,
+						serviceNames: ["agent-runner", "web-service"],
+						startTime: "2026-08-19 10:19:59.950000000",
+						endTime: "2026-08-19 10:45:00.000000000",
+						durationMs: 1_500_050,
+					},
+				],
 			})
 		} finally {
 			await harness.dispose()

--- a/apps/api/src/routes/internal/ai-sessions.http.ts
+++ b/apps/api/src/routes/internal/ai-sessions.http.ts
@@ -44,6 +44,14 @@ const countedFilters = (payload: {
 })
 
 /**
+ * How many of a page's details slices run at once. A page at production
+ * density is one to three slices, all of them in flight; a page over a sparse
+ * month is up to a slice a day, which this holds to a few warehouse queries
+ * at a time rather than thirty.
+ */
+const DETAILS_SLICE_CONCURRENCY = 6
+
+/**
  * Dashboard-only AI agent session reads.
  *
  * Serves the Agent Sessions page (behind the `agent_tracing` org rollout flag).
@@ -200,25 +208,39 @@ export const HttpAiSessionsInternalLive = HttpApiBuilder.group(
 				.handle("details", ({ payload }) =>
 					Effect.gen(function* () {
 						const tenant = yield* CurrentTenant.Context
-						yield* Effect.annotateCurrentSpan({
-							orgId: tenant.orgId,
-							"maple.ai.page_size": payload.sessionIds.length,
-						})
 						// The fan-out over `trace_detail_spans`, bounded by the page's own
 						// extent rather than the list's window — the client hands back the
 						// bounds the page rows carried. Seconds on a cold partition, which
-						// is why it is its own request rather than part of `list`.
-						const rows = yield* warehouse.compiledQuery(
-							tenant,
-							CH.compile(
-								Integrations.aiSessionDetailsQuery({
-									...countedFilters(payload),
-									sessionIds: payload.sessionIds,
-								}),
-								{ orgId: tenant.orgId, fanOutStart: payload.startTime, fanOutEnd: payload.endTime },
+						// is why it is its own request rather than part of `list`, and one
+						// read per partition the padded extent touches, side by side, so
+						// a cold day costs the page that day alone and the profile's
+						// ceiling bounds a day rather than the page.
+						const slices = Integrations.aiSessionDetailsSlices(payload.startTime, payload.endTime)
+						yield* Effect.annotateCurrentSpan({
+							orgId: tenant.orgId,
+							"maple.ai.page_size": payload.sessionIds.length,
+							"maple.ai.details_slices": slices.length,
+						})
+						const query = Integrations.aiSessionDetailsQuery({
+							...countedFilters(payload),
+							sessionIds: payload.sessionIds,
+						})
+						const sliced = yield* Effect.all(
+							slices.map((slice) =>
+								warehouse.compiledQuery(
+									tenant,
+									CH.compile(query, {
+										orgId: tenant.orgId,
+										fanOutStart: payload.startTime,
+										fanOutEnd: payload.endTime,
+										...slice,
+									}),
+									{ profile: "list", context: "aiSessionsDetails" },
+								),
 							),
-							{ profile: "list", context: "aiSessionsDetails" },
+							{ concurrency: DETAILS_SLICE_CONCURRENCY },
 						)
+						const rows = Integrations.mergeAiSessionDetails(sliced)
 						// A page session the fan-out did not return is simply absent: the
 						// two MVs are written one after the other from the same insert, so
 						// the newest session can be ranked a moment before it has span rows.

--- a/apps/api/src/services/warehouse/ai-trace-index-materialization.clickhouse.e2e.test.ts
+++ b/apps/api/src/services/warehouse/ai-trace-index-materialization.clickhouse.e2e.test.ts
@@ -573,15 +573,30 @@ describe.skipIf(!clickhouseE2eEnabled)("ai_trace_index materialization", () => {
 		assert.strictEqual(fanOutStart, chTimestamp(BASE_MS))
 		assert.strictEqual(fanOutEnd, chTimestamp(BASE_MS + 60_124))
 		assert.ok(fanOutEnd.endsWith(".124000000"))
-		// `orgId` and the page's two bounds — the details read takes no window
-		// param from the caller, so there is nothing else to pass.
-		const compiled = compileUnsafe(
-			Integrations.aiSessionDetailsQuery({
-				sessionIds: page.map((row) => row.sessionId),
-			}),
-			{ orgId: ORG_ID, fanOutStart, fanOutEnd },
-		)
-		const rows = Effect.runSync(compiled.decodeRows(await runJson(compiled.sql)))
+		// `orgId`, the page's two bounds and one slice of their padded extent —
+		// the details read takes no window param from the caller, so there is
+		// nothing else to pass. Run as the route runs it: once per slice, then
+		// folded; and once more over the whole padded extent as one read, which
+		// the folded rows must equal — a slice boundary that dropped or
+		// double-counted a span would show here and nowhere else.
+		const details = Integrations.aiSessionDetailsQuery({
+			sessionIds: page.map((row) => row.sessionId),
+		})
+		const readDetails = async (slice: Integrations.AiSessionDetailsSlice) => {
+			const compiled = compileUnsafe(details, { orgId: ORG_ID, fanOutStart, fanOutEnd, ...slice })
+			return Effect.runSync(compiled.decodeRows(await runJson(compiled.sql)))
+		}
+		const slices = Integrations.aiSessionDetailsSlices(fanOutStart, fanOutEnd)
+		const rows = Integrations.mergeAiSessionDetails(await Promise.all(slices.map(readDetails)))
+		const whole = await readDetails({
+			spansStart: slices[0]!.spansStart,
+			spansEnd: slices[slices.length - 1]!.spansEnd,
+		})
+		const sorted = (list: ReadonlyArray<Integrations.AiSessionDetailsOutput>) =>
+			[...list]
+				.sort((a, b) => a.sessionId.localeCompare(b.sessionId))
+				.map((row) => ({ ...row, serviceNames: [...row.serviceNames].sort() }))
+		assert.deepStrictEqual(sorted(rows), sorted(whole))
 
 		// Merged by session id, as the client does — the same two sessions, now
 		// with the facts the index cannot answer.

--- a/packages/domain/src/http/ai-sessions.ts
+++ b/packages/domain/src/http/ai-sessions.ts
@@ -219,6 +219,9 @@ export class ListAiSessionDetailsRequest extends Schema.Class<ListAiSessionDetai
 		Schema.makeFilter(
 			(request: { readonly startTime: string; readonly endTime: string }) => {
 				const extentMs = tinybirdDateTimeMs(request.endTime) - tinybirdDateTimeMs(request.startTime)
+				// The pattern admits `2026-13-45 99:99:99`, which parses to NaN and
+				// would slip past both comparisons below.
+				if (Number.isNaN(extentMs)) return "startTime and endTime must be valid datetimes"
 				if (extentMs < 0) return "startTime must not be after endTime"
 				if (extentMs > AI_SESSION_DETAILS_MAX_EXTENT_MS) return "the window is wider than any page's extent"
 				return true

--- a/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
+++ b/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
@@ -16,8 +16,8 @@ SELECT
           max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS traceEndNanos
         FROM trace_detail_spans
         WHERE OrgId = 'org_sql_catalog'
-          AND Timestamp >= '2026-01-02 10:30:00' - INTERVAL 3600 SECOND
-          AND Timestamp <= '2026-01-02 12:30:00' + INTERVAL 3600 SECOND
+          AND Timestamp >= '2026-01-02 09:30:00'
+          AND Timestamp <= '2026-01-02 13:30:00'
           AND TraceId IN (SELECT
           traceId AS traceId
         FROM (SELECT
@@ -96,8 +96,8 @@ SELECT
           max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS traceEndNanos
         FROM trace_detail_spans
         WHERE OrgId = 'org_sql_catalog'
-          AND Timestamp >= '2026-01-02 10:30:00' - INTERVAL 3600 SECOND
-          AND Timestamp <= '2026-01-02 12:30:00' + INTERVAL 3600 SECOND
+          AND Timestamp >= '2026-01-02 09:30:00'
+          AND Timestamp <= '2026-01-02 13:30:00'
           AND TraceId IN (SELECT
           traceId AS traceId
         FROM (SELECT
@@ -186,8 +186,8 @@ SELECT
           max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS traceEndNanos
         FROM trace_detail_spans
         WHERE OrgId = 'org_sql_catalog'
-          AND Timestamp >= '2026-01-02 10:30:00' - INTERVAL 3600 SECOND
-          AND Timestamp <= '2026-01-02 12:30:00' + INTERVAL 3600 SECOND
+          AND Timestamp >= '2026-01-02 09:30:00'
+          AND Timestamp <= '2026-01-02 13:30:00'
           AND TraceId IN (SELECT
           traceId AS traceId
         FROM (SELECT
@@ -358,6 +358,49 @@ FORMAT JSON
 
 -- builder:ai-sessions:aiSessionPageQuery:default
 SELECT
+          sessionId AS sessionId,
+          vendorId AS vendorId,
+          vendorVersion AS vendorVersion,
+          agentStart AS agentStart,
+          agentEnd AS agentEnd,
+          traceCount AS traceCount,
+          spanCount AS spanCount,
+          serviceNames AS serviceNames,
+          models AS models,
+          agentNames AS agentNames,
+          firstAgentName AS firstAgentName,
+          toolCalls AS toolCalls,
+          errorAgentSpans AS errorAgentSpans,
+          toolErrors AS toolErrors,
+          turnErrors AS turnErrors,
+          agentDurationMs AS agentDurationMs,
+          toFloat64(arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 2)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, toFloat64(n.2)), arrayFilter(n -> n.1 != '', netted)))))) AS llmCalls,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 3)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.3), arrayFilter(n -> n.1 != '', netted))))) AS totalTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 4)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.4), arrayFilter(n -> n.1 != '', netted))))) AS cost,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 5)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.5), arrayFilter(n -> n.1 != '', netted))))) AS inputTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 6)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.6), arrayFilter(n -> n.1 != '', netted))))) AS cacheReadTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 7)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.7), arrayFilter(n -> n.1 != '', netted))))) AS cacheWriteTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 8)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.8), arrayFilter(n -> n.1 != '', netted))))) AS outputTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 9)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.9), arrayFilter(n -> n.1 != '', netted))))) AS reasoningTokens
+        FROM (SELECT
+          sessionId AS sessionId,
+          vendorId AS vendorId,
+          vendorVersion AS vendorVersion,
+          agentStart AS agentStart,
+          agentEnd AS agentEnd,
+          traceCount AS traceCount,
+          spanCount AS spanCount,
+          serviceNames AS serviceNames,
+          models AS models,
+          agentNames AS agentNames,
+          firstAgentName AS firstAgentName,
+          toolCalls AS toolCalls,
+          errorAgentSpans AS errorAgentSpans,
+          toolErrors AS toolErrors,
+          turnErrors AS turnErrors,
+          agentDurationMs AS agentDurationMs,
+          arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arrayElement(tupleElement(childClaims, 2), indexOf(tupleElement(childClaims, 1), r.1))) > 0 OR greatest(0., r.4 - arrayElement(tupleElement(childClaims, 3), indexOf(tupleElement(childClaims, 1), r.1))) > 0, NOT has(reportingIds, r.2)), greatest(0., r.3 - arrayElement(tupleElement(childClaims, 2), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.4 - arrayElement(tupleElement(childClaims, 3), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.7 - arrayElement(tupleElement(childClaims, 4), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.8 - arrayElement(tupleElement(childClaims, 5), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.9 - arrayElement(tupleElement(childClaims, 6), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.10 - arrayElement(tupleElement(childClaims, 7), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.11 - arrayElement(tupleElement(childClaims, 8), indexOf(tupleElement(childClaims, 1), r.1)))), reporters) AS netted
+        FROM (SELECT
           if(rawSessionId = '', concat('trace:', traceId), rawSessionId) AS sessionId,
           argMin(vendorId, vendorAt) AS vendorId,
           argMin(vendorVersion, vendorAt) AS vendorVersion,
@@ -369,19 +412,14 @@ SELECT
           groupUniqArrayArray(models) AS models,
           groupUniqArrayArray(agentNames) AS agentNames,
           argMin(firstAgentName, firstAgentAt) AS firstAgentName,
-          toFloat64(arraySum(n -> if(n.2 AND n.1 = '', 1, 0), arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0 OR greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0, NOT arrayExists(p -> p.1 = r.2 AND (p.3 > 0 OR p.4 > 0), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + length(arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> if(n.2, n.1, ''), arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0 OR greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0, NOT arrayExists(p -> p.1 = r.2 AND (p.3 > 0 OR p.4 > 0), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))))))) AS llmCalls,
           sum(toolCalls) AS toolCalls,
           sum(errorAgentSpans) AS errorAgentSpans,
-          sum(arrayCount(f -> f.3 = 1 AND NOT arrayExists(c -> c.2 = f.1, failedSpans), failedSpans)) AS toolErrors,
-          sum(arrayCount(f -> f.3 != 1 AND NOT arrayExists(c -> c.2 = f.1, failedSpans), failedSpans)) AS turnErrors,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS totalTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS cost,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.7 - arraySum(c -> if(c.2 = r.1, c.7, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.7 - arraySum(c -> if(c.2 = r.1, c.7, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.7 - arraySum(c -> if(c.2 = r.1, c.7, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS inputTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.8 - arraySum(c -> if(c.2 = r.1, c.8, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.8 - arraySum(c -> if(c.2 = r.1, c.8, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.8 - arraySum(c -> if(c.2 = r.1, c.8, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS cacheReadTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.9 - arraySum(c -> if(c.2 = r.1, c.9, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.9 - arraySum(c -> if(c.2 = r.1, c.9, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.9 - arraySum(c -> if(c.2 = r.1, c.9, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS cacheWriteTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.10 - arraySum(c -> if(c.2 = r.1, c.10, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.10 - arraySum(c -> if(c.2 = r.1, c.10, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.10 - arraySum(c -> if(c.2 = r.1, c.10, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS outputTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.11 - arraySum(c -> if(c.2 = r.1, c.11, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.11 - arraySum(c -> if(c.2 = r.1, c.11, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.11 - arraySum(c -> if(c.2 = r.1, c.11, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS reasoningTokens,
-          intDiv(max(traceAgentEndNanos) - toUnixTimestamp64Nano(min(traceAgentStart)), 1000000) AS agentDurationMs
+          sum(arrayCount(f -> f.3 = 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS toolErrors,
+          sum(arrayCount(f -> f.3 != 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS turnErrors,
+          intDiv(max(traceAgentEndNanos) - toUnixTimestamp64Nano(min(traceAgentStart)), 1000000) AS agentDurationMs,
+          arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000) AS reporters,
+          arrayReduce('sumMap', arrayMap(c -> [c.2], reporters), arrayMap(c -> [c.3], reporters), arrayMap(c -> [c.4], reporters), arrayMap(c -> [c.7], reporters), arrayMap(c -> [c.8], reporters), arrayMap(c -> [c.9], reporters), arrayMap(c -> [c.10], reporters), arrayMap(c -> [c.11], reporters)) AS childClaims,
+          tupleElement(arrayFilter(p -> p.3 > 0 OR p.4 > 0, reporters), 1) AS reportingIds
         FROM (SELECT
           TraceId AS traceId,
           max(SessionId) AS rawSessionId,
@@ -408,11 +446,55 @@ SELECT
         GROUP BY traceId) AS index_traces
         GROUP BY sessionId
         ORDER BY agentStart DESC, sessionId ASC
-        LIMIT 50
+        LIMIT 50) AS ranked_sessions) AS netted_sessions
+        ORDER BY agentStart DESC, sessionId ASC
         FORMAT JSON
 
 -- builder:ai-sessions:aiSessionPageQuery:every-filter
 SELECT
+          sessionId AS sessionId,
+          vendorId AS vendorId,
+          vendorVersion AS vendorVersion,
+          agentStart AS agentStart,
+          agentEnd AS agentEnd,
+          traceCount AS traceCount,
+          spanCount AS spanCount,
+          serviceNames AS serviceNames,
+          models AS models,
+          agentNames AS agentNames,
+          firstAgentName AS firstAgentName,
+          toolCalls AS toolCalls,
+          errorAgentSpans AS errorAgentSpans,
+          toolErrors AS toolErrors,
+          turnErrors AS turnErrors,
+          agentDurationMs AS agentDurationMs,
+          toFloat64(arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 2)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, toFloat64(n.2)), arrayFilter(n -> n.1 != '', netted)))))) AS llmCalls,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 3)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.3), arrayFilter(n -> n.1 != '', netted))))) AS totalTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 4)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.4), arrayFilter(n -> n.1 != '', netted))))) AS cost,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 5)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.5), arrayFilter(n -> n.1 != '', netted))))) AS inputTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 6)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.6), arrayFilter(n -> n.1 != '', netted))))) AS cacheReadTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 7)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.7), arrayFilter(n -> n.1 != '', netted))))) AS cacheWriteTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 8)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.8), arrayFilter(n -> n.1 != '', netted))))) AS outputTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 9)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.9), arrayFilter(n -> n.1 != '', netted))))) AS reasoningTokens
+        FROM (SELECT
+          sessionId AS sessionId,
+          vendorId AS vendorId,
+          vendorVersion AS vendorVersion,
+          agentStart AS agentStart,
+          agentEnd AS agentEnd,
+          traceCount AS traceCount,
+          spanCount AS spanCount,
+          serviceNames AS serviceNames,
+          models AS models,
+          agentNames AS agentNames,
+          firstAgentName AS firstAgentName,
+          toolCalls AS toolCalls,
+          errorAgentSpans AS errorAgentSpans,
+          toolErrors AS toolErrors,
+          turnErrors AS turnErrors,
+          agentDurationMs AS agentDurationMs,
+          arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arrayElement(tupleElement(childClaims, 2), indexOf(tupleElement(childClaims, 1), r.1))) > 0 OR greatest(0., r.4 - arrayElement(tupleElement(childClaims, 3), indexOf(tupleElement(childClaims, 1), r.1))) > 0, NOT has(reportingIds, r.2)), greatest(0., r.3 - arrayElement(tupleElement(childClaims, 2), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.4 - arrayElement(tupleElement(childClaims, 3), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.7 - arrayElement(tupleElement(childClaims, 4), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.8 - arrayElement(tupleElement(childClaims, 5), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.9 - arrayElement(tupleElement(childClaims, 6), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.10 - arrayElement(tupleElement(childClaims, 7), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.11 - arrayElement(tupleElement(childClaims, 8), indexOf(tupleElement(childClaims, 1), r.1)))), reporters) AS netted
+        FROM (SELECT
           if(rawSessionId = '', concat('trace:', traceId), rawSessionId) AS sessionId,
           argMin(vendorId, vendorAt) AS vendorId,
           argMin(vendorVersion, vendorAt) AS vendorVersion,
@@ -424,19 +506,14 @@ SELECT
           groupUniqArrayArray(models) AS models,
           groupUniqArrayArray(agentNames) AS agentNames,
           argMin(firstAgentName, firstAgentAt) AS firstAgentName,
-          toFloat64(arraySum(n -> if(n.2 AND n.1 = '', 1, 0), arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0 OR greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0, NOT arrayExists(p -> p.1 = r.2 AND (p.3 > 0 OR p.4 > 0), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + length(arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> if(n.2, n.1, ''), arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0 OR greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0, NOT arrayExists(p -> p.1 = r.2 AND (p.3 > 0 OR p.4 > 0), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))))))) AS llmCalls,
           sum(toolCalls) AS toolCalls,
           sum(errorAgentSpans) AS errorAgentSpans,
-          sum(arrayCount(f -> f.3 = 1 AND NOT arrayExists(c -> c.2 = f.1, failedSpans), failedSpans)) AS toolErrors,
-          sum(arrayCount(f -> f.3 != 1 AND NOT arrayExists(c -> c.2 = f.1, failedSpans), failedSpans)) AS turnErrors,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS totalTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS cost,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.7 - arraySum(c -> if(c.2 = r.1, c.7, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.7 - arraySum(c -> if(c.2 = r.1, c.7, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.7 - arraySum(c -> if(c.2 = r.1, c.7, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS inputTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.8 - arraySum(c -> if(c.2 = r.1, c.8, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.8 - arraySum(c -> if(c.2 = r.1, c.8, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.8 - arraySum(c -> if(c.2 = r.1, c.8, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS cacheReadTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.9 - arraySum(c -> if(c.2 = r.1, c.9, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.9 - arraySum(c -> if(c.2 = r.1, c.9, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.9 - arraySum(c -> if(c.2 = r.1, c.9, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS cacheWriteTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.10 - arraySum(c -> if(c.2 = r.1, c.10, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.10 - arraySum(c -> if(c.2 = r.1, c.10, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.10 - arraySum(c -> if(c.2 = r.1, c.10, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS outputTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.11 - arraySum(c -> if(c.2 = r.1, c.11, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.11 - arraySum(c -> if(c.2 = r.1, c.11, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.11 - arraySum(c -> if(c.2 = r.1, c.11, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS reasoningTokens,
-          intDiv(max(traceAgentEndNanos) - toUnixTimestamp64Nano(min(traceAgentStart)), 1000000) AS agentDurationMs
+          sum(arrayCount(f -> f.3 = 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS toolErrors,
+          sum(arrayCount(f -> f.3 != 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS turnErrors,
+          intDiv(max(traceAgentEndNanos) - toUnixTimestamp64Nano(min(traceAgentStart)), 1000000) AS agentDurationMs,
+          arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000) AS reporters,
+          arrayReduce('sumMap', arrayMap(c -> [c.2], reporters), arrayMap(c -> [c.3], reporters), arrayMap(c -> [c.4], reporters), arrayMap(c -> [c.7], reporters), arrayMap(c -> [c.8], reporters), arrayMap(c -> [c.9], reporters), arrayMap(c -> [c.10], reporters), arrayMap(c -> [c.11], reporters)) AS childClaims,
+          tupleElement(arrayFilter(p -> p.3 > 0 OR p.4 > 0, reporters), 1) AS reportingIds
         FROM (SELECT
           TraceId AS traceId,
           max(SessionId) AS rawSessionId,
@@ -473,14 +550,14 @@ SELECT
           AND NOT (sessionId LIKE 'trace:%')
           AND agentDurationMs >= 1000
           AND agentDurationMs <= 600000
-          AND cost >= 0.01
+          AND toolCalls >= 1
+          AND toolCalls <= 50) AS ranked_sessions) AS netted_sessions
+        WHERE cost >= 0.01
           AND cost <= 5
           AND totalTokens >= 100
           AND totalTokens <= 1000000
           AND llmCalls >= 1
           AND llmCalls <= 50
-          AND toolCalls >= 1
-          AND toolCalls <= 50
         ORDER BY cost ASC, agentStart DESC, sessionId ASC
         LIMIT 25
         OFFSET 25
@@ -488,6 +565,49 @@ SELECT
 
 -- builder:ai-sessions:aiSessionPageQuery:filtered
 SELECT
+          sessionId AS sessionId,
+          vendorId AS vendorId,
+          vendorVersion AS vendorVersion,
+          agentStart AS agentStart,
+          agentEnd AS agentEnd,
+          traceCount AS traceCount,
+          spanCount AS spanCount,
+          serviceNames AS serviceNames,
+          models AS models,
+          agentNames AS agentNames,
+          firstAgentName AS firstAgentName,
+          toolCalls AS toolCalls,
+          errorAgentSpans AS errorAgentSpans,
+          toolErrors AS toolErrors,
+          turnErrors AS turnErrors,
+          agentDurationMs AS agentDurationMs,
+          toFloat64(arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 2)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, toFloat64(n.2)), arrayFilter(n -> n.1 != '', netted)))))) AS llmCalls,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 3)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.3), arrayFilter(n -> n.1 != '', netted))))) AS totalTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 4)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.4), arrayFilter(n -> n.1 != '', netted))))) AS cost,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 5)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.5), arrayFilter(n -> n.1 != '', netted))))) AS inputTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 6)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.6), arrayFilter(n -> n.1 != '', netted))))) AS cacheReadTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 7)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.7), arrayFilter(n -> n.1 != '', netted))))) AS cacheWriteTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 8)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.8), arrayFilter(n -> n.1 != '', netted))))) AS outputTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 9)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.9), arrayFilter(n -> n.1 != '', netted))))) AS reasoningTokens
+        FROM (SELECT
+          sessionId AS sessionId,
+          vendorId AS vendorId,
+          vendorVersion AS vendorVersion,
+          agentStart AS agentStart,
+          agentEnd AS agentEnd,
+          traceCount AS traceCount,
+          spanCount AS spanCount,
+          serviceNames AS serviceNames,
+          models AS models,
+          agentNames AS agentNames,
+          firstAgentName AS firstAgentName,
+          toolCalls AS toolCalls,
+          errorAgentSpans AS errorAgentSpans,
+          toolErrors AS toolErrors,
+          turnErrors AS turnErrors,
+          agentDurationMs AS agentDurationMs,
+          arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arrayElement(tupleElement(childClaims, 2), indexOf(tupleElement(childClaims, 1), r.1))) > 0 OR greatest(0., r.4 - arrayElement(tupleElement(childClaims, 3), indexOf(tupleElement(childClaims, 1), r.1))) > 0, NOT has(reportingIds, r.2)), greatest(0., r.3 - arrayElement(tupleElement(childClaims, 2), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.4 - arrayElement(tupleElement(childClaims, 3), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.7 - arrayElement(tupleElement(childClaims, 4), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.8 - arrayElement(tupleElement(childClaims, 5), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.9 - arrayElement(tupleElement(childClaims, 6), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.10 - arrayElement(tupleElement(childClaims, 7), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.11 - arrayElement(tupleElement(childClaims, 8), indexOf(tupleElement(childClaims, 1), r.1)))), reporters) AS netted
+        FROM (SELECT
           if(rawSessionId = '', concat('trace:', traceId), rawSessionId) AS sessionId,
           argMin(vendorId, vendorAt) AS vendorId,
           argMin(vendorVersion, vendorAt) AS vendorVersion,
@@ -499,19 +619,14 @@ SELECT
           groupUniqArrayArray(models) AS models,
           groupUniqArrayArray(agentNames) AS agentNames,
           argMin(firstAgentName, firstAgentAt) AS firstAgentName,
-          toFloat64(arraySum(n -> if(n.2 AND n.1 = '', 1, 0), arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0 OR greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0, NOT arrayExists(p -> p.1 = r.2 AND (p.3 > 0 OR p.4 > 0), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + length(arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> if(n.2, n.1, ''), arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0 OR greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0, NOT arrayExists(p -> p.1 = r.2 AND (p.3 > 0 OR p.4 > 0), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))))))) AS llmCalls,
           sum(toolCalls) AS toolCalls,
           sum(errorAgentSpans) AS errorAgentSpans,
-          sum(arrayCount(f -> f.3 = 1 AND NOT arrayExists(c -> c.2 = f.1, failedSpans), failedSpans)) AS toolErrors,
-          sum(arrayCount(f -> f.3 != 1 AND NOT arrayExists(c -> c.2 = f.1, failedSpans), failedSpans)) AS turnErrors,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS totalTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.4 - arraySum(c -> if(c.2 = r.1, c.4, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS cost,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.7 - arraySum(c -> if(c.2 = r.1, c.7, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.7 - arraySum(c -> if(c.2 = r.1, c.7, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.7 - arraySum(c -> if(c.2 = r.1, c.7, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS inputTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.8 - arraySum(c -> if(c.2 = r.1, c.8, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.8 - arraySum(c -> if(c.2 = r.1, c.8, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.8 - arraySum(c -> if(c.2 = r.1, c.8, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS cacheReadTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.9 - arraySum(c -> if(c.2 = r.1, c.9, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.9 - arraySum(c -> if(c.2 = r.1, c.9, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.9 - arraySum(c -> if(c.2 = r.1, c.9, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS cacheWriteTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.10 - arraySum(c -> if(c.2 = r.1, c.10, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.10 - arraySum(c -> if(c.2 = r.1, c.10, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.10 - arraySum(c -> if(c.2 = r.1, c.10, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS outputTokens,
-          arraySum(n -> if(n.1 = '', n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.11 - arraySum(c -> if(c.2 = r.1, c.11, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), arrayMap(r -> tuple(r.5, greatest(0., r.11 - arraySum(c -> if(c.2 = r.1, c.11, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, arrayMap(r -> tuple(r.5, greatest(0., r.11 - arraySum(c -> if(c.2 = r.1, c.11, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))))) AS reasoningTokens,
-          intDiv(max(traceAgentEndNanos) - toUnixTimestamp64Nano(min(traceAgentStart)), 1000000) AS agentDurationMs
+          sum(arrayCount(f -> f.3 = 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS toolErrors,
+          sum(arrayCount(f -> f.3 != 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS turnErrors,
+          intDiv(max(traceAgentEndNanos) - toUnixTimestamp64Nano(min(traceAgentStart)), 1000000) AS agentDurationMs,
+          arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000) AS reporters,
+          arrayReduce('sumMap', arrayMap(c -> [c.2], reporters), arrayMap(c -> [c.3], reporters), arrayMap(c -> [c.4], reporters), arrayMap(c -> [c.7], reporters), arrayMap(c -> [c.8], reporters), arrayMap(c -> [c.9], reporters), arrayMap(c -> [c.10], reporters), arrayMap(c -> [c.11], reporters)) AS childClaims,
+          tupleElement(arrayFilter(p -> p.3 > 0 OR p.4 > 0, reporters), 1) AS reportingIds
         FROM (SELECT
           TraceId AS traceId,
           max(SessionId) AS rawSessionId,
@@ -541,7 +656,8 @@ SELECT
         GROUP BY sessionId
         ORDER BY agentStart DESC, sessionId ASC
         LIMIT 25
-        OFFSET 25
+        OFFSET 25) AS ranked_sessions) AS netted_sessions
+        ORDER BY agentStart DESC, sessionId ASC
         FORMAT JSON
 
 -- builder:ai-sessions:aiSessionSpansQuery:ai-scope-after-cursor

--- a/packages/query-engine-integrations/src/ai/ai-sessions.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.test.ts
@@ -8,8 +8,10 @@ import {
 } from "@maple-dev/effect-clickhouse"
 import {
 	aiSessionDetailsQuery,
+	aiSessionDetailsSlices,
 	aiSessionFacetsQuery,
 	idSearchPattern,
+	mergeAiSessionDetails,
 	aiSessionPageQuery,
 	aiSessionSpansQuery,
 	aiSessionSpansRowSchema,
@@ -47,11 +49,24 @@ const LIST_SESSION_KEY =
 const FAN_OUT_START = "2026-08-18 10:00:00"
 const FAN_OUT_END = "2026-08-18 12:00:00"
 
+/** One slice of the page's padded extent — the bounds one fan-out read seeks in. */
+const SPANS_START = "2026-08-18 09:00:00.000000000"
+const SPANS_END = "2026-08-18 13:00:00.000000000"
+
 /** The details read's ENTIRE param set — the caller's window is not among them. */
 const listParams = {
 	orgId: params.orgId,
 	fanOutStart: FAN_OUT_START,
 	fanOutEnd: FAN_OUT_END,
+	spansStart: SPANS_START,
+	spansEnd: SPANS_END,
+}
+
+/** The page's levels, outermost first: the usage sums, the netting, the
+ *  session grouping, and the per-trace grouping over the index. */
+const levels = (sql: string) => {
+	const [sums = "", netted = "", sessions = "", traces = ""] = sql.split("FROM (SELECT")
+	return { sums, netted, sessions, traces }
 }
 
 /** A page of two sessions, one of each kind — the details read never runs without one. */
@@ -106,7 +121,7 @@ describe("aiSessionPageQuery", () => {
 
 	it("resolves the vendor from the earliest session-bearing agent span, not max()", () => {
 		const { sql } = compileUnsafe(aiSessionPageQuery(), params)
-		const [outer, inner] = sql.split("FROM (SELECT")
+		const { sessions: outer, traces: inner } = levels(sql)
 
 		// Per trace: session-bearing spans rank first, then the earliest wins —
 		// a tuple, so ties at one rank fall through to time rather than to
@@ -124,7 +139,7 @@ describe("aiSessionPageQuery", () => {
 
 	it("counts the session's traces, agent spans and services off the index", () => {
 		const { sql } = compileUnsafe(aiSessionPageQuery(), params)
-		const [outer, inner] = sql.split("FROM (SELECT")
+		const { sessions: outer, traces: inner } = levels(sql)
 
 		expect(inner).toContain("count() AS agentSpanCount")
 		expect(inner).toContain("groupUniqArrayIf(20)(ServiceName, ServiceName != '') AS serviceNames")
@@ -140,8 +155,11 @@ describe("aiSessionPageQuery", () => {
 		// `agentStart` is a fixed-width literal, so the String order is the
 		// instant order. The tiebreak is what stops a page boundary splitting two
 		// sessions that share a start — one would be shown twice and one never.
-		expect(sql).toContain("ORDER BY agentStart DESC, sessionId ASC")
-		expect(sql).toContain("LIMIT 50")
+		// The session level ranks and cuts the page, and the level that sums
+		// the usage keeps the order; the netting between them sees 50 rows.
+		expect(sql.split("ORDER BY agentStart DESC, sessionId ASC").length - 1).toBe(2)
+		expect(sql.split("LIMIT 50").length - 1).toBe(1)
+		expect(sql.indexOf("LIMIT 50")).toBeLessThan(sql.indexOf(") AS ranked_sessions"))
 	})
 
 	it("skips past the previous pages on the ordered session rows", () => {
@@ -207,6 +225,8 @@ describe("aiSessionPageQuery", () => {
 		expect(sql).not.toContain("HAVING")
 		expect(sql).not.toContain("VendorId IN")
 		expect(sql).not.toContain("ServiceName IN")
+		// The one WHERE is the index read's; the usage level filters nothing.
+		expect(sql.split("WHERE ").length - 1).toBe(1)
 	})
 
 	it("is org-scoped, and escapes an org id carrying a quote", () => {
@@ -325,62 +345,66 @@ describe("aiSessionPageQuery", () => {
 		expect(compileUnsafe(aiSessionPageQuery({ search: "   " }), params).sql).not.toContain("LIKE")
 	})
 
-	it("collects the measures per trace off the index, and sums them per session", () => {
+	it("collects the measures per trace off the index, and nets and sums them per session", () => {
 		const { sql } = compileUnsafe(aiSessionPageQuery(), params)
-		const [outer, inner] = sql.split("FROM (SELECT")
+		const { sums, netted, sessions, traces } = levels(sql)
 
-		expect(inner).toContain("groupUniqArrayIf(20)(Model, Model != '') AS models")
-		expect(inner).toContain("groupUniqArrayIf(20)(AgentName, AgentName != '') AS agentNames")
-		expect(inner).toContain("sum(IsToolCall) AS toolCalls")
-		expect(inner).toContain("sum(IsError) AS errorAgentSpans")
-		// Model calls travel as reporters too: they are counted one level up.
-		expect(inner).not.toContain("AS llmCalls")
-		expect(inner).toContain(
+		expect(traces).toContain("groupUniqArrayIf(20)(Model, Model != '') AS models")
+		expect(traces).toContain("groupUniqArrayIf(20)(AgentName, AgentName != '') AS agentNames")
+		expect(traces).toContain("sum(IsToolCall) AS toolCalls")
+		expect(traces).toContain("sum(IsError) AS errorAgentSpans")
+		// Model calls travel as reporters too: they are counted two levels up.
+		expect(traces).not.toContain("AS llmCalls")
+		expect(traces).toContain(
 			"groupArrayIf(2000)(tuple(SpanId, ParentSpanId, Tokens, Cost, ResponseId, IsLlmCall, InputTokens, CacheReadTokens, CacheWriteTokens, OutputTokens, ReasoningTokens), ((Tokens > 0 OR Cost > 0) OR IsLlmCall = 1)) AS usageReporters",
 		)
-		expect(inner).toContain(
+		expect(traces).toContain(
 			"max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS traceAgentEndNanos",
 		)
 
-		expect(outer).toContain("groupUniqArrayArray(models) AS models")
-		expect(outer).toContain("sum(errorAgentSpans) AS errorAgentSpans")
+		expect(sessions).toContain("groupUniqArrayArray(models) AS models")
+		expect(sessions).toContain("sum(errorAgentSpans) AS errorAgentSpans")
 		// The session's reporters, every trace's flattened, so a gateway's mirror
-		// trace of a call is in hand next to the app's own span of it.
-		const all = "arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)"
-		// Deepest reporter: a parent keeps only its excess over its reporting
-		// children; then one claim per response id.
-		expect(outer).toContain(
-			`arrayMap(r -> tuple(r.5, greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), ${all}))), ${all})`,
-		)
-		expect(outer).toContain("arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1,")
-		expect(outer).toContain(") AS totalTokens")
-		expect(outer).toContain(") AS cost")
-		// The five buckets the row draws, summed the same way off the tuple's
-		// tail — the detail page's split, which is the index's since 0031.
-		for (const [element, name] of [
-			[7, "inputTokens"],
-			[8, "cacheReadTokens"],
-			[9, "cacheWriteTokens"],
-			[10, "outputTokens"],
-			[11, "reasoningTokens"],
-		] as const) {
-			expect(outer).toContain(
-				`arrayMap(r -> tuple(r.5, greatest(0., r.${element} - arraySum(c -> if(c.2 = r.1, c.${element}, 0.), ${all}))), ${all})`,
-			)
-			expect(outer).toContain(`) AS ${name}`)
-		}
-		expect(outer).toContain("toFloat64(arraySum(n -> if(n.2 AND n.1 = '', 1, 0),")
-		expect(outer).toContain(") AS llmCalls")
-		expect(outer).toContain(
+		// trace of a call is in hand next to the app's own span of it — and the
+		// two lookups the netting makes, taken off them once per session.
+		expect(sessions).toContain("arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000) AS reporters")
+		expect(sessions).toContain("arrayReduce('sumMap', arrayMap(c -> [c.2], reporters)")
+		expect(sessions).toContain(") AS childClaims")
+		expect(sessions).toContain("tupleElement(arrayFilter(p -> p.3 > 0 OR p.4 > 0, reporters), 1) AS reportingIds")
+		expect(sessions).toContain(
 			"intDiv(max(traceAgentEndNanos) - toUnixTimestamp64Nano(min(traceAgentStart)), 1000000) AS agentDurationMs",
 		)
+		// Deepest reporter: a parent keeps only its excess over its reporting
+		// children — one pass over the reporters, on a level of its own.
+		expect(netted).toContain("arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0),")
+		expect(netted).toContain(", reporters) AS netted")
+		expect(netted).not.toContain("AS totalTokens")
+		// Then one claim per response id, per measure, off the netted column.
+		for (const [element, name] of [
+			[3, "totalTokens"],
+			[4, "cost"],
+			[5, "inputTokens"],
+			[6, "cacheReadTokens"],
+			[7, "cacheWriteTokens"],
+			[8, "outputTokens"],
+			[9, "reasoningTokens"],
+		] as const) {
+			expect(sums).toContain(
+				`arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), ${element})) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.${element}), arrayFilter(n -> n.1 != '', netted))))) AS ${name}`,
+			)
+		}
+		expect(sums).toContain("toFloat64(arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 2))")
+		expect(sums).toContain(") AS llmCalls")
+		// The row's own columns ride through both upper levels by name.
+		expect(sums).toContain("agentDurationMs AS agentDurationMs")
+		expect(netted).toContain("agentDurationMs AS agentDurationMs")
 		// Still index-only: none of it reaches for the fan-out table.
 		expect(sql).not.toContain("trace_detail_spans")
 	})
 
 	it("names the session by its earliest named agent, not by the unordered set", () => {
 		const { sql } = compileUnsafe(aiSessionPageQuery(), params)
-		const [outer, inner] = sql.split("FROM (SELECT")
+		const { sessions: outer, traces: inner } = levels(sql)
 
 		// Per trace: a span with no agent name sorts to the sentinel and can never
 		// win the argMin, so a trace that has one always resolves to it.
@@ -397,7 +421,7 @@ describe("aiSessionPageQuery", () => {
 
 	it("splits the failures into tool and turn, deepest failed span counted", () => {
 		const { sql } = compileUnsafe(aiSessionPageQuery(), params)
-		const [outer, inner] = sql.split("FROM (SELECT")
+		const { sessions: outer, traces: inner } = levels(sql)
 
 		expect(inner).toContain(
 			"groupArrayIf(2000)(tuple(SpanId, ParentSpanId, IsToolCall), IsError = 1) AS failedSpans",
@@ -405,10 +429,10 @@ describe("aiSessionPageQuery", () => {
 		// A failed span whose own child also failed is the child's echo, not a
 		// second failure — the turn span a framework fails alongside its call.
 		expect(outer).toContain(
-			"sum(arrayCount(f -> f.3 = 1 AND NOT arrayExists(c -> c.2 = f.1, failedSpans), failedSpans)) AS toolErrors",
+			"sum(arrayCount(f -> f.3 = 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS toolErrors",
 		)
 		expect(outer).toContain(
-			"sum(arrayCount(f -> f.3 != 1 AND NOT arrayExists(c -> c.2 = f.1, failedSpans), failedSpans)) AS turnErrors",
+			"sum(arrayCount(f -> f.3 != 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS turnErrors",
 		)
 	})
 
@@ -431,19 +455,26 @@ describe("aiSessionPageQuery", () => {
 			params,
 		)
 
-		const having = sql.slice(sql.indexOf("GROUP BY sessionId"), sql.indexOf("ORDER BY"))
-		expect(having).toContain("errorAgentSpans > 0")
+		// The measures the session level has: HAVING on the ranked row.
+		const having = sql.slice(sql.indexOf("GROUP BY sessionId"), sql.indexOf(") AS ranked_sessions"))
+		expect(having).toContain("HAVING errorAgentSpans > 0")
 		expect(having).toContain("NOT (sessionId LIKE 'trace:%')")
 		expect(having).toContain("agentDurationMs >= 1000")
 		expect(having).toContain("agentDurationMs <= 60000")
-		expect(having).toContain("cost >= 0.5")
-		expect(having).toContain("cost <= 2")
-		expect(having).toContain("totalTokens >= 100")
-		expect(having).toContain("totalTokens <= 200000")
-		expect(having).toContain("llmCalls >= 1")
-		expect(having).toContain("llmCalls <= 40")
 		expect(having).toContain("toolCalls >= 2")
 		expect(having).toContain("toolCalls <= 9")
+		expect(having).not.toContain("cost")
+		// The usage measures exist only once netted and summed: WHERE on that
+		// level, which then has to see every session — no LIMIT below it.
+		const where = sql.slice(sql.indexOf(") AS netted_sessions"), sql.indexOf("ORDER BY"))
+		expect(where).toContain("WHERE cost >= 0.5")
+		expect(where).toContain("cost <= 2")
+		expect(where).toContain("totalTokens >= 100")
+		expect(where).toContain("totalTokens <= 200000")
+		expect(where).toContain("llmCalls >= 1")
+		expect(where).toContain("llmCalls <= 40")
+		expect(having).not.toContain("LIMIT")
+		expect(sql.slice(sql.indexOf("ORDER BY"))).toContain("LIMIT 50")
 	})
 
 	it("treats an explicit false as no filter, and the default sort as the baseline order", () => {
@@ -457,12 +488,16 @@ describe("aiSessionPageQuery", () => {
 	})
 
 	it("sorts by the requested measure with newest-first and the session id as tiebreaks", () => {
-		expect(compileUnsafe(aiSessionPageQuery({ sortBy: "cost", sortDir: "asc" }), params).sql).toContain(
-			"ORDER BY cost ASC, agentStart DESC, sessionId ASC",
-		)
-		expect(compileUnsafe(aiSessionPageQuery({ sortBy: "durationMs" }), params).sql).toContain(
-			"ORDER BY agentDurationMs DESC, agentStart DESC, sessionId ASC",
-		)
+		// A usage sort ranks on the level that has the sums, over every session
+		// in the window: the LIMIT is the query's last clause.
+		const byCost = compileUnsafe(aiSessionPageQuery({ sortBy: "cost", sortDir: "asc" }), params).sql
+		expect(byCost.split("ORDER BY cost ASC, agentStart DESC, sessionId ASC").length - 1).toBe(1)
+		expect(byCost.indexOf("LIMIT 50")).toBeGreaterThan(byCost.indexOf(") AS netted_sessions"))
+		expect(byCost.split("ORDER BY").length - 1).toBe(1)
+		// A session-level sort ranks and cuts the page before the netting.
+		const byDuration = compileUnsafe(aiSessionPageQuery({ sortBy: "durationMs" }), params).sql
+		expect(byDuration.split("ORDER BY agentDurationMs DESC, agentStart DESC, sessionId ASC").length - 1).toBe(2)
+		expect(byDuration.indexOf("LIMIT 50")).toBeLessThan(byDuration.indexOf(") AS ranked_sessions"))
 		expect(compileUnsafe(aiSessionPageQuery({ sortBy: "errorSpanCount" }), params).sql).toContain(
 			"ORDER BY errorAgentSpans DESC, agentStart DESC, sessionId ASC",
 		)
@@ -644,22 +679,24 @@ describe("aiSessionDetailsQuery", () => {
 		expect(fanOut).not.toContain("IN ('eve')")
 	})
 
-	it("reads every level over the page's bounds — padded for the fan-out only", () => {
+	it("reads the index over the page's bounds and the spans over one slice of them", () => {
 		const { sql } = compileUnsafe(aiSessionDetailsQuery(listOpts), listParams)
 		const [fanOut, detection] = sql.split("TraceId IN (SELECT")
 
 		// `trace_detail_spans` is PARTITION BY toDate(Timestamp), so this predicate
-		// is the only thing that prunes partitions there — and the bounds are the
-		// page's own agent spans, which span hours, not the caller's 30 days.
-		expect(fanOut).toContain(`Timestamp >= '${FAN_OUT_START}' - INTERVAL 3600 SECOND`)
-		expect(fanOut).toContain(`Timestamp <= '${FAN_OUT_END}' + INTERVAL 3600 SECOND`)
-		// The index levels take the same bounds unpadded: a page trace's index rows
-		// lie between its own session's agentStart and agentEnd by construction, so
+		// is the only thing that prunes partitions there — and the bounds are one
+		// slice of the page's own padded extent (`aiSessionDetailsSlices`), which
+		// spans hours inside one partition, not the caller's 30 days.
+		expect(fanOut).toContain(`Timestamp >= '${SPANS_START}'`)
+		expect(fanOut).toContain(`Timestamp <= '${SPANS_END}'`)
+		expect(fanOut).not.toContain("INTERVAL")
+		// The index levels take the page's bounds: a page trace's index rows lie
+		// between its own session's agentStart and agentEnd by construction, so
 		// the key and the filters come out of hours of the index rather than the
-		// caller's month, and the two index scans stop being the cost they were.
+		// caller's month, and the same rows whichever slice is being read.
 		expect(detection).toContain(`Timestamp >= '${FAN_OUT_START}'`)
 		expect(detection).toContain(`Timestamp <= '${FAN_OUT_END}'`)
-		expect(detection).not.toContain("INTERVAL")
+		expect(detection).not.toContain(SPANS_START)
 	})
 
 	it("takes no window param from the caller at all", () => {
@@ -708,6 +745,83 @@ describe("aiSessionDetailsQuery", () => {
 			endTime: "2026-08-19 10:33:36.242000000",
 			durationMs: 10_417,
 		})
+	})
+})
+
+describe("aiSessionDetailsSlices", () => {
+	it("pads the page's extent by an hour and reads it as one slice inside a day", () => {
+		expect(aiSessionDetailsSlices("2026-08-18 10:00:00", "2026-08-18 12:00:00")).toEqual([
+			{ spansStart: "2026-08-18 09:00:00.000000000", spansEnd: "2026-08-18 13:00:00.000000000" },
+		])
+	})
+
+	it("cuts the padded extent at midnight, contiguous to the nanosecond", () => {
+		// The bounds come back off the page's rows with their nanoseconds, and
+		// the cut has to keep them: a span at 23:59:59.999999999 belongs to the
+		// first slice and one at 00:00:00.000000000 to the second, never both.
+		expect(aiSessionDetailsSlices("2026-08-18 23:30:00.500000000", "2026-08-19 00:10:00")).toEqual([
+			{ spansStart: "2026-08-18 22:30:00.500000000", spansEnd: "2026-08-18 23:59:59.999999999" },
+			{ spansStart: "2026-08-19 00:00:00.000000000", spansEnd: "2026-08-19 01:10:00.000000000" },
+		])
+	})
+
+	it("reads a sparse page's extent as one slice per day it touches", () => {
+		const slices = aiSessionDetailsSlices("2026-08-18 12:00:00", "2026-08-21 06:00:00")
+		expect(slices.map((slice) => slice.spansStart)).toEqual([
+			"2026-08-18 11:00:00.000000000",
+			"2026-08-19 00:00:00.000000000",
+			"2026-08-20 00:00:00.000000000",
+			"2026-08-21 00:00:00.000000000",
+		])
+		expect(slices.at(-1)?.spansEnd).toBe("2026-08-21 07:00:00.000000000")
+	})
+})
+
+describe("mergeAiSessionDetails", () => {
+	const row = (overrides: Partial<Parameters<typeof mergeAiSessionDetails>[0][number][number]>) => ({
+		sessionId: "wrun_01",
+		spanCount: 3,
+		errorSpanCount: 1,
+		serviceNames: ["agent"],
+		startTime: "2026-08-18 23:59:59.900000000",
+		endTime: "2026-08-18 23:59:59.950000000",
+		durationMs: 0,
+		...overrides,
+	})
+
+	it("folds a session that straddles midnight into the row one read would return", () => {
+		const merged = mergeAiSessionDetails([
+			[row({})],
+			[
+				row({
+					spanCount: 2,
+					errorSpanCount: 0,
+					serviceNames: ["gateway", "agent"],
+					startTime: "2026-08-19 00:00:00.100000000",
+					endTime: "2026-08-19 00:00:00.350000000",
+				}),
+				row({ sessionId: "trace:abc", serviceNames: ["web"] }),
+			],
+		])
+
+		expect(merged).toEqual([
+			{
+				sessionId: "wrun_01",
+				spanCount: 5,
+				errorSpanCount: 1,
+				serviceNames: ["agent", "gateway"],
+				startTime: "2026-08-18 23:59:59.900000000",
+				endTime: "2026-08-19 00:00:00.350000000",
+				// The whole nanosecond difference in milliseconds, as `intDiv` takes it.
+				durationMs: 450,
+			},
+			row({ sessionId: "trace:abc", serviceNames: ["web"] }),
+		])
+	})
+
+	it("passes a session found in one slice through untouched", () => {
+		const only = row({ durationMs: 50 })
+		expect(mergeAiSessionDetails([[only], []])).toEqual([only])
 	})
 })
 

--- a/packages/query-engine-integrations/src/ai/ai-sessions.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.ts
@@ -45,8 +45,12 @@
 //     spans: their count, every service they touched, failures outside the
 //     agent's own spans, and the true extent — and the client asks for it
 //     after the page has rendered, replacing the index's agent-only figures
-//     as it lands. The same fan-out against raw `traces` times out at 10s on a
-//     7-day window in production: that table is sorted
+//     as it lands. The route runs it once per partition the page's padded
+//     extent touches, side by side (`aiSessionDetailsSlices`), and folds the
+//     rows back together (`mergeAiSessionDetails`): a cold day then costs its
+//     own seconds rather than every other day's, and the 15s ceiling is per
+//     day rather than per page. The same fan-out against raw `traces` times
+//     out at 10s on a 7-day window in production: that table is sorted
 //     `(OrgId, ServiceName, SpanName, Timestamp)` and `idx_trace_id` is only a
 //     bloom skip index, which prunes far too little at this org's volume.
 //
@@ -89,14 +93,13 @@
 // The window predicate on the fan-out is the PAGE's, not the caller's: the
 // bounds of the page's agent spans as the page rows report them, padded by
 // `FAN_OUT_PAD_SECONDS` so a trace's non-agent spans on either side are
-// counted too. `trace_detail_spans`
-// is `PARTITION BY toDate(Timestamp)`, so the predicate is the only thing that
-// prunes partitions there. What that buys depends on how densely an org runs
-// agents: at production volume a page of sessions ordered by start spans
-// hours — one partition, two around midnight — while an org with a few
-// sessions a day has a first page that spans weeks, and its fan-out probes
-// every partition in between exactly as the old shape did (no worse, no
-// better; a chunked or per-partition fan-out is the follow-up if that bites).
+// counted too. `trace_detail_spans` is `PARTITION BY toDate(Timestamp)`, so
+// the predicate is the only thing that prunes partitions there, and the
+// padded extent is cut at every midnight into one read per partition. At
+// production volume a page of sessions ordered by start spans hours — one
+// read, two around midnight — while an org with a few sessions a day has a
+// first page that spans weeks, and its details are as many reads as days,
+// each the cost of one partition rather than all of them in one query.
 //
 // A caller that has no window — a deep link carrying only a session id —
 // resolves one with `aiSessionWindowQuery` first, rather than running the
@@ -155,8 +158,12 @@ import {
 } from "@maple/domain/gen-ai"
 import { aiFieldSourceKeys, aiSpanAttributeKeys } from "./ai-integrations"
 import {
+	childClaimsExpr,
 	MAX_USAGE_REPORTERS_PER_TRACE,
+	nettedReportersExpr,
+	reportingSpanIdsExpr,
 	sessionLlmCalls,
+	sessionReportersExpr,
 	sessionUsageSum,
 	usageReportersExpr,
 } from "./ai-span-columns"
@@ -183,7 +190,8 @@ const SESSION_ORDER_SENTINEL = "2106-01-01 00:00:00"
 
 /**
  * How far past the page's own agent-span bounds the `trace_detail_spans`
- * fan-out reads, in seconds — see `aiSessionDetailsQuery`.
+ * fan-out reads, in seconds — applied by `aiSessionDetailsSlices`, which cuts
+ * the padded extent into the reads `aiSessionDetailsQuery` is run as.
  *
  * The pad exists because a trace's non-agent spans lie outside its agent
  * spans: measured over two days of production (4,920 agent traces,
@@ -195,7 +203,7 @@ const SESSION_ORDER_SENTINEL = "2106-01-01 00:00:00"
  * the fan-out's cost is made of. A trace whose spans reach further than an
  * hour past its agent spans is clamped in the list row alone.
  */
-const FAN_OUT_PAD_SECONDS = 3_600
+export const FAN_OUT_PAD_SECONDS = 3_600
 
 /**
  * The pad on the bounds `aiSessionWindowQuery`/`aiTraceWindowQuery` report for
@@ -268,7 +276,7 @@ const failedSpansExpr = ($: {
  */
 const deepestFailureCount = (failedSpans: string, kind: "tool" | "turn"): CH.Expr<number> =>
 	CH.rawExpr(
-		`sum(arrayCount(f -> f.3 ${kind === "tool" ? "=" : "!="} 1 AND NOT arrayExists(c -> c.2 = f.1, ${failedSpans}), ${failedSpans}))`,
+		`sum(arrayCount(f -> f.3 ${kind === "tool" ? "=" : "!="} 1 AND NOT has(tupleElement(${failedSpans}, 2), f.1), ${failedSpans}))`,
 		T.float64,
 	)
 
@@ -569,6 +577,32 @@ const indexTraces = (opts: AiSessionFilterOpts, bounds: IndexBounds) => {
 		])
 }
 
+/** The session-level columns of the page, carried through every level above
+ *  the one that computes them — the row as the index answers it, less the
+ *  usage the netting still has to sum. */
+const SESSION_COLUMNS = [
+	"sessionId",
+	"vendorId",
+	"vendorVersion",
+	"agentStart",
+	"agentEnd",
+	"traceCount",
+	"spanCount",
+	"serviceNames",
+	"models",
+	"agentNames",
+	"firstAgentName",
+	"toolCalls",
+	"errorAgentSpans",
+	"toolErrors",
+	"turnErrors",
+	"agentDurationMs",
+] as const
+type SessionColumn = (typeof SESSION_COLUMNS)[number]
+
+const carry = <Row extends Record<SessionColumn, unknown>>(row: Row): Pick<Row, SessionColumn> =>
+	Object.fromEntries(SESSION_COLUMNS.map((column) => [column, row[column]])) as Pick<Row, SessionColumn>
+
 /**
  * The page: which sessions the list shows, in what order, and everything a
  * row shows about them that the index can answer — the read the list renders
@@ -582,6 +616,17 @@ const indexTraces = (opts: AiSessionFilterOpts, bounds: IndexBounds) => {
  * its own, keyed `trace:<TraceId>`. Sessionless is the normal state for whole
  * vendors, not an edge case; see this file's header.
  *
+ * Three levels above the trace. The session level groups the traces: every
+ * measure the index carries per span, summed, and the session's usage
+ * reporters collected for the two levels above it, which net them into
+ * claims and sum the claims (`nettedReportersExpr`, `sessionUsageSum`). What
+ * a level computes is what it costs — not per row but per query: the
+ * warehouse analyses every lambda in a SELECT before it reads a row, and the
+ * netting written out per measure at one level was most of a page read in
+ * production (~300ms of a 450ms read over a week, the same on an empty
+ * window). One netting pass, then eight small sums off its result, is half
+ * of that.
+ *
  * Ordered by the first AGENT span, not the first span of any kind: the index
  * carries only agent spans, and the two differ by under a second in practice
  * (see `FAN_OUT_PAD_SECONDS`). The row's `startTime` still reports the true
@@ -591,8 +636,12 @@ const indexTraces = (opts: AiSessionFilterOpts, bounds: IndexBounds) => {
  * `sessionId` breaking ties, so a page boundary never splits two sessions that
  * share a start.
  *
- * The session-level filters are `HAVING` on the ranked row, over the measures
- * the index carries per span, and cost nothing beyond the index scan the page
+ * Which level ranks follows the sort: the session level has every measure
+ * but usage in hand, so it orders and cuts the page before the netting runs,
+ * which then grades the page alone; a sort or a filter on cost, tokens or
+ * model calls nets every session in the window and ranks on the level that
+ * has the sums. The session-level filters are `HAVING` on the ranked row, or
+ * `WHERE` on the summed one, and cost nothing beyond the index scan the page
  * already is. What they cannot do is count — a facet for "sessions over $1"
  * would be another pass over the same index per bucket, which the sidebar
  * does not ask for.
@@ -605,8 +654,8 @@ export function aiSessionPageQuery(opts: AiSessionPageOpts = {}) {
 	const limit = opts.limit ?? 50
 	const offset = opts.offset ?? 0
 
-	// The `HAVING` level sees the outer aliases by name only.
-	const having = {
+	// The `HAVING` and `WHERE` levels see the aliases by name only.
+	const column = {
 		sessionId: CH.dynamicColumn<string>("sessionId", T.string),
 		errorAgentSpans: CH.dynamicColumn<number>("errorAgentSpans", T.float64),
 		agentDurationMs: CH.dynamicColumn<number>("agentDurationMs", T.float64),
@@ -629,7 +678,9 @@ export function aiSessionPageQuery(opts: AiSessionPageOpts = {}) {
 		llmCalls: "llmCalls",
 		toolCalls: "toolCalls",
 	} as const satisfies Record<AiSessionSortKey, string>
-	const order: Array<[(typeof sortColumn)[AiSessionSortKey] | "sessionId", AiSessionSortDir]> =
+	type UsageSort = "cost" | "totalTokens" | "llmCalls"
+	type SessionSort = Exclude<(typeof sortColumn)[AiSessionSortKey], UsageSort> | "sessionId"
+	const order: Array<[SessionSort | UsageSort, AiSessionSortDir]> =
 		sortBy === "startTime"
 			? [["agentStart", sortDir]]
 			: [
@@ -637,8 +688,24 @@ export function aiSessionPageQuery(opts: AiSessionPageOpts = {}) {
 					["agentStart", "desc"],
 				]
 	order.push(["sessionId", "asc"])
+	// Usage exists only once the reporters are netted, two levels up; the
+	// session level orders on everything else.
+	const sortsOnSession = (specs: typeof order): specs is Array<[SessionSort, AiSessionSortDir]> =>
+		sortBy !== "cost" && sortBy !== "totalTokens" && sortBy !== "llmCalls"
+	const filtersOnUsage = [
+		opts.costMin,
+		opts.costMax,
+		opts.tokensMin,
+		opts.tokensMax,
+		opts.llmCallsMin,
+		opts.llmCallsMax,
+	].some((bound) => bound !== undefined)
+	// Only a positive offset is emitted: `OFFSET 0` is a no-op that would still
+	// change the compiled SQL of every first-page read.
+	const paged = <Q extends { limit(n: number): Q; offset(n: number): Q }>(query: Q): Q =>
+		offset > 0 ? query.limit(limit).offset(offset) : query.limit(limit)
 
-	const page = fromQuery(indexTraces(opts, "window"), "index_traces")
+	const sessions = fromQuery(indexTraces(opts, "window"), "index_traces")
 		.select(($) => ({
 			// The grouping key, and the only level that can compute it: the
 			// derived table is one row per trace, so a trace with no session id
@@ -664,49 +731,68 @@ export function aiSessionPageQuery(opts: AiSessionPageOpts = {}) {
 			// named agent: a trace that named none carries the sentinel and loses
 			// to any trace that did.
 			firstAgentName: CH.argMin($.firstAgentName, $.firstAgentAt),
-			llmCalls: sessionLlmCalls("usageReporters"),
 			toolCalls: CH.sum($.toolCalls),
 			errorAgentSpans: CH.sum($.errorAgentSpans),
 			toolErrors: deepestFailureCount("failedSpans", "tool"),
 			turnErrors: deepestFailureCount("failedSpans", "turn"),
-			totalTokens: sessionUsageSum("usageReporters", 3),
-			cost: sessionUsageSum("usageReporters", 4),
-			inputTokens: sessionUsageSum("usageReporters", 7),
-			cacheReadTokens: sessionUsageSum("usageReporters", 8),
-			cacheWriteTokens: sessionUsageSum("usageReporters", 9),
-			outputTokens: sessionUsageSum("usageReporters", 10),
-			reasoningTokens: sessionUsageSum("usageReporters", 11),
 			// Nanoseconds first, wrapped in `intDiv` — see `durationMs` in
 			// `aiSessionDetailsQuery` for both.
 			agentDurationMs: CH.intDiv(
 				CH.max_($.traceAgentEndNanos).sub(CH.toUnixTimestamp64Nano(CH.min_($.traceAgentStart))),
 				1_000_000,
 			),
+			// The usage, still as reporters: netted one level up, summed two —
+			// with the two lookups the netting makes taken off the reporters here,
+			// once per session, rather than once per reporter inside the netting.
+			reporters: sessionReportersExpr("usageReporters"),
+			childClaims: childClaimsExpr("reporters"),
+			reportingIds: reportingSpanIdsExpr("reporters"),
 		}))
 		.groupBy("sessionId")
 		.having(() => [
-			CH.whenTrue(opts.hasErrors, () => having.errorAgentSpans.gt(0)),
+			CH.whenTrue(opts.hasErrors, () => column.errorAgentSpans.gt(0)),
 			CH.whenTrue(opts.excludeTraceSessions, () =>
-				CH.not(having.sessionId.like(`${MAPLE_AI_TRACE_SESSION_PREFIX}%`)),
+				CH.not(column.sessionId.like(`${MAPLE_AI_TRACE_SESSION_PREFIX}%`)),
 			),
-			CH.when(opts.durationMinMs, (v) => having.agentDurationMs.gte(v)),
-			CH.when(opts.durationMaxMs, (v) => having.agentDurationMs.lte(v)),
-			CH.when(opts.costMin, (v) => having.cost.gte(v)),
-			CH.when(opts.costMax, (v) => having.cost.lte(v)),
-			CH.when(opts.tokensMin, (v) => having.totalTokens.gte(v)),
-			CH.when(opts.tokensMax, (v) => having.totalTokens.lte(v)),
-			CH.when(opts.llmCallsMin, (v) => having.llmCalls.gte(v)),
-			CH.when(opts.llmCallsMax, (v) => having.llmCalls.lte(v)),
-			CH.when(opts.toolCallsMin, (v) => having.toolCalls.gte(v)),
-			CH.when(opts.toolCallsMax, (v) => having.toolCalls.lte(v)),
+			CH.when(opts.durationMinMs, (v) => column.agentDurationMs.gte(v)),
+			CH.when(opts.durationMaxMs, (v) => column.agentDurationMs.lte(v)),
+			CH.when(opts.toolCallsMin, (v) => column.toolCalls.gte(v)),
+			CH.when(opts.toolCallsMax, (v) => column.toolCalls.lte(v)),
 		])
-		// A String order, and a correct one: the literal is fixed-width
-		// `YYYY-MM-DD hh:mm:ss.nnnnnnnnn`, so it sorts as the instant does.
+	// A String order, and a correct one: the literal is fixed-width
+	// `YYYY-MM-DD hh:mm:ss.nnnnnnnnn`, so it sorts as the instant does.
+	const ranked =
+		sortsOnSession(order) && !filtersOnUsage ? paged(sessions.orderBy(...order)) : sessions
+
+	const netted = fromQuery(ranked, "ranked_sessions").select(($) => ({
+		...carry($),
+		netted: nettedReportersExpr("reporters", "childClaims", "reportingIds"),
+	}))
+
+	const page = fromQuery(netted, "netted_sessions")
+		.select(($) => ({
+			...carry($),
+			llmCalls: sessionLlmCalls("netted"),
+			totalTokens: sessionUsageSum("netted", "tokens"),
+			cost: sessionUsageSum("netted", "cost"),
+			inputTokens: sessionUsageSum("netted", "inputTokens"),
+			cacheReadTokens: sessionUsageSum("netted", "cacheReadTokens"),
+			cacheWriteTokens: sessionUsageSum("netted", "cacheWriteTokens"),
+			outputTokens: sessionUsageSum("netted", "outputTokens"),
+			reasoningTokens: sessionUsageSum("netted", "reasoningTokens"),
+		}))
+		.where(() => [
+			CH.when(opts.costMin, (v) => column.cost.gte(v)),
+			CH.when(opts.costMax, (v) => column.cost.lte(v)),
+			CH.when(opts.tokensMin, (v) => column.totalTokens.gte(v)),
+			CH.when(opts.tokensMax, (v) => column.totalTokens.lte(v)),
+			CH.when(opts.llmCallsMin, (v) => column.llmCalls.gte(v)),
+			CH.when(opts.llmCallsMax, (v) => column.llmCalls.lte(v)),
+		])
+		// Re-ordered even when the session level already did: a level of its
+		// own keeps no order, and the page's order is the page's.
 		.orderBy(...order)
-		.limit(limit)
-	// Only a positive offset is emitted: `OFFSET 0` is a no-op that would still
-	// change the compiled SQL of every first-page read.
-	return (offset > 0 ? page.offset(offset) : page).format("JSON")
+	return (sortsOnSession(order) && !filtersOnUsage ? page : paged(page)).format("JSON")
 }
 
 /**
@@ -715,9 +801,12 @@ export function aiSessionPageQuery(opts: AiSessionPageOpts = {}) {
  * spans. The client asks for it once the page has rendered, and each field
  * replaces the row's agent-only figure of the same name. Bounded by the page
  * alone: `fanOutStart`/`fanOutEnd` are the extent of the page's agent spans,
- * and both the index reads and the fan-out run inside them (padded, for the
- * fan-out) — see `indexTraces` for why the index level resolves a page trace
- * exactly as the page did without the caller's window.
+ * and the index reads run inside them — see `indexTraces` for why the index
+ * level resolves a page trace exactly as the page did without the caller's
+ * window. The fan-out runs inside `spansStart`/`spansEnd`: one slice of the
+ * padded extent, as `aiSessionDetailsSlices` cuts it, so a read touches one
+ * partition of `trace_detail_spans`; the caller runs the slices side by side
+ * and folds the rows with `mergeAiSessionDetails`.
  *
  * The filters land on the index level, which means "the trace's agent spans
  * came from this service" rather than "the trace touched this service". A
@@ -726,12 +815,14 @@ export function aiSessionPageQuery(opts: AiSessionPageOpts = {}) {
  * spans come from the agent's own service, which is the one a user filtering by
  * service means.
  *
- * Once a trace is on the page it is aggregated across the padded fan-out window
- * rather than the caller's, so `startTime`/`endTime`/`durationMs`/`spanCount`/
- * `errorSpanCount`/`serviceNames` describe the whole trace rather than the
- * slice of it that fell inside the range — a session that began an hour before
- * the range no longer reports the range edge as its start, and the detail page
- * can read the bounds this row carries as the session's own.
+ * Once a trace is on the page it is aggregated across the padded extent
+ * rather than the caller's window, so `startTime`/`endTime`/`durationMs`/
+ * `spanCount`/`errorSpanCount`/`serviceNames` describe the whole trace rather
+ * than the slice of it that fell inside the range — a session that began an
+ * hour before the range no longer reports the range edge as its start, and
+ * the detail page can read the bounds this row carries as the session's own.
+ * Whole, that is, once the slices are merged: a trace whose spans straddle
+ * midnight is two rows until then.
  *
  * Ordered by `startTime` for a caller that reads it alone; the list's caller
  * merges by session id, and the page's order is the page's.
@@ -801,8 +892,8 @@ export function aiSessionDetailsQuery(opts: AiSessionDetailsOpts) {
 		})
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
-			$.Timestamp.gte(CH.intervalSub(param.dateTimeString("fanOutStart"), FAN_OUT_PAD_SECONDS)),
-			$.Timestamp.lte(CH.intervalAdd(param.dateTimeString("fanOutEnd"), FAN_OUT_PAD_SECONDS)),
+			$.Timestamp.gte(param.dateTimeString("spansStart")),
+			$.Timestamp.lte(param.dateTimeString("spansEnd")),
 			inSubquery($.TraceId, pageTraceIds),
 		])
 		.groupBy("traceId")
@@ -829,6 +920,107 @@ export function aiSessionDetailsQuery(opts: AiSessionDetailsOpts) {
 		.groupBy("sessionId")
 		.orderBy(["startTime", "desc"])
 		.format("JSON")
+}
+
+/** One read of `aiSessionDetailsQuery`: the bounds of its `trace_detail_spans`
+ *  seek, warehouse datetime literals — the `spansStart`/`spansEnd` params. */
+export interface AiSessionDetailsSlice {
+	readonly spansStart: string
+	readonly spansEnd: string
+}
+
+const NANOS_PER_SECOND = 1_000_000_000n
+const NANOS_PER_MS = 1_000_000n
+
+/** `YYYY-MM-DD hh:mm:ss[.fffffffff]`, read as UTC, to nanoseconds since the epoch. */
+const warehouseNanos = (literal: string): bigint => {
+	const [datetime = "", fraction = ""] = literal.split(".")
+	return (
+		BigInt(Date.parse(`${datetime.replace(" ", "T")}Z`)) * NANOS_PER_MS +
+		BigInt(fraction.padEnd(9, "0"))
+	)
+}
+
+/** Nanoseconds since the epoch as the literal the warehouse renders — nine
+ *  fractional digits, so a bound round-trips exactly. */
+const warehouseDateTime = (nanos: bigint): string => {
+	const seconds = new Date(Number(nanos / NANOS_PER_SECOND) * 1000).toISOString()
+	return `${seconds.slice(0, 19).replace("T", " ")}.${(nanos % NANOS_PER_SECOND).toString().padStart(9, "0")}`
+}
+
+const nextUtcMidnight = (nanos: bigint): bigint => {
+	const day = new Date(Number(nanos / NANOS_PER_SECOND) * 1000)
+	return BigInt(Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), day.getUTCDate() + 1)) * NANOS_PER_MS
+}
+
+/**
+ * The reads one page's details are split into: the page's extent, padded by
+ * `FAN_OUT_PAD_SECONDS`, cut at every midnight — one slice per partition of
+ * `trace_detail_spans` (`PARTITION BY toDate(Timestamp)`), contiguous to the
+ * nanosecond, for the caller to run side by side.
+ *
+ * A seek on that table costs by the partitions it touches, and a cold one
+ * costs seconds: measured in production before this, a page spanning three
+ * days ran 5s at the median and hit the profile's 15s ceiling at the 90th
+ * percentile, whole. Sliced, each read pays for one day, the page for the
+ * slowest of them, and a page over a sparse month is as many one-partition
+ * reads as it has days rather than one read over all of them.
+ *
+ * Bounds are read and rendered as UTC, the zone the warehouse renders its
+ * literals in; a warehouse in another zone would cut at its own midnight
+ * plus the offset, which costs a slice two partitions and nothing else.
+ */
+export function aiSessionDetailsSlices(
+	fanOutStart: string,
+	fanOutEnd: string,
+): ReadonlyArray<AiSessionDetailsSlice> {
+	const pad = BigInt(FAN_OUT_PAD_SECONDS) * NANOS_PER_SECOND
+	const end = warehouseNanos(fanOutEnd) + pad
+	const slices: Array<AiSessionDetailsSlice> = []
+	for (let at = warehouseNanos(fanOutStart) - pad; at <= end; ) {
+		const midnight = nextUtcMidnight(at)
+		slices.push({
+			spansStart: warehouseDateTime(at),
+			spansEnd: warehouseDateTime(midnight - 1n < end ? midnight - 1n : end),
+		})
+		at = midnight
+	}
+	return slices
+}
+
+/**
+ * The slices' rows folded back into one per session — what one read over the
+ * whole padded extent returns. A session whose spans straddle midnight is a
+ * row in each slice: the counts add, the services union, the extent is the
+ * outermost bounds, and the duration is those bounds' difference the way the
+ * query takes it, whole milliseconds of the nanosecond difference. The
+ * literals carry nine fractional digits, so the difference is exact.
+ */
+export function mergeAiSessionDetails(
+	slices: ReadonlyArray<ReadonlyArray<AiSessionDetailsOutput>>,
+): ReadonlyArray<AiSessionDetailsOutput> {
+	const merged = new Map<string, AiSessionDetailsOutput>()
+	for (const rows of slices) {
+		for (const row of rows) {
+			const prior = merged.get(row.sessionId)
+			if (prior === undefined) {
+				merged.set(row.sessionId, row)
+				continue
+			}
+			const startTime = prior.startTime < row.startTime ? prior.startTime : row.startTime
+			const endTime = prior.endTime > row.endTime ? prior.endTime : row.endTime
+			merged.set(row.sessionId, {
+				sessionId: row.sessionId,
+				spanCount: prior.spanCount + row.spanCount,
+				errorSpanCount: prior.errorSpanCount + row.errorSpanCount,
+				serviceNames: [...new Set([...prior.serviceNames, ...row.serviceNames])],
+				startTime,
+				endTime,
+				durationMs: Number((warehouseNanos(endTime) - warehouseNanos(startTime)) / NANOS_PER_MS),
+			})
+		}
+	}
+	return [...merged.values()]
 }
 
 // List facets (UNION ALL — one branch per index dimension)

--- a/packages/query-engine-integrations/src/ai/ai-sessions.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.ts
@@ -690,7 +690,7 @@ export function aiSessionPageQuery(opts: AiSessionPageOpts = {}) {
 	order.push(["sessionId", "asc"])
 	// Usage exists only once the reporters are netted, two levels up; the
 	// session level orders on everything else.
-	const sortsOnSession = (specs: typeof order): specs is Array<[SessionSort, AiSessionSortDir]> =>
+	const sortsOnSession = (_specs: typeof order): _specs is Array<[SessionSort, AiSessionSortDir]> =>
 		sortBy !== "cost" && sortBy !== "totalTokens" && sortBy !== "llmCalls"
 	const filtersOnUsage = [
 		opts.costMin,

--- a/packages/query-engine-integrations/src/ai/ai-sessions.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.ts
@@ -203,7 +203,7 @@ const SESSION_ORDER_SENTINEL = "2106-01-01 00:00:00"
  * the fan-out's cost is made of. A trace whose spans reach further than an
  * hour past its agent spans is clamped in the list row alone.
  */
-export const FAN_OUT_PAD_SECONDS = 3_600
+const FAN_OUT_PAD_SECONDS = 3_600
 
 /**
  * The pad on the bounds `aiSessionWindowQuery`/`aiTraceWindowQuery` report for

--- a/packages/query-engine-integrations/src/ai/ai-span-columns.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-span-columns.test.ts
@@ -25,7 +25,15 @@ import {
 } from "@maple/domain/gen-ai"
 import { LEGACY_SYSTEM_VALUES, genAiIntegration, resolveAiIntegration } from "./ai-integrations"
 import { AI_VENDOR_INTEGRATIONS } from "./ai-vendors"
-import { sessionLlmCalls, sessionUsageSum, usageReportersExpr } from "./ai-span-columns"
+import {
+	childClaimsExpr,
+	nettedReportersExpr,
+	reportingSpanIdsExpr,
+	sessionLlmCalls,
+	sessionReportersExpr,
+	sessionUsageSum,
+	usageReportersExpr,
+} from "./ai-span-columns"
 
 /** Every key any integration reads for `field` — the default's plus each vendor's. */
 const decodedKeys = (field: AiGenAiField): ReadonlySet<string> =>
@@ -196,36 +204,62 @@ describe("span classification SQL", () => {
 		)
 	})
 
-	it.each([3, 4, 7, 11] as const)(
-		"sums usage at the session level: children off their parent, one claim per response id (element %i)",
-		(element) => {
-			const all = "arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)"
-			const claims = `arrayMap(r -> tuple(r.5, greatest(0., r.${element} - arraySum(c -> if(c.2 = r.1, c.${element}, 0.), ${all}))), ${all})`
-			expect(sql(sessionUsageSum("usageReporters", element))).toBe(
-				`arraySum(n -> if(n.1 = '', n.2, 0.), ${claims}) + arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), ${claims}), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, ${claims}))))`,
-			)
-		},
-	)
-
-	it("takes the response id from another tuple position when told to", () => {
-		expect(sql(sessionUsageSum("usageBuckets", 6, { responseId: 8 }))).toContain(
-			"arrayMap(r -> tuple(r.8, greatest(0., r.6 - arraySum(c -> if(c.2 = r.1, c.6, 0.),",
+	it("collects the session's reporters once, and the two lookups the netting makes off them", () => {
+		expect(sql(sessionReportersExpr("usageReporters"))).toBe(
+			"arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)",
+		)
+		// What the children already claimed, per parent: one sumMap over the
+		// reporters, not a search of them per reporter.
+		expect(sql(childClaimsExpr("reporters"))).toBe(
+			"arrayReduce('sumMap', arrayMap(c -> [c.2], reporters), arrayMap(c -> [c.3], reporters), arrayMap(c -> [c.4], reporters), arrayMap(c -> [c.7], reporters), arrayMap(c -> [c.8], reporters), arrayMap(c -> [c.9], reporters), arrayMap(c -> [c.10], reporters), arrayMap(c -> [c.11], reporters))",
+		)
+		expect(sql(reportingSpanIdsExpr("reporters"))).toBe(
+			"tupleElement(arrayFilter(p -> p.3 > 0 OR p.4 > 0, reporters), 1)",
 		)
 	})
 
-	it("counts a model call at its deepest account, once per response id", () => {
-		const text = sql(sessionLlmCalls("usageReporters"))
+	it("nets every claim in one pass: children off their parent, a call at its deepest account", () => {
+		const text = sql(nettedReportersExpr("reporters", "childClaims", "reportingIds"))
+		const childClaim = (element: number) =>
+			`arrayElement(tupleElement(childClaims, ${element}), indexOf(tupleElement(childClaims, 1), r.1))`
+
+		expect(text).toMatch(/^arrayMap\(r -> tuple\(r\.5, /)
+		expect(text).toMatch(/, reporters\)$/)
 		// A reporting call counts by its netted claim; a non-reporting one by
 		// having no reporting parent.
 		expect(text).toContain(
-			"if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arraySum(c -> if(c.2 = r.1, c.3, 0.), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000))) > 0 OR greatest(0., r.4 -",
+			`r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - ${childClaim(2)}) > 0 OR greatest(0., r.4 - ${childClaim(3)}) > 0, NOT has(reportingIds, r.2))`,
 		)
-		expect(text).toContain(
-			"NOT arrayExists(p -> p.1 = r.2 AND (p.3 > 0 OR p.4 > 0), arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000)))",
+		// Tokens, cost and the five buckets, each less its children's, floored at zero.
+		for (const [element, child] of [
+			[3, 2],
+			[4, 3],
+			[7, 4],
+			[8, 5],
+			[9, 6],
+			[10, 7],
+			[11, 8],
+		] as const) {
+			expect(text).toContain(`greatest(0., r.${element} - ${childClaim(child)})`)
+		}
+		// One lambda over the reporters, and none inside it searching them again.
+		expect(text.split("->").length - 1).toBe(1)
+	})
+
+	it.each([
+		["tokens", 3],
+		["cost", 4],
+		["inputTokens", 5],
+		["reasoningTokens", 9],
+	] as const)("sums the netted claims: every unkeyed one, and the largest per response id (%s)", (measure, element) => {
+		expect(sql(sessionUsageSum("netted", measure))).toBe(
+			`arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), ${element})) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.${element}), arrayFilter(n -> n.1 != '', netted)))))`,
 		)
-		expect(text).toMatch(/^toFloat64\(arraySum\(n -> if\(n\.2 AND n\.1 = '', 1, 0\), /)
-		expect(text).toContain(
-			"length(arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> if(n.2, n.1, ''),",
+	})
+
+	it("counts the model calls the same way, off the netted flag", () => {
+		expect(sql(sessionLlmCalls("netted"))).toBe(
+			"toFloat64(arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 2)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, toFloat64(n.2)), arrayFilter(n -> n.1 != '', netted))))))",
 		)
 	})
 })

--- a/packages/query-engine-integrations/src/ai/ai-span-columns.ts
+++ b/packages/query-engine-integrations/src/ai/ai-span-columns.ts
@@ -94,56 +94,120 @@ export function usageReportersExpr($: {
 	)
 }
 
-/** Every reporter of the session: the per-trace arrays, flattened at the
- *  session level and capped again. Span ids are unique across traces, so the
- *  parent lookups below cannot cross into another trace. */
-const sessionReporters = (reporters: string): string =>
-	`arraySlice(arrayFlatten(groupArray(${reporters})), 1, ${MAX_USAGE_REPORTERS_PER_TRACE})`
-
-/** A reporter's own claim for `element` (3 tokens, 4 cost) less what its
- *  reporting children already claimed — zero for a clean roll-up. */
-const netted = (all: string, element: number, reporter = "r"): string =>
-	`greatest(0., ${reporter}.${element} - arraySum(c -> if(c.2 = ${reporter}.1, c.${element}, 0.), ${all}))`
-
 /**
- * The session's tokens (`element` 3), cost (`element` 4) or one token bucket
- * (`element` 7–11): each reporter's netted claim, summed — with reporters
- * sharing a response id collapsed to the largest claim among them. The same
- * sum serves any tuple of the `(SpanId, ParentSpanId, …claims, …)` shape,
- * hence `responseId` for a tuple that carries the id elsewhere.
+ * Every reporter of the session — the per-trace arrays, flattened and capped
+ * again — selected as a column of the session level, so the netting one level
+ * up reads a name rather than repeating the aggregate.
  *
- * `reporters` is the column {@link usageReportersExpr} was selected as, named
- * in raw SQL because the builder has no lambda syntax. `0.` keeps the whole
- * expression Float64.
+ * `reporters` is the column {@link usageReportersExpr} was selected as.
  */
-export function sessionUsageSum(
-	reporters: string,
-	element: number,
-	{ responseId = 5 }: { readonly responseId?: number } = {},
-): Expr<number> {
-	const all = sessionReporters(reporters)
-	// `(responseId, netted claim)` per reporter.
-	const claims = `arrayMap(r -> tuple(r.${responseId}, ${netted(all, element)}), ${all})`
-	const unkeyed = `arraySum(n -> if(n.1 = '', n.2, 0.), ${claims})`
-	const keyed = `arraySum(id -> arrayMax(n -> if(n.1 = id, n.2, 0.), ${claims}), arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> n.1, ${claims}))))`
-	return CH.rawExpr(`${unkeyed} + ${keyed}`, T.float64)
+export function sessionReportersExpr(reporters: string): Expr<unknown> {
+	return CH.untypedExpr(
+		`arraySlice(arrayFlatten(groupArray(${reporters})), 1, ${MAX_USAGE_REPORTERS_PER_TRACE})`,
+	)
 }
 
 /**
- * The session's model calls. A model span counts when it is the deepest
- * account of its call — it reported usage its children do not already cover,
- * or it reported none and neither did its parent (a failed call still counts;
- * a gateway's provider attempt under the call that reports does not) — and
- * calls sharing a response id count once. One level, like the netting above;
- * the detail page (`countedLlmCalls`) looks at every ancestor.
+ * What the reporters' children already claimed, per parent — `(ParentSpanId,
+ * tokens, cost, input, cacheRead, cacheWrite, output, reasoning)` as eight
+ * parallel arrays, elements 1–8, one entry per span that some reporter names
+ * as its parent — off the column {@link sessionReportersExpr} was selected
+ * as. One `sumMap` over the reporters rather than a search of them per
+ * reporter: a lambda captures a column by copying it once per element, so a
+ * per-reporter search of the reporters costs the square of their count in
+ * memory — measured in production, past the read's ceiling on a cost sort —
+ * while this costs the reporters once and the netting a lookup by position.
  */
-export function sessionLlmCalls(reporters: string): Expr<number> {
-	const all = sessionReporters(reporters)
-	const reportsUsage = (reporter: string) => `(${reporter}.3 > 0 OR ${reporter}.4 > 0)`
-	const deepest = `if(${reportsUsage("r")}, ${netted(all, 3)} > 0 OR ${netted(all, 4)} > 0, NOT arrayExists(p -> p.1 = r.2 AND ${reportsUsage("p")}, ${all}))`
-	// `(responseId, counts)` per reporter.
-	const counted = `arrayMap(r -> tuple(r.5, r.6 = 1 AND ${deepest}), ${all})`
-	const unkeyed = `arraySum(n -> if(n.2 AND n.1 = '', 1, 0), ${counted})`
-	const keyed = `length(arrayDistinct(arrayFilter(id -> id != '', arrayMap(n -> if(n.2, n.1, ''), ${counted}))))`
-	return CH.rawExpr(`toFloat64(${unkeyed} + ${keyed})`, T.float64)
+export function childClaimsExpr(reporters: string): Expr<unknown> {
+	const column = (element: number) => `arrayMap(c -> [c.${element}], ${reporters})`
+	return CH.untypedExpr(`arrayReduce('sumMap', ${[2, 3, 4, 7, 8, 9, 10, 11].map(column).join(", ")})`)
+}
+
+/** The span ids of the reporters that reported usage — what a model call
+ *  that reported none is counted against. Same column as above. */
+export function reportingSpanIdsExpr(reporters: string): Expr<unknown> {
+	return CH.untypedExpr(`tupleElement(arrayFilter(p -> p.3 > 0 OR p.4 > 0, ${reporters}), 1)`)
+}
+
+/**
+ * Each reporter's netted claims — `(responseId, counts, tokens, cost, input,
+ * cacheRead, cacheWrite, output, reasoning)` per reporter of the session,
+ * elements 1–9 — off the three columns the session level selects:
+ * {@link sessionReportersExpr}, {@link childClaimsExpr} and
+ * {@link reportingSpanIdsExpr}. Columns, not aliases of the same level: an
+ * alias expands inside the lambda and is evaluated there, once per reporter.
+ *
+ * A claim is the reporter's own less what its reporting children already
+ * claimed, floored at zero (a clean roll-up nets to nothing). `counts` is
+ * whether the reporter is a model call at its deepest account: a call that
+ * reported usage counts by its netted claim, one that reported none counts
+ * unless its parent reported — a failed call still counts, a gateway's
+ * provider attempt under the call that reports does not.
+ *
+ * One lambda over the reporters, netting the seven measures at once. This
+ * expression is analysed once per query, and the analysis of a lambda body
+ * is what a page read paid for before it touched a row — seven copies of the
+ * netting, three times each, were most of the read.
+ */
+export function nettedReportersExpr(reporters: string, childClaims: string, reportingIds: string): Expr<unknown> {
+	// Where the reporter's own children sit in the parallel arrays: zero, and
+	// so a zero claim, for a reporter no reporter names as its parent.
+	const position = `indexOf(tupleElement(${childClaims}, 1), r.1)`
+	const netted = (element: number, childElement: number) =>
+		`greatest(0., r.${element} - arrayElement(tupleElement(${childClaims}, ${childElement}), ${position}))`
+	const claims = [
+		[3, 2],
+		[4, 3],
+		[7, 4],
+		[8, 5],
+		[9, 6],
+		[10, 7],
+		[11, 8],
+	] as const
+	const counts = `r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), ${netted(3, 2)} > 0 OR ${netted(4, 3)} > 0, NOT has(${reportingIds}, r.2))`
+	return CH.untypedExpr(
+		`arrayMap(r -> tuple(r.5, ${counts}, ${claims.map(([element, childElement]) => netted(element, childElement)).join(", ")}), ${reporters})`,
+	)
+}
+
+/** A usage measure of the session, by its position in the netted tuple. */
+export type SessionUsageMeasure =
+	| "tokens"
+	| "cost"
+	| "inputTokens"
+	| "cacheReadTokens"
+	| "cacheWriteTokens"
+	| "outputTokens"
+	| "reasoningTokens"
+
+const NETTED_ELEMENT: Record<SessionUsageMeasure, number> = {
+	tokens: 3,
+	cost: 4,
+	inputTokens: 5,
+	cacheReadTokens: 6,
+	cacheWriteTokens: 7,
+	outputTokens: 8,
+	reasoningTokens: 9,
+}
+
+/**
+ * The claims of one element of the netted tuple, summed over the session:
+ * every reporter without a response id as it is, and of the reporters sharing
+ * one the largest claim (a gateway prices a call the app's SDK could not) —
+ * `maxMap` keyed by the id, then summed.
+ *
+ * `netted` is the column {@link nettedReportersExpr} was selected as.
+ */
+const nettedSum = (netted: string, element: number, claim: string): string =>
+	`arraySum(tupleElement(arrayFilter(n -> n.1 = '', ${netted}), ${element})) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, ${claim}), arrayFilter(n -> n.1 != '', ${netted})))))`
+
+/** The session's tokens, cost or one token bucket — see {@link nettedSum}. */
+export function sessionUsageSum(netted: string, measure: SessionUsageMeasure): Expr<number> {
+	const element = NETTED_ELEMENT[measure]
+	return CH.rawExpr(nettedSum(netted, element, `n.${element}`), T.float64)
+}
+
+/** The session's model calls: the reporters that count, once per response id. */
+export function sessionLlmCalls(netted: string): Expr<number> {
+	return CH.rawExpr(`toFloat64(${nettedSum(netted, 2, "toFloat64(n.2)")})`, T.float64)
 }

--- a/packages/query-engine-integrations/src/ai/ai-span-columns.ts
+++ b/packages/query-engine-integrations/src/ai/ai-span-columns.ts
@@ -180,7 +180,7 @@ export type SessionUsageMeasure =
 	| "outputTokens"
 	| "reasoningTokens"
 
-const NETTED_ELEMENT: Record<SessionUsageMeasure, number> = {
+const NETTED_ELEMENT = {
 	tokens: 3,
 	cost: 4,
 	inputTokens: 5,
@@ -188,7 +188,7 @@ const NETTED_ELEMENT: Record<SessionUsageMeasure, number> = {
 	cacheWriteTokens: 7,
 	outputTokens: 8,
 	reasoningTokens: 9,
-}
+} as const satisfies Record<SessionUsageMeasure, number>
 
 /**
  * The claims of one element of the netted tuple, summed over the session:

--- a/packages/query-engine-integrations/src/ai/index.ts
+++ b/packages/query-engine-integrations/src/ai/index.ts
@@ -8,9 +8,11 @@
 // the decoder read one list.
 
 export {
-	aiSessionFacetsQuery,
 	aiSessionDetailsQuery,
+	aiSessionDetailsSlices,
+	aiSessionFacetsQuery,
 	aiSessionPageQuery,
+	mergeAiSessionDetails,
 	aiSessionSpansQuery,
 	aiSessionSpansRowSchema,
 	aiSessionSummaryQuery,
@@ -28,6 +30,7 @@ export {
 	type AiSessionFilterOpts,
 	type AiSessionDetailsOpts,
 	type AiSessionDetailsOutput,
+	type AiSessionDetailsSlice,
 	type AiSessionPageOpts,
 	type AiSessionPageOutput,
 	type AiSessionSpansOpts,

--- a/packages/query-engine-integrations/src/benchmark/index.ts
+++ b/packages/query-engine-integrations/src/benchmark/index.ts
@@ -64,11 +64,15 @@ const traceWindow = {
  *  because the page was ranked inside it. */
 const AI_PAGE_SESSION_IDS = ["wrun_sql_catalog", `${MAPLE_AI_TRACE_SESSION_PREFIX}${AI_TRACE_ID}`]
 
-/** Stage two's whole param set — it never sees the caller's window. */
+/** Stage two's whole param set — it never sees the caller's window: the
+ *  page's bounds for the index levels, and one slice of the padded extent
+ *  (`aiSessionDetailsSlices`) for the fan-out. */
 const aiPageBounds = {
 	orgId: ORG_ID,
 	fanOutStart: "2026-01-02 10:30:00",
 	fanOutEnd: "2026-01-02 12:30:00",
+	spansStart: "2026-01-02 09:30:00",
+	spansEnd: "2026-01-02 13:30:00",
 }
 
 export const integrationFixtures: ReadonlyArray<IntegrationFixture> = [


### PR DESCRIPTION
## What

Second round on the Agent Sessions list after #826, measured against production data through the MCP self-trace harness (`rawInteractive` profile, `max_threads=2`, so numbers are relative, not prod absolutes).

**Details read (`POST /internal/ai-sessions/details`)** — split per partition.
- `aiSessionDetailsSlices(startTime, endTime)` pads the page's extent by the fan-out hour and cuts it at UTC midnight into one `spansStart`/`spansEnd` slice per `trace_detail_spans` partition; the index levels keep the page's `fanOutStart`/`fanOutEnd`, so a trace resolves to the same session in every slice.
- The route runs the slices with `Effect.all` (concurrency 6) and folds the rows per session with `mergeAiSessionDetails`: counts add, services union, extent = outermost bounds, `durationMs` recomputed from the nanosecond literals exactly as `intDiv` does.
- Correctness bar: on a production page straddling midnight the two slices returned 40 + 1 rows identical to the single read's 41; the ClickHouse e2e now runs the slices and asserts the merge equals one read over the whole extent.
- Before (prod, 2026-09-10): `aiSessionsDetails` p50 2.5s / p90 14s, hitting the 15s cap. Each slice is one partition (~0.4s warm, 0.2–0.6s measured), and the page waits for the slowest rather than the sum.

**Page query (`POST /internal/ai-sessions/list`)** — netting reshaped, rows unchanged.
- The usage netting moved out of seven per-measure lambda expressions (each capturing the whole reporter array once per reporter — O(n²) memory) into one pass: children's claims via `arrayReduce('sumMap', …)` once per session, then one lambda with `indexOf` lookups, then eight small sums on the level above.
- Session-level sorts rank and `LIMIT` before the netting; usage sorts/filters rank on the summed level.
- Output verified identical to the current query on production (row hash over all 24 columns, default sort and cost sort).

## Measurements (MCP harness, ms)

| read | before | after |
|---|---|---|
| page, default sort, 7-day window | 445, 519 | 403, 411, 362 |
| page, cost sort, 7-day window | 873 | 505 |
| page, empty window (fixed cost), warm, alternating | 308, 290, 352, 305, 308 | 310, 292, 232, 299 |
| details, midnight page, one read over 2 partitions | 443 | 582 + 238 in parallel |

What the experiments showed:
- "Rank first, grade later" via `TraceId IN (subquery)` was slower (704–891ms), as were `GLOBAL IN`, a `has()` scalar subquery and a three-level `IN`; the ranking alone is ~50ms and the per-trace level ~220ms, so the per-row math was never the cost.
- The page read carries a flat ~150ms of lambda analysis per query (no-lambda variant of the same query: 120–170ms on an empty window; either lambda shape: ~300ms). That floor is the same for the old and the new shape once warm; first runs of a new shape are +200–300ms.
- Nesting `arrayFilter` inside `arrayMap` over the reporters exceeded the 512MB harness cap on the cost sort where the old nested `arraySum` did not; the `sumMap` lookup form fits and is O(n·p).
- A production list request: server span 247ms = the query; the browser-side span 715ms, so ~470ms of the ~700ms a user sees is transport, not the API.

## Verification

- `packages/query-engine-integrations`: unit tests (112) and typecheck.
- `apps/api`: route tests (27, incl. a midnight-straddling page), typecheck, `ai-trace-index-materialization.clickhouse.e2e` (5) and the SQL catalog analyzer sweep (359) against docker ClickHouse.
- SQL baselines regenerated (query-engine, integrations).

After deploy: dashboard `e4baed24-9b1e-41fe-8f49-bb97a166c091`, `query.context IN ('aiSessionsPage','aiSessionsDetails')` — details spans now come one per slice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791665469&installation_model_id=427786&pr_number=831&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F831&signature=4e1e49f7d1eb14ae1c0d604fb5d88c762613282791d821392919eb59599870e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI session details now support time ranges that cross midnight, returning one unified result.
* **Bug Fixes**
  * Improved session detail retrieval across time boundaries to prevent missing or duplicated spans.
  * Corrected usage totals, token counts, costs, and failure metrics in AI session results.
  * Invalid date and time values now produce a clear validation error.
* **Performance**
  * Improved AI session page and detail query efficiency, especially for larger time ranges and filtered results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->