### PR TITLE
fix(dev): stop .env.example pinning the web app to dead fixed ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,13 +62,12 @@ MAPLE_ROOT_PASSWORD=change-me
 # Required when MAPLE_AUTH_MODE=self_hosted
 MAPLE_DEFAULT_ORG_ID=default
 
-# Web app overrides (auto-derived from above if not set)
-# When running `bun dev:portless`, VITE_API_BASE_URL / VITE_INGEST_URL /
-# VITE_CHAT_AGENT_URL are auto-set to https://<worktree>-<app>.localhost so
-# multiple worktrees can run side by side. Values set here still win.
-VITE_API_BASE_URL=http://localhost:3472
+# Web app overrides. `bun dev` derives VITE_API_BASE_URL / VITE_INGEST_URL /
+# VITE_ELECTRIC_SYNC_URL from the portless routes (https://[<worktree>.]<app>.localhost).
+# A value set here wins over that, so leave them unset unless an app runs on a raw port.
+# VITE_API_BASE_URL=http://localhost:3472
 # Origin of the standalone ElectricSQL shape-proxy worker (apps/electric-sync).
-VITE_ELECTRIC_SYNC_URL=http://localhost:3476
+# VITE_ELECTRIC_SYNC_URL=http://localhost:3476
 VITE_MAPLE_AUTH_MODE=self_hosted
 VITE_CLERK_SIGN_IN_URL=/sign-in
 VITE_CLERK_SIGN_UP_URL=/sign-up


### PR DESCRIPTION
- `bun dev` derives `VITE_API_BASE_URL` / `VITE_ELECTRIC_SYNC_URL` from portless routes, but `apps/web/vite.config.ts` uses `??=`, so a set value wins
- `.env.example` still set the pre-alchemy fixed ports (`localhost:3472`, `:3476`); nothing listens there under `bun dev`
- Any `.env.local` copied from the template → every web API call `ERR_CONNECTION_REFUSED`, app shows "Failed to load environments"
- Fix: comment both out (kept as raw-port examples, same as `VITE_INGEST_URL`); drop the reference to the removed `bun dev:portless` script

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791722345&installation_model_id=427786&pr_number=842&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F842&signature=7b64060c1672ba53988e4998a1e24d32915c54fdb668bd572a53ce93d90e17be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration guidance for `bun dev` and portless routes.
  * Clarified that automatically derived service URLs can be overridden with explicit values.
  * Documented when to leave API, ingest, and sync URL settings unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->