### PR TITLE
feat(agent-sessions): load large sessions whole in the background

### DIFF
--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -1172,7 +1172,7 @@ describe("SessionViews", () => {
 	// in hand and marks that its end is not here yet. Nothing asks the reader
 	// to load anything.
 	it("waits for the agent's spans in the Overview and marks the transcript's open end while loading", () => {
-		const progress: SessionLoadProgress = { phase: "agent", loadedSpans: 8, loadedAgentSpans: 6, retry: noop }
+		const progress: SessionLoadProgress = { phase: "agent", agentSpansComplete: false, loadedSpans: 8, loadedAgentSpans: 6, retry: noop }
 		render(<Views view="overview" progress={progress} totals={totals} />)
 
 		const waiting = screen.getByTestId("overview-waiting")
@@ -1188,7 +1188,7 @@ describe("SessionViews", () => {
 	// while the app's spans are still filling in behind it, and the transcript
 	// has its end.
 	it("renders the Overview and a closed transcript once the agent's spans are all in", () => {
-		const progress: SessionLoadProgress = { phase: "app", loadedSpans: 8, loadedAgentSpans: 6, retry: noop }
+		const progress: SessionLoadProgress = { phase: "app", agentSpansComplete: true, loadedSpans: 8, loadedAgentSpans: 6, retry: noop }
 		render(<Views view="overview" progress={progress} totals={totals} />)
 		expect(screen.queryByTestId("overview-waiting")).toBeNull()
 		fireEvent.click(screen.getByRole("tab", { name: /Transcript/ }))
@@ -1196,13 +1196,25 @@ describe("SessionViews", () => {
 	})
 
 	// A page that did not come back is the one case with something to press.
-	it("offers a retry where a page failed", () => {
+	it("offers a retry where an agent page failed", () => {
 		const retry = vi.fn()
-		const progress: SessionLoadProgress = { phase: "failed", loadedSpans: 8, loadedAgentSpans: 6, retry }
+		const progress: SessionLoadProgress = { phase: "failed", agentSpansComplete: false, loadedSpans: 8, loadedAgentSpans: 6, retry }
 		render(<Views view="transcript" progress={progress} totals={totals} />)
 		expect(screen.getByText("The rest of this session didn't load")).toBeTruthy()
 		fireEvent.click(screen.getByRole("button", { name: "Retry" }))
 		expect(retry).toHaveBeenCalledTimes(1)
+	})
+
+	// A failed APP page changes nothing for the views that read agent spans
+	// alone: the Overview stands and the transcript has its end. The header
+	// indicator is where that failure is reported.
+	it("keeps the Overview and a closed transcript when only an app page failed", () => {
+		const progress: SessionLoadProgress = { phase: "failed", agentSpansComplete: true, loadedSpans: 8, loadedAgentSpans: 6, retry: noop }
+		render(<Views view="overview" progress={progress} totals={totals} />)
+		expect(screen.queryByTestId("overview-waiting")).toBeNull()
+		fireEvent.click(screen.getByRole("tab", { name: /Transcript/ }))
+		expect(screen.queryByText("The rest of this session didn't load")).toBeNull()
+		expect(screen.queryByText("Loading the rest of this session")).toBeNull()
 	})
 
 	it("shows neither for a session loaded whole", () => {

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -47,14 +47,14 @@ vi.mock("@/lib/services/atoms/warehouse-query-atoms", async (importOriginal) => 
 
 import type { AiSessionSpan, GetAiSessionSummaryResponse } from "@maple/domain/http"
 import { formatSessionDuration } from "@maple/ui/lib/replay-format"
-import type { SessionSpansState } from "@/hooks/use-session-spans"
+import type { SessionLoadProgress } from "@/hooks/use-session-spans"
 import { agentSpan, llmSpan, makeSpan, toolSpan, userMessages } from "@/lib/agent-sessions/span-test-support"
 import { buildSessionSummary, type SessionSummary } from "@/lib/agent-sessions/session-summary"
 import { buildSessionTurns, type SessionTurn } from "@/lib/agent-sessions/session-turns"
 import { SessionFlow } from "./session-flow"
 import { SessionHeader, sessionIdentity } from "./session-header"
 import { SessionOverview } from "./session-overview"
-import { SessionViews, type SessionPaging, type SessionView } from "./session-views"
+import { SessionViews, type SessionView } from "./session-views"
 import { SessionWaterfall } from "./session-waterfall"
 import type { SpanDetailTab } from "./span-expansion"
 
@@ -305,7 +305,6 @@ function Waterfall(props: {
 	revealedSpanId?: string
 	onSelectSpan?: (spanId: string | undefined) => void
 	spanTab?: SpanDetailTab
-	appSpans?: SessionSpansState["appSpans"]
 }) {
 	return (
 		<SessionWaterfall
@@ -316,7 +315,6 @@ function Waterfall(props: {
 			collapseIdle={props.collapseIdle ?? true}
 			collapsedTurns={props.collapsedTurns ?? EMPTY}
 			onToggleTurn={props.onToggleTurn ?? noop}
-			appSpans={props.appSpans}
 			selectedSpanId={props.selectedSpanId}
 			revealedSpanId={props.revealedSpanId}
 			onSelectSpan={props.onSelectSpan ?? noop}
@@ -632,33 +630,6 @@ describe("SessionWaterfall", () => {
 
 		view.rerender(<Waterfall agentSpansOnly={false} />)
 		expect(screen.getByText("GET /repo/file")).toBeTruthy()
-	})
-
-	// A partly loaded session: a turn past the first page holds agent spans
-	// alone, and the header is where the reader asks for the rest.
-	it("offers to load app spans for a turn that has none, once they would be shown", () => {
-		const load = vi.fn()
-		const appSpans = { of: () => undefined, load }
-		const view = render(<Waterfall appSpans={appSpans} />)
-		// Hidden under the agent-only toggle: fetching them would draw nothing.
-		expect(screen.queryByRole("button", { name: /^Load app spans/ })).toBeNull()
-
-		view.rerender(<Waterfall appSpans={appSpans} agentSpansOnly={false} />)
-		// Turn 1 came with its HTTP span; turn 2 did not.
-		const buttons = screen.getAllByRole("button", { name: /^Load app spans for Turn/ })
-		expect(buttons).toHaveLength(1)
-		expect(buttons[0]!.getAttribute("aria-label")).toBe("Load app spans for Turn 2")
-		fireEvent.click(buttons[0]!)
-		expect(load).toHaveBeenCalledWith(turns[1])
-	})
-
-	it("says how far a turn's app spans have come", () => {
-		const appSpans = {
-			of: () => ({ loading: false, loaded: 2000, cursor: { timestamp: "t", spanId: "s" }, complete: false, failed: false }),
-			load: noop,
-		}
-		render(<Waterfall appSpans={appSpans} agentSpansOnly={false} />)
-		expect(screen.getAllByRole("button", { name: /Load more app spans \(2,000 loaded\)/ }).length).toBe(2)
 	})
 
 	it("narrows to the spans that match the filter", () => {
@@ -1157,7 +1128,7 @@ describe("SessionViews", () => {
 		turns?: readonly SessionTurn[]
 		summary?: SessionSummary
 		view?: SessionView
-		paging?: SessionPaging
+		progress?: SessionLoadProgress
 		totals?: GetAiSessionSummaryResponse
 	}) {
 		const [view, setView] = useState<SessionView>(props.view ?? "trace")
@@ -1168,7 +1139,7 @@ describe("SessionViews", () => {
 				onViewChange={setView}
 				turns={props.turns ?? turns}
 				summary={props.summary ?? summary}
-				paging={props.paging}
+				progress={props.progress}
 				totals={props.totals}
 				selectedSpanId={selectedSpanId}
 				onSelectSpan={setSelectedSpanId}
@@ -1195,31 +1166,50 @@ describe("SessionViews", () => {
 		turnsTruncated: false,
 	}
 
-	// A session larger than one page: the Overview leads with the whole
-	// session's totals, and the transcript ends on a way to load the rest.
-	it("shows the whole session's totals and a way to load more when partly loaded", () => {
-		const onLoadMore = vi.fn()
-		const paging = { hasMore: true, loadingMore: false, onLoadMore, appSpans: { of: () => undefined, load: noop } }
-		render(<Views view="overview" paging={paging} totals={totals} />)
+	// A session larger than one page loads on its own. While the agent's spans
+	// are still arriving the Overview — a statement about the whole session —
+	// waits and says how far along the load is; the transcript shows what is
+	// in hand and marks that its end is not here yet. Nothing asks the reader
+	// to load anything.
+	it("waits for the agent's spans in the Overview and marks the transcript's open end while loading", () => {
+		const progress: SessionLoadProgress = { phase: "agent", loadedSpans: 8, loadedAgentSpans: 6, retry: noop }
+		render(<Views view="overview" progress={progress} totals={totals} />)
 
-		const whole = screen.getByTestId("whole-session")
-		expect(within(whole).getByText("209,220")).toBeTruthy()
-		expect(within(whole).getByText("19,506")).toBeTruthy()
-		expect(within(whole).getByText("17,439")).toBeTruthy()
-		expect(within(whole).getByText("$12.50")).toBeTruthy()
-		expect(within(whole).getByText(/read from the 8 spans loaded so far/)).toBeTruthy()
+		const waiting = screen.getByTestId("overview-waiting")
+		expect(within(waiting).getByText(/Loading 6 of 19,506 agent spans/)).toBeTruthy()
+		expect(screen.queryByRole("button", { name: /^load/i })).toBeNull()
 
 		fireEvent.click(screen.getByRole("tab", { name: /Transcript/ }))
-		expect(screen.getByText("More of this session follows")).toBeTruthy()
-		fireEvent.click(screen.getByRole("button", { name: "Load more" }))
-		expect(onLoadMore).toHaveBeenCalledTimes(1)
+		expect(screen.getByText("Loading the rest of this session")).toBeTruthy()
+		expect(screen.queryByRole("button", { name: /^load/i })).toBeNull()
+	})
+
+	// Once every agent span is in, the Overview is the whole session's even
+	// while the app's spans are still filling in behind it, and the transcript
+	// has its end.
+	it("renders the Overview and a closed transcript once the agent's spans are all in", () => {
+		const progress: SessionLoadProgress = { phase: "app", loadedSpans: 8, loadedAgentSpans: 6, retry: noop }
+		render(<Views view="overview" progress={progress} totals={totals} />)
+		expect(screen.queryByTestId("overview-waiting")).toBeNull()
+		fireEvent.click(screen.getByRole("tab", { name: /Transcript/ }))
+		expect(screen.queryByText("Loading the rest of this session")).toBeNull()
+	})
+
+	// A page that did not come back is the one case with something to press.
+	it("offers a retry where a page failed", () => {
+		const retry = vi.fn()
+		const progress: SessionLoadProgress = { phase: "failed", loadedSpans: 8, loadedAgentSpans: 6, retry }
+		render(<Views view="transcript" progress={progress} totals={totals} />)
+		expect(screen.getByText("The rest of this session didn't load")).toBeTruthy()
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+		expect(retry).toHaveBeenCalledTimes(1)
 	})
 
 	it("shows neither for a session loaded whole", () => {
 		render(<Views view="overview" />)
-		expect(screen.queryByTestId("whole-session")).toBeNull()
+		expect(screen.queryByTestId("overview-waiting")).toBeNull()
 		fireEvent.click(screen.getByRole("tab", { name: /Transcript/ }))
-		expect(screen.queryByText("More of this session follows")).toBeNull()
+		expect(screen.queryByText("Loading the rest of this session")).toBeNull()
 	})
 
 	// Both debug views read the query and the span-kind toggle, so both controls

--- a/apps/web/src/components/agent-sessions/session-detail/session-load-indicator.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-load-indicator.tsx
@@ -1,0 +1,76 @@
+import type { GetAiSessionSummaryResponse } from "@maple/domain/http"
+import { Button } from "@maple/ui/components/ui/button"
+import { Spinner } from "@maple/ui/components/ui/spinner"
+import { cn } from "@maple/ui/lib/utils"
+
+import type { SessionLoadProgress } from "@/hooks/use-session-spans"
+
+/**
+ * The page's one sign that a session larger than a page is still arriving:
+ * a count, a bar, and — only if a page failed — a way to resume. Quiet on
+ * purpose. Every view already renders what is in hand and grows as pages
+ * land, so this says how far along that is and nothing else.
+ *
+ * The count is of the phase in flight: the agent's spans first (the totals'
+ * `aiSpanCount` is the denominator), then every span (`spanCount`). Without
+ * the totals — they come from their own read, and may not have landed — the
+ * count stands alone and the bar stays indeterminate.
+ */
+export function SessionLoadIndicator({
+	progress,
+	totals,
+	className,
+}: {
+	progress: SessionLoadProgress
+	totals: GetAiSessionSummaryResponse | undefined
+	className?: string
+}) {
+	const { phase } = progress
+	const format = (value: number) => value.toLocaleString("en-US")
+
+	if (phase === "failed") {
+		return (
+			<div
+				data-testid="session-load-indicator"
+				className={cn("flex items-center gap-2 text-xs text-muted-foreground", className)}
+			>
+				<span>Couldn't load the rest of this session.</span>
+				<Button variant="outline" size="xs" onClick={progress.retry}>
+					Retry
+				</Button>
+			</div>
+		)
+	}
+
+	const loaded = phase === "agent" ? progress.loadedAgentSpans : progress.loadedSpans
+	const total = totals === undefined ? undefined : phase === "agent" ? totals.aiSpanCount : totals.spanCount
+	// A total the loaded count has passed is a session still being written;
+	// the bar fills rather than overflows.
+	const fraction = total === undefined || total <= 0 ? undefined : Math.min(1, loaded / total)
+	const noun = phase === "agent" ? "agent spans" : "spans"
+
+	return (
+		<div
+			data-testid="session-load-indicator"
+			aria-live="polite"
+			className={cn("flex min-w-0 flex-col gap-1 text-xs text-muted-foreground", className)}
+		>
+			<div className="flex items-center gap-2">
+				<Spinner size={12} className="shrink-0" aria-hidden />
+				<span className="tabular-nums">
+					Loading {format(loaded)}
+					{total !== undefined && ` of ${format(total)}`} {noun}
+				</span>
+			</div>
+			<div className="h-0.5 w-40 overflow-hidden rounded-full bg-muted" aria-hidden>
+				<div
+					className={cn(
+						"h-full rounded-full bg-primary/70 transition-[width] duration-300",
+						fraction === undefined && "w-1/3 animate-pulse",
+					)}
+					style={fraction === undefined ? undefined : { width: `${Math.round(fraction * 100)}%` }}
+				/>
+			</div>
+		</div>
+	)
+}

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -98,7 +98,7 @@ export function SessionOverview({
 
 	const openSpan = (spanId: string) => onSelectSpan(selectedSpanId === spanId ? undefined : spanId)
 
-	if (progress !== undefined && (progress.phase === "agent" || progress.phase === "failed")) {
+	if (progress !== undefined && !progress.agentSpansComplete) {
 		return (
 			<div
 				data-testid="overview-waiting"

--- a/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-overview.tsx
@@ -5,7 +5,6 @@ import type { GetAiSessionSummaryResponse } from "@maple/domain/http"
 import { ArrowRightIcon, ChevronRightIcon } from "@/components/icons"
 import { Button } from "@maple/ui/components/ui/button"
 import { Separator } from "@maple/ui/components/ui/separator"
-import { shortTarget } from "@/lib/agent-sessions/span-filters"
 import { formatNumber, formatPercent } from "@maple/ui/lib/format"
 import { formatSessionDuration } from "@maple/ui/lib/replay-format"
 import { cn } from "@maple/ui/lib/utils"
@@ -27,6 +26,8 @@ import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
 import { TOKEN_BUCKETS } from "@/lib/agent-sessions/token-buckets"
 import type { SessionToolResults } from "@/lib/agent-sessions/span-detail"
 import { useDetectedModels } from "@/hooks/use-detected-models"
+import type { SessionLoadProgress } from "@/hooks/use-session-spans"
+import { SessionLoadIndicator } from "./session-load-indicator"
 import { ModelLabel } from "../model-label"
 import type { SpanDetailTab } from "./span-expansion"
 import { SpanPopover } from "./span-popover"
@@ -56,6 +57,7 @@ const SEVERITY_DOT = {
 export function SessionOverview({
 	turns,
 	summary,
+	progress,
 	totals,
 	selectedSpanId,
 	onSelectSpan,
@@ -67,10 +69,14 @@ export function SessionOverview({
 	turns: readonly SessionTurn[]
 	summary: SessionSummary
 	/**
-	 * The whole session's totals from the warehouse, for a session only partly
-	 * loaded — everything else on this page is computed from the spans in
-	 * hand, and says so when these are present.
+	 * The background load of a session larger than one page. Everything on
+	 * this page is a statement about the whole session — a verdict, findings,
+	 * the tool ledger — so it waits for the agent's spans to all be in hand
+	 * rather than pronounce on half of them; the app's spans, which none of it
+	 * reads, may still be arriving behind it.
 	 */
+	progress?: SessionLoadProgress
+	/** The whole session's totals, for the wait's progress count. */
 	totals?: GetAiSessionSummaryResponse
 	/** The one span open in the popover (`?span=`). */
 	selectedSpanId: string | undefined
@@ -92,6 +98,23 @@ export function SessionOverview({
 
 	const openSpan = (spanId: string) => onSelectSpan(selectedSpanId === spanId ? undefined : spanId)
 
+	if (progress !== undefined && (progress.phase === "agent" || progress.phase === "failed")) {
+		return (
+			<div
+				data-testid="overview-waiting"
+				className="flex grow flex-col items-center justify-center gap-3 py-16 text-center"
+			>
+				<p className="text-sm text-muted-foreground">
+					The overview reads the whole session, and this one is still arriving.
+				</p>
+				<SessionLoadIndicator progress={progress} totals={totals} className="items-center" />
+				<p className="text-xs text-muted-foreground/70">
+					The Traces, Flow and Transcript views already show what has loaded.
+				</p>
+			</div>
+		)
+	}
+
 	return (
 		<div className="@container flex grow flex-col pt-5 pb-10">
 			<div className="flex flex-col gap-8 @4xl:flex-row @4xl:gap-8">
@@ -99,12 +122,6 @@ export function SessionOverview({
 				    question, so every boundary is the same hairline with the same
 				    air either side of it. */}
 				<div className="flex min-w-0 grow flex-col gap-6">
-					{totals !== undefined && (
-						<>
-							<WholeSession totals={totals} loadedSpanCount={summary.spanCount} />
-							<Separator />
-						</>
-					)}
 					{/* A session that completed with findings has no verdict line: the
 					    findings below are the verdict, and a headline counting them
 					    only said it twice. Failed and clean sessions do carry one —
@@ -133,67 +150,6 @@ export function SessionOverview({
 				onOpenTraceView={onOpenTraceView}
 			/>
 		</div>
-	)
-}
-
-/* -------------------------------------------------------------------------- */
-/* Whole session                                                              */
-/* -------------------------------------------------------------------------- */
-
-/**
- * The warehouse's totals for a session the page holds only part of. Shown
- * first, because every panel under it is computed from the loaded spans and
- * would otherwise read as the whole story.
- */
-function WholeSession({
-	totals,
-	loadedSpanCount,
-}: {
-	totals: GetAiSessionSummaryResponse
-	loadedSpanCount: number
-}) {
-	const tokens = totals.tokens.input + totals.tokens.output + totals.tokens.cacheRead
-	// Exact counts, not compact ones: these are the figures the rest of the page
-	// is measured against, and "209.2K" cannot be compared with "2,000 loaded".
-	const exact = (value: number) => value.toLocaleString("en-US")
-	const facts: ReadonlyArray<{ label: string; value: string }> = [
-		{ label: "Spans", value: exact(totals.spanCount) },
-		{ label: "Agent spans", value: exact(totals.aiSpanCount) },
-		{ label: "Traces", value: exact(totals.traceCount) },
-		{ label: "Duration", value: formatSessionDuration(totals.durationMs) },
-		{ label: "Model calls", value: exact(totals.llmCalls) },
-		{ label: "Tool calls", value: exact(totals.toolCalls) },
-		{ label: "Errors", value: exact(totals.errorSpanCount) },
-		{ label: "Tokens", value: totals.tokenReporting === "none" ? "—" : formatNumber(tokens) },
-		{ label: "Cost", value: totals.cost === undefined ? "—" : formatCost(totals.cost) },
-	]
-
-	return (
-		<section
-			data-testid="whole-session"
-			className="rounded-md border border-border bg-card px-4 py-3"
-			aria-label="Whole session"
-		>
-			<div className="flex flex-wrap items-baseline justify-between gap-2">
-				<h2 className="font-medium text-sm">Whole session</h2>
-				<p className="text-muted-foreground text-xs">
-					Everything below is read from the {exact(loadedSpanCount)} spans loaded so far.
-				</p>
-			</div>
-			<dl className="mt-3 grid grid-cols-3 gap-x-6 gap-y-2 @lg:grid-cols-9">
-				{facts.map((fact) => (
-					<div key={fact.label} className="flex flex-col">
-						<dt className="text-[10px] text-muted-foreground uppercase tracking-wider">{fact.label}</dt>
-						<dd className="font-mono text-sm tabular-nums">{fact.value}</dd>
-					</div>
-				))}
-			</dl>
-			{totals.models.length > 0 && (
-				<p className="mt-2 truncate text-muted-foreground text-xs" title={totals.models.join(", ")}>
-					{totals.models.map(shortTarget).join(" · ")}
-				</p>
-			)}
-		</section>
 	)
 }
 

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -3,12 +3,12 @@ import { useVirtualizer } from "@tanstack/react-virtual"
 
 import type { AiSessionSpan } from "@maple/domain/http"
 import { Button } from "@maple/ui/components/ui/button"
+import { Spinner } from "@maple/ui/components/ui/spinner"
 import { CopyButton } from "@maple/ui/components/ui/copy-button"
 import { formatBytes, formatDuration, formatNumber } from "@maple/ui/lib/format"
 import { cn } from "@maple/ui/lib/utils"
 
 import {
-	AlertWarningIcon,
 	BranchForkIcon,
 	ChevronDownIcon,
 	ChevronRightIcon,
@@ -25,6 +25,7 @@ import {
 	type IconComponent,
 } from "@/components/icons"
 import { usePageScrollMargin } from "@/hooks/use-page-scroll-margin"
+import type { SessionLoadProgress } from "@/hooks/use-session-spans"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { callMetaLine, callMetaParts } from "@/lib/agent-sessions/session-summary"
 import { spanModel, type SessionTurn } from "@/lib/agent-sessions/session-turns"
@@ -91,9 +92,7 @@ export function SessionTranscript({
 	query,
 	showThinking,
 	showPayloads,
-	hasMore,
-	loadingMore,
-	onLoadMore,
+	progress,
 	collapsedTurns,
 	onToggleTurn,
 	openRows,
@@ -110,9 +109,8 @@ export function SessionTranscript({
 	/** The toolbar's "Expand tool payloads" chip: arguments and results open by default. */
 	showPayloads: boolean
 	/** Agent spans remain past the loaded pages: the END of the session is not here yet. */
-	hasMore: boolean
-	loadingMore: boolean
-	onLoadMore: (() => void) | undefined
+	/** The background load of a session larger than one page; absent for one that fit. */
+	progress: SessionLoadProgress | undefined
 	collapsedTurns: ReadonlySet<string>
 	onToggleTurn: (turnId: string) => void
 	/** Rows whose disclosure the reader has flipped away from its default — held
@@ -135,8 +133,14 @@ export function SessionTranscript({
 		[turns, toolResults, deferredQuery, showThinking],
 	)
 	const rows = useMemo(
-		() => assembleTranscript(prepared, { collapsedTurns, hasMore }),
-		[prepared, collapsedTurns, hasMore],
+		() =>
+			assembleTranscript(prepared, {
+				collapsedTurns,
+				// The end of the session is missing while the agent's pages are
+				// still arriving, or stopped arriving.
+				hasMore: progress !== undefined && (progress.phase === "agent" || progress.phase === "failed"),
+			}),
+		[prepared, collapsedTurns, progress],
 	)
 
 	const virtualizer = useVirtualizer({
@@ -209,8 +213,7 @@ export function SessionTranscript({
 								<TranscriptBlock
 									row={row}
 									timeZone={effectiveTimezone}
-									loadingMore={loadingMore}
-									onLoadMore={onLoadMore}
+									progress={progress}
 									showPayloads={showPayloads}
 									collapsed={row.kind === "turn" && collapsedTurns.has(row.turn.id)}
 									onToggleTurn={onToggleTurn}
@@ -230,8 +233,7 @@ export function SessionTranscript({
 
 interface BlockProps {
 	/** For the terminal divider of a partly loaded session. */
-	loadingMore: boolean
-	onLoadMore: (() => void) | undefined
+	progress: SessionLoadProgress | undefined
 	row: TranscriptRow
 	timeZone: string
 	showPayloads: boolean
@@ -1289,8 +1291,7 @@ function NoteBlock({ row }: { row: Extract<TranscriptRow, { kind: "note" }> }) {
 function DividerBlock({
 	row,
 	timeZone,
-	loadingMore,
-	onLoadMore,
+	progress,
 }: BlockProps & { row: Extract<TranscriptRow, { kind: "divider" }> }) {
 	if (row.dividerKind === "compaction") {
 		return (
@@ -1314,23 +1315,32 @@ function DividerBlock({
 		)
 	}
 
-	// The pages end here, the session does not. Never a synthetic conclusion:
-	// the divider says the reading stops here, not that the agent did. The
-	// wording matches the page's own banner, so the two read as one fact stated
-	// twice rather than as two different problems.
+	// The loaded pages end here, the session does not. Never a synthetic
+	// conclusion: the row says the reading stops here for now, not that the
+	// agent did. The rest is arriving on its own; the count is the header
+	// indicator's, so the two read as one fact stated twice.
 	return (
-		<div className="mt-8 flex flex-col items-center gap-3 border-input border-t border-dashed pt-6 pb-2">
-			<div className="flex items-center gap-2">
-				<AlertWarningIcon size={14} className="text-severity-warn" />
-				<span className={cn(LABEL, "text-severity-warn")}>More of this session follows</span>
-			</div>
-			<p className="text-center text-[13px] text-muted-foreground">
-				The agent's later spans are not loaded yet — this is not where the session ended.
-			</p>
-			{onLoadMore !== undefined && (
-				<Button variant="outline" size="sm" onClick={onLoadMore} disabled={loadingMore}>
-					{loadingMore ? "Loading…" : "Load more"}
-				</Button>
+		<div
+			data-testid="transcript-more"
+			className="mt-8 flex flex-col items-center gap-2 border-input border-t border-dashed pt-6 pb-2"
+		>
+			{progress?.phase === "failed" ? (
+				<>
+					<span className={cn(LABEL, "text-severity-warn")}>The rest of this session didn't load</span>
+					<Button variant="outline" size="sm" onClick={progress.retry}>
+						Retry
+					</Button>
+				</>
+			) : (
+				<>
+					<div className="flex items-center gap-2">
+						<Spinner size={13} className="text-muted-foreground" aria-hidden />
+						<span className={cn(LABEL, "text-muted-foreground")}>Loading the rest of this session</span>
+					</div>
+					<p className="text-center text-[13px] text-muted-foreground">
+						The agent's later turns are still arriving — this is not where the session ended.
+					</p>
+				</>
 			)}
 		</div>
 	)

--- a/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-transcript.tsx
@@ -138,7 +138,7 @@ export function SessionTranscript({
 				collapsedTurns,
 				// The end of the session is missing while the agent's pages are
 				// still arriving, or stopped arriving.
-				hasMore: progress !== undefined && (progress.phase === "agent" || progress.phase === "failed"),
+				hasMore: progress !== undefined && !progress.agentSpansComplete,
 			}),
 		[prepared, collapsedTurns, progress],
 	)

--- a/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-views.tsx
@@ -16,7 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@maple/ui/components/u
 import type { GetAiSessionSummaryResponse } from "@maple/domain/http"
 
 import { useAppHotkey } from "@/hooks/use-app-hotkey"
-import type { SessionSpansState } from "@/hooks/use-session-spans"
+import type { SessionLoadProgress } from "@/hooks/use-session-spans"
 import type { SessionSummary } from "@/lib/agent-sessions/session-summary"
 import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
 import { SessionFlow } from "./session-flow"
@@ -51,24 +51,12 @@ const DEBUG_VIEWS: readonly SessionView[] = ["trace", "flow"]
  * but not the span-kind toggle, which it has no use for: it never shows the
  * app's own HTTP spans at all.
  */
-/**
- * How a session larger than one page continues: the next page of agent spans,
- * and each turn's app spans on demand. Absent for a session that fit one page
- * — then every view already holds the whole session.
- */
-export interface SessionPaging {
-	readonly hasMore: boolean
-	readonly loadingMore: boolean
-	readonly onLoadMore: () => void
-	readonly appSpans: SessionSpansState["appSpans"]
-}
-
 export function SessionViews({
 	view,
 	onViewChange,
 	turns,
 	summary,
-	paging,
+	progress,
 	totals,
 	selectedSpanId,
 	onSelectSpan,
@@ -77,9 +65,13 @@ export function SessionViews({
 	onViewChange: (view: SessionView) => void
 	turns: readonly SessionTurn[]
 	summary: SessionSummary
-	/** Present while the session is only partly loaded. */
-	paging: SessionPaging | undefined
-	/** The whole session's totals, for the Overview of a partly loaded session. */
+	/**
+	 * How far a session larger than one page has loaded — present from the
+	 * first page of such a session on, `complete` once the whole session is in
+	 * hand. Absent for a session that fit one page.
+	 */
+	progress: SessionLoadProgress | undefined
+	/** The whole session's totals, for the progress of a session still loading. */
 	totals: GetAiSessionSummaryResponse | undefined
 	/** The span open in the inspection popover, in whichever view (`?span=`). */
 	selectedSpanId: string | undefined
@@ -282,6 +274,7 @@ export function SessionViews({
 					<SessionOverview
 						turns={turns}
 						summary={summary}
+						progress={progress}
 						totals={totals}
 						selectedSpanId={selectedSpanId}
 						onSelectSpan={selectSpan}
@@ -302,7 +295,6 @@ export function SessionViews({
 						collapseIdle={collapseIdle}
 						collapsedTurns={collapsedTurns}
 						onToggleTurn={toggleTurn}
-						appSpans={paging?.appSpans}
 						selectedSpanId={selectedSpanId}
 						revealedSpanId={revealedSpanId}
 						onSelectSpan={selectSpan}
@@ -338,9 +330,7 @@ export function SessionViews({
 						query={query}
 						showThinking={showThinking}
 						showPayloads={showPayloads}
-						hasMore={paging?.hasMore === true}
-						loadingMore={paging?.loadingMore === true}
-						onLoadMore={paging?.onLoadMore}
+						progress={progress}
 						collapsedTurns={collapsedTurns}
 						onToggleTurn={toggleTurn}
 						openRows={openRows}

--- a/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-waterfall.tsx
@@ -9,7 +9,6 @@ import { formatSessionDuration } from "@maple/ui/lib/replay-format"
 import { cn } from "@maple/ui/lib/utils"
 
 import { useListNavigation } from "@/hooks/use-list-navigation"
-import type { SessionSpansState } from "@/hooks/use-session-spans"
 import { usePageScrollMargin } from "@/hooks/use-page-scroll-margin"
 import { buildSessionAxis, type AxisTick, type SessionAxis } from "@/lib/agent-sessions/session-axis"
 import {
@@ -87,12 +86,6 @@ interface SessionWaterfallProps {
 	/** Expansion state lives in SessionViews so a Trace → Flow → Trace round-trip keeps it. */
 	collapsedTurns: ReadonlySet<string>
 	onToggleTurn: (turnId: string) => void
-	/**
-	 * How a turn's app spans are fetched, for a session larger than one page —
-	 * its later turns hold the agent's spans alone until asked. Absent for a
-	 * session loaded whole.
-	 */
-	appSpans?: SessionSpansState["appSpans"]
 	/** The one span open in the popover (`?span=`). */
 	selectedSpanId: string | undefined
 	/** A span sent here from another view's inspection panel: its row is scrolled
@@ -117,7 +110,6 @@ export function SessionWaterfall({
 	collapseIdle,
 	collapsedTurns,
 	onToggleTurn,
-	appSpans,
 	selectedSpanId,
 	revealedSpanId,
 	onSelectSpan,
@@ -307,10 +299,6 @@ export function SessionWaterfall({
 											turns={turns}
 											axis={axis}
 											collapsed={collapsedTurns.has(row.turn.id)}
-											// App spans are hidden under the agent-only toggle, so
-											// offering to load them there would fetch rows the view
-											// then does not draw.
-											appSpans={agentSpansOnly ? undefined : appSpans}
 											onToggle={() => onToggleTurn(row.turn.id)}
 										/>
 									)}
@@ -458,7 +446,6 @@ function TurnHeader({
 	axis,
 	collapsed,
 	onToggle,
-	appSpans,
 }: {
 	row: Extract<WaterfallRow, { kind: "turn" }>
 	/** The whole session's turns: a reporter wider than this one belongs to none. */
@@ -466,7 +453,6 @@ function TurnHeader({
 	axis: SessionAxis
 	collapsed: boolean
 	onToggle: () => void
-	appSpans: SessionSpansState["appSpans"] | undefined
 }) {
 	const { turn } = row
 	// Tokens and duration are facts about the turn, not about the rows on screen:
@@ -480,7 +466,6 @@ function TurnHeader({
 	// is a segment of the session, not an established exchange with the user.
 	const ordinal = `${turn.anchorKind === "trace" ? "Segment" : "Turn"} ${turn.index}`
 	const traceId = turn.traceIds[0]
-	const appLoad = appSpanLoad(turn, appSpans)
 
 	return (
 		<div className="flex h-full w-full items-center rounded-md bg-card px-2.5 text-left text-xs hover:bg-accent/40">
@@ -518,23 +503,6 @@ function TurnHeader({
 						</span>
 					)}
 				</button>
-				{appLoad !== undefined && (
-					<button
-						type="button"
-						onClick={appLoad.onClick}
-						disabled={appLoad.disabled}
-						// Every uncovered turn offers the same words; the ordinal is
-						// what tells them apart to a reader who cannot see the row.
-						aria-label={`${appLoad.label} for ${ordinal}`}
-						className={cn(
-							"shrink-0 rounded-sm border border-input px-1.5 py-px text-[10px] text-muted-foreground",
-							"hover:bg-accent hover:text-foreground disabled:opacity-60",
-							"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-						)}
-					>
-						{appLoad.label}
-					</button>
-				)}
 				{traceId !== undefined && (
 					<span className="flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground uppercase tracking-wider">
 						<TraceLink traceId={traceId} timestamp={turn.anchor.timestamp} />
@@ -866,31 +834,4 @@ function TokenCell({ tokens, errored }: { tokens: SessionTokenTotals | undefined
 			</span>
 		</span>
 	)
-}
-
-/**
- * The header's "load app spans" control for one turn, or nothing when there
- * is nothing to load: the session came whole, the turn already holds app
- * spans from the first page, or every page of them has been fetched.
- */
-function appSpanLoad(
-	turn: SessionTurn,
-	appSpans: SessionSpansState["appSpans"] | undefined,
-): { label: string; disabled: boolean; onClick: () => void } | undefined {
-	if (appSpans === undefined) return undefined
-	const state = appSpans.of(turn)
-	if (state === undefined) {
-		// The first page carried the session's opening whole, app spans and all,
-		// so a turn that already shows some was never cut.
-		if (turn.spans.some((span) => !span.isAiSpan)) return undefined
-		return { label: "Load app spans", disabled: false, onClick: () => appSpans.load(turn) }
-	}
-	if (state.loading) return { label: "Loading app spans…", disabled: true, onClick: () => undefined }
-	if (state.failed) return { label: "Retry app spans", disabled: false, onClick: () => appSpans.load(turn) }
-	if (state.complete) return undefined
-	return {
-		label: `Load more app spans (${state.loaded.toLocaleString("en-US")} loaded)`,
-		disabled: false,
-		onClick: () => appSpans.load(turn),
-	}
 }

--- a/apps/web/src/hooks/use-session-spans.test.tsx
+++ b/apps/web/src/hooks/use-session-spans.test.tsx
@@ -2,12 +2,11 @@
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import type { AiSessionSpan } from "@maple/domain/http"
+import { AiSessionTooLargeError, type AiSessionSpan } from "@maple/domain/http"
 import type { AiSessionSpansPage } from "@/api/warehouse/ai-sessions"
 import { Atom, Result } from "@/lib/effect-atom"
 import type { QueryAtomFailure } from "@/lib/services/atoms/warehouse-query-atoms"
 import { agentSpan, llmSpan, makeSpan } from "@/lib/agent-sessions/span-test-support"
-import { buildSessionTurns } from "@/lib/agent-sessions/session-turns"
 
 import { useSessionSpans, type SessionSpansReads } from "./use-session-spans"
 
@@ -56,113 +55,110 @@ describe("useSessionSpans", () => {
 		mocks.firstPage = { data: firstPageSpans, nextCursor: undefined }
 		const { result } = renderHook(() => useSessionSpans("s1", undefined, reads))
 
-		expect(result.current.partial).toBe(false)
-		expect(result.current.hasMore).toBe(false)
+		expect(result.current.progress).toBeUndefined()
 		expect(result.current.spans.map((span) => span.spanId)).toEqual(["agent-1", "llm-1", "http-1"])
+		expect(fetchPage).not.toHaveBeenCalled()
 	})
 
-	it("continues past the first page with the agent's spans alone, after the cursor", async () => {
+	// Nothing is asked of the reader: the agent's pages drain first, then the
+	// app's, both continuing from the first page's cursor.
+	it("drains the agent's pages and then the app's on its own, after the first page's cursor", async () => {
 		mocks.firstPage = { data: firstPageSpans, nextCursor: CURSOR }
-		fetchPage.mockResolvedValueOnce({ data: secondPageSpans, nextCursor: undefined })
-		const { result } = renderHook(() =>
-			useSessionSpans("s1", { startTime: "2026-08-19 09:00:00", endTime: "2026-08-19 11:00:00" }, reads),
-		)
+		const appSpan = makeSpan({ spanId: "http-2", parentSpanId: "agent-2", startMs: 62 * SECOND, durationMs: 100, spanName: "GET /y", isAiSpan: false })
+		const AI_CURSOR = { timestamp: "2026-08-19 10:01:00.000000000", spanId: "llm-2" }
+		fetchPage
+			.mockResolvedValueOnce({ data: secondPageSpans, nextCursor: AI_CURSOR })
+			.mockResolvedValueOnce({ data: [agentSpan({ spanId: "agent-3", startMs: 120 * SECOND, durationMs: SECOND })], nextCursor: undefined })
+			.mockResolvedValueOnce({ data: [appSpan], nextCursor: undefined })
+		const window = { startTime: "2026-08-19 09:00:00", endTime: "2026-08-19 11:00:00" }
+		const { result } = renderHook(() => useSessionSpans("s1", window, reads))
 
-		expect(result.current.partial).toBe(true)
-		expect(result.current.hasMore).toBe(true)
-		act(() => result.current.loadMore())
-		await waitFor(() => expect(result.current.hasMore).toBe(false))
+		expect(result.current.progress?.phase).toBe("agent")
+		await waitFor(() => expect(result.current.progress?.phase).toBe("complete"))
 
-		expect(fetchPage).toHaveBeenCalledWith({
-			sessionId: "s1",
-			startTime: "2026-08-19 09:00:00",
-			endTime: "2026-08-19 11:00:00",
-			scope: "ai",
-			after: CURSOR,
-			limit: 2000,
-		})
-		expect(result.current.spans.map((span) => span.spanId)).toEqual(["agent-1", "llm-1", "http-1", "agent-2", "llm-2"])
-		// The session stays partial: the later turns hold agent spans alone.
-		expect(result.current.partial).toBe(true)
+		expect(fetchPage.mock.calls.map((call) => call[0])).toEqual([
+			{ sessionId: "s1", ...window, scope: "ai", after: CURSOR, limit: 2000 },
+			{ sessionId: "s1", ...window, scope: "ai", after: AI_CURSOR, limit: 2000 },
+			{ sessionId: "s1", ...window, scope: "app", after: CURSOR, limit: 2000 },
+		])
+		expect(result.current.spans.map((span) => span.spanId)).toEqual([
+			"agent-1", "llm-1", "http-1", "agent-2", "llm-2", "agent-3", "http-2",
+		])
+		expect(result.current.progress).toMatchObject({ loadedSpans: 7, loadedAgentSpans: 5 })
 	})
 
-	it("loads a turn's app spans by its traces and bounds, and drops repeats", async () => {
+	it("reports the app phase once every agent span is in", async () => {
 		mocks.firstPage = { data: firstPageSpans, nextCursor: CURSOR }
-		const appSpan = makeSpan({ spanId: "http-2", parentSpanId: "agent-1", startMs: 3 * SECOND, durationMs: 100, spanName: "GET /y", isAiSpan: false })
-		// `http-1` comes back too — the first page already had it.
-		fetchPage.mockResolvedValueOnce({ data: [firstPageSpans[2]!, appSpan], nextCursor: undefined })
+		let resolveApp: (page: AiSessionSpansPage) => void = () => undefined
+		fetchPage
+			.mockResolvedValueOnce({ data: secondPageSpans, nextCursor: undefined })
+			.mockImplementationOnce(() => new Promise((resolve) => { resolveApp = resolve }))
 		const { result } = renderHook(() => useSessionSpans("s1", undefined, reads))
-		const turn = buildSessionTurns(firstPageSpans)[0]!
 
-		expect(result.current.appSpans.of(turn)).toBeUndefined()
-		act(() => result.current.appSpans.load(turn))
-		expect(result.current.appSpans.of(turn)?.loading).toBe(true)
-		await waitFor(() => expect(result.current.appSpans.of(turn)?.complete).toBe(true))
-
-		const call = fetchPage.mock.calls[0]![0]
-		expect(call).toMatchObject({ sessionId: "s1", scope: "app", traceIds: turn.traceIds, limit: 2000 })
-		// A minute either side: the trace's opening span, parent of the turn's
-		// root, started before the turn's first agent span.
-		expect(call.startTime).toBe("2026-08-19 09:59:00")
-		expect(call.endTime).toBe("2026-08-19 10:01:30")
-		expect(result.current.appSpans.of(turn)?.loaded).toBe(2)
-		expect(result.current.spans.map((span) => span.spanId)).toEqual(["agent-1", "llm-1", "http-1", "http-2"])
+		await waitFor(() => expect(result.current.progress?.phase).toBe("app"))
+		expect(result.current.spans).toHaveLength(5)
+		await act(async () => resolveApp({ data: [], nextCursor: undefined }))
+		expect(result.current.progress?.phase).toBe("complete")
 	})
 
-	it("reads a turn of more traces than one request names by its bounds alone", async () => {
+	// A 413 is the byte cap, not the row cap: the same read with fewer rows.
+	it("halves the page when the byte cap ends one, and keeps going", async () => {
 		mocks.firstPage = { data: firstPageSpans, nextCursor: CURSOR }
-		fetchPage.mockResolvedValueOnce({ data: [], nextCursor: undefined })
+		fetchPage
+			.mockRejectedValueOnce(new AiSessionTooLargeError({ sessionId: "s1", message: "too large" }))
+			.mockResolvedValueOnce({ data: secondPageSpans, nextCursor: undefined })
+			.mockResolvedValueOnce({ data: [], nextCursor: undefined })
 		const { result } = renderHook(() => useSessionSpans("s1", undefined, reads))
-		const wide = {
-			...buildSessionTurns(firstPageSpans)[0]!,
-			traceIds: Array.from({ length: 101 }, (_, i) => i.toString(16).padStart(32, "0")),
-		}
 
-		act(() => result.current.appSpans.load(wide))
-		await waitFor(() => expect(result.current.appSpans.of(wide)?.complete).toBe(true))
-
-		const call = fetchPage.mock.calls[0]![0]
-		expect(call).toMatchObject({ sessionId: "s1", scope: "app", limit: 2000 })
-		expect(call).not.toHaveProperty("traceIds")
-		expect(call.startTime).toBe("2026-08-19 09:59:00")
-		expect(call.endTime).toBe("2026-08-19 10:01:30")
+		await waitFor(() => expect(result.current.progress?.phase).toBe("complete"))
+		expect(fetchPage.mock.calls[0]![0].limit).toBe(2000)
+		expect(fetchPage.mock.calls[1]![0].limit).toBe(1000)
+		expect(result.current.spans).toHaveLength(5)
 	})
 
-	it("keeps a turn loadable when a page of its app spans failed", async () => {
+	it("keeps what loaded when a page fails, and resumes from there on retry", async () => {
 		mocks.firstPage = { data: firstPageSpans, nextCursor: CURSOR }
-		fetchPage.mockRejectedValueOnce(new Error("boom"))
+		const AI_CURSOR = { timestamp: "2026-08-19 10:01:00.000000000", spanId: "llm-2" }
+		fetchPage
+			.mockResolvedValueOnce({ data: secondPageSpans, nextCursor: AI_CURSOR })
+			.mockRejectedValueOnce(new Error("boom"))
+			.mockResolvedValueOnce({ data: [agentSpan({ spanId: "agent-3", startMs: 120 * SECOND, durationMs: SECOND })], nextCursor: undefined })
+			.mockResolvedValueOnce({ data: [], nextCursor: undefined })
 		const { result } = renderHook(() => useSessionSpans("s1", undefined, reads))
-		const turn = buildSessionTurns(firstPageSpans)[0]!
 
-		act(() => result.current.appSpans.load(turn))
-		await waitFor(() => expect(result.current.appSpans.of(turn)?.failed).toBe(true))
-		expect(result.current.appSpans.of(turn)?.loading).toBe(false)
+		await waitFor(() => expect(result.current.progress?.phase).toBe("failed"))
+		expect(result.current.spans).toHaveLength(5)
+
+		act(() => result.current.progress?.retry())
+		await waitFor(() => expect(result.current.progress?.phase).toBe("complete"))
+		// Resumed after the last page that landed, not from the start.
+		expect(fetchPage.mock.calls[2]![0]).toMatchObject({ scope: "ai", after: AI_CURSOR })
+		expect(result.current.spans.map((span) => span.spanId)).toContain("agent-3")
 	})
 
 	it("drops the pages of a read the window moved on from, and a response landing late", async () => {
 		mocks.firstPage = { data: firstPageSpans, nextCursor: CURSOR }
-		let resolveLate: (page: { data: readonly AiSessionSpan[]; nextCursor: undefined }) => void = () => undefined
+		let resolveLate: (page: AiSessionSpansPage) => void = () => undefined
 		fetchPage
 			.mockResolvedValueOnce({ data: secondPageSpans, nextCursor: CURSOR })
 			.mockImplementationOnce(() => new Promise((resolve) => { resolveLate = resolve }))
+			// The new window's own drain.
+			.mockImplementation(() => new Promise(() => undefined))
 		const early = { startTime: "2026-08-19 09:00:00", endTime: "2026-08-19 11:00:00" }
 		const { result, rerender } = renderHook(({ window }) => useSessionSpans("s1", window, reads), {
 			initialProps: { window: early },
 		})
 
-		act(() => result.current.loadMore())
 		await waitFor(() => expect(result.current.spans).toHaveLength(5))
 		// A second page is in flight when the window changes.
-		act(() => result.current.loadMore())
-		expect(result.current.loadingMore).toBe(true)
 		rerender({ window: { startTime: "2026-08-19 08:00:00", endTime: "2026-08-19 12:00:00" } })
 
 		expect(result.current.spans).toHaveLength(3)
-		expect(result.current.loadingMore).toBe(false)
+		expect(result.current.progress?.phase).toBe("agent")
 		await act(async () => {
 			resolveLate({ data: [agentSpan({ spanId: "late", startMs: 0, durationMs: SECOND })], nextCursor: undefined })
 		})
 		expect(result.current.spans.map((span) => span.spanId)).not.toContain("late")
-		expect(result.current.hasMore).toBe(true)
+		expect(result.current.spans).toHaveLength(3)
 	})
 })

--- a/apps/web/src/hooks/use-session-spans.test.tsx
+++ b/apps/web/src/hooks/use-session-spans.test.tsx
@@ -84,7 +84,7 @@ describe("useSessionSpans", () => {
 		expect(result.current.spans.map((span) => span.spanId)).toEqual([
 			"agent-1", "llm-1", "http-1", "agent-2", "llm-2", "agent-3", "http-2",
 		])
-		expect(result.current.progress).toMatchObject({ loadedSpans: 7, loadedAgentSpans: 5 })
+		expect(result.current.progress).toMatchObject({ agentSpansComplete: true, loadedSpans: 7, loadedAgentSpans: 5 })
 	})
 
 	it("reports the app phase once every agent span is in", async () => {
@@ -96,6 +96,7 @@ describe("useSessionSpans", () => {
 		const { result } = renderHook(() => useSessionSpans("s1", undefined, reads))
 
 		await waitFor(() => expect(result.current.progress?.phase).toBe("app"))
+		expect(result.current.progress?.agentSpansComplete).toBe(true)
 		expect(result.current.spans).toHaveLength(5)
 		await act(async () => resolveApp({ data: [], nextCursor: undefined }))
 		expect(result.current.progress?.phase).toBe("complete")
@@ -127,6 +128,7 @@ describe("useSessionSpans", () => {
 		const { result } = renderHook(() => useSessionSpans("s1", undefined, reads))
 
 		await waitFor(() => expect(result.current.progress?.phase).toBe("failed"))
+		expect(result.current.progress?.agentSpansComplete).toBe(false)
 		expect(result.current.spans).toHaveLength(5)
 
 		act(() => result.current.progress?.retry())
@@ -134,6 +136,19 @@ describe("useSessionSpans", () => {
 		// Resumed after the last page that landed, not from the start.
 		expect(fetchPage.mock.calls[2]![0]).toMatchObject({ scope: "ai", after: AI_CURSOR })
 		expect(result.current.spans.map((span) => span.spanId)).toContain("agent-3")
+	})
+
+	// An app page failing leaves every agent span in hand, and says so.
+	it("reports a failed app page as failed with the agent's spans complete", async () => {
+		mocks.firstPage = { data: firstPageSpans, nextCursor: CURSOR }
+		fetchPage
+			.mockResolvedValueOnce({ data: secondPageSpans, nextCursor: undefined })
+			.mockRejectedValueOnce(new Error("boom"))
+		const { result } = renderHook(() => useSessionSpans("s1", undefined, reads))
+
+		await waitFor(() => expect(result.current.progress?.phase).toBe("failed"))
+		expect(result.current.progress?.agentSpansComplete).toBe(true)
+		expect(result.current.spans).toHaveLength(5)
 	})
 
 	it("drops the pages of a read the window moved on from, and a response landing late", async () => {

--- a/apps/web/src/hooks/use-session-spans.ts
+++ b/apps/web/src/hooks/use-session-spans.ts
@@ -21,10 +21,14 @@ import { aiSessionSpansResultAtom, type QueryAtomFailure } from "@/lib/services/
  * so the END of the session is not in hand yet. `app`: every agent span is
  * loaded and the app's HTTP/DB spans are filling in behind them. `complete`:
  * the whole session is here. `failed`: a page did not come back; what was
- * loaded stays, and `retry` picks up where it stopped.
+ * loaded stays, and `retry` picks up where it stopped. `agentSpansComplete`
+ * is what a view that reads the agent's spans alone should look at: a page of
+ * the app's spans failing does not make the transcript's end go missing.
  */
 export interface SessionLoadProgress {
 	readonly phase: "agent" | "app" | "complete" | "failed"
+	/** Every agent span is in hand, whatever the app's pages are doing. */
+	readonly agentSpansComplete: boolean
 	/** Every span in hand, both kinds. */
 	readonly loadedSpans: number
 	/** Agent spans in hand. */
@@ -239,7 +243,7 @@ export function useSessionSpans(
 						: "agent"
 		let loadedAgentSpans = 0
 		for (const span of spans) if (span.isAiSpan) loadedAgentSpans += 1
-		return { phase, loadedSpans: spans.length, loadedAgentSpans, retry }
+		return { phase, agentSpansComplete: agentDone, loadedSpans: spans.length, loadedAgentSpans, retry }
 	}, [firstCursor, loaded.status, loaded.pages, spans, retry])
 
 	return { firstPage, spans, progress }

--- a/apps/web/src/hooks/use-session-spans.ts
+++ b/apps/web/src/hooks/use-session-spans.ts
@@ -1,35 +1,35 @@
 import * as React from "react"
 
-import { AI_SESSION_SPANS_MAX_TRACE_IDS, type AiSessionSpan, type AiSessionSpanCursor } from "@maple/domain/http"
-import { formatWarehouseDateTime } from "@maple/query-engine"
+import type { AiSessionSpan, AiSessionSpanCursor, AiSessionSpanScope } from "@maple/domain/http"
 
 import {
 	getAiSessionSpans,
 	type AiSessionSpansInput,
 	type AiSessionSpansPage,
 } from "@/api/warehouse/ai-sessions"
-import type { SessionTurn } from "@/lib/agent-sessions/session-turns"
 import type { SessionWindow } from "@/lib/agent-sessions/session-window"
 import { Result, useAtomValue, type Atom } from "@/lib/effect-atom"
+import { displayError } from "@/lib/error-messages"
 import { mapleRuntime } from "@/lib/registry"
 import { logClientError } from "@/lib/services/common/telemetry"
 import { aiSessionSpansResultAtom, type QueryAtomFailure } from "@/lib/services/atoms/warehouse-query-atoms"
 
 /**
- * One turn's app spans — the service's own HTTP/DB work sharing the agent's
- * traces — as far as they have been loaded.
+ * How far the background load of a session larger than one page has come.
  *
- * `loaded` counts spans this hook fetched for the turn, not the app spans the
- * turn holds: the first page carried every span of the session's opening, so a
- * turn inside it has its app spans without a fetch. `cursor` set means the
- * turn has more than one page of them.
+ * `agent`: the agent's own spans are still arriving — the transcript's input,
+ * so the END of the session is not in hand yet. `app`: every agent span is
+ * loaded and the app's HTTP/DB spans are filling in behind them. `complete`:
+ * the whole session is here. `failed`: a page did not come back; what was
+ * loaded stays, and `retry` picks up where it stopped.
  */
-export interface TurnAppSpansState {
-	readonly loading: boolean
-	readonly loaded: number
-	readonly cursor: AiSessionSpanCursor | undefined
-	readonly complete: boolean
-	readonly failed: boolean
+export interface SessionLoadProgress {
+	readonly phase: "agent" | "app" | "complete" | "failed"
+	/** Every span in hand, both kinds. */
+	readonly loadedSpans: number
+	/** Agent spans in hand. */
+	readonly loadedAgentSpans: number
+	readonly retry: () => void
 }
 
 export interface SessionSpansState {
@@ -38,31 +38,22 @@ export interface SessionSpansState {
 	/** Every span loaded so far, deduplicated, in the session's own order. */
 	readonly spans: readonly AiSessionSpan[]
 	/**
-	 * The session did not fit the first page. Every later page carries the
-	 * agent's spans alone, so a turn beyond the opening shows the app's spans
-	 * only once `loadAppSpans` fetched them.
+	 * The session did not fit the first page and is (or was) being loaded in
+	 * the background. `undefined` for a session that came whole: then the spans
+	 * in hand ARE the session.
 	 */
-	readonly partial: boolean
-	/** Agent spans remain past what is loaded. */
-	readonly hasMore: boolean
-	readonly loadingMore: boolean
-	readonly loadMore: () => void
-	readonly appSpans: {
-		readonly of: (turn: SessionTurn) => TurnAppSpansState | undefined
-		readonly load: (turn: SessionTurn) => void
-	}
+	readonly progress: SessionLoadProgress | undefined
 }
 
-/** Agent spans a page carries past the first: the same ceiling the first page has. */
+/** Spans a page carries past the first: the same ceiling the first page has. */
 const PAGE_SIZE = 2_000
-
 /**
- * Slack around a turn's bounds for its app-span read. A turn past the first
- * page is bounded by its AGENT spans alone, and the server span that opened
- * the trace — the parent of the turn's own root — started before the first of
- * them. Same figure as the session window's own padding.
+ * The floor a page shrinks to when the byte cap (a 413) ends it. Spans heavy
+ * enough to trip 10MB at this many rows carry ~40KB each after mapping, which
+ * no session in production has come near.
  */
-const APP_SPANS_PADDING_MS = 60_000
+const MIN_PAGE_SIZE = 250
+const SESSION_TOO_LARGE_TAG = "@maple/http/ai-sessions/AiSessionTooLargeError"
 
 /** The two reads, injectable so a test can stand in fakes for both. */
 export interface SessionSpansReads {
@@ -77,55 +68,48 @@ const warehouseReads: SessionSpansReads = {
 	fetchPage: (data) => mapleRuntime.runPromise(getAiSessionSpans({ data })),
 }
 
-const NO_APP_SPANS: TurnAppSpansState = {
-	loading: false,
-	loaded: 0,
-	cursor: undefined,
-	complete: false,
-	failed: false,
-}
-
 /** What the hook has loaded past the first page, for one first-page input. */
 interface Loaded {
 	readonly key: string
+	/** Pages of the agent's spans, in order. */
 	readonly pages: ReadonlyArray<AiSessionSpansPage>
+	/** Pages of the app's spans, in order — read once every agent page is in. */
 	readonly appPages: ReadonlyArray<AiSessionSpansPage>
-	readonly appSpans: ReadonlyMap<string, TurnAppSpansState>
-	readonly loadingMore: boolean
+	readonly status: "loading" | "complete" | "failed"
+	/** Bumped by `retry`, which is what restarts the loader after a failure. */
+	readonly attempt: number
 }
 
 // Shared empties, so the derived `loaded` below keeps its identities across
 // renders while nothing has been fetched under the key — every memo downstream
 // of `spans` is keyed on them.
 const NO_PAGES: ReadonlyArray<AiSessionSpansPage> = []
-const NO_TURNS: ReadonlyMap<string, TurnAppSpansState> = new Map()
 
 const nothingLoaded = (key: string): Loaded => ({
 	key,
 	pages: NO_PAGES,
 	appPages: NO_PAGES,
-	appSpans: NO_TURNS,
-	loadingMore: false,
+	status: "loading",
+	attempt: 0,
 })
 
 /**
- * What a turn's app-span state is keyed by. Turn ids are derived from the
- * spans in hand and a page appended later can re-derive every one of them
- * (`buildSessionTurns` picks its anchor rule from the whole list); the span
- * that opened the turn survives that far more often than the id does.
- */
-const turnKey = (turn: SessionTurn) => turn.anchor.spanId
-
-/**
- * A session's spans, loaded in the order the reader needs them.
+ * A session's spans, all of them, loaded in the order the reader needs them.
  *
  * The first page is the session's opening, every span of it — a session that
- * fits is complete after one read, which is the common case and the only one
- * the page used to handle. A session that does not fit continues in pages of
- * the AGENT's spans alone: the transcript is built from those, and they are a
- * fraction of a large session's rows (in production a tenth, the rest being
- * the app's own SQL and HTTP). The app's spans for a turn past the opening are
- * fetched when the reader asks for that turn, by the turn's traces and bounds.
+ * fits is complete after one read, which is the common case. A session that
+ * does not fit is drained in the background from the moment the first page
+ * lands, without anything being asked of the reader: first every page of the
+ * AGENT's spans, which are what the transcript and the findings are built from
+ * and a fraction of a large session's rows (in production a tenth, the rest
+ * being the app's own SQL and HTTP), then every page of the app's spans behind
+ * them. Each view renders what is in hand and grows as pages arrive; the
+ * page's one progress indicator is the only sign anything is happening.
+ *
+ * Both phases continue from the first page's cursor: the cursor is a keyset
+ * position in the session's one span order, and a scope only filters rows, so
+ * `after` the first page's last span skips exactly the spans that page already
+ * carried — of either kind.
  *
  * Pages after the first live in component state rather than in atoms: they
  * are appended to one growing list keyed by the first page's input, the way
@@ -159,9 +143,74 @@ export function useSessionSpans(
 	)
 
 	const firstCursor = Result.isSuccess(firstPage) ? firstPage.value.nextCursor : undefined
-	const lastCursor = loaded.pages.length > 0 ? loaded.pages[loaded.pages.length - 1]!.nextCursor : firstCursor
-	const partial = firstCursor !== undefined
-	const hasMore = lastCursor !== undefined
+
+	// The loader reads where to resume from at start rather than from its
+	// closure: a retry after a failure continues from the pages in hand, and
+	// those are in state, not in the effect's dependencies.
+	const loadedRef = React.useRef(loaded)
+	loadedRef.current = loaded
+
+	React.useEffect(() => {
+		if (firstCursor === undefined) return
+		const resumeFrom = loadedRef.current.key === key ? loadedRef.current : nothingLoaded(key)
+		if (resumeFrom.status === "complete") return
+		let cancelled = false
+		const append = (scope: AiSessionSpanScope, page: AiSessionSpansPage) =>
+			update(key, (previous) =>
+				scope === "ai"
+					? { ...previous, pages: [...previous.pages, page] }
+					: { ...previous, appPages: [...previous.appPages, page] },
+			)
+		const setStatus = (status: Loaded["status"]) => update(key, (previous) => ({ ...previous, status }))
+
+		/** Fetches pages of one scope from `cursor` until the read ends. False if it stopped short. */
+		const drain = async (scope: AiSessionSpanScope, from: AiSessionSpanCursor | undefined): Promise<boolean> => {
+			let cursor: AiSessionSpanCursor | undefined = from
+			let limit = PAGE_SIZE
+			while (cursor !== undefined) {
+				if (cancelled) return false
+				let page: AiSessionSpansPage
+				try {
+					page = await reads.fetchPage({ ...input, scope, after: cursor, limit })
+				} catch (error: unknown) {
+					// The byte cap, not the row cap, ended the page: the same read
+					// with fewer rows is the fix the 413 asks for.
+					if (displayError(error)._tag === SESSION_TOO_LARGE_TAG && limit > MIN_PAGE_SIZE) {
+						limit = Math.max(MIN_PAGE_SIZE, Math.floor(limit / 2))
+						continue
+					}
+					logClientError("ai_session.pagination_failed", error)
+					if (!cancelled) setStatus("failed")
+					return false
+				}
+				if (cancelled) return false
+				append(scope, page)
+				cursor = page.nextCursor
+			}
+			return true
+		}
+
+		const lastCursor = (pages: ReadonlyArray<AiSessionSpansPage>) => pages[pages.length - 1]?.nextCursor
+		void (async () => {
+			if (resumeFrom.status === "failed") setStatus("loading")
+			const agentDone =
+				resumeFrom.pages.length > 0 && lastCursor(resumeFrom.pages) === undefined
+					? true
+					: await drain("ai", lastCursor(resumeFrom.pages) ?? firstCursor)
+			if (!agentDone) return
+			const appDone = await drain(
+				"app",
+				resumeFrom.appPages.length > 0 ? lastCursor(resumeFrom.appPages) : firstCursor,
+			)
+			if (appDone && !cancelled) setStatus("complete")
+		})()
+
+		return () => {
+			cancelled = true
+		}
+		// `loaded.attempt` is the retry signal; the pages themselves are read
+		// from the ref at start and must not restart the loop as they arrive.
+	}, [reads, input, key, firstCursor, loaded.attempt, update])
 
 	const spans = React.useMemo(() => {
 		const first = Result.isSuccess(firstPage) ? firstPage.value.data : []
@@ -172,80 +221,36 @@ export function useSessionSpans(
 		])
 	}, [firstPage, loaded.pages, loaded.appPages])
 
-	const loadMore = React.useCallback(() => {
-		if (loaded.loadingMore || lastCursor === undefined) return
-		update(key, (previous) => ({ ...previous, loadingMore: true }))
-		reads
-			.fetchPage({ ...input, scope: "ai", after: lastCursor, limit: PAGE_SIZE })
-			.then((page) => {
-				update(key, (previous) => ({ ...previous, pages: [...previous.pages, page], loadingMore: false }))
-			})
-			.catch((error: unknown) => {
-				logClientError("ai_session.pagination_failed", error)
-				update(key, (previous) => ({ ...previous, loadingMore: false }))
-			})
-	}, [reads, input, key, lastCursor, loaded.loadingMore, update])
-
-	const loadAppSpans = React.useCallback(
-		(turn: SessionTurn) => {
-			const id = turnKey(turn)
-			const state = loaded.appSpans.get(id) ?? NO_APP_SPANS
-			if (state.loading || state.complete) return
-			const setTurn = (next: TurnAppSpansState) =>
-				update(key, (previous) => ({ ...previous, appSpans: new Map(previous.appSpans).set(id, next) }))
-			setTurn({ ...state, loading: true, failed: false })
-			reads
-				.fetchPage({
-					sessionId,
-					startTime: formatWarehouseDateTime(turn.startMs - APP_SPANS_PADDING_MS),
-					endTime: formatWarehouseDateTime(turn.endMs + APP_SPANS_PADDING_MS),
-					// A turn of more traces than one read names — every model call
-					// its own trace, say — is read the way the session is, by its
-					// bounds: the same spans, one session resolution more.
-					...(turn.traceIds.length <= AI_SESSION_SPANS_MAX_TRACE_IDS && { traceIds: turn.traceIds }),
-					scope: "app",
-					limit: PAGE_SIZE,
-					...(state.cursor !== undefined && { after: state.cursor }),
-				})
-				.then((page) => {
-					update(key, (previous) => ({
-						...previous,
-						appPages: [...previous.appPages, page],
-						appSpans: new Map(previous.appSpans).set(id, {
-							loading: false,
-							loaded: state.loaded + page.data.length,
-							cursor: page.nextCursor,
-							complete: page.nextCursor === undefined,
-							failed: false,
-						}),
-					}))
-				})
-				.catch((error: unknown) => {
-					logClientError("ai_session.app_spans_failed", error)
-					setTurn({ ...state, loading: false, failed: true })
-				})
-		},
-		[reads, key, loaded.appSpans, sessionId, update],
+	const retry = React.useCallback(
+		() => update(key, (previous) => (previous.status === "failed" ? { ...previous, attempt: previous.attempt + 1 } : previous)),
+		[key, update],
 	)
 
-	const of = React.useCallback((turn: SessionTurn) => loaded.appSpans.get(turnKey(turn)), [loaded.appSpans])
+	const progress = React.useMemo<SessionLoadProgress | undefined>(() => {
+		if (firstCursor === undefined) return undefined
+		const agentDone = loaded.pages.length > 0 && loaded.pages[loaded.pages.length - 1]!.nextCursor === undefined
+		const phase: SessionLoadProgress["phase"] =
+			loaded.status === "failed"
+				? "failed"
+				: loaded.status === "complete"
+					? "complete"
+					: agentDone
+						? "app"
+						: "agent"
+		let loadedAgentSpans = 0
+		for (const span of spans) if (span.isAiSpan) loadedAgentSpans += 1
+		return { phase, loadedSpans: spans.length, loadedAgentSpans, retry }
+	}, [firstCursor, loaded.status, loaded.pages, spans, retry])
 
-	return {
-		firstPage,
-		spans,
-		partial,
-		hasMore,
-		loadingMore: loaded.loadingMore,
-		loadMore,
-		appSpans: { of, load: loadAppSpans },
-	}
+	return { firstPage, spans, progress }
 }
 
 /**
- * Later pages never repeat a span, but a turn's app-span read can: the first
- * page carried the session's opening whole, so a turn straddling its end has
- * some app spans twice. First occurrence wins, and the session's order — the
- * page order — is kept, since every consumer sorts by start time anyway.
+ * The scopes never overlap and the cursor skips the first page, so no span
+ * should arrive twice — but a session whose spans share a timestamp AND id
+ * across traces would, and one copy is the honest render. First occurrence
+ * wins, and the session's order — the page order — is kept, since every
+ * consumer sorts by start time anyway.
  */
 function dedupeInOrder(spans: readonly AiSessionSpan[]): readonly AiSessionSpan[] {
 	const seen = new Set<string>()

--- a/apps/web/src/routes/agent-sessions/$sessionId.tsx
+++ b/apps/web/src/routes/agent-sessions/$sessionId.tsx
@@ -8,13 +8,13 @@ import { toEpochMs } from "@maple/ui/lib/time-format"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 
 import { SquareSparkleIcon } from "@/components/icons"
-import { Alert, AlertDescription } from "@maple/ui/components/ui/alert"
 import { Button } from "@maple/ui/components/ui/button"
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@maple/ui/components/ui/empty"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { NotFoundError } from "@/components/route-error"
 import { QueryErrorState } from "@/components/common/query-error-state"
 import { SessionHeader } from "@/components/agent-sessions/session-detail/session-header"
+import { SessionLoadIndicator } from "@/components/agent-sessions/session-detail/session-load-indicator"
 import {
 	isSessionView,
 	SessionViews,
@@ -81,10 +81,11 @@ function AgentSessionDetailContent() {
 	// reads as "resolve this session from its id".
 	const spansState = useSessionSpans(sessionId, queryWindow)
 	// The whole session's totals — only for a session that did not fit the
-	// first page. One that did is complete in hand, and what the page computes
-	// from it IS the total; the extra warehouse read would buy nothing.
+	// first page, where they are what the progress indicator counts toward.
+	// One that did is complete in hand, and what the page computes from it IS
+	// the total; the extra warehouse read would buy nothing.
 	const summaryResult = useAtomValue(
-		spansState.partial
+		spansState.progress !== undefined
 			? aiSessionSummaryResultAtom({ data: { sessionId, ...queryWindow } })
 			: disabledResultAtom<GetAiSessionSummaryResponse>(),
 	)
@@ -177,7 +178,7 @@ function SessionDetailBody({
 	spansState: SessionSpansState
 	totals: GetAiSessionSummaryResponse | undefined
 }) {
-	const { spans, partial, hasMore, loadingMore, loadMore, appSpans } = spansState
+	const { spans, progress } = spansState
 	const turns = useMemo(() => buildSessionTurns(spans), [spans])
 	const summary = useMemo(() => buildSessionSummary({ spans, turns }), [spans, turns])
 
@@ -220,7 +221,7 @@ function SessionDetailBody({
 	const startMs = totals?.startTime === undefined ? summary.startMs : toEpochMs(totals.startTime)
 	const endMs = totals?.endTime === undefined ? summary.endMs : toEpochMs(totals.endTime)
 	useEffect(() => {
-		if (search.t !== undefined || (partial && totals === undefined)) return
+		if (search.t !== undefined || (progress !== undefined && totals === undefined)) return
 		navigate({
 			replace: true,
 			search: (prev: Record<string, unknown>) => ({
@@ -229,7 +230,7 @@ function SessionDetailBody({
 				end: formatWarehouseDateTime(endMs),
 			}),
 		})
-	}, [navigate, search.t, partial, totals, startMs, endMs])
+	}, [navigate, search.t, progress, totals, startMs, endMs])
 
 	const selectSpan = useCallback(
 		(spanId: string | undefined) => {
@@ -249,7 +250,14 @@ function SessionDetailBody({
 				<DashboardLayout.Sticky>
 					<DashboardLayout.Header
 						titleContent={<SessionHeader sessionId={sessionId} summary={summary} />}
-					/>
+					>
+						{/* The one sign a session larger than a page is still arriving.
+						    Every view renders what is in hand and grows as pages land;
+						    nothing below asks the reader to fetch anything. */}
+						{progress !== undefined && progress.phase !== "complete" && (
+							<SessionLoadIndicator progress={progress} totals={totals} />
+						)}
+					</DashboardLayout.Header>
 				</DashboardLayout.Sticky>
 				{/* `py-0` (the content blocks carry the padding instead) so the views'
 				    sticky elements pin flush to the scroller's edges — sticky offsets
@@ -261,27 +269,6 @@ function SessionDetailBody({
 				    `overflow-x-hidden` means a span that escapes its truncation can
 				    never make the whole page scroll sideways. */}
 				<DashboardLayout.Scroll className="overflow-x-hidden py-0 pr-6">
-					{partial && (
-						<div className="shrink-0 py-4">
-							<Alert variant="warning">
-								<AlertDescription className="flex flex-wrap items-center gap-x-3 gap-y-2">
-									<span>
-										{hasMore ? "Showing the first " : "Showing "}
-										{summary.spanCount.toLocaleString()}
-										{totals === undefined ? " spans" : ` of ${totals.spanCount.toLocaleString()} spans`}
-										{hasMore
-											? " — the agent's later spans load in pages, and a turn's app spans on demand in the Traces view."
-											: " — every agent span is loaded; a turn's app spans load on demand in the Traces view."}
-									</span>
-									{hasMore && (
-										<Button variant="outline" size="xs" onClick={loadMore} disabled={loadingMore}>
-											{loadingMore ? "Loading…" : "Load more agent spans"}
-										</Button>
-									)}
-								</AlertDescription>
-							</Alert>
-						</div>
-					)}
 					{/* Content-driven height inside the scroller: `shrink-0` because a
 					    scroll container's flex items shrink to fit before they overflow,
 					    which would collapse the views instead of scrolling them; `grow`
@@ -293,8 +280,8 @@ function SessionDetailBody({
 							onViewChange={changeView}
 							turns={turns}
 							summary={summary}
-							paging={partial ? { hasMore, loadingMore, onLoadMore: loadMore, appSpans } : undefined}
-							totals={partial ? totals : undefined}
+							progress={progress}
+							totals={totals}
 							selectedSpanId={search.span}
 							onSelectSpan={selectSpan}
 						/>


### PR DESCRIPTION
## Summary

- A session past the first 2,000-span page used to stop there and push the rest onto the reader: warning banner, "Load more" buttons in the page and transcript, per-turn "Load app spans" buttons in the waterfall, and a "Whole session" card qualifying every Overview figure.
- `useSessionSpans` now drains the whole session in the background from the first page on — every `scope: "ai"` page first, then every `scope: "app"` page, both keyset-continuing from the first page's cursor so nothing is re-read. Views render what is in hand and grow as pages land.
- A 413 halves the page size and continues; a failed page keeps what loaded and `retry` resumes from the last page that landed.
- The only visible sign is one small header indicator ("Loading 4,000 of 19,506 agent spans" + bar, denominators from the summary read), gone on completion. The Overview waits for the agent phase behind the same indicator since everything on it is a whole-session statement; the transcript's open end is a quiet loading row with Retry only on failure.
- Removed: banner, all load buttons, `WholeSession`, `SessionPaging`, per-turn `appSpans` plumbing.


## Test plan

- [x] `use-session-spans.test.tsx` — auto-drain order, app phase, 413 halving, fail + resume, stale-window discard
- [x] `session-detail.test.tsx` — Overview waits during agent phase, renders during app phase, transcript loading row, retry
- [x] `session-transcript.test.ts`
- [ ] stg/prd: open a >2,000-span session, watch the indicator count to completion, no buttons anywhere (local Tinybird cannot produce one)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791683503&installation_model_id=427786&pr_number=840&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F840&signature=f2b542b0c9905cb75986a135fe271e81ba1b844a7866ca24a5b602578133ecde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session details now load automatically in the background, including agent and application spans.
  * Progress indicators show loading status and span counts when available.
  * Retry actions are available when session loading fails.
  * The transcript displays loading and failure states while additional content is retrieved.
  * The session overview waits for agent spans before displaying its content.

* **Changes**
  * Removed the manual “Load more” workflow and per-turn application-span loading controls.
  * Oversized sessions now automatically adjust load sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->