### PR TITLE
chore: add .company/environment.json for cloud environments

### DIFF
--- a/.company/environment.json
+++ b/.company/environment.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://api.thecompany.company/schemas/v1/environment.json",
+	"scripts": {
+		"install": {
+			"command": "bun install --frozen-lockfile",
+			"timeout": 1200
+		},
+		"prepare": {
+			"command": "bun install --frozen-lockfile",
+			"timeout": 600
+		}
+	}
+}


### PR DESCRIPTION
Adds `.company/environment.json` (schema: https://api.thecompany.company/schemas/v1/environment.json) so The Company Company cloud environments can build and ready this repo.

**Phases**

- `install` — `bun install --frozen-lockfile`, run once into the cached snapshot. This is the same command every CI job runs through the shared `.github/actions/bun-install` composite action.
- `prepare` — the same install, re-run per task after checkout to reconcile `node_modules` with the branch's lockfile. Idempotent; a no-op when nothing drifted.
- `start` — omitted. The repo's long-running services (docker Postgres, ClickHouse, the full `alchemy dev` stack) need Docker and `.env.local` secrets, and the test suite runs on embedded PGlite, so no background service is required for agent tasks.
- `env` — omitted. No non-secret variables are required; CI runs the same install without `.env.local`.

**Verification**

Ran the install command in a fresh worktree in the cloud sandbox: `bun install --frozen-lockfile` exits 0 (1593 packages installed, ~8s), including the repo's own `prepare` hook (`effect-tsgo patch`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791669348&installation_model_id=427786&pr_number=833&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F833&signature=87ef4fe43236c12f04ae12b32d12129bf6714973e6cfa5af1c9a62da00e40502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment configuration for automated installation and preparation workflows.
  * Configured dependency installation to use the frozen lockfile with defined timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->