### PR TITLE
Add a turn rail to the chat transcript gutter

### DIFF
--- a/apps/web/src/components/chat/chat-transcript.test.tsx
+++ b/apps/web/src/components/chat/chat-transcript.test.tsx
@@ -423,3 +423,62 @@ describe("ChatTranscript sub-agent cards", () => {
 		expect(items().map((el) => (el as HTMLElement).dataset.messageId)).toEqual(["m1"])
 	})
 })
+
+describe("ChatTranscript turn rail", () => {
+	const rail = () => document.querySelector('[data-slot="turn-minimap"]')
+	const markers = () =>
+		Array.from(document.querySelectorAll('[data-slot="turn-minimap"] span[aria-hidden]'))
+
+	/** jsdom has no layout, and the rail maps pointer position onto its own box. */
+	const withLayout = (height: number) => {
+		const original = HTMLElement.prototype.getBoundingClientRect
+		HTMLElement.prototype.getBoundingClientRect = function rect(this: HTMLElement) {
+			return {
+				top: 0,
+				left: 0,
+				right: 1440,
+				bottom: height,
+				width: 1440,
+				height,
+				x: 0,
+				y: 0,
+			} as DOMRect
+		}
+		return () => {
+			HTMLElement.prototype.getBoundingClientRect = original
+		}
+	}
+
+	const thread = [
+		message("u1", "user", "why is checkout slow"),
+		message("a1", "assistant", "the db pool is exhausted"),
+		message("u2", "user", "how do I fix it"),
+		message("a2", "assistant", "raise the pool size"),
+	]
+
+	it("stays away until the thread has more than one turn", () => {
+		render(<ChatTranscript {...baseProps} messages={[message("u1", "user", "hi")]} />)
+
+		expect(rail()).toBeNull()
+	})
+
+	it("draws one marker per human turn", () => {
+		render(<ChatTranscript {...baseProps} messages={thread} />)
+
+		expect(markers()).toHaveLength(2)
+	})
+
+	it("previews the turn under the pointer, question and reply", () => {
+		const restore = withLayout(200)
+		try {
+			render(<ChatTranscript {...baseProps} messages={thread} />)
+			fireEvent.mouseMove(screen.getByLabelText("Jump to a turn"), { clientY: 0 })
+
+			// Both texts are on screen twice: once in the transcript, once in the preview.
+			expect(screen.getAllByText("why is checkout slow")).toHaveLength(2)
+			expect(screen.getAllByText("the db pool is exhausted")).toHaveLength(2)
+		} finally {
+			restore()
+		}
+	})
+})

--- a/apps/web/src/components/chat/chat-transcript.tsx
+++ b/apps/web/src/components/chat/chat-transcript.tsx
@@ -33,9 +33,11 @@ import {
 	isToolPart,
 	toolNameFor,
 	toolPartsOf,
+	isMachineTurn,
 	type ToolPart,
 	type TranscriptRow,
 } from "./transcript-rows"
+import { TurnMinimap } from "./turn-minimap"
 import type { UIMessage } from "@/components/ai-elements/types"
 import type { AiTriageResult } from "@maple/domain/http"
 
@@ -255,11 +257,6 @@ export interface ChatTranscriptProps {
  * `apps/api` sends to open an investigation. Nobody typed it, so it shouldn't
  * appear as though someone did.
  */
-const isMachineTurn = (message: UIMessage): boolean =>
-	message.role === "user" &&
-	message.parts.length > 0 &&
-	message.parts.every((part) => part.type === "text" && stripContextPreamble(part.text).length === 0)
-
 /** Leading marker for a thread that can't be continued. */
 const READ_ONLY_LABEL: Record<"shared" | "resolved" | "transcript", string> = {
 	shared: "Shared conversation · read-only",
@@ -453,6 +450,7 @@ export function ChatTranscript({
 						) : null}
 					</MessageScrollerContent>
 				</MessageScrollerViewport>
+				<TurnMinimap rows={rows} />
 				<MessageScrollerButton />
 				{focusMessageId ? <FocusMessageOnMount messageId={focusMessageId} /> : null}
 				{diagnosisMessageId ? <JumpToDiagnosis messageId={diagnosisMessageId} /> : null}

--- a/apps/web/src/components/chat/transcript-rows.ts
+++ b/apps/web/src/components/chat/transcript-rows.ts
@@ -1,3 +1,4 @@
+import { stripContextPreamble } from "./context-preamble"
 import { parseDiagnosisMarker } from "./diagnosis-marker"
 import type { UIMessage } from "@/components/ai-elements/types"
 
@@ -97,3 +98,13 @@ export function buildTranscriptRows(messages: readonly UIMessage[]): TranscriptR
 export function toolPartsOf(row: Extract<TranscriptRow, { kind: "tool-run" }>): ToolPart[] {
 	return row.messages.flatMap((message) => message.parts.filter(isToolPart))
 }
+
+/**
+ * A user turn with nothing in it but a context preamble: the server seeded the
+ * conversation with its subject. The transcript draws it as a separator, and the
+ * turn rail skips it — there is no human message to navigate back to.
+ */
+export const isMachineTurn = (message: UIMessage): boolean =>
+	message.role === "user" &&
+	message.parts.length > 0 &&
+	message.parts.every((part) => part.type === "text" && stripContextPreamble(part.text).length === 0)

--- a/apps/web/src/components/chat/turn-minimap-logic.test.ts
+++ b/apps/web/src/components/chat/turn-minimap-logic.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest"
+
+import { buildTranscriptRows } from "./transcript-rows"
+import { wrapContextPreamble } from "./context-preamble"
+import {
+	deriveTurnMinimap,
+	minimapHasPersistentGutter,
+	minimapHitStripWidth,
+	minimapIndexFromPointer,
+	minimapPreviewTranslate,
+	minimapTopPercent,
+	resolveCurrentTurnIndex,
+} from "./turn-minimap-logic"
+import type { UIMessage } from "@/components/ai-elements/types"
+
+const text = (id: string, role: "user" | "assistant", body: string): UIMessage =>
+	({ id, role, parts: [{ type: "text", text: body }] }) as UIMessage
+
+// SAFETY: this fixture constructs the tool-only message variant the row builder merges.
+const tools = (id: string): UIMessage =>
+	({
+		id,
+		role: "assistant",
+		parts: [
+			{
+				type: "tool-list_services",
+				toolCallId: `${id}-0`,
+				state: "output-available",
+				input: {},
+				output: { ok: true },
+			},
+		],
+	}) as unknown as UIMessage
+
+describe("deriveTurnMinimap", () => {
+	it("marks one turn per user message and carries the turn's last reply", () => {
+		const rows = buildTranscriptRows([
+			text("u1", "user", "why is checkout slow"),
+			text("a1", "assistant", "looking"),
+			text("a2", "assistant", "the db pool is exhausted"),
+			text("u2", "user", "how do I fix it"),
+			text("a3", "assistant", "raise the pool size"),
+		])
+
+		const { items } = deriveTurnMinimap(rows)
+
+		expect(items.map((item) => item.id)).toEqual(["u1", "u2"])
+		expect(items[0]!.userText).toBe("why is checkout slow")
+		expect(items[0]!.assistantText).toBe("the db pool is exhausted")
+		expect(items[1]!.assistantText).toBe("raise the pool size")
+	})
+
+	it("attributes a merged tool-run row to the turn that opened it", () => {
+		const rows = buildTranscriptRows([
+			text("u1", "user", "investigate"),
+			tools("m1"),
+			tools("m2"),
+			text("a1", "assistant", "done"),
+		])
+
+		const { items, turnByRowId } = deriveTurnMinimap(rows)
+
+		expect(items).toHaveLength(1)
+		// The burst registers with the scroller under its first message's id.
+		expect(turnByRowId.get("m1")).toBe(0)
+		expect(turnByRowId.get("a1")).toBe(0)
+	})
+
+	it("skips a server-seeded machine turn", () => {
+		const rows = buildTranscriptRows([
+			text("u0", "user", wrapContextPreamble("Investigation context", "")),
+			text("a0", "assistant", "starting"),
+			text("u1", "user", "what happened"),
+		])
+
+		const { items, turnByRowId } = deriveTurnMinimap(rows)
+
+		expect(items.map((item) => item.id)).toEqual(["u1"])
+		// Rows before the first human turn belong to no marker.
+		expect(turnByRowId.has("u0")).toBe(false)
+	})
+
+	it("collapses whitespace in previews and drops empty ones", () => {
+		const rows = buildTranscriptRows([text("u1", "user", "  why   is\n\nit slow  ")])
+
+		const { items } = deriveTurnMinimap(rows)
+
+		expect(items[0]!.userText).toBe("why is it slow")
+		expect(items[0]!.assistantText).toBeNull()
+	})
+})
+
+describe("resolveCurrentTurnIndex", () => {
+	const turnByRowId = new Map([
+		["u1", 0],
+		["a1", 0],
+		["u2", 1],
+	])
+
+	it("is the earliest turn with a row on screen", () => {
+		expect(resolveCurrentTurnIndex(["u2", "a1"], turnByRowId)).toBe(0)
+	})
+
+	it("is null when nothing on screen belongs to a turn", () => {
+		expect(resolveCurrentTurnIndex(["__status"], turnByRowId)).toBeNull()
+	})
+})
+
+describe("rail geometry", () => {
+	it("spreads markers evenly and clamps out-of-range indices", () => {
+		expect(minimapTopPercent(0, 5)).toBe(0)
+		expect(minimapTopPercent(2, 5)).toBe(50)
+		expect(minimapTopPercent(9, 5)).toBe(100)
+		expect(minimapTopPercent(0, 1)).toBe(0)
+	})
+
+	it("maps a pointer position to the nearest marker", () => {
+		const rail = { itemCount: 5, railTop: 100, railHeight: 200 }
+
+		expect(minimapIndexFromPointer({ ...rail, pointerY: 100 })).toBe(0)
+		expect(minimapIndexFromPointer({ ...rail, pointerY: 200 })).toBe(2)
+		expect(minimapIndexFromPointer({ ...rail, pointerY: 900 })).toBe(4)
+		expect(minimapIndexFromPointer({ ...rail, railHeight: 0, pointerY: 120 })).toBeNull()
+	})
+
+	it("shows the rail permanently only when the gutter can hold it", () => {
+		expect(minimapHasPersistentGutter(1440)).toBe(true)
+		expect(minimapHasPersistentGutter(820)).toBe(false)
+		expect(minimapHasPersistentGutter(0)).toBe(false)
+	})
+
+	it("never lets the hover strip reach into the transcript column", () => {
+		expect(minimapHitStripWidth(1440)).toBe(40)
+		expect(minimapHitStripWidth(800)).toBe(4)
+		expect(minimapHitStripWidth(768)).toBe(0)
+	})
+
+	it("keeps the preview inside the rail at both ends", () => {
+		expect(minimapPreviewTranslate(0, 4)).toBe("0%")
+		expect(minimapPreviewTranslate(1, 4)).toBe("-50%")
+		expect(minimapPreviewTranslate(3, 4)).toBe("-100%")
+	})
+})

--- a/apps/web/src/components/chat/turn-minimap-logic.ts
+++ b/apps/web/src/components/chat/turn-minimap-logic.ts
@@ -1,0 +1,141 @@
+import { messageText } from "./message-actions"
+import { stripContextPreamble } from "./context-preamble"
+import { isMachineTurn, type TranscriptRow } from "./transcript-rows"
+
+/** Vertical space one turn marker gets before the rail stops growing. */
+const ITEM_SPACING_PX = 8
+/** The rail is centred in the scroller; leave room for the composer and the header. */
+const MAX_HEIGHT_CSS = "calc(100% - 6rem)"
+/** `max-w-3xl` on the transcript column, in pixels. */
+const CONTENT_MAX_WIDTH_PX = 768
+/** Below this much free gutter the rail hides until the pointer comes near it. */
+const PERSISTENT_GUTTER_PX = 48
+/** Where the hover strip starts, measured from the viewport's inline edge. */
+const HIT_STRIP_INSET_PX = 12
+const HIT_STRIP_MAX_WIDTH_PX = 40
+/** Once a preview is open, the space leading to it stays interactive. */
+const EXPANDED_HIT_STRIP_WIDTH = "22rem"
+
+/** A rail below this many turns is noise, not navigation. */
+export const TURN_MINIMAP_MIN_ITEMS = 2
+
+export interface TurnMinimapItem {
+	/** The scroller item id to jump to — the user turn's own row. */
+	readonly id: string
+	readonly userText: string | null
+	readonly assistantText: string | null
+}
+
+export interface TurnMinimapModel {
+	readonly items: readonly TurnMinimapItem[]
+	/** Every transcript row id → the index of the turn it belongs to. */
+	readonly turnByRowId: ReadonlyMap<string, number>
+}
+
+const compactPreview = (text: string | null | undefined): string | null => {
+	const compact = text?.replace(/\s+/gu, " ").trim() ?? ""
+	return compact.length > 0 ? compact : null
+}
+
+/**
+ * One marker per human turn, with the reply that turn produced.
+ *
+ * The rail addresses *rows*, not messages: adjacent tool-only turns are merged into a
+ * single `tool-run` row and only that row is registered with the scroller, so a message
+ * id from inside a burst would never resolve. `turnByRowId` covers every row for the same
+ * reason — visibility arrives as row ids and has to be attributed back to a turn.
+ *
+ * A machine turn (an investigation's server-seeded opener) renders as a separator, not a
+ * bubble, so it starts no marker; it belongs to whatever turn is already open.
+ */
+export function deriveTurnMinimap(rows: readonly TranscriptRow[]): TurnMinimapModel {
+	const items: TurnMinimapItem[] = []
+	const turnByRowId = new Map<string, number>()
+
+	for (const row of rows) {
+		if (row.kind === "message" && row.message.role === "user" && !isMachineTurn(row.message)) {
+			items.push({
+				id: row.id,
+				userText: compactPreview(stripContextPreamble(messageText(row.message))),
+				assistantText: null,
+			})
+		} else if (row.kind === "message" && row.message.role === "assistant") {
+			const current = items[items.length - 1]
+			const text = compactPreview(messageText(row.message))
+			// The turn's last prose wins: it is what the reader remembers the turn by.
+			if (current && text) items[items.length - 1] = { ...current, assistantText: text }
+		}
+		if (items.length > 0) turnByRowId.set(row.id, items.length - 1)
+	}
+
+	return { items, turnByRowId }
+}
+
+/** The turn the reader is currently on — the first one with a row on screen. */
+export function resolveCurrentTurnIndex(
+	visibleRowIds: readonly string[],
+	turnByRowId: ReadonlyMap<string, number>,
+): number | null {
+	let current: number | null = null
+	for (const id of visibleRowIds) {
+		const index = turnByRowId.get(id)
+		if (index === undefined) continue
+		if (current === null || index < current) current = index
+	}
+	return current
+}
+
+export function minimapHeightStyle(itemCount: number): string {
+	return `min(${Math.max(1, (itemCount - 1) * ITEM_SPACING_PX)}px, ${MAX_HEIGHT_CSS})`
+}
+
+export function minimapTopPercent(index: number, itemCount: number): number {
+	if (itemCount <= 1) return 0
+	return (Math.max(0, Math.min(index, itemCount - 1)) / (itemCount - 1)) * 100
+}
+
+export function minimapIndexFromPointer(input: {
+	readonly itemCount: number
+	readonly railTop: number
+	readonly railHeight: number
+	readonly pointerY: number
+}): number | null {
+	if (input.itemCount <= 0 || input.railHeight <= 0) return null
+	if (input.itemCount === 1) return 0
+	const progress = Math.max(0, Math.min(1, (input.pointerY - input.railTop) / input.railHeight))
+	return Math.max(0, Math.min(input.itemCount - 1, Math.round(progress * (input.itemCount - 1))))
+}
+
+const sideGutterPx = (viewportWidth: number): number =>
+	Math.max(0, (viewportWidth - Math.min(viewportWidth, CONTENT_MAX_WIDTH_PX)) / 2)
+
+/** Wide enough to show the rail permanently instead of on hover. */
+export function minimapHasPersistentGutter(viewportWidth: number): boolean {
+	if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return false
+	return sideGutterPx(viewportWidth) >= PERSISTENT_GUTTER_PX
+}
+
+/**
+ * The rail overlays the viewport's inline edge while the transcript column stays centred,
+ * so the gutter between them shrinks under zoom or in the side panel. A fixed-width hover
+ * strip would then sit on top of the message text and swallow its clicks and selection.
+ * Cap it to the gutter; 0 makes the strip inert.
+ */
+export function minimapHitStripWidth(viewportWidth: number): number {
+	if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return 0
+	return Math.max(
+		0,
+		Math.min(HIT_STRIP_MAX_WIDTH_PX, Math.floor(sideGutterPx(viewportWidth)) - HIT_STRIP_INSET_PX),
+	)
+}
+
+export function minimapInteractiveWidth(collapsedWidth: number, expanded: boolean): number | string {
+	return expanded ? EXPANDED_HIT_STRIP_WIDTH : collapsedWidth
+}
+
+/** Keeps the open preview from hanging off the top or bottom of the rail. */
+export function minimapPreviewTranslate(index: number, itemCount: number): string {
+	if (index <= 0) return "0%"
+	if (index >= itemCount - 1) return "-100%"
+	return "-50%"
+}

--- a/apps/web/src/components/chat/turn-minimap.tsx
+++ b/apps/web/src/components/chat/turn-minimap.tsx
@@ -1,0 +1,270 @@
+import { useCallback, useEffect, useMemo, useState, type MouseEvent } from "react"
+
+import { cn } from "@maple/ui/lib/utils"
+import { Button } from "@maple/ui/components/ui/button"
+import { useMessageScroller, useMessageScrollerVisibility } from "@maple/ui/components/ui/message-scroller"
+import { ChevronDownIcon, ChevronUpIcon } from "@/components/icons"
+import type { TranscriptRow } from "./transcript-rows"
+import {
+	deriveTurnMinimap,
+	minimapHasPersistentGutter,
+	minimapHeightStyle,
+	minimapHitStripWidth,
+	minimapIndexFromPointer,
+	minimapInteractiveWidth,
+	minimapPreviewTranslate,
+	minimapTopPercent,
+	resolveCurrentTurnIndex,
+	TURN_MINIMAP_MIN_ITEMS,
+	type TurnMinimapItem,
+} from "./turn-minimap-logic"
+
+/**
+ * A rail of one marker per human turn, down the transcript's inline gutter.
+ *
+ * It answers "where am I, and what happened before this" without scrolling: the marker
+ * for every turn on screen is lit, running the pointer down the rail previews each turn's
+ * question and the reply it got, and a click jumps there. Long agent threads are the case
+ * — a dozen turns of tool bursts read as an undifferentiated column otherwise.
+ *
+ * Pointer-fine only. There is no gutter to hover on a touch device, and the strip would
+ * fight the transcript for the same swipes.
+ */
+export function TurnMinimap({ rows }: { rows: readonly TranscriptRow[] }) {
+	const { items, turnByRowId } = useMemo(() => deriveTurnMinimap(rows), [rows])
+	const { visibleMessageIds } = useMessageScrollerVisibility()
+	const { scrollToMessage } = useMessageScroller()
+
+	const [railElement, setRailElement] = useState<HTMLDivElement | null>(null)
+	const [hasPersistentGutter, setHasPersistentGutter] = useState(false)
+	const [hitStripWidth, setHitStripWidth] = useState(0)
+	const [activeIndex, setActiveIndex] = useState<number | null>(null)
+
+	// The rail spans the scroller, so its own box is the width the transcript is centred in.
+	useEffect(() => {
+		if (!railElement) return
+		const measure = () => {
+			const width = railElement.getBoundingClientRect().width
+			setHasPersistentGutter(minimapHasPersistentGutter(width))
+			setHitStripWidth(minimapHitStripWidth(width))
+		}
+		measure()
+		const observer = new ResizeObserver(measure)
+		observer.observe(railElement)
+		return () => observer.disconnect()
+	}, [railElement])
+
+	const currentIndex = resolveCurrentTurnIndex(visibleMessageIds, turnByRowId)
+	const visibleTurns = useMemo(() => {
+		const turns = new Set<number>()
+		for (const id of visibleMessageIds) {
+			const index = turnByRowId.get(id)
+			if (index !== undefined) turns.add(index)
+		}
+		return turns
+	}, [visibleMessageIds, turnByRowId])
+
+	const resolvedActiveIndex = activeIndex !== null && activeIndex < items.length ? activeIndex : null
+	const activeItem = resolvedActiveIndex === null ? null : (items[resolvedActiveIndex] ?? null)
+	const previousItem = currentIndex === null ? null : (items[currentIndex - 1] ?? null)
+	const nextItem = currentIndex === null ? null : (items[currentIndex + 1] ?? null)
+
+	const select = useCallback(
+		(item: TurnMinimapItem) => {
+			scrollToMessage(item.id, { align: "start", behavior: "smooth" })
+		},
+		[scrollToMessage],
+	)
+
+	const indexFromPointer = useCallback(
+		(event: MouseEvent<HTMLElement>) => {
+			const rect = event.currentTarget.getBoundingClientRect()
+			return minimapIndexFromPointer({
+				itemCount: items.length,
+				railTop: rect.top,
+				railHeight: rect.height,
+				pointerY: event.clientY,
+			})
+		},
+		[items.length],
+	)
+
+	const moveActiveIndex = useCallback(
+		(delta: number) => {
+			setActiveIndex((current) =>
+				Math.max(0, Math.min(items.length - 1, (current ?? currentIndex ?? 0) + delta)),
+			)
+		},
+		[items.length, currentIndex],
+	)
+
+	if (items.length < TURN_MINIMAP_MIN_ITEMS) return null
+
+	return (
+		<div
+			ref={setRailElement}
+			className={cn(
+				"pointer-events-none absolute inset-y-0 start-0 z-30 hidden w-full [@media(pointer:fine)]:block",
+				hasPersistentGutter
+					? "opacity-100"
+					: "opacity-0 transition-opacity duration-150 focus-within:opacity-100 hover:opacity-100",
+			)}
+			data-slot="turn-minimap"
+		>
+			<div
+				className={cn(
+					"absolute top-1/2 start-3 -translate-y-1/2 select-none",
+					hitStripWidth > 0 ? "pointer-events-auto" : "pointer-events-none",
+				)}
+				style={{
+					height: minimapHeightStyle(items.length),
+					width: minimapInteractiveWidth(hitStripWidth, activeItem !== null),
+				}}
+			>
+				<TurnMinimapStep
+					direction="previous"
+					disabled={previousItem === null}
+					onClick={() => {
+						if (previousItem) select(previousItem)
+					}}
+				/>
+				<button
+					type="button"
+					aria-label={
+						activeItem
+							? `Jump to turn: ${activeItem.userText ?? "user message"}`
+							: "Jump to a turn"
+					}
+					className="absolute inset-y-0 start-0 w-full cursor-pointer bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70"
+					onBlur={() => setActiveIndex(null)}
+					onFocus={() => setActiveIndex((current) => current ?? currentIndex ?? 0)}
+					onMouseLeave={() => setActiveIndex(null)}
+					onMouseMove={(event) => setActiveIndex(indexFromPointer(event))}
+					// The rail is a navigation control, not text: a drag on it should not
+					// start a selection that the preview then inherits.
+					onMouseDown={(event) => {
+						if (targetsPreview(event.target)) return
+						event.preventDefault()
+					}}
+					onClick={(event) => {
+						if (targetsPreview(event.target)) return
+						const index = indexFromPointer(event)
+						const item = index === null ? null : (items[index] ?? null)
+						if (item) select(item)
+						event.currentTarget.blur()
+					}}
+					onKeyDown={(event) => {
+						if (event.key === "ArrowDown") {
+							event.preventDefault()
+							moveActiveIndex(1)
+						} else if (event.key === "ArrowUp") {
+							event.preventDefault()
+							moveActiveIndex(-1)
+						} else if (event.key === "Home") {
+							event.preventDefault()
+							setActiveIndex(0)
+						} else if (event.key === "End") {
+							event.preventDefault()
+							setActiveIndex(items.length - 1)
+						} else if (event.key === "Enter" || event.key === " ") {
+							event.preventDefault()
+							if (activeItem) select(activeItem)
+						}
+					}}
+				>
+					<div className="absolute top-0 start-3 h-full w-px bg-border/20" />
+					{items.map((item, index) => {
+						const distance =
+							resolvedActiveIndex === null ? null : Math.abs(index - resolvedActiveIndex)
+						return (
+							<span
+								key={item.id}
+								aria-hidden
+								className={cn(
+									"pointer-events-none absolute start-0 h-0.5 -translate-y-1/2 rounded-full transition-[background-color,width] duration-150",
+									visibleTurns.has(index) ? "bg-foreground/80" : "bg-muted-foreground/35",
+									distance === 0
+										? "w-6 bg-muted-foreground/75"
+										: distance === 1
+											? "w-4"
+											: distance === 2
+												? "w-2.5"
+												: "w-2",
+								)}
+								style={{ top: `${minimapTopPercent(index, items.length)}%` }}
+							/>
+						)
+					})}
+					{activeItem ? (
+						<span
+							className="pointer-events-auto absolute start-8 w-80 cursor-text select-text"
+							data-turn-minimap-preview
+							onMouseMove={(event) => event.stopPropagation()}
+							style={{
+								top: `${minimapTopPercent(resolvedActiveIndex ?? 0, items.length)}%`,
+								transform: `translateY(${minimapPreviewTranslate(resolvedActiveIndex ?? 0, items.length)})`,
+							}}
+						>
+							<span className="block rounded-lg border border-border bg-popover p-3 text-start text-popover-foreground shadow-md">
+								<span className="block truncate text-sm font-medium leading-5">
+									{activeItem.userText ?? "User message"}
+								</span>
+								{activeItem.assistantText ? (
+									<span className="mt-1 line-clamp-3 block text-sm leading-5 text-muted-foreground">
+										{activeItem.assistantText}
+									</span>
+								) : null}
+							</span>
+						</span>
+					) : null}
+				</button>
+				<TurnMinimapStep
+					direction="next"
+					disabled={nextItem === null}
+					onClick={() => {
+						if (nextItem) select(nextItem)
+					}}
+				/>
+			</div>
+		</div>
+	)
+}
+
+/** The preview is selectable text; pointer events that land in it are not rail clicks. */
+function targetsPreview(target: EventTarget): boolean {
+	return target instanceof Element && target.closest("[data-turn-minimap-preview]") !== null
+}
+
+function TurnMinimapStep({
+	direction,
+	disabled,
+	onClick,
+}: {
+	direction: "previous" | "next"
+	disabled: boolean
+	onClick: () => void
+}) {
+	const previous = direction === "previous"
+	const label = previous ? "Previous turn" : "Next turn"
+	const Icon = previous ? ChevronUpIcon : ChevronDownIcon
+
+	return (
+		<span
+			className={cn(
+				"pointer-events-auto absolute start-0 z-10 inline-flex opacity-0 transition-opacity duration-150 focus-within:opacity-100 hover:opacity-100",
+				previous ? "bottom-[calc(100%+4px)]" : "top-[calc(100%+4px)]",
+			)}
+		>
+			<Button
+				type="button"
+				variant="ghost"
+				size="icon-xs"
+				aria-label={label}
+				disabled={disabled}
+				onClick={onClick}
+			>
+				<Icon className="size-3.5" />
+			</Button>
+		</span>
+	)
+}


### PR DESCRIPTION
## What

A vertical rail of markers in the chat transcript's inline gutter, one per human turn.

- Every turn with a row on screen is lit.
- Running the pointer down the rail opens a preview of that turn's question and the reply it produced.
- Clicking jumps to the turn; chevrons above and below step to the previous or next one.
- Arrows, Home, End and Enter drive it from the keyboard.

## Why

A long agent thread is one undifferentiated column of tool bursts, prose and cards. There is no way to see where you are in the conversation, or what the earlier turns asked, without scrolling back through all of it.

## Notes for review

- **The rail addresses rows, not messages.** Adjacent tool-only turns are merged into a single `tool-run` row and only that row registers with the scroller, so a message id from inside a burst would never resolve. `turnByRowId` maps every row back to its turn for the same reason: visibility arrives as row ids and has to be attributed to a turn.
- **Machine turns start no marker.** An investigation's server-seeded opener renders as a separator, not a bubble, so there is no human message to navigate back to.
- **The hover strip is capped to the free gutter.** The transcript column stays centred, so the gutter shrinks under zoom and in the side panel. A fixed-width strip would sit on top of the message text and swallow its clicks and selection. At zero gutter the strip goes inert; below 48px of gutter the rail fades in on hover instead of showing permanently.
- Pointer-fine only. A touch device has no gutter to hover, and the strip would fight the transcript for the same swipes.
- `isMachineTurn` moved from `chat-transcript.tsx` into `transcript-rows.ts` so the rail and the transcript share one definition.

## Testing

- 11 unit tests over the derivation and rail geometry, 3 render tests over the transcript (rail absent below two turns, one marker per turn, preview on hover).
- `bun run --cwd apps/web test src/components/chat` — 72 passed.
- `bun run --filter=@maple/web typecheck` and oxlint clean.
- **Not verified in a live browser.** jsdom has no layout, so the rail's real position and the preview's placement are unproven.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791670830&installation_model_id=427786&pr_number=835&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F835&signature=3bda25e907696a86626023bad5e652c49032ed0d56198c92a98145126b9a5955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a turn minimap to chat transcripts, showing one marker for each human turn.
  - Hover over markers to preview questions and replies.
  - Click markers or use keyboard controls to jump between turns.
  - Added previous and next turn navigation controls.
  - The minimap appears only when the transcript contains multiple human turns.

- **Tests**
  - Added coverage for turn grouping, navigation, previews, pointer interactions, and responsive rail behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->