### PR TITLE
feat(agent-sessions): distribution histograms and percentile presets for the range filters

### DIFF
--- a/apps/api/src/routes/internal/ai-sessions.http.ts
+++ b/apps/api/src/routes/internal/ai-sessions.http.ts
@@ -12,6 +12,7 @@ import {
 	GetAiSessionSpansResponse,
 	GetAiSessionSummaryResponse,
 	ListAiSessionDetailsResponse,
+	ListAiSessionsDistributionsResponse,
 	ListAiSessionsFacetsResponse,
 	ListAiSessionsResponse,
 	MapleInternalApi,
@@ -281,6 +282,42 @@ export const HttpAiSessionsInternalLive = HttpApiBuilder.group(
 							models: pick("model"),
 							agents: pick("agent"),
 							tools: pick("tool"),
+						})
+					}),
+				)
+				.handle("distributions", ({ payload }) =>
+					Effect.gen(function* () {
+						const tenant = yield* CurrentTenant.Context
+						yield* Effect.annotateCurrentSpan({ orgId: tenant.orgId })
+						// Nets every session in the window — the cost of a cost-sorted
+						// page — which is why it is its own request rather than a branch
+						// of the facets, whose index scan the Tools pages also wait on.
+						const rows = yield* warehouse.compiledQuery(
+							tenant,
+							CH.compile(Integrations.aiSessionDistributionsQuery(), {
+								orgId: tenant.orgId,
+								startTime: payload.startTime,
+								endTime: payload.endTime,
+							}),
+							{ profile: "list", context: "aiSessionsDistributions" },
+						)
+						const distribution = (measure: Integrations.AiSessionDistributionMeasure) => {
+							const row = rows.find((candidate) => candidate.measure === measure)
+							if (row === undefined) return { buckets: [], p50: 0, p95: 0 }
+							return {
+								buckets: Object.entries(row.buckets)
+									.map(([floor, count]) => ({ floor: Number(floor), count }))
+									.sort((a, b) => a.floor - b.floor),
+								p50: row.p50,
+								p95: row.p95,
+							}
+						}
+						return new ListAiSessionsDistributionsResponse({
+							durationMs: distribution("durationMs"),
+							cost: distribution("cost"),
+							totalTokens: distribution("totalTokens"),
+							llmCalls: distribution("llmCalls"),
+							toolCalls: distribution("toolCalls"),
 						})
 					}),
 				)

--- a/apps/api/src/services/warehouse/ai-trace-index-materialization.clickhouse.e2e.test.ts
+++ b/apps/api/src/services/warehouse/ai-trace-index-materialization.clickhouse.e2e.test.ts
@@ -727,6 +727,39 @@ describe.skipIf(!clickhouseE2eEnabled)("ai_trace_index materialization", () => {
 		])
 	})
 
+	it("distributes the sessions over each range the way the page measures them", async () => {
+		const compiled = compileUnsafe(Integrations.aiSessionDistributionsQuery(), WINDOW)
+		const rows = Effect.runSync(compiled.decodeRows(await runJson(compiled.sql)))
+		const distribution = (measure: Integrations.AiSessionDistributionMeasure) => {
+			const row = rows.find((candidate) => candidate.measure === measure)
+			return row === undefined
+				? undefined
+				: Object.entries(row.buckets)
+						.map(([floor, count]) => [Number(floor), count])
+						.sort(([a], [b]) => a! - b!)
+		}
+
+		// The page's figures (see "measures each session off the index"), bucketed:
+		// the sessionless trace's 1ms clamps into the first second, the eve
+		// session's 30.001s falls in the half-octave from 2^4.5 s.
+		assert.deepStrictEqual(distribution("durationMs"), [
+			[1000, 1],
+			[2 ** 4.5 * 1000, 1],
+		])
+		// Netted, not summed: 150 tokens and one call for the eve session, whose
+		// roll-up and gateway mirror would otherwise read 300 and 450, and two.
+		assert.deepStrictEqual(distribution("totalTokens"), [
+			[8, 1],
+			[128, 1],
+		])
+		assert.deepStrictEqual(distribution("llmCalls"), [[1, 2]])
+		// Zeros have no bucket: the sessionless trace reported no cost and ran no tool.
+		assert.deepStrictEqual(distribution("cost"), [[2 ** -5.5, 1]])
+		assert.deepStrictEqual(distribution("toolCalls"), [[1, 1]])
+		const tokens = rows.find((row) => row.measure === "totalTokens")
+		assert.ok(tokens !== undefined && tokens.p50 >= 15 && tokens.p95 <= 150)
+	})
+
 	it("counts the facets the filters select", async () => {
 		const compiled = compileUnionUnsafe(Integrations.aiSessionFacetsQuery(), WINDOW)
 		const rows = Effect.runSync(compiled.decodeRows(await runJson(compiled.sql)))

--- a/apps/web/src/api/warehouse/ai-sessions.ts
+++ b/apps/web/src/api/warehouse/ai-sessions.ts
@@ -9,6 +9,7 @@ import {
 	GetAiSessionSpansRequest,
 	GetAiSessionSummaryRequest,
 	ListAiSessionDetailsRequest,
+	ListAiSessionsDistributionsRequest,
 	ListAiSessionsFacetsRequest,
 	ListAiSessionsRequest,
 } from "@maple/domain/http"
@@ -151,6 +152,36 @@ export const getAiSessionsFacets = Effect.fn("AiSessions.aiSessionsFacets")(func
 		models: result.models,
 		agents: result.agents,
 		tools: result.tools,
+	}
+})
+
+// List distributions (filter sidebar histograms and percentile presets)
+
+/** Same window as the facets, and as unfiltered — see `ListAiSessionsDistributionsRequest`. */
+export const getAiSessionsDistributions = Effect.fn("AiSessions.aiSessionsDistributions")(function* ({
+	data,
+}: {
+	data: AiSessionsFacetsInput
+}) {
+	const input = yield* decodeInput(AiSessionsFacetsInput, data, "aiSessionsDistributions")
+	const fallback = defaultTimeRange(yield* Clock.currentTimeMillis)
+	const result = yield* runWarehouseQuery("aiSessionsDistributions", () =>
+		Effect.gen(function* () {
+			const client = yield* MapleInternalAtomClient
+			return yield* client.aiSessionsInternal.distributions({
+				payload: new ListAiSessionsDistributionsRequest({
+					startTime: input.startTime ?? fallback.startTime,
+					endTime: input.endTime ?? fallback.endTime,
+				}),
+			})
+		}),
+	)
+	return {
+		durationMs: result.durationMs,
+		cost: result.cost,
+		totalTokens: result.totalTokens,
+		llmCalls: result.llmCalls,
+		toolCalls: result.toolCalls,
 	}
 })
 

--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.test.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.test.tsx
@@ -29,6 +29,58 @@ const facets = Result.success({
 	tools: [{ name: "search_traces", count: 4 }],
 })
 
+const distributions = Result.success({
+	durationMs: {
+		buckets: [
+			{ floor: 1000, count: 3 },
+			{ floor: 22627.41699796952, count: 2 },
+		],
+		p50: 30_000,
+		p95: 30_000,
+	},
+	cost: {
+		buckets: [
+			{ floor: 2 ** -5.5, count: 1 },
+			{ floor: 1, count: 1 },
+		],
+		p50: 0.03,
+		p95: 1.234,
+	},
+	totalTokens: {
+		buckets: [
+			{ floor: 8, count: 1 },
+			{ floor: 128, count: 1 },
+		],
+		p50: 15,
+		p95: 150,
+	},
+	llmCalls: {
+		buckets: [
+			{ floor: 1, count: 2 },
+			{ floor: 4, count: 1 },
+		],
+		p50: 1,
+		p95: 4,
+	},
+	toolCalls: {
+		buckets: [
+			{ floor: 1, count: 1 },
+			{ floor: 8, count: 1 },
+		],
+		p50: 1,
+		p95: 8,
+	},
+})
+
+const Sidebar = (props: {
+	distributionsResult?: Parameters<typeof AgentSessionsFilterSidebar>[0]["distributionsResult"]
+}) => (
+	<AgentSessionsFilterSidebar
+		facetsResult={facets}
+		distributionsResult={props.distributionsResult ?? distributions}
+	/>
+)
+
 /** What the recorded navigate call would write, given the search it started from. */
 const nextSearch = (): Record<string, unknown> => {
 	const call = navigate.mock.calls.at(-1)?.[0] as {
@@ -41,11 +93,14 @@ describe("AgentSessionsFilterSidebar", () => {
 	beforeEach(() => {
 		navigate.mockReset()
 		search = {}
+		// A section toggled open is remembered where storage exists, and a click in
+		// the next test would shut it.
+		globalThis.localStorage?.clear()
 	})
 	afterEach(cleanup)
 
 	it("renders a section per counted dimension, hiding the ones with nothing to offer", () => {
-		render(<AgentSessionsFilterSidebar facetsResult={facets} />)
+		render(<Sidebar />)
 
 		for (const title of ["Framework", "Service", "Environment", "Model", "Tool"]) {
 			expect(screen.getByText(title)).toBeTruthy()
@@ -63,7 +118,7 @@ describe("AgentSessionsFilterSidebar", () => {
 
 	it("accumulates a second framework rather than replacing the first", () => {
 		search = { vendors: ["eve"] }
-		render(<AgentSessionsFilterSidebar facetsResult={facets} />)
+		render(<Sidebar />)
 
 		fireEvent.click(screen.getByText("Vercel AI SDK"))
 		expect(nextSearch().vendors).toEqual(["eve", "vercel_ai_sdk"])
@@ -71,26 +126,66 @@ describe("AgentSessionsFilterSidebar", () => {
 
 	it("keeps a selected value that the window no longer offers", () => {
 		search = { tools: ["send_email"] }
-		render(<AgentSessionsFilterSidebar facetsResult={facets} />)
+		render(<Sidebar />)
 
 		expect(screen.getByText("send_email")).toBeTruthy()
 	})
 
-	it("writes a preset as the range it names, and clears it on a second click", () => {
-		render(<AgentSessionsFilterSidebar facetsResult={facets} />)
+	it("writes a percentile preset as the range it names, and clears it on a second click", () => {
+		render(<Sidebar />)
 
 		fireEvent.click(screen.getByText("Cost"))
-		fireEvent.click(screen.getByText("Over $1"))
-		expect(nextSearch()).toMatchObject({ costMin: 1, costMax: undefined })
+		// p95 of $1.234, rounded to two significant figures.
+		fireEvent.click(screen.getByRole("button", { name: /^> p95\s?\$1\.20$/ }))
+		expect(nextSearch()).toMatchObject({ costMin: 1.2, costMax: undefined })
 
-		search = { costMin: 1 }
+		search = { costMin: 1.2 }
 		cleanup()
-		render(<AgentSessionsFilterSidebar facetsResult={facets} />)
-		fireEvent.click(screen.getByText("Over $1"))
+		render(<Sidebar />)
+		fireEvent.click(screen.getByRole("button", { name: /^> p95\s?\$1\.20$/ }))
 		expect(nextSearch()).toMatchObject({
 			costMin: undefined,
 			costMax: undefined,
 		})
+	})
+
+	it("draws a histogram per range once the distributions land, and only the intents before", () => {
+		render(<Sidebar distributionsResult={Result.initial()} />)
+		expect(screen.queryByRole("img")).toBeNull()
+		fireEvent.click(screen.getByText("Tool calls"))
+		expect(screen.getByRole("button", { name: /^No tools\s?0$/ })).toBeTruthy()
+		expect(screen.queryByRole("button", { name: /p50/ })).toBeNull()
+
+		cleanup()
+		render(<Sidebar />)
+		for (const title of ["Session length", "Cost", "Tokens", "LLM calls", "Tool calls"]) {
+			fireEvent.click(screen.getByText(title))
+		}
+		// Durations arrive in ms and are drawn in the URL's seconds.
+		expect(screen.getByRole("img", { name: /^Session length distribution .* from 1s to / })).toBeTruthy()
+		expect(screen.getByRole("button", { name: /^> p50\s?30s$/ })).toBeTruthy()
+		for (const title of ["Cost", "Tokens", "LLM calls", "Tool calls"]) {
+			expect(screen.getByRole("img", { name: new RegExp(`^${title} distribution`) })).toBeTruthy()
+		}
+	})
+
+	it("selects whole counts off a count histogram, its top bucket's last member inclusive", () => {
+		// jsdom lays nothing out and has no pointer capture; give the bars a width.
+		const rect = vi
+			.spyOn(HTMLElement.prototype, "getBoundingClientRect")
+			.mockReturnValue({ left: 0, width: 100 } as DOMRect)
+		HTMLElement.prototype.setPointerCapture = vi.fn()
+		render(<Sidebar />)
+		fireEvent.click(screen.getByText("Tool calls"))
+
+		// Buckets [1,2) [2,4) [4,8) [8,16): a drag from the first bar to the third.
+		const bars = screen.getByRole("img", {
+			name: /^Tool calls distribution across 4 buckets, from 1 to 15$/,
+		})
+		fireEvent.pointerDown(bars, { clientX: 10, pointerId: 1 })
+		fireEvent.pointerUp(bars, { clientX: 60, pointerId: 1 })
+		expect(nextSearch()).toMatchObject({ toolCallsMin: 1, toolCallsMax: 7 })
+		rect.mockRestore()
 	})
 
 	it("clears every filter but leaves the window and the sort alone", () => {
@@ -103,7 +198,7 @@ describe("AgentSessionsFilterSidebar", () => {
 			sortBy: "cost",
 			sortDir: "desc",
 		}
-		render(<AgentSessionsFilterSidebar facetsResult={facets} />)
+		render(<Sidebar />)
 
 		fireEvent.click(screen.getByRole("button", { name: /clear all/i }))
 		const next = nextSearch()
@@ -119,7 +214,7 @@ describe("AgentSessionsFilterSidebar", () => {
 	})
 
 	it("toggles the single-trace filter on and writes nothing when it is off", () => {
-		render(<AgentSessionsFilterSidebar facetsResult={facets} />)
+		render(<Sidebar />)
 
 		fireEvent.click(screen.getByLabelText("Hide single-trace sessions"))
 		expect(nextSearch().grouped).toBe(true)

--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.test.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.test.tsx
@@ -93,9 +93,6 @@ describe("AgentSessionsFilterSidebar", () => {
 	beforeEach(() => {
 		navigate.mockReset()
 		search = {}
-		// A section toggled open is remembered where storage exists, and a click in
-		// the next test would shut it.
-		globalThis.localStorage?.clear()
 	})
 	afterEach(cleanup)
 
@@ -134,7 +131,6 @@ describe("AgentSessionsFilterSidebar", () => {
 	it("writes a percentile preset as the range it names, and clears it on a second click", () => {
 		render(<Sidebar />)
 
-		fireEvent.click(screen.getByText("Cost"))
 		// p95 of $1.234, rounded to two significant figures.
 		fireEvent.click(screen.getByRole("button", { name: /^> p95\s?\$1\.20$/ }))
 		expect(nextSearch()).toMatchObject({ costMin: 1.2, costMax: undefined })
@@ -152,15 +148,11 @@ describe("AgentSessionsFilterSidebar", () => {
 	it("draws a histogram per range once the distributions land, and only the intents before", () => {
 		render(<Sidebar distributionsResult={Result.initial()} />)
 		expect(screen.queryByRole("img")).toBeNull()
-		fireEvent.click(screen.getByText("Tool calls"))
 		expect(screen.getByRole("button", { name: /^No tools\s?0$/ })).toBeTruthy()
 		expect(screen.queryByRole("button", { name: /p50/ })).toBeNull()
 
 		cleanup()
 		render(<Sidebar />)
-		for (const title of ["Session length", "Cost", "Tokens", "LLM calls", "Tool calls"]) {
-			fireEvent.click(screen.getByText(title))
-		}
 		// Durations arrive in ms and are drawn in the URL's seconds.
 		expect(screen.getByRole("img", { name: /^Session length distribution .* from 1s to / })).toBeTruthy()
 		expect(screen.getByRole("button", { name: /^> p50\s?30s$/ })).toBeTruthy()
@@ -176,7 +168,6 @@ describe("AgentSessionsFilterSidebar", () => {
 			.mockReturnValue({ left: 0, width: 100 } as DOMRect)
 		HTMLElement.prototype.setPointerCapture = vi.fn()
 		render(<Sidebar />)
-		fireEvent.click(screen.getByText("Tool calls"))
 
 		// Buckets [1,2) [2,4) [4,8) [8,16): a drag from the first bar to the third.
 		const bars = screen.getByRole("img", {

--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import { getRouteApi } from "@tanstack/react-router"
+import type { AiSessionDistribution } from "@maple/domain/http"
 
 import { Result } from "@/lib/effect-atom"
 import {
@@ -15,7 +16,12 @@ import {
 	FilterSidebarHeader,
 	FilterSidebarLoading,
 } from "@/components/filters/filter-sidebar"
-import { RangeFilterSection, type RangePreset } from "@maple/ui/components/filters/range-filter-section"
+import { percentilePresets, toLogBuckets } from "@/components/filters/range-distribution"
+import {
+	RangeFilterSection,
+	type RangeBucket,
+	type RangePreset,
+} from "@maple/ui/components/filters/range-filter-section"
 import { Separator } from "@maple/ui/components/ui/separator"
 import { modelVendorIcon } from "@/lib/agent-sessions/model-vendor-icon"
 import { useDetectedModels } from "@/hooks/use-detected-models"
@@ -38,31 +44,36 @@ function withSelected(
 	return [...missing.map((name) => ({ name, count: 0 })), ...options]
 }
 
-// No distribution behind these — a histogram would need the fan-out for every
-// session in the window, which the facets read is built to avoid. Static
-// thresholds, named for the question each one answers.
-const DURATION_PRESETS: RangePreset[] = [
-	{ key: "quick", label: "Quick", value: "<10s", max: 10 },
-	{ key: "minute", label: "Over a minute", value: ">1m", min: 60 },
-	{ key: "long", label: "Long-running", value: ">10m", min: 600 },
-]
-const COST_PRESETS: RangePreset[] = [
-	{ key: "dime", label: "Over 10¢", value: ">$0.10", min: 0.1 },
-	{ key: "dollar", label: "Over $1", value: ">$1", min: 1 },
-]
-const TOKEN_PRESETS: RangePreset[] = [
-	{ key: "100k", label: "Over 100k", min: 100_000 },
-	{ key: "1m", label: "Over 1M", min: 1_000_000 },
-]
-const LLM_CALL_PRESETS: RangePreset[] = [
-	{ key: "single", label: "Single call", value: "1", min: 1, max: 1 },
-	{ key: "loop", label: "Over 10", min: 10 },
-	{ key: "deep", label: "Over 50", min: 50 },
-]
-const TOOL_CALL_PRESETS: RangePreset[] = [
-	{ key: "none", label: "No tools", value: "0", max: 0 },
-	{ key: "many", label: "Over 10", min: 10 },
-]
+// The shortcuts that name an intent rather than a threshold. The percentiles
+// join them once the distributions land; until then these are the presets.
+const QUICK_PRESET: RangePreset = { key: "quick", label: "Quick", value: "<10s", max: 10 }
+const SINGLE_CALL_PRESET: RangePreset = { key: "single", label: "Single call", value: "1", min: 1, max: 1 }
+const NO_TOOLS_PRESET: RangePreset = { key: "none", label: "No tools", value: "0", max: 0 }
+
+type Distributions = Record<
+	"durationMs" | "cost" | "totalTokens" | "llmCalls" | "toolCalls",
+	AiSessionDistribution
+>
+
+/** One range section's histogram and presets. `scale` takes the warehouse's
+ *  unit to the control's — ms to the URL's seconds — and `stepsPerOctave` is
+ *  the spacing `aiSessionDistributionsQuery` buckets the measure at. */
+function distributionControls(
+	distribution: AiSessionDistribution | undefined,
+	unit: "s" | "usd" | "count",
+	stepsPerOctave: number,
+	intents: ReadonlyArray<RangePreset>,
+	scale = 1,
+): { histogram?: RangeBucket[]; presets: RangePreset[] } {
+	if (distribution === undefined) return { presets: [...intents] }
+	return {
+		histogram: toLogBuckets(
+			distribution.buckets.map((bucket) => ({ floor: bucket.floor * scale, count: bucket.count })),
+			stepsPerOctave,
+		),
+		presets: [...intents, ...percentilePresets(distribution.p50 * scale, distribution.p95 * scale, unit)],
+	}
+}
 
 type ListKey = "vendors" | "services" | "environments" | "models" | "agents" | "tools"
 type RangeKey =
@@ -94,9 +105,19 @@ interface AgentSessionsFilterSidebarProps {
 		},
 		unknown
 	>
+	/**
+	 * How the same window's sessions spread over each range, unfiltered like the
+	 * facets. A read of its own and a slower one — it nets every session's usage —
+	 * so the ranges work from their inputs and intent presets until it lands, or
+	 * if it fails.
+	 */
+	distributionsResult: Result.Result<Distributions, unknown>
 }
 
-export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilterSidebarProps) {
+export function AgentSessionsFilterSidebar({
+	facetsResult,
+	distributionsResult,
+}: AgentSessionsFilterSidebarProps) {
 	const navigate = routeApi.useNavigate()
 	const search: AgentSessionsSearchState = routeApi.useSearch()
 
@@ -110,6 +131,17 @@ export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilter
 		[facetsResult],
 	)
 	const detectModel = useDetectedModels(modelNames)
+
+	const distributions = Result.builder(distributionsResult)
+		.onSuccess((value): Distributions | undefined => value)
+		.orElse(() => undefined)
+	// Half-octaves for the continuous two, octaves for the counts, whose bounds
+	// have to stay whole for the request schema to take them.
+	const duration = distributionControls(distributions?.durationMs, "s", 2, [QUICK_PRESET], 1 / 1000)
+	const cost = distributionControls(distributions?.cost, "usd", 2, [])
+	const tokens = distributionControls(distributions?.totalTokens, "count", 1, [])
+	const llmCalls = distributionControls(distributions?.llmCalls, "count", 1, [SINGLE_CALL_PRESET])
+	const toolCalls = distributionControls(distributions?.toolCalls, "count", 1, [NO_TOOLS_PRESET])
 
 	const setList = (key: ListKey, values: string[]) => {
 		navigate({ search: (prev) => ({ ...prev, [key]: values.length > 0 ? values : undefined }) })
@@ -212,13 +244,17 @@ export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilter
 
 						<Separator className="my-2" />
 
+						{/* Each histogram counts the sessions where its measure is above
+						    zero — a log axis has no place for none — so the readouts that
+						    would otherwise overstate what they hold say who they count. */}
 						<RangeFilterSection
 							title="Session length"
 							unit="s"
 							minValue={search.durationMin}
 							maxValue={search.durationMax}
 							onRangeChange={setRange("durationMin", "durationMax")}
-							presets={DURATION_PRESETS}
+							histogram={duration.histogram}
+							presets={duration.presets}
 							defaultOpen={false}
 						/>
 
@@ -229,7 +265,9 @@ export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilter
 							minValue={search.costMin}
 							maxValue={search.costMax}
 							onRangeChange={setRange("costMin", "costMax")}
-							presets={COST_PRESETS}
+							histogram={cost.histogram}
+							histogramUnitLabel="priced sessions"
+							presets={cost.presets}
 							defaultOpen={false}
 						/>
 
@@ -239,7 +277,8 @@ export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilter
 							minValue={search.tokensMin}
 							maxValue={search.tokensMax}
 							onRangeChange={setRange("tokensMin", "tokensMax")}
-							presets={TOKEN_PRESETS}
+							histogram={tokens.histogram}
+							presets={tokens.presets}
 							defaultOpen={false}
 						/>
 
@@ -249,7 +288,8 @@ export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilter
 							minValue={search.llmCallsMin}
 							maxValue={search.llmCallsMax}
 							onRangeChange={setRange("llmCallsMin", "llmCallsMax")}
-							presets={LLM_CALL_PRESETS}
+							histogram={llmCalls.histogram}
+							presets={llmCalls.presets}
 							defaultOpen={false}
 						/>
 
@@ -259,7 +299,9 @@ export function AgentSessionsFilterSidebar({ facetsResult }: AgentSessionsFilter
 							minValue={search.toolCallsMin}
 							maxValue={search.toolCallsMax}
 							onRangeChange={setRange("toolCallsMin", "toolCallsMax")}
-							presets={TOOL_CALL_PRESETS}
+							histogram={toolCalls.histogram}
+							histogramUnitLabel="sessions with tools"
+							presets={toolCalls.presets}
 							defaultOpen={false}
 						/>
 

--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.tsx
@@ -255,7 +255,6 @@ export function AgentSessionsFilterSidebar({
 							onRangeChange={setRange("durationMin", "durationMax")}
 							histogram={duration.histogram}
 							presets={duration.presets}
-							defaultOpen={false}
 						/>
 
 						<RangeFilterSection
@@ -268,7 +267,6 @@ export function AgentSessionsFilterSidebar({
 							histogram={cost.histogram}
 							histogramUnitLabel="priced sessions"
 							presets={cost.presets}
-							defaultOpen={false}
 						/>
 
 						<RangeFilterSection
@@ -279,7 +277,6 @@ export function AgentSessionsFilterSidebar({
 							onRangeChange={setRange("tokensMin", "tokensMax")}
 							histogram={tokens.histogram}
 							presets={tokens.presets}
-							defaultOpen={false}
 						/>
 
 						<RangeFilterSection
@@ -290,7 +287,6 @@ export function AgentSessionsFilterSidebar({
 							onRangeChange={setRange("llmCallsMin", "llmCallsMax")}
 							histogram={llmCalls.histogram}
 							presets={llmCalls.presets}
-							defaultOpen={false}
 						/>
 
 						<RangeFilterSection
@@ -302,7 +298,6 @@ export function AgentSessionsFilterSidebar({
 							histogram={toolCalls.histogram}
 							histogramUnitLabel="sessions with tools"
 							presets={toolCalls.presets}
-							defaultOpen={false}
 						/>
 
 						<Separator className="my-2" />

--- a/apps/web/src/components/filters/range-distribution.test.ts
+++ b/apps/web/src/components/filters/range-distribution.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+
+import { percentilePresets, toLogBuckets } from "./range-distribution"
+
+// The half-octave case is covered through the replays wrapper
+// (`replays-filter-sidebar.test.ts`); these are the parts only other units reach.
+
+describe("toLogBuckets", () => {
+	it("rebuilds octave buckets over a count with whole bounds and no gaps", () => {
+		const buckets = toLogBuckets(
+			[
+				{ floor: 16, count: 2 },
+				{ floor: 1, count: 5 },
+			],
+			1,
+		)
+		expect(buckets).toEqual([
+			{ from: 1, to: 2, count: 5 },
+			{ from: 2, to: 4, count: 0 },
+			{ from: 4, to: 8, count: 0 },
+			{ from: 8, to: 16, count: 0 },
+			{ from: 16, to: 32, count: 2 },
+		])
+	})
+
+	it("places floors below 1, as a cost's are", () => {
+		// $0.0221 is the half-octave floor 2^-5.5 the warehouse writes for $0.03.
+		const [bucket] = toLogBuckets([{ floor: 2 ** -5.5, count: 1 }], 2)
+		expect(bucket!.from).toBeCloseTo(0.0221, 4)
+		expect(bucket!.to).toBeCloseTo(0.03125, 5)
+	})
+})
+
+describe("percentilePresets", () => {
+	it("names each percentile with the threshold it resolves to", () => {
+		expect(percentilePresets(47.4, 2647, "s")).toEqual([
+			{ key: "p50", label: "> p50", value: "47s", min: 47 },
+			{ key: "p95", label: "> p95", value: "44m", min: 2640 },
+		])
+	})
+
+	it("rounds a count to two significant figures and keeps it whole", () => {
+		expect(percentilePresets(48_213, 7.5, "count").map((preset) => preset.min)).toEqual([48_000, 8])
+	})
+
+	it("rounds dollars to two significant figures", () => {
+		expect(percentilePresets(0.04372, 1.234, "usd")).toEqual([
+			{ key: "p50", label: "> p50", value: "$0.04", min: 0.044 },
+			{ key: "p95", label: "> p95", value: "$1.20", min: 1.2 },
+		])
+	})
+
+	it("skips thresholds too small to narrow anything, and a p95 equal to the p50", () => {
+		expect(percentilePresets(0.4, 0.2, "s")).toEqual([])
+		// A count of 1 is every session the histogram holds.
+		expect(percentilePresets(1, 3, "count").map((preset) => preset.key)).toEqual(["p95"])
+		expect(percentilePresets(12, 12.4, "count").map((preset) => preset.key)).toEqual(["p50"])
+	})
+})

--- a/apps/web/src/components/filters/range-distribution.ts
+++ b/apps/web/src/components/filters/range-distribution.ts
@@ -1,0 +1,97 @@
+import {
+	formatValue,
+	type RangeBucket,
+	type RangePreset,
+	type RangeUnit,
+} from "@maple/ui/components/filters/range-filter-section"
+
+/** One non-empty log bucket as the warehouse counts it: its floor, already in
+ *  the control's unit, and the sessions in it. */
+export interface LogBucketCount {
+	readonly floor: number
+	readonly count: number
+}
+
+/** Share of sessions the axis must cover before the rest is folded into a single
+ *  overflow bar. Real data has abandoned tabs measured in days; on a log axis one
+ *  of those stretches the range past 500h and squashes every genuine session into
+ *  the first few pixels. */
+const AXIS_COVERAGE = 0.99
+
+/**
+ * The warehouse buckets a heavy-tailed measure on a log scale — `stepsPerOctave`
+ * buckets per doubling, anchored at 1 in the control's unit — and returns only
+ * the non-empty ones. Rebuild the full run so the histogram's axis stays
+ * continuous instead of collapsing gaps into neighbouring bars. Each ceiling is
+ * the next floor, so octave buckets over a count keep whole bounds.
+ */
+export function toLogBuckets(raw: ReadonlyArray<LogBucketCount>, stepsPerOctave: number): RangeBucket[] {
+	const counts = new Map<number, number>()
+	for (const item of raw) {
+		if (!Number.isFinite(item.floor) || item.floor <= 0) continue
+		counts.set(Math.round(Math.log2(item.floor) * stepsPerOctave), item.count)
+	}
+	if (counts.size === 0) return []
+
+	const steps = [...counts.keys()]
+	const buckets: RangeBucket[] = []
+	for (let k = Math.min(...steps); k <= Math.max(...steps); k++) {
+		buckets.push({
+			from: 2 ** (k / stepsPerOctave),
+			to: 2 ** ((k + 1) / stepsPerOctave),
+			count: counts.get(k) ?? 0,
+		})
+	}
+
+	// Keep the outliers visible as one unbounded bar at the right edge rather than
+	// dropping them — they're real sessions, and folding them into the last kept
+	// bucket would misreport it as a spike.
+	const total = buckets.reduce((sum, b) => sum + b.count, 0)
+	if (total === 0) return buckets
+	let covered = 0
+	for (const [index, bucket] of buckets.entries()) {
+		covered += bucket.count
+		if (covered < total * AXIS_COVERAGE) continue
+		const tail = buckets.slice(index + 1)
+		const tailCount = tail.reduce((sum, b) => sum + b.count, 0)
+		if (tailCount === 0) return buckets.slice(0, index + 1)
+		return [
+			...buckets.slice(0, index + 1),
+			{ from: tail[0]!.from, to: Number.POSITIVE_INFINITY, count: tailCount, unbounded: true },
+		]
+	}
+	return buckets
+}
+
+/** The smallest threshold worth a shortcut. Under a second is noise; a count of
+ *  1 is every session a count's histogram holds; a dollar amount below what
+ *  `formatUsd` can show reads as "$0.0000". */
+const MIN_THRESHOLD = { ms: 1, s: 1, count: 2, usd: 0.0001 } satisfies Record<RangeUnit, number>
+
+/** A percentile lands on values like 2647s or 48213 tokens — precision no one
+ *  asked for on a shortcut. Round durations to the minute above a minute, and
+ *  everything else to two significant figures; a count stays whole, since the
+ *  request schema rejects a fractional one. */
+function roundThreshold(value: number, unit: RangeUnit): number {
+	if (unit === "s") return value < 60 ? Math.round(value) : Math.round(value / 60) * 60
+	const rounded = Number(value.toPrecision(2))
+	return unit === "count" ? Math.round(rounded) : rounded
+}
+
+/**
+ * "> p50" and "> p95" shortcuts, each carrying the threshold it resolves to —
+ * the percentiles are this audience's own vocabulary. A threshold too small to
+ * mean anything is skipped, and so is a p95 that rounds to the p50.
+ */
+export function percentilePresets(p50: number, p95: number, unit: RangeUnit): RangePreset[] {
+	const presets: RangePreset[] = []
+	for (const [key, value] of [
+		["p50", p50],
+		["p95", p95],
+	] as const) {
+		const threshold = roundThreshold(value, unit)
+		if (threshold < MIN_THRESHOLD[unit] || presets.some((preset) => preset.min === threshold)) continue
+		presets.push({ key, label: `> ${key}`, value: formatValue(threshold, unit), min: threshold })
+	}
+	return presets
+}

--- a/apps/web/src/components/replays/replays-filter-sidebar.tsx
+++ b/apps/web/src/components/replays/replays-filter-sidebar.tsx
@@ -20,10 +20,10 @@ import { Separator } from "@maple/ui/components/ui/separator"
 import { cn } from "@maple/ui/lib/utils"
 import {
 	RangeFilterSection,
-	formatSeconds,
 	type RangeBucket,
 	type RangePreset,
 } from "@maple/ui/components/filters/range-filter-section"
+import { percentilePresets, toLogBuckets } from "@/components/filters/range-distribution"
 import {
 	FilterSidebarBody,
 	FilterSidebarError,
@@ -54,73 +54,21 @@ interface ReplaysFacets {
 	readonly durationP95: number
 }
 
-/** Share of sessions the axis must cover before the rest is folded into a single
- *  overflow bar. Real data has abandoned tabs measured in days; on a log axis one
- *  of those stretches the range past 500h and squashes every genuine session into
- *  the first few pixels. */
-const AXIS_COVERAGE = 0.99
-
 // The warehouse buckets session length into half-octaves from 1s and returns only
-// the non-empty ones (see sessionReplaysFacetsQuery). Rebuild the full run, in
-// seconds, so the histogram's axis stays continuous instead of collapsing gaps
-// into neighbouring bars.
+// the non-empty ones, named by their floor in ms (see sessionReplaysFacetsQuery).
 export function toDurationBuckets(raw: ReadonlyArray<ReplaysFacetItem>): RangeBucket[] {
-	const counts = new Map<number, number>()
-	for (const item of raw) {
-		const floorMs = Number(item.name)
-		if (!Number.isFinite(floorMs) || floorMs <= 0) continue
-		counts.set(Math.round(Math.log2(floorMs / 1000) * 2), item.count)
-	}
-	if (counts.size === 0) return []
-
-	const octaves = [...counts.keys()]
-	const buckets: RangeBucket[] = []
-	for (let k = Math.min(...octaves); k <= Math.max(...octaves); k++) {
-		const from = 2 ** (k / 2)
-		buckets.push({ from, to: from * Math.SQRT2, count: counts.get(k) ?? 0 })
-	}
-
-	// Keep the outliers visible as one unbounded bar at the right edge rather than
-	// dropping them — they're real sessions, and folding them into the last kept
-	// bucket would misreport it as a spike.
-	const total = buckets.reduce((sum, b) => sum + b.count, 0)
-	if (total === 0) return buckets
-	let covered = 0
-	for (const [index, bucket] of buckets.entries()) {
-		covered += bucket.count
-		if (covered < total * AXIS_COVERAGE) continue
-		const tail = buckets.slice(index + 1)
-		const tailCount = tail.reduce((sum, b) => sum + b.count, 0)
-		if (tailCount === 0) return buckets.slice(0, index + 1)
-		return [
-			...buckets.slice(0, index + 1),
-			{ from: tail[0]!.from, to: Number.POSITIVE_INFINITY, count: tailCount, unbounded: true },
-		]
-	}
-	return buckets
+	return toLogBuckets(
+		raw.map((item) => ({ floor: Number(item.name) / 1000, count: item.count })),
+		2,
+	)
 }
 
-// "Bounced" is the one shortcut that names an intent rather than a threshold;
-// the percentiles are this audience's own vocabulary and carry their resolved
-// value. Percentiles under a second make a degenerate preset — skip them.
+// "Bounced" is the one shortcut that names an intent rather than a threshold.
 function sessionLengthPresets(p50Ms: number, p95Ms: number): RangePreset[] {
-	const presets: RangePreset[] = [{ key: "bounced", label: "Bounced", value: "<10s", max: 10 }]
-	for (const [key, label, ms] of [
-		["p50", "> p50", p50Ms],
-		["p95", "> p95", p95Ms],
-	] as const) {
-		const seconds = roundThreshold(ms / 1000)
-		if (seconds >= 1) presets.push({ key, label, value: formatSeconds(seconds), min: seconds })
-	}
-	return presets
-}
-
-/** A percentile lands on values like 2647s, which reads as "44m 7s" — precision
- *  no one asked for on a shortcut. Round to the nearest minute above a minute;
- *  the seconds it drops can't change which sessions you care about. */
-function roundThreshold(seconds: number): number {
-	if (seconds < 60) return Math.round(seconds)
-	return Math.round(seconds / 60) * 60
+	return [
+		{ key: "bounced", label: "Bounced", value: "<10s", max: 10 },
+		...percentilePresets(p50Ms / 1000, p95Ms / 1000, "s"),
+	]
 }
 
 // Active time has no distribution behind it — computing one means scanning

--- a/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
+++ b/apps/web/src/lib/services/atoms/warehouse-query-atoms.ts
@@ -114,7 +114,13 @@ import {
 	getSessionTraceSummaries,
 	listReplays,
 } from "@/api/warehouse/replays"
-import { getAiSessionSpans, getAiSessionSummary, getAiSessionsFacets, listAiSessions } from "@/api/warehouse/ai-sessions"
+import {
+	getAiSessionSpans,
+	getAiSessionSummary,
+	getAiSessionsDistributions,
+	getAiSessionsFacets,
+	listAiSessions,
+} from "@/api/warehouse/ai-sessions"
 import {
 	getAiToolBreakdowns,
 	getAiToolErrorDetail,
@@ -346,6 +352,10 @@ export const listAiSessionsResultAtom = makeQueryAtomFamily(listAiSessions, {
 })
 
 export const aiSessionsFacetsResultAtom = makeQueryAtomFamily(getAiSessionsFacets, {
+	staleTime: 30_000,
+})
+
+export const aiSessionsDistributionsResultAtom = makeQueryAtomFamily(getAiSessionsDistributions, {
 	staleTime: 30_000,
 })
 

--- a/apps/web/src/routes/agent-sessions/index.tsx
+++ b/apps/web/src/routes/agent-sessions/index.tsx
@@ -21,7 +21,10 @@ import { ReloadControls } from "@/components/time-range-picker/reload-controls"
 import { QueryErrorState } from "@/components/common/query-error-state"
 import { Result, useAtomValue } from "@/lib/effect-atom"
 import { BooleanFromStringParam, NumberFromStringParam, OptionalStringArrayParam } from "@/lib/search-params"
-import { aiSessionsFacetsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
+import {
+	aiSessionsDistributionsResultAtom,
+	aiSessionsFacetsResultAtom,
+} from "@/lib/services/atoms/warehouse-query-atoms"
 import { resolveEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useInfiniteAiSessions } from "@/hooks/use-infinite-ai-sessions"
 import { useOrganizationFeatureFlags } from "@/hooks/use-organization-feature-flags"
@@ -136,6 +139,11 @@ function AgentSessionsBody() {
 	// the Reload subscription — the facets refetch when the window rolls, which
 	// is enough.
 	const facetsResult = useAtomValue(aiSessionsFacetsResultAtom({ data: { startTime, endTime } }))
+	// The ranges' histograms, over the same unfiltered window — a request of its
+	// own, because it nets every session's usage and the facets need not wait.
+	const distributionsResult = useAtomValue(
+		aiSessionsDistributionsResultAtom({ data: { startTime, endTime } }),
+	)
 	const sessions = allData
 	const sortOption = sortOptionFor(search.sortBy, search.sortDir)
 
@@ -179,7 +187,10 @@ function AgentSessionsBody() {
 	return (
 		<>
 			<DashboardLayout.Filters>
-				<AgentSessionsFilterSidebar facetsResult={facetsResult} />
+				<AgentSessionsFilterSidebar
+					facetsResult={facetsResult}
+					distributionsResult={distributionsResult}
+				/>
 			</DashboardLayout.Filters>
 			<DashboardLayout.Content>
 				<DashboardLayout.Sticky>

--- a/packages/domain/src/http/ai-sessions.ts
+++ b/packages/domain/src/http/ai-sessions.ts
@@ -78,8 +78,9 @@ export class ListAiSessionsRequest extends Schema.Class<ListAiSessionsRequest>("
 	...aiSessionCountedFilters,
 	// The session-level filters: applied to the ranked row over the measures
 	// the index carries per agent span, so they have no facet count behind
-	// them. `hasErrors` means a failed agent span; a session whose only error
-	// is on a non-agent span shows the badge but is not matched.
+	// them — the ranges' histograms are `POST /distributions`. `hasErrors`
+	// means a failed agent span; a session whose only error is on a non-agent
+	// span shows the badge but is not matched.
 	hasErrors: Schema.optional(Schema.Boolean),
 	/** Drop the `trace:` sessions — traces whose vendor exposes no session key. */
 	excludeTraceSessions: Schema.optional(Schema.Boolean),
@@ -274,6 +275,47 @@ export class ListAiSessionsFacetsResponse extends Schema.Class<ListAiSessionsFac
 	agents: Schema.Array(AiSessionFacetItem),
 	/** …per tool name, matching `toolNames`. */
 	tools: Schema.Array(AiSessionFacetItem),
+}) {}
+
+export class ListAiSessionsDistributionsRequest extends Schema.Class<ListAiSessionsDistributionsRequest>(
+	"ListAiSessionsDistributionsRequest",
+)({
+	// The window alone, like the facets: a distribution the range filters had
+	// narrowed would hide the values a reader is about to widen a range to.
+	startTime: TinybirdDateTime,
+	endTime: TinybirdDateTime,
+}) {}
+
+/** One non-empty bucket: sessions whose measure is at least `floor` and
+ *  below the next bucket's. */
+export const AiSessionDistributionBucket = Schema.Struct({
+	floor: Schema.Number,
+	count: Schema.Number,
+})
+
+/**
+ * How the window's sessions spread over one measure, counting the sessions
+ * where it is above zero. The buckets are log-spaced from 1 in the measure's
+ * own unit — half-octaves for `durationMs` and `cost`, octaves for the counts,
+ * whose bounds stay whole — ascending, and only the non-empty ones: the client
+ * fills the gaps. A measure no session has is no buckets and zero percentiles.
+ */
+export const AiSessionDistribution = Schema.Struct({
+	buckets: Schema.Array(AiSessionDistributionBucket),
+	p50: Schema.Number,
+	p95: Schema.Number,
+})
+export type AiSessionDistribution = Schema.Schema.Type<typeof AiSessionDistribution>
+
+export class ListAiSessionsDistributionsResponse extends Schema.Class<ListAiSessionsDistributionsResponse>(
+	"ListAiSessionsDistributionsResponse",
+)({
+	/** The agent spans' extent in ms — what `durationMinMs`/`durationMaxMs` filter. */
+	durationMs: AiSessionDistribution,
+	cost: AiSessionDistribution,
+	totalTokens: AiSessionDistribution,
+	llmCalls: AiSessionDistribution,
+	toolCalls: AiSessionDistribution,
 }) {}
 
 /** Which of a session's spans a read returns. `ai` is the vendor-stamped
@@ -831,6 +873,13 @@ export class AiSessionsInternalApiGroup extends HttpApiGroup.make("aiSessionsInt
 		HttpApiEndpoint.post("facets", "/facets", {
 			payload: ListAiSessionsFacetsRequest,
 			success: ListAiSessionsFacetsResponse,
+			error: warehouseReadHttpErrors,
+		}),
+	)
+	.add(
+		HttpApiEndpoint.post("distributions", "/distributions", {
+			payload: ListAiSessionsDistributionsRequest,
+			success: ListAiSessionsDistributionsResponse,
 			error: warehouseReadHttpErrors,
 		}),
 	)

--- a/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
+++ b/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
@@ -252,6 +252,73 @@ SELECT
         ORDER BY startTime DESC
         FORMAT JSON
 
+-- builder:ai-sessions:aiSessionDistributionsQuery:default
+SELECT
+          tupleElement(measured, 1) AS measure,
+          sumMap(map(toString(tupleElement(measured, 3)), toUInt64(1))) AS buckets,
+          quantile(0.5)(tupleElement(measured, 2)) AS p50,
+          quantile(0.95)(tupleElement(measured, 2)) AS p95
+        FROM (SELECT
+          arrayJoin([tuple('durationMs', durationMs, pow(2, floor(log2(greatest(durationMs / 1000, 1)) * 2) / 2) * 1000), tuple('cost', cost, pow(2, floor(log2(greatest(cost, 0.001)) * 2) / 2)), tuple('totalTokens', totalTokens, pow(2, floor(log2(totalTokens)))), tuple('llmCalls', llmCalls, pow(2, floor(log2(llmCalls)))), tuple('toolCalls', toolCalls, pow(2, floor(log2(toolCalls))))]) AS measured
+        FROM (SELECT
+          toFloat64(agentDurationMs) AS durationMs,
+          toFloat64(toolCalls) AS toolCalls,
+          toFloat64(arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 2)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, toFloat64(n.2)), arrayFilter(n -> n.1 != '', netted)))))) AS llmCalls,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 3)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.3), arrayFilter(n -> n.1 != '', netted))))) AS totalTokens,
+          arraySum(tupleElement(arrayFilter(n -> n.1 = '', netted), 4)) + arraySum(mapValues(arrayReduce('maxMap', arrayMap(n -> map(n.1, n.4), arrayFilter(n -> n.1 != '', netted))))) AS cost
+        FROM (SELECT
+          agentDurationMs AS agentDurationMs,
+          toolCalls AS toolCalls,
+          arrayMap(r -> tuple(r.5, r.6 = 1 AND if((r.3 > 0 OR r.4 > 0), greatest(0., r.3 - arrayElement(tupleElement(childClaims, 2), indexOf(tupleElement(childClaims, 1), r.1))) > 0 OR greatest(0., r.4 - arrayElement(tupleElement(childClaims, 3), indexOf(tupleElement(childClaims, 1), r.1))) > 0, NOT has(reportingIds, r.2)), greatest(0., r.3 - arrayElement(tupleElement(childClaims, 2), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.4 - arrayElement(tupleElement(childClaims, 3), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.7 - arrayElement(tupleElement(childClaims, 4), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.8 - arrayElement(tupleElement(childClaims, 5), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.9 - arrayElement(tupleElement(childClaims, 6), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.10 - arrayElement(tupleElement(childClaims, 7), indexOf(tupleElement(childClaims, 1), r.1))), greatest(0., r.11 - arrayElement(tupleElement(childClaims, 8), indexOf(tupleElement(childClaims, 1), r.1)))), reporters) AS netted
+        FROM (SELECT
+          if(rawSessionId = '', concat('trace:', traceId), rawSessionId) AS sessionId,
+          argMin(vendorId, vendorAt) AS vendorId,
+          argMin(vendorVersion, vendorAt) AS vendorVersion,
+          toString(min(traceAgentStart)) AS agentStart,
+          toString(fromUnixTimestamp64Nano(max(traceAgentEndNanos))) AS agentEnd,
+          count() AS traceCount,
+          sum(agentSpanCount) AS spanCount,
+          groupUniqArrayArray(serviceNames) AS serviceNames,
+          groupUniqArrayArray(models) AS models,
+          groupUniqArrayArray(agentNames) AS agentNames,
+          argMin(firstAgentName, firstAgentAt) AS firstAgentName,
+          sum(toolCalls) AS toolCalls,
+          sum(errorAgentSpans) AS errorAgentSpans,
+          sum(arrayCount(f -> f.3 = 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS toolErrors,
+          sum(arrayCount(f -> f.3 != 1 AND NOT has(tupleElement(failedSpans, 2), f.1), failedSpans)) AS turnErrors,
+          intDiv(max(traceAgentEndNanos) - toUnixTimestamp64Nano(min(traceAgentStart)), 1000000) AS agentDurationMs,
+          arraySlice(arrayFlatten(groupArray(usageReporters)), 1, 2000) AS reporters,
+          arrayReduce('sumMap', arrayMap(c -> [c.2], reporters), arrayMap(c -> [c.3], reporters), arrayMap(c -> [c.4], reporters), arrayMap(c -> [c.7], reporters), arrayMap(c -> [c.8], reporters), arrayMap(c -> [c.9], reporters), arrayMap(c -> [c.10], reporters), arrayMap(c -> [c.11], reporters)) AS childClaims,
+          tupleElement(arrayFilter(p -> p.3 > 0 OR p.4 > 0, reporters), 1) AS reportingIds
+        FROM (SELECT
+          TraceId AS traceId,
+          max(SessionId) AS rawSessionId,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS vendorId,
+          argMin(VendorVersion, tuple(if(SessionId != '', 0, 1), Timestamp)) AS vendorVersion,
+          min(tuple(if(SessionId != '', 0, 1), Timestamp)) AS vendorAt,
+          min(Timestamp) AS traceAgentStart,
+          max(Timestamp) AS traceAgentEnd,
+          max(toUnixTimestamp64Nano(Timestamp) + toInt64(Duration)) AS traceAgentEndNanos,
+          count() AS agentSpanCount,
+          groupUniqArrayIf(20)(ServiceName, ServiceName != '') AS serviceNames,
+          groupUniqArrayIf(20)(Model, Model != '') AS models,
+          groupUniqArrayIf(20)(AgentName, AgentName != '') AS agentNames,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS firstAgentName,
+          min(if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS firstAgentAt,
+          sum(IsToolCall) AS toolCalls,
+          sum(IsError) AS errorAgentSpans,
+          groupArrayIf(2000)(tuple(SpanId, ParentSpanId, IsToolCall), IsError = 1) AS failedSpans,
+          groupArrayIf(2000)(tuple(SpanId, ParentSpanId, Tokens, Cost, ResponseId, IsLlmCall, InputTokens, CacheReadTokens, CacheWriteTokens, OutputTokens, ReasoningTokens), ((Tokens > 0 OR Cost > 0) OR IsLlmCall = 1)) AS usageReporters
+        FROM ai_trace_index
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+        GROUP BY traceId) AS index_traces
+        GROUP BY sessionId) AS window_sessions) AS netted_sessions) AS session_measures) AS measured_sessions
+        WHERE tupleElement(measured, 2) > 0
+        GROUP BY measure
+        FORMAT JSON
+
 -- builder:ai-sessions:aiSessionFacetsQuery:default
 SELECT
           arrayJoin(names) AS name,

--- a/packages/query-engine-integrations/src/ai/ai-sessions.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.test.ts
@@ -9,6 +9,7 @@ import {
 import {
 	aiSessionDetailsQuery,
 	aiSessionDetailsSlices,
+	aiSessionDistributionsQuery,
 	aiSessionFacetsQuery,
 	idSearchPattern,
 	mergeAiSessionDetails,
@@ -911,6 +912,90 @@ describe("aiSessionFacetsQuery", () => {
 			{ name: "eve", count: 12, facetType: "vendor" },
 			{ name: "maple-slack-agent", count: 9, facetType: "service" },
 		])
+	})
+})
+
+describe("aiSessionDistributionsQuery", () => {
+	/** The levels, outermost first: the grouping by measure, the unnesting,
+	 *  the sums, the netting, the sessions and the traces. */
+	const distributionLevels = (sql: string) => {
+		const [grouped = "", unnested = "", sums = "", netted = "", sessions = "", traces = ""] =
+			sql.split("FROM (SELECT")
+		return { grouped, unnested, sums, netted, sessions, traces }
+	}
+
+	it("reads ai_trace_index alone, once, org-scoped", () => {
+		const compiled = compileUnsafe(aiSessionDistributionsQuery(), params)
+
+		expect(compiled.sql).toContain("FROM ai_trace_index")
+		expect(compiled.sql).not.toContain("trace_detail_spans")
+		expect(compiled.sql).not.toContain("FROM traces")
+		expect(compiled.sql.split("FROM ai_trace_index").length - 1).toBe(1)
+		expect(orgPredicateCount(compiled.sql)).toBe(1)
+		expect(compiled.tenantScope).toBe("single-tenant")
+		expect(compiled.sql).not.toContain("__PARAM_")
+	})
+
+	it("nets the reporters once over the unfiltered window, the way the page does", () => {
+		const { sql } = compileUnsafe(aiSessionDistributionsQuery(), params)
+		const { sums, netted, sessions, traces } = distributionLevels(sql)
+
+		// One netting pass for all three usage measures: five grouped passes, or
+		// a netting per measure, would multiply the cost of the page's slowest part.
+		expect(sql.split("arrayMap(r -> tuple(").length - 1).toBe(1)
+		expect(netted).toContain("AS netted")
+		expect(sums).toMatch(/AS llmCalls,/)
+		expect(sums).toMatch(/AS totalTokens,/)
+		expect(sums).toMatch(/AS cost\b/)
+		expect(sessions).toContain(`${SESSION_KEY} AS sessionId`)
+		expect(sql).toContain("GROUP BY sessionId")
+		// No range, sort or page: every session in the window is placed.
+		expect(sql).not.toContain("HAVING")
+		expect(sql).not.toContain("LIMIT")
+		expect(sql).not.toContain("ORDER BY")
+		expect(traces).toContain(`Timestamp >= '${params.startTime}'`)
+		expect(traces).toContain(`Timestamp <= '${params.endTime}'`)
+	})
+
+	it("unnests every measure into one Float64 tuple per session, then groups by measure", () => {
+		const { sql } = compileUnsafe(aiSessionDistributionsQuery(), params)
+		const { grouped, unnested, sums } = distributionLevels(sql)
+
+		// Float64 throughout: `UInt64` and `Float64` have no supertype, so an
+		// array mixing the two sums with the three nettings would not analyze.
+		expect(sums).toContain("toFloat64(agentDurationMs) AS durationMs")
+		expect(sums).toContain("toFloat64(toolCalls) AS toolCalls")
+		expect(unnested.split("arrayJoin(").length - 1).toBe(1)
+		for (const measure of ["durationMs", "cost", "totalTokens", "llmCalls", "toolCalls"]) {
+			expect(unnested).toContain(`tuple('${measure}', ${measure}, `)
+		}
+		expect(grouped).toContain("tupleElement(measured, 1) AS measure")
+		expect(grouped).toContain("sumMap(map(toString(tupleElement(measured, 3)), toUInt64(1))) AS buckets")
+		expect(grouped).toContain("quantile(0.5)(tupleElement(measured, 2)) AS p50")
+		expect(grouped).toContain("quantile(0.95)(tupleElement(measured, 2)) AS p95")
+		// Zero has no place on a log axis: a session with no priced call has no cost.
+		expect(sql).toContain("WHERE tupleElement(measured, 2) > 0")
+		expect(sql).toContain("GROUP BY measure")
+	})
+
+	it("steps the continuous measures in clamped half-octaves and the counts in octaves", () => {
+		const { sql } = compileUnsafe(aiSessionDistributionsQuery(), params)
+
+		expect(sql).toContain("pow(2, floor(log2(greatest(durationMs / 1000, 1)) * 2) / 2) * 1000")
+		expect(sql).toContain("pow(2, floor(log2(greatest(cost, 0.001)) * 2) / 2)")
+		for (const count of ["totalTokens", "llmCalls", "toolCalls"]) {
+			expect(sql).toContain(`pow(2, floor(log2(${count})))`)
+		}
+	})
+
+	it("decodes the quoted 64-bit bucket counts", () => {
+		const compiled = compileUnsafe(aiSessionDistributionsQuery(), params)
+
+		expect(
+			decodeRows(compiled, [
+				{ measure: "totalTokens", buckets: { "8": "1", "128": 2 }, p50: 150, p95: "150" },
+			]),
+		).toEqual([{ measure: "totalTokens", buckets: { "8": 1, "128": 2 }, p50: 150, p95: 150 }])
 	})
 })
 

--- a/packages/query-engine-integrations/src/ai/ai-sessions.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.ts
@@ -604,6 +604,58 @@ const carry = <Row extends Record<SessionColumn, unknown>>(row: Row): Pick<Row, 
 	Object.fromEntries(SESSION_COLUMNS.map((column) => [column, row[column]])) as Pick<Row, SessionColumn>
 
 /**
+ * One row per session in the caller's window, off `indexTraces`: every
+ * measure the index carries per span, summed, and the usage reporters the
+ * netting reads — the session level of the page and of the distributions,
+ * so a session measures the same in the row and in the histogram above it.
+ */
+const indexSessions = (opts: AiSessionFilterOpts) =>
+	fromQuery(indexTraces(opts, "window"), "index_traces")
+		.select(($) => ({
+			// The grouping key, and the only level that can compute it: the
+			// derived table is one row per trace, so a trace with no session id
+			// of its own becomes a session of one trace here rather than joining
+			// every other sessionless trace under `''`.
+			sessionId: sessionKey($.rawSessionId, $.traceId),
+			// Across traces the same ordering resolves the session's vendor: its
+			// earliest session-bearing span's, else its earliest agent span's.
+			vendorId: CH.argMin($.vendorId, $.vendorAt),
+			vendorVersion: CH.argMin($.vendorVersion, $.vendorAt),
+			agentStart: CH.toString_(CH.min_($.traceAgentStart)),
+			// The extent's END, not the last agent span's start: the row shows
+			// this as the session's end until the details replace it.
+			agentEnd: CH.toString_(fromUnixTimestamp64Nano(CH.max_($.traceAgentEndNanos))),
+			// `count()`, not `uniq()`: the derived table already emits exactly one
+			// row per trace, so this is exact and cheaper.
+			traceCount: CH.count(),
+			spanCount: CH.sum($.agentSpanCount),
+			serviceNames: CH.groupUniqArrayArray($.serviceNames),
+			models: CH.groupUniqArrayArray($.models),
+			agentNames: CH.groupUniqArrayArray($.agentNames),
+			// Across traces the same ordering resolves the session's own first
+			// named agent: a trace that named none carries the sentinel and loses
+			// to any trace that did.
+			firstAgentName: CH.argMin($.firstAgentName, $.firstAgentAt),
+			toolCalls: CH.sum($.toolCalls),
+			errorAgentSpans: CH.sum($.errorAgentSpans),
+			toolErrors: deepestFailureCount("failedSpans", "tool"),
+			turnErrors: deepestFailureCount("failedSpans", "turn"),
+			// Nanoseconds first, wrapped in `intDiv` — see `durationMs` in
+			// `aiSessionDetailsQuery` for both.
+			agentDurationMs: CH.intDiv(
+				CH.max_($.traceAgentEndNanos).sub(CH.toUnixTimestamp64Nano(CH.min_($.traceAgentStart))),
+				1_000_000,
+			),
+			// The usage, still as reporters: netted one level up, summed two —
+			// with the two lookups the netting makes taken off the reporters here,
+			// once per session, rather than once per reporter inside the netting.
+			reporters: sessionReportersExpr("usageReporters"),
+			childClaims: childClaimsExpr("reporters"),
+			reportingIds: reportingSpanIdsExpr("reporters"),
+		}))
+		.groupBy("sessionId")
+
+/**
  * The page: which sessions the list shows, in what order, and everything a
  * row shows about them that the index can answer — the read the list renders
  * from, and the only one that sees the caller's whole window. See the file
@@ -642,9 +694,9 @@ const carry = <Row extends Record<SessionColumn, unknown>>(row: Row): Pick<Row, 
  * model calls nets every session in the window and ranks on the level that
  * has the sums. The session-level filters are `HAVING` on the ranked row, or
  * `WHERE` on the summed one, and cost nothing beyond the index scan the page
- * already is. What they cannot do is count — a facet for "sessions over $1"
- * would be another pass over the same index per bucket, which the sidebar
- * does not ask for.
+ * already is. What they cannot do is count: the sidebar's histograms of the
+ * same measures are `aiSessionDistributionsQuery`, which nets every session in
+ * the window once and buckets all five off that one pass.
  *
  * The remaining gap is between traces, not inside one: a session whose OTHER
  * traces lie entirely outside the range is still found only by the traces that
@@ -705,60 +757,16 @@ export function aiSessionPageQuery(opts: AiSessionPageOpts = {}) {
 	const paged = <Q extends { limit(n: number): Q; offset(n: number): Q }>(query: Q): Q =>
 		offset > 0 ? query.limit(limit).offset(offset) : query.limit(limit)
 
-	const sessions = fromQuery(indexTraces(opts, "window"), "index_traces")
-		.select(($) => ({
-			// The grouping key, and the only level that can compute it: the
-			// derived table is one row per trace, so a trace with no session id
-			// of its own becomes a session of one trace here rather than joining
-			// every other sessionless trace under `''`.
-			sessionId: sessionKey($.rawSessionId, $.traceId),
-			// Across traces the same ordering resolves the session's vendor: its
-			// earliest session-bearing span's, else its earliest agent span's.
-			vendorId: CH.argMin($.vendorId, $.vendorAt),
-			vendorVersion: CH.argMin($.vendorVersion, $.vendorAt),
-			agentStart: CH.toString_(CH.min_($.traceAgentStart)),
-			// The extent's END, not the last agent span's start: the row shows
-			// this as the session's end until the details replace it.
-			agentEnd: CH.toString_(fromUnixTimestamp64Nano(CH.max_($.traceAgentEndNanos))),
-			// `count()`, not `uniq()`: the derived table already emits exactly one
-			// row per trace, so this is exact and cheaper.
-			traceCount: CH.count(),
-			spanCount: CH.sum($.agentSpanCount),
-			serviceNames: CH.groupUniqArrayArray($.serviceNames),
-			models: CH.groupUniqArrayArray($.models),
-			agentNames: CH.groupUniqArrayArray($.agentNames),
-			// Across traces the same ordering resolves the session's own first
-			// named agent: a trace that named none carries the sentinel and loses
-			// to any trace that did.
-			firstAgentName: CH.argMin($.firstAgentName, $.firstAgentAt),
-			toolCalls: CH.sum($.toolCalls),
-			errorAgentSpans: CH.sum($.errorAgentSpans),
-			toolErrors: deepestFailureCount("failedSpans", "tool"),
-			turnErrors: deepestFailureCount("failedSpans", "turn"),
-			// Nanoseconds first, wrapped in `intDiv` — see `durationMs` in
-			// `aiSessionDetailsQuery` for both.
-			agentDurationMs: CH.intDiv(
-				CH.max_($.traceAgentEndNanos).sub(CH.toUnixTimestamp64Nano(CH.min_($.traceAgentStart))),
-				1_000_000,
-			),
-			// The usage, still as reporters: netted one level up, summed two —
-			// with the two lookups the netting makes taken off the reporters here,
-			// once per session, rather than once per reporter inside the netting.
-			reporters: sessionReportersExpr("usageReporters"),
-			childClaims: childClaimsExpr("reporters"),
-			reportingIds: reportingSpanIdsExpr("reporters"),
-		}))
-		.groupBy("sessionId")
-		.having(() => [
-			CH.whenTrue(opts.hasErrors, () => column.errorAgentSpans.gt(0)),
-			CH.whenTrue(opts.excludeTraceSessions, () =>
-				CH.not(column.sessionId.like(`${MAPLE_AI_TRACE_SESSION_PREFIX}%`)),
-			),
-			CH.when(opts.durationMinMs, (v) => column.agentDurationMs.gte(v)),
-			CH.when(opts.durationMaxMs, (v) => column.agentDurationMs.lte(v)),
-			CH.when(opts.toolCallsMin, (v) => column.toolCalls.gte(v)),
-			CH.when(opts.toolCallsMax, (v) => column.toolCalls.lte(v)),
-		])
+	const sessions = indexSessions(opts).having(() => [
+		CH.whenTrue(opts.hasErrors, () => column.errorAgentSpans.gt(0)),
+		CH.whenTrue(opts.excludeTraceSessions, () =>
+			CH.not(column.sessionId.like(`${MAPLE_AI_TRACE_SESSION_PREFIX}%`)),
+		),
+		CH.when(opts.durationMinMs, (v) => column.agentDurationMs.gte(v)),
+		CH.when(opts.durationMaxMs, (v) => column.agentDurationMs.lte(v)),
+		CH.when(opts.toolCallsMin, (v) => column.toolCalls.gte(v)),
+		CH.when(opts.toolCallsMax, (v) => column.toolCalls.lte(v)),
+	])
 	// A String order, and a correct one: the literal is fixed-width
 	// `YYYY-MM-DD hh:mm:ss.nnnnnnnnn`, so it sorts as the instant does.
 	const ranked =
@@ -1041,8 +1049,10 @@ export type AiSessionFacetType = "vendor" | "service" | "environment" | "model" 
  * `trace_detail_spans` fan-out, which is the expensive half. It can be: every
  * one of the list's counted filters is applied at that level, so the population
  * a facet describes is exactly the population its filter selects. The
- * session-level filters (errors, the ranges) have no facet for the same reason
- * in reverse — their numbers exist only per ranked row.
+ * session-level filters (errors, the ranges) have no facet here for the same
+ * reason in reverse — their numbers exist only per session, after the netting
+ * this read is built to skip; the ranges are counted by
+ * `aiSessionDistributionsQuery`, a request of its own.
  *
  * What it cannot do is count per span. A session id is a fact about the TRACE,
  * so a facet keyed on the span's own value would count every agent span of a
@@ -1106,6 +1116,106 @@ export function aiSessionFacetsQuery(): CHUnionQuery<AiSessionFacetsOutput> {
 		facet("agent", ($) => $.AgentName),
 		facet("tool", ($) => $.ToolName),
 	).format("JSON")
+}
+
+// Range distributions (the sidebar's histograms and percentile presets)
+
+/** The session measures the list's range filters read, by the name the list row gives each. */
+export type AiSessionDistributionMeasure = "durationMs" | "cost" | "totalTokens" | "llmCalls" | "toolCalls"
+
+export interface AiSessionDistributionsOutput {
+	readonly measure: AiSessionDistributionMeasure
+	/** Sessions per non-empty bucket, keyed by the bucket's floor in the
+	 *  measure's own unit — see `DISTRIBUTION_BUCKET_FLOORS` for the spacing. */
+	readonly buckets: Record<string, number>
+	readonly p50: number
+	readonly p95: number
+}
+
+/**
+ * Where each measure's bucket starts, in SQL over the column of the same name:
+ * log-spaced, because every one of these is heavy-tailed. The continuous two
+ * step in half-octaves from 1 — floor × √2 is the ceiling — clamping what lies
+ * below their first bucket into it: a second, as the replays histogram does,
+ * and a tenth of a cent. The three counts step in octaves from 1, so every
+ * bound is a whole number a count filter accepts; a count is at least 1 once
+ * its zeros are gone.
+ */
+const DISTRIBUTION_BUCKET_FLOORS = {
+	durationMs: "pow(2, floor(log2(greatest(durationMs / 1000, 1)) * 2) / 2) * 1000",
+	cost: "pow(2, floor(log2(greatest(cost, 0.001)) * 2) / 2)",
+	totalTokens: "pow(2, floor(log2(totalTokens)))",
+	llmCalls: "pow(2, floor(log2(llmCalls)))",
+	toolCalls: "pow(2, floor(log2(toolCalls)))",
+} as const satisfies Record<AiSessionDistributionMeasure, string>
+
+/**
+ * How the window's sessions spread over each measure the list filters on —
+ * session length, cost, tokens, model calls and tool calls — as log-spaced
+ * bucket counts and the p50/p95 the presets name, for the sidebar's range
+ * sections.
+ *
+ * One read. Cost, tokens and model calls exist only once the session's usage
+ * reporters are netted, and the netting is most of what a page read costs
+ * (see `aiSessionPageQuery`), so it runs once here over every session in the
+ * window — the same work a cost sort does — and every measure is bucketed off
+ * its result: each session row is unnested into one `(measure, value, floor)`
+ * per measure and grouped by measure. Five grouped passes over the same
+ * sessions would be five nettings. Its own request rather than a branch of
+ * `aiSessionFacetsQuery`, which stays the index scan alone and is also what
+ * the Tools pages read.
+ *
+ * Unfiltered, like the facets: a distribution narrowed by the ranges would
+ * hide the values a reader is about to widen a range to. Each measure counts
+ * the sessions where it is above zero — a session with no priced call has no
+ * cost to place on a log axis, and the "no tools" population is a preset, not
+ * a bar — and a measure no session has returns no row.
+ *
+ * The session level is the page's own (`indexSessions`), so a session sits in
+ * the bucket its row's figure falls in. `quantile` is approximate past its
+ * reservoir, which a preset threshold does not notice.
+ */
+export function aiSessionDistributionsQuery() {
+	// The page's netting and sums, less every column the histograms do not read.
+	const netted = fromQuery(indexSessions({}), "window_sessions").select(($) => ({
+		agentDurationMs: $.agentDurationMs,
+		toolCalls: $.toolCalls,
+		netted: nettedReportersExpr("reporters", "childClaims", "reportingIds"),
+	}))
+	const measured = fromQuery(netted, "netted_sessions").select(($) => ({
+		durationMs: CH.toFloat64($.agentDurationMs),
+		toolCalls: CH.toFloat64($.toolCalls),
+		llmCalls: sessionLlmCalls("netted"),
+		totalTokens: sessionUsageSum("netted", "tokens"),
+		cost: sessionUsageSum("netted", "cost"),
+	}))
+	// Every element Float64, so the tuples share a type — `UInt64` and
+	// `Float64` have no supertype.
+	const unnested = fromQuery(measured, "session_measures").select(() => ({
+		measured: CH.untypedExpr(
+			`arrayJoin([${Object.entries(DISTRIBUTION_BUCKET_FLOORS)
+				.map(([measure, floor]) => `tuple('${measure}', ${measure}, ${floor})`)
+				.join(", ")}])`,
+		),
+	}))
+	const value = CH.rawExpr("tupleElement(measured, 2)", T.float64)
+	return fromQuery(unnested, "measured_sessions")
+		.select(() => ({
+			measure: CH.rawExpr(
+				"tupleElement(measured, 1)",
+				T.string,
+			) as CH.Expr<AiSessionDistributionMeasure>,
+			// Keyed by the floor as a string: a `Map` key cannot be a float.
+			buckets: CH.rawExpr(
+				"sumMap(map(toString(tupleElement(measured, 3)), toUInt64(1)))",
+				T.map(T.string, T.uint64),
+			),
+			p50: CH.rawExpr("quantile(0.5)(tupleElement(measured, 2))", T.float64),
+			p95: CH.rawExpr("quantile(0.95)(tupleElement(measured, 2))", T.float64),
+		}))
+		.where(() => [value.gt(0)])
+		.groupBy("measure")
+		.format("JSON")
 }
 
 // Session window resolution (id → bounds)

--- a/packages/query-engine-integrations/src/ai/index.ts
+++ b/packages/query-engine-integrations/src/ai/index.ts
@@ -10,6 +10,7 @@
 export {
 	aiSessionDetailsQuery,
 	aiSessionDetailsSlices,
+	aiSessionDistributionsQuery,
 	aiSessionFacetsQuery,
 	aiSessionPageQuery,
 	mergeAiSessionDetails,
@@ -25,6 +26,8 @@ export {
 	aiTraceTotalsQuery,
 	aiTraceWindowQuery,
 	idSearchPattern,
+	type AiSessionDistributionMeasure,
+	type AiSessionDistributionsOutput,
 	type AiSessionFacetType,
 	type AiSessionFacetsOutput,
 	type AiSessionFilterOpts,

--- a/packages/query-engine-integrations/src/benchmark/index.ts
+++ b/packages/query-engine-integrations/src/benchmark/index.ts
@@ -221,6 +221,14 @@ export const integrationFixtures: ReadonlyArray<IntegrationFixture> = [
 		compile: () => compileUnionUnsafe(CH.aiSessionFacetsQuery(), window),
 	},
 	{
+		// The netting over every session in the window, unnested per measure:
+		// the tuple array only type-checks when every element agrees.
+		module: "ai-sessions",
+		name: "aiSessionDistributionsQuery",
+		label: "default",
+		compile: () => compileUnsafe(CH.aiSessionDistributionsQuery(), window),
+	},
+	{
 		// Agent Sessions › Tools. The chart's series key is derived from the
 		// selection, so the unfiltered shape (per-tool series, with the long tail
 		// folded into `other`) and the tool-selected one (per-model series) are

--- a/packages/ui/src/components/filters/range-filter-section.tsx
+++ b/packages/ui/src/components/filters/range-filter-section.tsx
@@ -341,6 +341,15 @@ function RangeHistogram({
 	const peak = Math.max(...buckets.map((b) => b.count), 1)
 	const total = buckets.reduce((sum, b) => sum + b.count, 0)
 
+	// A count is whole and the filter's bounds are inclusive, so a count bucket's
+	// last member is `to - 1` — the bound a selection writes and the readout names.
+	const lastOf = (bucket: RangeBucket): number => (unit === "count" ? bucket.to - 1 : bucket.to)
+	const describe = (bucket: RangeBucket): string => {
+		if (bucket.unbounded) return `≥ ${formatValue(bucket.from, unit)}`
+		if (lastOf(bucket) === bucket.from) return formatValue(bucket.from, unit)
+		return `${formatValue(bucket.from, unit)} – ${formatValue(lastOf(bucket), unit)}`
+	}
+
 	const indexAt = (clientX: number): number => {
 		const rect = barsRef.current?.getBoundingClientRect()
 		if (!rect || rect.width === 0) return 0
@@ -373,7 +382,7 @@ function RangeHistogram({
 			return
 		}
 		const top = buckets[hi] ?? last
-		onSelect(bottom.from, top.unbounded ? undefined : top.to)
+		onSelect(bottom.from, top.unbounded ? undefined : lastOf(top))
 	}
 
 	// While dragging, preview the pending selection instead of the applied one.
@@ -388,7 +397,7 @@ function RangeHistogram({
 		}
 		if (minValue === undefined && maxValue === undefined) return false
 		return (
-			(maxValue === undefined || bucket.from < maxValue) &&
+			(maxValue === undefined || bucket.from < (unit === "count" ? maxValue + 1 : maxValue)) &&
 			(minValue === undefined || bucket.to > minValue)
 		)
 	}
@@ -403,11 +412,7 @@ function RangeHistogram({
 			<div className="mb-1 flex h-4 items-center justify-between text-[10px] tabular-nums text-muted-foreground">
 				{hovered ? (
 					<>
-						<span>
-							{hovered.unbounded
-								? `≥ ${formatValue(hovered.from, unit)}`
-								: `${formatValue(hovered.from, unit)} – ${formatValue(hovered.to, unit)}`}
-						</span>
+						<span>{describe(hovered)}</span>
 						<span className="text-foreground">{hovered.count.toLocaleString()}</span>
 					</>
 				) : (
@@ -419,7 +424,7 @@ function RangeHistogram({
 			<div
 				ref={barsRef}
 				role="img"
-				aria-label={`${title} distribution across ${buckets.length} buckets, from ${formatValue(first.from, unit)} to ${last.unbounded ? `over ${formatValue(last.from, unit)}` : formatValue(last.to, unit)}`}
+				aria-label={`${title} distribution across ${buckets.length} buckets, from ${formatValue(first.from, unit)} to ${last.unbounded ? `over ${formatValue(last.from, unit)}` : formatValue(lastOf(last), unit)}`}
 				className="flex h-8 cursor-crosshair touch-none items-end gap-px"
 				onPointerDown={handlePointerDown}
 				onPointerMove={handlePointerMove}
@@ -456,7 +461,7 @@ function RangeHistogram({
 				<span>{formatValue(first.from, unit)}</span>
 				<span>{formatValue((buckets[Math.floor(buckets.length / 2)] ?? first).from, unit)}</span>
 				<span>
-					{last.unbounded ? `${formatValue(last.from, unit)}+` : formatValue(last.to, unit)}
+					{last.unbounded ? `${formatValue(last.from, unit)}+` : formatValue(lastOf(last), unit)}
 				</span>
 			</div>
 		</div>


### PR DESCRIPTION
## What

The Agent Sessions sidebar's five range filters (Session length, Cost, Tokens, LLM calls, Tool calls) now work like the Replays one: a small distribution graph you can drag across, plus `> p50` / `> p95` presets taken from the data. The intent presets stay (Quick, Single call, No tools); the fixed-threshold ones are gone. The range sections now start open, as they do on Replays and as `RangeFilterSection` recommends.

## How

- **Query:** new `aiSessionDistributionsQuery`, served by `POST /internal/ai-sessions/distributions` and loaded by its own atom.
  - Reuses the page query's session level (moved out into `indexSessions`, SQL baseline unchanged) and runs the reporter netting once over the unfiltered 7-day window.
  - Each session is then split into one `(measure, value, floor)` tuple per measure with `arrayJoin`, and grouped by measure into `sumMap` bucket counts plus `quantile` p50/p95.
  - Everything happens in one read: no extra netting per measure, and the facets read doesn't get slower.
- **Buckets:** log-spaced. Duration and cost use half-octaves (clamped at 1s and $0.001). The three counts use octaves, so drag-selected bounds are whole numbers that the `CountBound` schema accepts. Zeros are left out (a log axis has no place for them).
- **Web:** the Replays histogram helper moves to `components/filters/range-distribution.ts` (`toLogBuckets`, `percentilePresets`) and both sidebars use it.
- **`RangeFilterSection`:** for `count` units, a bucket's upper bound is now inclusive (`to - 1`), so dragging over `[4,8)` writes `max 7`. The readout and axis labels match.
- **Expected cost:** about the same as a cost-sorted page read, which already nets every session in the window. The page read was ~450ms per week, and the netting was most of that. Bucketing adds only a 5× row fan-out over the session rows plus `sumMap`/`quantile`.

## Verification

- `packages/query-engine-integrations`: `src/ai/ai-sessions.test.ts` (new SQL tests) and `src/benchmark/catalog.test.ts`. The baseline only adds the new query, and the new query is fixtured.
- `apps/web`: `src/components/filters` (new helper tests), `replays-filter-sidebar.test.ts`, `agent-sessions-filter-sidebar.test.tsx` (histograms render, percentile preset, drag-select on a count histogram).
- ClickHouse 26.7 e2e (`CLICKHOUSE_E2E=1`):
  - `query-benchmark.clickhouse.e2e.test.ts -t ai-sessions`: the analyzer and both wire decodings accept the new query.
  - `ai-trace-index-materialization.clickhouse.e2e.test.ts`: the real query over seeded spans gives exactly the buckets the page's per-session figures imply.
- Not verified: production timing, and the UI in a running app (no dev server).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791724942&installation_model_id=427786&pr_number=846&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F846&signature=5f26876dce15c3f5c2c56e29b6743f4cdc24e6b053b6bba82c7cc90b6c3a151d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->