### PR TITLE
fix(api): assert the tool-errors span read's (TraceId, SpanId) prefilter

### DIFF
--- a/apps/api/src/routes/internal/ai-sessions.http.test.ts
+++ b/apps/api/src/routes/internal/ai-sessions.http.test.ts
@@ -1278,9 +1278,9 @@ describe("POST /internal/ai-sessions/tools/errors", () => {
 			})
 			expect(response.status).toBe(200)
 			expect(seen[0]).toContain("'run_tests'")
-			// The span read is pruned by the trace ids the index answered — without
-			// that subquery it is a whole-window scan of every span in the org.
-			expect(seen[0]).toContain("trace_detail_spans.TraceId IN")
+			// The span read is pruned by the (trace, span) ids the index answered —
+			// without that subquery it is a whole-window scan of every span in the org.
+			expect(seen[0]).toContain("(trace_detail_spans.TraceId, trace_detail_spans.SpanId) IN")
 			expect(
 				(response.body.data as ReadonlyArray<{ errorType: string }>)[0]?.errorType,
 			).toBe("TimeoutError")


### PR DESCRIPTION
- `ai-sessions.http.test.ts` failed on main (`test-api-2`), blocking Deploy PRD
- #832 switched the tool-errors span read to a `(TraceId, SpanId) IN` prefilter (see `ai-tools.ts` failingToolSpans); the test still expected `trace_detail_spans.TraceId IN`
- Test-only change: assertion now matches the tuple prefilter

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791723005&installation_model_id=427786&pr_number=843&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F843&signature=6b448116704f75ffdb4e95f7c94df689d0636ebfde25e453b0228ac9cec9bb10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AI session tool-error coverage to validate span-level pruning using trace and span identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->