### PR TITLE
feat(agent-sessions): add a Reload button to the sessions list

### DIFF
--- a/apps/web/src/components/agent-sessions/agent-sessions-toolbar.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-toolbar.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react"
 import { ToolbarSearch, ToolbarStat } from "@maple/ui/components/toolbar"
 import { StopwatchIcon } from "@maple/ui/components/icons"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@maple/ui/components/ui/select"
@@ -59,6 +60,8 @@ interface AgentSessionsToolbarProps {
 	sessionCount: number
 	/** Dim the controls while the list is refetching. */
 	waiting?: boolean
+	/** Trailing controls after the sort — the route's Reload button. */
+	actions?: ReactNode
 }
 
 /**
@@ -74,6 +77,7 @@ export function AgentSessionsToolbar({
 	onSortChange,
 	sessionCount,
 	waiting = false,
+	actions,
 }: AgentSessionsToolbarProps) {
 	const sortOption =
 		AGENT_SESSIONS_SORT_OPTIONS.find((option) => option.key === sortKey) ?? DEFAULT_SORT_OPTION
@@ -131,6 +135,8 @@ export function AgentSessionsToolbar({
 						))}
 					</SelectContent>
 				</Select>
+
+				{actions}
 			</div>
 		</div>
 	)

--- a/apps/web/src/routes/agent-sessions/index.tsx
+++ b/apps/web/src/routes/agent-sessions/index.tsx
@@ -12,6 +12,11 @@ import {
 	sortOptionFor,
 } from "@/components/agent-sessions/agent-sessions-filter-inputs"
 import { NotFoundError } from "@/components/route-error"
+import {
+	PageRefreshProvider,
+	usePageRefreshContext,
+} from "@/components/time-range-picker/page-refresh-context"
+import { ReloadControls } from "@/components/time-range-picker/reload-controls"
 import { QueryErrorState } from "@/components/common/query-error-state"
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { BooleanFromStringParam, NumberFromStringParam, OptionalStringArrayParam } from "@/lib/search-params"
@@ -86,12 +91,14 @@ function AgentSessionsPage() {
 
 function AgentSessionsPageContent() {
 	return (
-		<DashboardLayout.Root>
-			<DashboardLayout.Breadcrumbs items={[{ label: "Agent Sessions" }]} />
-			<DashboardLayout.Body>
-				<AgentSessionsBody />
-			</DashboardLayout.Body>
-		</DashboardLayout.Root>
+		<PageRefreshProvider>
+			<DashboardLayout.Root>
+				<DashboardLayout.Breadcrumbs items={[{ label: "Agent Sessions" }]} />
+				<DashboardLayout.Body>
+					<AgentSessionsBody />
+				</DashboardLayout.Body>
+			</DashboardLayout.Root>
+		</PageRefreshProvider>
 	)
 }
 
@@ -103,14 +110,19 @@ function AgentSessionsBody() {
 	// back: the hook keys its accumulated pages on these inputs, and a fresh
 	// object per render would reset them every time.
 	const searchKey = JSON.stringify(search)
+	const { refreshVersion } = usePageRefreshContext()
 	// The window rolls forward with every navigation — a filter or sort change
 	// re-resolves "the last week" against now, snapped to the cache grid so a
-	// change within the grid interval keeps its key. There is no picker and no
-	// reload button to advance it otherwise; a tab left open sees new sessions
-	// the next time it touches a control.
+	// change within the grid interval keeps its key — and with every Reload.
+	// Once Reload has been pressed the window stops snapping, as in
+	// `useEffectiveTimeRange`: a snapped end would keep the newest sessions out
+	// however many times it is clicked.
 	const { startTime, endTime } = useMemo(
-		() => resolveEffectiveTimeRange(undefined, undefined, AGENT_SESSIONS_WINDOW),
-		[searchKey],
+		() =>
+			resolveEffectiveTimeRange(undefined, undefined, AGENT_SESSIONS_WINDOW, {
+				snap: refreshVersion === 0,
+			}),
+		[searchKey, refreshVersion],
 	)
 	const filterInputs = useMemo(
 		() => agentSessionsFilterInputs(search, { startTime, endTime }),
@@ -159,6 +171,7 @@ function AgentSessionsBody() {
 				})
 			}
 			waiting={firstPageResult.waiting}
+			actions={<ReloadControls />}
 		/>
 	)
 


### PR DESCRIPTION
- Sessions list window (7d) only rolled on filter/sort change; an open tab never picked up new sessions
- Wraps `/agent-sessions` in `PageRefreshProvider`, renders shared `ReloadControls` at the end of the toolbar (new `actions` slot)
- Reload bumps `refreshVersion` → window re-resolves unsnapped (same as `useEffectiveTimeRange`), resets infinite-scroll pages, refetches first page
- Facets stay on plain `useAtomValue`; they refetch via the rolled window key

## Testing
- `vitest run agent-sessions-filter-sidebar.test.tsx` (toolbar tests) passes
- oxlint/oxfmt clean on changed files
- Not browser-verified: local Tinybird lacks `ai_trace_index`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791673848&installation_model_id=427786&pr_number=838&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F838&signature=42074655b297cd36a2b642e95c402418dafb95db169a7484514a96e58dee9493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reload controls to the agent sessions dashboard.
  * Added support for displaying additional toolbar actions alongside search, sorting, and other controls.
  * Refreshing the dashboard now updates the effective time range for session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->