### PR TITLE
feat(web): agent sessions list as a sortable table

### DIFF
--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-inputs.test.ts
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-inputs.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { agentSessionsFilterInputs, hasAgentSessionsFilters } from "./agent-sessions-filter-inputs"
+import {
+	agentSessionsFilterInputs,
+	agentSessionsSortPatch,
+	hasAgentSessionsFilters,
+} from "./agent-sessions-filter-inputs"
 
 const window = { startTime: "2026-08-19 09:00:00", endTime: "2026-08-19 11:00:00" }
 
@@ -47,10 +51,19 @@ describe("agentSessionsFilterInputs", () => {
 		})
 	})
 
-	it("sorts by the menu row the URL resolves to, never by a pair the menu lacks", () => {
+	it("sends a sort only when it is not the default, filling in the half the URL leaves off", () => {
 		expect(agentSessionsFilterInputs({ sortBy: "startTime", sortDir: "desc" }, window)).toEqual(window)
-		expect(agentSessionsFilterInputs({ sortBy: "cost", sortDir: "asc" }, window)).toEqual(window)
-		expect(agentSessionsFilterInputs({ sortBy: "startTime", sortDir: "asc" }, window)).toEqual({
+		expect(agentSessionsFilterInputs({ sortBy: "cost", sortDir: "asc" }, window)).toEqual({
+			...window,
+			sortBy: "cost",
+			sortDir: "asc",
+		})
+		expect(agentSessionsFilterInputs({ sortBy: "cost" }, window)).toEqual({
+			...window,
+			sortBy: "cost",
+			sortDir: "desc",
+		})
+		expect(agentSessionsFilterInputs({ sortDir: "asc" }, window)).toEqual({
 			...window,
 			sortBy: "startTime",
 			sortDir: "asc",
@@ -64,5 +77,34 @@ describe("agentSessionsFilterInputs", () => {
 		expect(hasAgentSessionsFilters({ durationMin: 0 })).toBe(true)
 		const inputs = agentSessionsFilterInputs({ hasErrors: false, grouped: false, q: "  " }, window)
 		expect(inputs).toEqual(window)
+	})
+})
+
+describe("agentSessionsSortPatch", () => {
+	it("starts a newly sorted column descending", () => {
+		expect(agentSessionsSortPatch({}, "cost")).toEqual({ sortBy: "cost", sortDir: "desc" })
+		expect(agentSessionsSortPatch({ sortBy: "cost", sortDir: "asc" }, "toolCalls")).toEqual({
+			sortBy: "toolCalls",
+			sortDir: "desc",
+		})
+	})
+
+	it("flips the column the list is already sorted by", () => {
+		expect(agentSessionsSortPatch({ sortBy: "cost", sortDir: "desc" }, "cost")).toEqual({
+			sortBy: "cost",
+			sortDir: "asc",
+		})
+		expect(agentSessionsSortPatch({ sortBy: "cost", sortDir: "asc" }, "cost")).toEqual({
+			sortBy: "cost",
+			sortDir: "desc",
+		})
+	})
+
+	// The default order leaves the URL clean, so a shared link only carries a
+	// sort when one was chosen.
+	it("clears both params when a click lands back on newest first", () => {
+		expect(agentSessionsSortPatch({}, "startTime")).toEqual({ sortBy: "startTime", sortDir: "asc" })
+		const patch = agentSessionsSortPatch({ sortBy: "startTime", sortDir: "asc" }, "startTime")
+		expect(patch).toStrictEqual({ sortBy: undefined, sortDir: undefined })
 	})
 })

--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-inputs.ts
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-inputs.ts
@@ -56,45 +56,41 @@ export const AGENT_SESSIONS_FILTER_KEYS = [
 	"toolCallsMax",
 ] as const satisfies ReadonlyArray<keyof AgentSessionsSearchState>
 
-/**
- * One row of the sort menu: the measure and the direction it makes sense in.
- * The list exposes no direction toggle — "most expensive" is the question, and
- * "least expensive" is not one anybody asks a session list.
- */
-export interface AgentSessionsSortOption {
-	readonly key: string
-	readonly label: string
+export interface AgentSessionsSort {
 	readonly sortBy: AiSessionSortKey
 	readonly sortDir: AiSessionSortDir
 }
 
-export const AGENT_SESSIONS_SORT_OPTIONS: ReadonlyArray<AgentSessionsSortOption> = [
-	{ key: "newest", label: "Newest first", sortBy: "startTime", sortDir: "desc" },
-	{ key: "oldest", label: "Oldest first", sortBy: "startTime", sortDir: "asc" },
-	{ key: "longest", label: "Longest", sortBy: "durationMs", sortDir: "desc" },
-	{ key: "cost", label: "Most expensive", sortBy: "cost", sortDir: "desc" },
-	{ key: "tokens", label: "Most tokens", sortBy: "totalTokens", sortDir: "desc" },
-	{ key: "errors", label: "Most errors", sortBy: "errorSpanCount", sortDir: "desc" },
-	{ key: "llm-calls", label: "Most LLM calls", sortBy: "llmCalls", sortDir: "desc" },
-	{ key: "tool-calls", label: "Most tool calls", sortBy: "toolCalls", sortDir: "desc" },
-]
+/** The order the list reads in when the URL names none: newest first. */
+const DEFAULT_SORT: AgentSessionsSort = { sortBy: "startTime", sortDir: "desc" }
 
-export const DEFAULT_SORT_OPTION = AGENT_SESSIONS_SORT_OPTIONS[0]!
+const isDefaultSort = (sort: AgentSessionsSort) =>
+	sort.sortBy === DEFAULT_SORT.sortBy && sort.sortDir === DEFAULT_SORT.sortDir
+
+/** The order a URL names, with either half it leaves off taken from the default. */
+export function agentSessionsSort(search: Pick<AgentSessionsSearchState, "sortBy" | "sortDir">): AgentSessionsSort {
+	return {
+		sortBy: search.sortBy ?? DEFAULT_SORT.sortBy,
+		sortDir: search.sortDir ?? DEFAULT_SORT.sortDir,
+	}
+}
 
 /**
- * The menu row a URL pair names; the default when the URL names none, or a
- * pair the menu does not offer. The query is built from THIS, so what the
- * select says is always what the list is sorted by.
+ * The URL patch a click on a column header writes. The sorted column flips
+ * direction; any other starts descending — the longest, costliest, busiest end
+ * of a measure is the one a session list is read for. Landing back on the
+ * default order clears both params, so a shared link only carries a sort when
+ * one was chosen.
  */
-export function sortOptionFor(
-	sortBy: AiSessionSortKey | undefined,
-	sortDir: AiSessionSortDir | undefined,
-): AgentSessionsSortOption {
-	return (
-		AGENT_SESSIONS_SORT_OPTIONS.find(
-			(option) => option.sortBy === (sortBy ?? "startTime") && option.sortDir === (sortDir ?? "desc"),
-		) ?? DEFAULT_SORT_OPTION
-	)
+export function agentSessionsSortPatch(
+	search: Pick<AgentSessionsSearchState, "sortBy" | "sortDir">,
+	key: AiSessionSortKey,
+): { sortBy: AiSessionSortKey | undefined; sortDir: AiSessionSortDir | undefined } {
+	const current = agentSessionsSort(search)
+	const sortDir: AiSessionSortDir = key === current.sortBy && current.sortDir === "desc" ? "asc" : "desc"
+	return isDefaultSort({ sortBy: key, sortDir })
+		? { sortBy: undefined, sortDir: undefined }
+		: { sortBy: key, sortDir }
 }
 
 export function hasAgentSessionsFilters(search: AgentSessionsSearchState): boolean {
@@ -118,7 +114,7 @@ export function agentSessionsFilterInputs(
 	search: AgentSessionsSearchState,
 	window: { readonly startTime: string; readonly endTime: string },
 ): AiSessionsFilterInputs {
-	const sortOption = sortOptionFor(search.sortBy, search.sortDir)
+	const sort = agentSessionsSort(search)
 	return {
 		startTime: window.startTime,
 		endTime: window.endTime,
@@ -141,10 +137,7 @@ export function agentSessionsFilterInputs(
 		llmCallsMax: search.llmCallsMax,
 		toolCallsMin: search.toolCallsMin,
 		toolCallsMax: search.toolCallsMax,
-		// Resolved through the menu, and left off for the default so the first
-		// page's SQL stays the baseline shape.
-		...(sortOption === DEFAULT_SORT_OPTION
-			? undefined
-			: { sortBy: sortOption.sortBy, sortDir: sortOption.sortDir }),
+		// Left off for the default so the first page's SQL stays the baseline shape.
+		...(isDefaultSort(sort) ? undefined : sort),
 	}
 }

--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.test.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.test.tsx
@@ -14,8 +14,6 @@ vi.mock("@tanstack/react-router", () => ({
 }))
 
 import { AgentSessionsFilterSidebar } from "./agent-sessions-filter-sidebar"
-import { AgentSessionsToolbar } from "./agent-sessions-toolbar"
-import { sortOptionFor } from "./agent-sessions-filter-inputs"
 
 const facets = Result.success({
 	vendors: [
@@ -123,44 +121,5 @@ describe("AgentSessionsFilterSidebar", () => {
 
 		fireEvent.click(screen.getByLabelText("Hide single-trace sessions"))
 		expect(nextSearch().grouped).toBe(true)
-	})
-})
-
-describe("AgentSessionsToolbar", () => {
-	afterEach(cleanup)
-
-	it("names the current sort and offers every measure", () => {
-		const onSortChange = vi.fn()
-		const onToggleErrorsOnly = vi.fn()
-		render(
-			<AgentSessionsToolbar
-				query=""
-				onSearch={vi.fn()}
-				errorsOnly={false}
-				onToggleErrorsOnly={onToggleErrorsOnly}
-				sortKey={sortOptionFor("cost", "desc").key}
-				onSortChange={onSortChange}
-				sessionCount={12}
-			/>,
-		)
-
-		// The menu itself is portal-rendered on open; jsdom sees the trigger,
-		// which names the sort it is set to.
-		const sort = screen.getByRole("combobox", { name: "Sort sessions" })
-		expect(sort.textContent).toContain("Most expensive")
-		// The error filter is a switch: on or off, never a button that looks
-		// like a warning about the list.
-		const errors = screen.getByRole("switch", { name: "With errors" })
-		expect(errors.getAttribute("aria-checked")).toBe("false")
-		fireEvent.click(errors)
-		expect(onToggleErrorsOnly).toHaveBeenCalledOnce()
-		expect(screen.getByText("12")).toBeTruthy()
-		expect(screen.getByPlaceholderText("Session or trace ID…")).toBeTruthy()
-	})
-
-	it("falls back to newest-first for a pair the menu does not offer", () => {
-		expect(sortOptionFor(undefined, undefined).key).toBe("newest")
-		expect(sortOptionFor("cost", "asc").key).toBe("newest")
-		expect(sortOptionFor("startTime", "asc").key).toBe("oldest")
 	})
 })

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.test.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 // TEST-SEAM: This focused test replaces process-global modules that have no instance-level injection seam.
+// The virtualizer sizes its viewport from offsetHeight, which jsdom reports as 0, so the page
+// scroller's height is stubbed — the scroller's alone, since a list that found no scroller must
+// not pass here on the strength of its own stubbed height. ResizeObserver is stubbed because jsdom
+// has none and the scroll-margin hook observes the scroller.
 
+import type { ReactNode } from "react"
 import { cleanup, fireEvent, render, within } from "@testing-library/react"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { sessionLinkWindow } from "@/lib/agent-sessions/session-window"
 import { AgentSessionsList, type AgentSessionRow } from "./agent-sessions-list"
 
@@ -15,24 +20,27 @@ vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigate,
 }))
 
-// The table is virtualized against a scroll ancestor that jsdom gives zero
-// height, so the real `useVirtualizer` yields no rows and nothing renders.
-// Stub it to emit one row per session — that keeps the assertions on the
-// component's actual row markup.
-vi.mock("@tanstack/react-virtual", () => ({
-	useVirtualizer: ({ count }: { count: number }) => ({
-		getVirtualItems: () =>
-			Array.from({ length: count }, (_, index) => ({
-				index,
-				key: index,
-				start: index * 53,
-				end: (index + 1) * 53,
-			})),
-		getTotalSize: () => count * 53,
-		measureElement: () => {},
-		options: { scrollMargin: 0 },
-	}),
-}))
+const offsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetHeight")
+
+beforeAll(() => {
+	Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+		configurable: true,
+		get(this: HTMLElement) {
+			return this.dataset.slot === "page-scroll-area" ? 900 : 0
+		},
+	})
+})
+
+afterAll(() => {
+	if (offsetHeight) Object.defineProperty(HTMLElement.prototype, "offsetHeight", offsetHeight)
+})
+
+/** What `PageLayout.ScrollArea` renders — the scroller the list virtualizes against. */
+function PageScroller({ children }: { children: ReactNode }) {
+	return <div data-slot="page-scroll-area">{children}</div>
+}
+
+const renderList = (ui: ReactNode) => render(ui, { wrapper: PageScroller })
 
 const session: AgentSessionRow = {
 	sessionId: "wrun_01M0CSAEW96BH2W9185XZPRPKH",
@@ -72,10 +80,17 @@ class MockIntersectionObserver {
 	}
 }
 
+class MockResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
 describe("AgentSessionsList", () => {
 	beforeEach(() => {
 		MockIntersectionObserver.instances = []
 		vi.stubGlobal("IntersectionObserver", MockIntersectionObserver)
+		vi.stubGlobal("ResizeObserver", MockResizeObserver)
 		navigate.mockReset()
 	})
 
@@ -84,9 +99,21 @@ describe("AgentSessionsList", () => {
 		vi.unstubAllGlobals()
 	})
 
+	it("renders a row per session inside the page's scroller", () => {
+		const view = renderList(
+			<AgentSessionsList
+				{...sort}
+				sessions={[session, { ...session, sessionId: "wrun_01M0CSAEW96BH2W9185XZPRQ44" }]}
+			/>,
+		)
+		// The header row, then one per session; the virtualizer's spacer rows are
+		// aria-hidden and so not counted.
+		expect(view.getAllByRole("row")).toHaveLength(3)
+	})
+
 	it("asks for the next page when the sentinel comes into view, but not while one is in flight", () => {
 		const onReachEnd = vi.fn()
-		const view = render(
+		const view = renderList(
 			<AgentSessionsList {...sort} sessions={[session]} hasMore onReachEnd={onReachEnd} loadingMore={false} />,
 		)
 
@@ -110,12 +137,12 @@ describe("AgentSessionsList", () => {
 	})
 
 	it("renders no sentinel once the backend has no more pages", () => {
-		render(<AgentSessionsList {...sort} sessions={[session]} hasMore={false} />)
+		renderList(<AgentSessionsList {...sort} sessions={[session]} hasMore={false} />)
 		expect(MockIntersectionObserver.instances).toHaveLength(0)
 	})
 
 	it("names the framework by its mark alone, and splits the failures by kind", () => {
-		const view = render(
+		const view = renderList(
 			<AgentSessionsList
 				{...sort}
 				sessions={[
@@ -144,13 +171,13 @@ describe("AgentSessionsList", () => {
 	})
 
 	it("says a session without errors has none, rather than leaving the cell blank", () => {
-		const view = render(<AgentSessionsList {...sort} sessions={[session]} />)
+		const view = renderList(<AgentSessionsList {...sort} sessions={[session]} />)
 		const errors = view.getAllByRole("cell")[8]!
 		expect(errors.textContent).toBe("—")
 	})
 
 	it("labels a framework's session key apart from a session that is one trace", () => {
-		const view = render(
+		const view = renderList(
 			<AgentSessionsList
 				{...sort}
 				sessions={[session, { ...session, sessionId: "trace:7f3a4b5c6d7e8f901234567890abcdef" }]}
@@ -162,7 +189,7 @@ describe("AgentSessionsList", () => {
 
 	it("sorts through the column headers, marking the one the rows are in", () => {
 		const onSortChange = vi.fn()
-		const view = render(
+		const view = renderList(
 			<AgentSessionsList sessions={[session]} sortBy="cost" sortDir="desc" onSortChange={onSortChange} />,
 		)
 		const cost = view.getByRole("columnheader", { name: "Cost" })
@@ -174,7 +201,7 @@ describe("AgentSessionsList", () => {
 	})
 
 	it("opens the session over its own window from the row, and only once from its link", () => {
-		const view = render(<AgentSessionsList {...sort} sessions={[session]} />)
+		const view = renderList(<AgentSessionsList {...sort} sessions={[session]} />)
 
 		fireEvent.click(view.getAllByRole("row")[1]!)
 		expect(navigate).toHaveBeenCalledWith({
@@ -189,7 +216,7 @@ describe("AgentSessionsList", () => {
 	})
 
 	it("explains the retention cap instead of paging further", () => {
-		const view = render(<AgentSessionsList {...sort} sessions={[session]} isCapped />)
+		const view = renderList(<AgentSessionsList {...sort} sessions={[session]} isCapped />)
 		expect(MockIntersectionObserver.instances).toHaveLength(0)
 		expect(view.getByText(/Showing the 1 most recent sessions/)).toBeTruthy()
 	})

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.test.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.test.tsx
@@ -1,14 +1,37 @@
 // @vitest-environment jsdom
 // TEST-SEAM: This focused test replaces process-global modules that have no instance-level injection seam.
 
-import { cleanup, render } from "@testing-library/react"
+import { cleanup, fireEvent, render, within } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { sessionLinkWindow } from "@/lib/agent-sessions/session-window"
 import { AgentSessionsList, type AgentSessionRow } from "./agent-sessions-list"
+
+const navigate = vi.fn()
 
 vi.mock("@tanstack/react-router", () => ({
 	Link: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
 		<a {...(props as Record<string, string>)}>{children}</a>
 	),
+	useNavigate: () => navigate,
+}))
+
+// The table is virtualized against a scroll ancestor that jsdom gives zero
+// height, so the real `useVirtualizer` yields no rows and nothing renders.
+// Stub it to emit one row per session — that keeps the assertions on the
+// component's actual row markup.
+vi.mock("@tanstack/react-virtual", () => ({
+	useVirtualizer: ({ count }: { count: number }) => ({
+		getVirtualItems: () =>
+			Array.from({ length: count }, (_, index) => ({
+				index,
+				key: index,
+				start: index * 53,
+				end: (index + 1) * 53,
+			})),
+		getTotalSize: () => count * 53,
+		measureElement: () => {},
+		options: { scrollMargin: 0 },
+	}),
 }))
 
 const session: AgentSessionRow = {
@@ -37,6 +60,8 @@ const session: AgentSessionRow = {
 	durationMs: 60_000,
 }
 
+const sort = { sortBy: "startTime", sortDir: "desc", onSortChange: () => {} } as const
+
 class MockIntersectionObserver {
 	static instances: MockIntersectionObserver[] = []
 	readonly observe = vi.fn()
@@ -47,10 +72,11 @@ class MockIntersectionObserver {
 	}
 }
 
-describe("AgentSessionsList pagination observer", () => {
+describe("AgentSessionsList", () => {
 	beforeEach(() => {
 		MockIntersectionObserver.instances = []
 		vi.stubGlobal("IntersectionObserver", MockIntersectionObserver)
+		navigate.mockReset()
 	})
 
 	afterEach(() => {
@@ -61,7 +87,7 @@ describe("AgentSessionsList pagination observer", () => {
 	it("asks for the next page when the sentinel comes into view, but not while one is in flight", () => {
 		const onReachEnd = vi.fn()
 		const view = render(
-			<AgentSessionsList sessions={[session]} hasMore onReachEnd={onReachEnd} loadingMore={false} />,
+			<AgentSessionsList {...sort} sessions={[session]} hasMore onReachEnd={onReachEnd} loadingMore={false} />,
 		)
 
 		const first = MockIntersectionObserver.instances[0]!
@@ -69,7 +95,9 @@ describe("AgentSessionsList pagination observer", () => {
 		first.callback([{ isIntersecting: true } as IntersectionObserverEntry], first as never)
 		expect(onReachEnd).toHaveBeenCalledOnce()
 
-		view.rerender(<AgentSessionsList sessions={[session]} hasMore onReachEnd={onReachEnd} loadingMore />)
+		view.rerender(
+			<AgentSessionsList {...sort} sessions={[session]} hasMore onReachEnd={onReachEnd} loadingMore />,
+		)
 		expect(first.disconnect).toHaveBeenCalledOnce()
 		expect(view.getByText("Loading more sessions…")).toBeTruthy()
 
@@ -82,13 +110,14 @@ describe("AgentSessionsList pagination observer", () => {
 	})
 
 	it("renders no sentinel once the backend has no more pages", () => {
-		render(<AgentSessionsList sessions={[session]} hasMore={false} />)
+		render(<AgentSessionsList {...sort} sessions={[session]} hasMore={false} />)
 		expect(MockIntersectionObserver.instances).toHaveLength(0)
 	})
 
 	it("names the framework by its mark alone, and splits the failures by kind", () => {
 		const view = render(
 			<AgentSessionsList
+				{...sort}
 				sessions={[
 					{
 						...session,
@@ -99,26 +128,68 @@ describe("AgentSessionsList pagination observer", () => {
 				]}
 			/>,
 		)
-		// The agent names the row, the id sits under it, and the framework is the
-		// mark's title rather than more text.
-		expect(view.getAllByText("slack-agent")).toHaveLength(1)
+		// The agent names the row and the framework is the mark's label rather
+		// than more text.
+		expect(view.getByText("slack-agent")).toBeTruthy()
 		expect(view.queryByText(/^eve/)).toBeNull()
-		expect(view.getAllByTitle("eve").length).toBeGreaterThan(0)
-		// Two chips in two tones — one per lane that shows them (phone + desktop).
-		// The chip splits its count and noun into fixed-width slots, so match on
-		// the whole chip's text rather than a single text node.
+		expect(view.getByRole("img", { name: "eve" })).toBeTruthy()
+		// Two chips in two tones under the Errors header. The chip splits its
+		// count and noun into fixed-width slots, so match on the whole chip's text.
 		const chip = (label: string) => (_: string, element: Element | null) =>
 			element?.classList.contains("rounded-full") === true && element.textContent === label
-		expect(view.getAllByText(chip("2 tool errors"))).toHaveLength(2)
-		expect(view.getAllByText(chip("1 turn error"))).toHaveLength(2)
-		// The buckets are the bar's title (one per line; the matcher collapses
-		// whitespace), the total the text beside it.
-		expect(view.getAllByTitle(/18,400 tokens Input: 12,000 Cache read: 4,000/)).toHaveLength(2)
-		expect(view.getByText("18.4k tok")).toBeTruthy()
+		expect(view.getAllByText(chip("2 tools"))).toHaveLength(1)
+		expect(view.getAllByText(chip("1 turn"))).toHaveLength(1)
+		expect(view.getByText("18.4k")).toBeTruthy()
+		expect(view.getByText("maple-slack-agent")).toBeTruthy()
+	})
+
+	it("says a session without errors has none, rather than leaving the cell blank", () => {
+		const view = render(<AgentSessionsList {...sort} sessions={[session]} />)
+		const errors = view.getAllByRole("cell")[8]!
+		expect(errors.textContent).toBe("—")
+	})
+
+	it("labels a framework's session key apart from a session that is one trace", () => {
+		const view = render(
+			<AgentSessionsList
+				{...sort}
+				sessions={[session, { ...session, sessionId: "trace:7f3a4b5c6d7e8f901234567890abcdef" }]}
+			/>,
+		)
+		expect(view.getByText(session.sessionId).previousElementSibling?.textContent).toBe("Session")
+		expect(view.getByText("7f3a4b5c6d7e…").previousElementSibling?.textContent).toBe("Trace")
+	})
+
+	it("sorts through the column headers, marking the one the rows are in", () => {
+		const onSortChange = vi.fn()
+		const view = render(
+			<AgentSessionsList sessions={[session]} sortBy="cost" sortDir="desc" onSortChange={onSortChange} />,
+		)
+		const cost = view.getByRole("columnheader", { name: "Cost" })
+		expect(cost.getAttribute("aria-sort")).toBe("descending")
+		expect(view.getByRole("columnheader", { name: "Started" }).getAttribute("aria-sort")).toBeNull()
+
+		fireEvent.click(within(cost).getByRole("button"))
+		expect(onSortChange).toHaveBeenCalledWith("cost")
+	})
+
+	it("opens the session over its own window from the row, and only once from its link", () => {
+		const view = render(<AgentSessionsList {...sort} sessions={[session]} />)
+
+		fireEvent.click(view.getAllByRole("row")[1]!)
+		expect(navigate).toHaveBeenCalledWith({
+			to: "/agent-sessions/$sessionId",
+			params: { sessionId: session.sessionId },
+			search: sessionLinkWindow(session),
+		})
+
+		navigate.mockReset()
+		fireEvent.click(view.getByText("slack-agent"))
+		expect(navigate).not.toHaveBeenCalled()
 	})
 
 	it("explains the retention cap instead of paging further", () => {
-		const view = render(<AgentSessionsList sessions={[session]} isCapped />)
+		const view = render(<AgentSessionsList {...sort} sessions={[session]} isCapped />)
 		expect(MockIntersectionObserver.instances).toHaveLength(0)
 		expect(view.getByText(/Showing the 1 most recent sessions/)).toBeTruthy()
 	})

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
@@ -102,7 +102,9 @@ const TABLE_FEATURES = tableFeatures({ columnSizingFeature })
 /** Two lines — the name over the id — at text-sm and text-xs, plus the cell padding. */
 const ROW_HEIGHT = 53
 
-const HEADER_CELL_CLASS = "h-10 px-2 text-left align-middle font-medium text-muted-foreground"
+// No wrap: a two-word label ("LLM calls") breaking onto a second line would
+// make the whole header row taller.
+const HEADER_CELL_CLASS = "h-10 whitespace-nowrap px-2 text-left align-middle font-medium text-muted-foreground"
 
 /**
  * Column layout, shared by the real table and the loading skeleton so the two can't drift apart.
@@ -114,9 +116,10 @@ const HEADER_CELL_CLASS = "h-10 px-2 text-left align-middle font-medium text-mut
  *
  * Budget: Errors (100) is always on — the triage signal, as Status is for traces. Every other column
  * joins where Session keeps ≥200px beside it, the sortable measures first, so a width that shows a
- * measure can also sort by it: Started (88) at 400, Duration (88) at 480, Cost (80) at 560, LLM calls
- * (100) at 660, Tool calls (100) at 760 and Tokens (130) at 900. Services (170) at 1060 and Model
- * (160) at 1220 come last — the filter rail answers both for the whole list.
+ * measure can also sort by it: Started (96) at 400, Duration (100) at 500, Cost (80) at 580, LLM
+ * calls (110) at 690, Tool calls (116) at 810 and Tokens (130) at 940. Services (170) at 1110 and
+ * Model (160) at 1270 come last — the filter rail answers both for the whole list. A sortable
+ * column is at least as wide as its label and arrow at text-sm plus the cell's padding.
  */
 interface SessionColumnLayout {
 	readonly id: string
@@ -135,55 +138,55 @@ const SESSION_COLUMNS: readonly SessionColumnLayout[] = [
 		header: "Services",
 		width: 170,
 		skeleton: "w-24",
-		responsive: "hidden @min-[1060px]/page:table-cell",
+		responsive: "hidden @min-[1110px]/page:table-cell",
 	},
 	{
 		id: "model",
 		header: "Model",
 		width: 160,
 		skeleton: "w-24",
-		responsive: "hidden @min-[1220px]/page:table-cell",
+		responsive: "hidden @min-[1270px]/page:table-cell",
 	},
 	{
 		id: "durationMs",
 		header: "Duration",
-		width: 88,
+		width: 100,
 		skeleton: "w-12",
-		responsive: "hidden @min-[480px]/page:table-cell",
+		responsive: "hidden @min-[500px]/page:table-cell",
 	},
 	{
 		id: "llmCalls",
 		header: "LLM calls",
-		width: 100,
+		width: 110,
 		skeleton: "w-8",
-		responsive: "hidden @min-[660px]/page:table-cell",
+		responsive: "hidden @min-[690px]/page:table-cell",
 	},
 	{
 		id: "toolCalls",
 		header: "Tool calls",
-		width: 100,
+		width: 116,
 		skeleton: "w-8",
-		responsive: "hidden @min-[760px]/page:table-cell",
+		responsive: "hidden @min-[810px]/page:table-cell",
 	},
 	{
 		id: "totalTokens",
 		header: "Tokens",
 		width: 130,
 		skeleton: "w-20",
-		responsive: "hidden @min-[900px]/page:table-cell",
+		responsive: "hidden @min-[940px]/page:table-cell",
 	},
 	{
 		id: "cost",
 		header: "Cost",
 		width: 80,
 		skeleton: "w-10",
-		responsive: "hidden @min-[560px]/page:table-cell",
+		responsive: "hidden @min-[580px]/page:table-cell",
 	},
 	{ id: "errorSpanCount", header: "Errors", width: 100, skeleton: "w-12" },
 	{
 		id: "startTime",
 		header: "Started",
-		width: 88,
+		width: 96,
 		skeleton: "w-14",
 		responsive: "hidden @min-[400px]/page:table-cell",
 	},
@@ -321,7 +324,7 @@ export function AgentSessionsList({
 			{
 				id: "durationMs",
 				header: sortHeader("Duration", "durationMs", "From the first agent span to the last"),
-				size: 88,
+				size: 100,
 				// Traces and spans live in the tooltip — they describe ingestion, the
 				// calls and tools beside them describe the agent.
 				cell: ({ row }) => (
@@ -336,7 +339,7 @@ export function AgentSessionsList({
 			{
 				id: "llmCalls",
 				header: sortHeader("LLM calls", "llmCalls", "Model requests the agent made"),
-				size: 100,
+				size: 110,
 				cell: ({ row }) => (
 					<WorkCount
 						icon={PixelSparkleIcon}
@@ -349,7 +352,7 @@ export function AgentSessionsList({
 			{
 				id: "toolCalls",
 				header: sortHeader("Tool calls", "toolCalls", "Tools the agent invoked"),
-				size: 100,
+				size: 116,
 				cell: ({ row }) => (
 					<WorkCount
 						icon={GearIcon}
@@ -387,7 +390,7 @@ export function AgentSessionsList({
 			{
 				id: "startTime",
 				header: sortHeader("Started", "startTime"),
-				size: 88,
+				size: 96,
 				cell: ({ row }) => (
 					<StartedAt
 						startTime={row.original.startTime}
@@ -404,6 +407,9 @@ export function AgentSessionsList({
 
 	// Rows ride the page's own scroller, as on /replays, rather than an inner
 	// one: the sentinel below the table then still marks the end of the list.
+	// So the table must sit inside a `PageLayout.ScrollArea`. Outside one the
+	// hook falls back to the tbody itself, which has no height until it has
+	// rows and gets no rows until it has height.
 	const { ref: listRef, getScrollElement, scrollMargin } = usePageScrollMargin()
 	const virtualizer = useVirtualizer({
 		count: rows.length,

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
@@ -1,7 +1,18 @@
-import { useCallback } from "react"
-import { Link } from "@tanstack/react-router"
+import { useCallback, useMemo, type ReactNode } from "react"
+import { Link, useNavigate } from "@tanstack/react-router"
+import {
+	columnSizingFeature,
+	type ColumnDef,
+	flexRender,
+	tableFeatures,
+	useTable,
+} from "@tanstack/react-table"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import type { AiSessionSortDir, AiSessionSortKey } from "@maple/domain/http"
 
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@maple/ui/components/ui/empty"
+import { TableSkeleton } from "@maple/ui/components/ui/table-skeleton"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@maple/ui/components/ui/tooltip"
 import { formatRelativeTimeOrDate, toEpochMs } from "@maple/ui/lib/time-format"
 import { formatSessionDuration } from "@maple/ui/lib/replay-format"
 import { formatCount } from "@maple/ui/components/filters/range-filter-section"
@@ -13,15 +24,18 @@ import {
 	SquareSparkleIcon,
 	type IconComponent,
 } from "@/components/icons"
+import { ServicePills } from "@/components/common/service-pills"
+import { SortableHeader } from "@/components/common/sortable-header"
 import { useDetectedModels } from "@/hooks/use-detected-models"
+import { usePageScrollMargin } from "@/hooks/use-page-scroll-margin"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { formatTimestampInTimezone } from "@/lib/timezone-format"
 import { formatCost } from "@/lib/agent-sessions/session-summary"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
-import { sessionLinkWindow, sessionRowId } from "@/lib/agent-sessions/session-window"
+import { sessionLinkWindow, sessionRowIdParts } from "@/lib/agent-sessions/session-window"
 import { TOKEN_BUCKETS, type TokenBucketKey } from "@/lib/agent-sessions/token-buckets"
 import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
-import { ModelLabel } from "./model-label"
+import { ModelLabel, modelTitle } from "./model-label"
 import { sessionIdentity } from "./session-detail/session-header"
 import { CATEGORY_TEXT } from "./session-detail/span-visuals"
 
@@ -66,7 +80,7 @@ function absoluteTs(startTime: string, timeZone: string): string {
 	return Number.isNaN(parsed) ? startTime : formatTimestampInTimezone(parsed, { timeZone, withYear: true })
 }
 
-const plural = (count: number, noun: string) => `${count} ${noun}${count === 1 ? "" : "s"}`
+const plural = (count: number, noun: string) => `${count.toLocaleString()} ${noun}${count === 1 ? "" : "s"}`
 
 /** The row's buckets under the detail page's keys, so one palette serves both. */
 function rowTokenBuckets(session: AgentSessionRow): Record<TokenBucketKey, number> {
@@ -79,8 +93,112 @@ function rowTokenBuckets(session: AgentSessionRow): Record<TokenBucketKey, numbe
 	}
 }
 
+/**
+ * v9 registers features explicitly. Sorting is server-side and nothing else here is table-driven,
+ * so column sizing — the declared widths the header cells read back — is the only one needed.
+ */
+const TABLE_FEATURES = tableFeatures({ columnSizingFeature })
+
+/** Two lines — the name over the id — at text-sm and text-xs, plus the cell padding. */
+const ROW_HEIGHT = 53
+
+const HEADER_CELL_CLASS = "h-10 px-2 text-left align-middle font-medium text-muted-foreground"
+
+/**
+ * Column layout, shared by the real table and the loading skeleton so the two can't drift apart.
+ *
+ * `responsive` drops a column when the table gets too narrow to hold it, protecting Session — the
+ * only column that identifies the row, and the only one that flexes. Thresholds are *container*
+ * queries against `@container/page` (declared by PageLayout.Content), as on the traces table: the
+ * app sidebar and the filter rail take width the viewport knows nothing about.
+ *
+ * Budget: Errors (100) is always on — the triage signal, as Status is for traces. Every other column
+ * joins where Session keeps ≥200px beside it, the sortable measures first, so a width that shows a
+ * measure can also sort by it: Started (88) at 400, Duration (88) at 480, Cost (80) at 560, LLM calls
+ * (100) at 660, Tool calls (100) at 760 and Tokens (130) at 900. Services (170) at 1060 and Model
+ * (160) at 1220 come last — the filter rail answers both for the whole list.
+ */
+interface SessionColumnLayout {
+	readonly id: string
+	readonly header: string
+	readonly skeleton: string
+	readonly width?: number
+	/** Applied to both the th and the td — keep it a literal so Tailwind's scanner sees it. */
+	readonly responsive?: string
+}
+
+const SESSION_COLUMNS: readonly SessionColumnLayout[] = [
+	// No width: under table-fixed the unsized column absorbs whatever the sized ones leave.
+	{ id: "session", header: "Session", skeleton: "w-40" },
+	{
+		id: "services",
+		header: "Services",
+		width: 170,
+		skeleton: "w-24",
+		responsive: "hidden @min-[1060px]/page:table-cell",
+	},
+	{
+		id: "model",
+		header: "Model",
+		width: 160,
+		skeleton: "w-24",
+		responsive: "hidden @min-[1220px]/page:table-cell",
+	},
+	{
+		id: "durationMs",
+		header: "Duration",
+		width: 88,
+		skeleton: "w-12",
+		responsive: "hidden @min-[480px]/page:table-cell",
+	},
+	{
+		id: "llmCalls",
+		header: "LLM calls",
+		width: 100,
+		skeleton: "w-8",
+		responsive: "hidden @min-[660px]/page:table-cell",
+	},
+	{
+		id: "toolCalls",
+		header: "Tool calls",
+		width: 100,
+		skeleton: "w-8",
+		responsive: "hidden @min-[760px]/page:table-cell",
+	},
+	{
+		id: "totalTokens",
+		header: "Tokens",
+		width: 130,
+		skeleton: "w-20",
+		responsive: "hidden @min-[900px]/page:table-cell",
+	},
+	{
+		id: "cost",
+		header: "Cost",
+		width: 80,
+		skeleton: "w-10",
+		responsive: "hidden @min-[560px]/page:table-cell",
+	},
+	{ id: "errorSpanCount", header: "Errors", width: 100, skeleton: "w-12" },
+	{
+		id: "startTime",
+		header: "Started",
+		width: 88,
+		skeleton: "w-14",
+		responsive: "hidden @min-[400px]/page:table-cell",
+	},
+]
+
+const COLUMN_LAYOUT: ReadonlyMap<string, SessionColumnLayout> = new Map(
+	SESSION_COLUMNS.map((column) => [column.id, column]),
+)
+
 interface AgentSessionsListProps {
 	sessions: ReadonlyArray<AgentSessionRow>
+	/** The order the server returned the rows in — the header it names is marked. */
+	sortBy: AiSessionSortKey
+	sortDir: AiSessionSortDir
+	onSortChange: (key: AiSessionSortKey) => void
 	/** Fetch the next page — invoked when the bottom sentinel scrolls into view. */
 	onReachEnd?: () => void
 	/** Whether more pages remain (renders the sentinel + footer). */
@@ -119,14 +237,183 @@ function SessionsSentinel({
 	return <div ref={elementRef} aria-hidden className="h-px w-full" />
 }
 
+export function AgentSessionsListSkeleton() {
+	return (
+		<TableSkeleton
+			rows={10}
+			tableClassName="w-full table-fixed"
+			columns={SESSION_COLUMNS.map((column) => ({
+				header: column.header,
+				headClassName: column.responsive,
+				cellClassName: column.responsive,
+				skeleton: column.skeleton,
+				width: column.width,
+			}))}
+		/>
+	)
+}
+
 export function AgentSessionsList({
 	sessions,
+	sortBy,
+	sortDir,
+	onSortChange,
 	onReachEnd,
 	hasMore = false,
 	loadingMore = false,
 	isCapped = false,
 }: AgentSessionsListProps) {
+	const navigate = useNavigate()
 	const { effectiveTimezone } = useTimezonePreference()
+	// One batch for the whole page, re-asked only when paging brings a model
+	// the list has not seen. Before it lands every row still names its model.
+	const detect = useDetectedModels(sessions.flatMap((session) => session.models))
+
+	const columns = useMemo<ColumnDef<typeof TABLE_FEATURES, AgentSessionRow>[]>(() => {
+		const sortHeader = (label: string, sortKey: AiSessionSortKey, hint?: string) => () => (
+			<SortableHeader
+				label={label}
+				sortKey={sortKey}
+				activeKey={sortBy}
+				dir={sortDir}
+				onSort={onSortChange}
+				hint={hint}
+			/>
+		)
+		return [
+			{
+				id: "session",
+				header: "Session",
+				cell: ({ row }) => <SessionCell session={row.original} timeZone={effectiveTimezone} />,
+			},
+			{
+				id: "services",
+				header: "Services",
+				size: 170,
+				cell: ({ row }) => <ServicePills services={row.original.serviceNames} />,
+			},
+			{
+				id: "model",
+				header: "Model",
+				size: 160,
+				cell: ({ row }) => {
+					const { models } = row.original
+					const [firstModel] = models
+					// The first model by name and mark, the rest as a count; the raw ids
+					// gateways report go in the tooltip, where two models that truncate
+					// alike are still told apart.
+					return firstModel === undefined ? null : (
+						<Hint
+							className="block min-w-0 text-xs text-muted-foreground"
+							content={
+								<div className="flex flex-col gap-0.5">
+									{models.map((model) => (
+										<span key={model}>{modelTitle(detect(model))}</span>
+									))}
+								</div>
+							}
+						>
+							<ModelLabel detected={detect(firstModel)} moreCount={models.length - 1} title={null} />
+						</Hint>
+					)
+				},
+			},
+			{
+				id: "durationMs",
+				header: sortHeader("Duration", "durationMs", "From the first agent span to the last"),
+				size: 88,
+				// Traces and spans live in the tooltip — they describe ingestion, the
+				// calls and tools beside them describe the agent.
+				cell: ({ row }) => (
+					<Hint
+						className="font-mono text-xs tabular-nums"
+						content={`Across ${plural(row.original.traceCount, "trace")} · ${plural(row.original.spanCount, "span")}`}
+					>
+						{formatSessionDuration(row.original.durationMs)}
+					</Hint>
+				),
+			},
+			{
+				id: "llmCalls",
+				header: sortHeader("LLM calls", "llmCalls", "Model requests the agent made"),
+				size: 100,
+				cell: ({ row }) => (
+					<WorkCount
+						icon={PixelSparkleIcon}
+						tone={CATEGORY_TEXT.inference}
+						count={row.original.llmCalls}
+						noun="LLM call"
+					/>
+				),
+			},
+			{
+				id: "toolCalls",
+				header: sortHeader("Tool calls", "toolCalls", "Tools the agent invoked"),
+				size: 100,
+				cell: ({ row }) => (
+					<WorkCount
+						icon={GearIcon}
+						tone={CATEGORY_TEXT.tool}
+						count={row.original.toolCalls}
+						noun="tool call"
+					/>
+				),
+			},
+			{
+				id: "totalTokens",
+				header: sortHeader("Tokens", "totalTokens", "Reported by the session's model calls"),
+				size: 130,
+				cell: ({ row }) => <TokenBar session={row.original} />,
+			},
+			{
+				id: "cost",
+				header: sortHeader("Cost", "cost", "As priced by the instrumentation; blank where it reported none"),
+				size: 80,
+				// Blank where nothing was reported — a "$0.00" would read as "measured,
+				// and it was free".
+				cell: ({ row }) =>
+					row.original.cost > 0 ? (
+						<Hint className="font-mono text-xs tabular-nums" content="As priced by the instrumentation">
+							{formatCost(row.original.cost)}
+						</Hint>
+					) : null,
+			},
+			{
+				id: "errorSpanCount",
+				header: sortHeader("Errors", "errorSpanCount", "Failed turns and tool calls"),
+				size: 100,
+				cell: ({ row }) => <ErrorChips session={row.original} />,
+			},
+			{
+				id: "startTime",
+				header: sortHeader("Started", "startTime"),
+				size: 88,
+				cell: ({ row }) => (
+					<StartedAt
+						startTime={row.original.startTime}
+						timeZone={effectiveTimezone}
+						className="block truncate text-xs text-muted-foreground"
+					/>
+				),
+			},
+		]
+	}, [effectiveTimezone, detect, sortBy, sortDir, onSortChange])
+
+	const table = useTable({ features: TABLE_FEATURES, data: sessions, columns })
+	const { rows } = table.getRowModel()
+
+	// Rows ride the page's own scroller, as on /replays, rather than an inner
+	// one: the sentinel below the table then still marks the end of the list.
+	const { ref: listRef, getScrollElement, scrollMargin } = usePageScrollMargin()
+	const virtualizer = useVirtualizer({
+		count: rows.length,
+		getScrollElement,
+		estimateSize: () => ROW_HEIGHT,
+		overscan: 10,
+		scrollMargin,
+	})
+	const virtualItems = virtualizer.getVirtualItems()
+
 	if (sessions.length === 0) {
 		return (
 			<Empty>
@@ -149,163 +436,102 @@ export function AgentSessionsList({
 		)
 	}
 
-	// One batch for the whole page, re-asked only when paging brings a model
-	// the list has not seen. Before it lands every row still names its model.
-	const detect = useDetectedModels(sessions.flatMap((session) => session.models))
+	const firstItem = virtualItems[0]
+	const lastItem = virtualItems[virtualItems.length - 1]
 
 	return (
-		<div className="@container">
-			{sessions.map((session) => {
-				const hasErrors = session.errorSpanCount > 0
-				const VendorIcon = vendorIcon(session.vendorId)
-				const vendor = vendorLabel(session.vendorId)
-				// `sessionIdentity` reads the first name, so it is handed the one
-				// name the warehouse resolved in span order rather than the
-				// unordered `agentNames` set — see `firstAgentName`.
-				const { heading } = sessionIdentity({
-					agentNames: session.firstAgentName === "" ? [] : [session.firstAgentName],
-					vendorIds: [session.vendorId],
-				})
-				const [firstModel, ...otherModels] = session.models
-				return (
-					<Link
-						key={session.sessionId}
-						to="/agent-sessions/$sessionId"
-						params={{ sessionId: session.sessionId }}
-						// The session's own bounds, not the list's window — its agent spans'
-						// extent until the row's details land, the true one after — so the
-						// detail page reads straight from these.
-						search={sessionLinkWindow(session)}
-						className="relative flex w-full items-center gap-3 border-b border-border px-3 py-2.5 text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset @2xl:gap-4"
-					>
-						{/* Errored sessions get a left accent so they can be picked out
-						    while scanning — same signal as the replays list. */}
-						{hasErrors && (
-							<span aria-hidden className="absolute inset-y-0 left-0 w-[3px] bg-destructive" />
+		<div>
+			<div className="rounded-md border">
+				{/*
+				 * table-fixed makes the declared column widths authoritative: the sized columns stay
+				 * pinned and Session, the only column that should flex, takes the remainder.
+				 */}
+				<table className="w-full table-fixed caption-bottom text-sm" aria-label="Agent sessions">
+					<thead className="sticky top-0 z-10 bg-background [&_tr]:border-b">
+						{table.getHeaderGroups().map((headerGroup) => (
+							<tr key={headerGroup.id}>
+								{headerGroup.headers.map((header) => (
+									<th
+										key={header.id}
+										aria-sort={
+											header.id === sortBy
+												? sortDir === "asc"
+													? "ascending"
+													: "descending"
+												: undefined
+										}
+										className={cn(HEADER_CELL_CLASS, COLUMN_LAYOUT.get(header.id)?.responsive)}
+										style={{
+											width: header.getSize() !== 150 ? header.getSize() : undefined,
+										}}
+									>
+										{header.isPlaceholder
+											? null
+											: flexRender(header.column.columnDef.header, header.getContext())}
+									</th>
+								))}
+							</tr>
+						))}
+					</thead>
+					<tbody ref={listRef}>
+						{firstItem && (
+							<tr aria-hidden style={{ height: firstItem.start - virtualizer.options.scrollMargin }}>
+								<td />
+							</tr>
 						)}
-
-						{/* Identity lane: what the session IS on the first line — the agent
-						    it ran, beside the framework's mark — and what it is CALLED on
-						    the second. The id is how you cite a session, not how you
-						    recognise one, so it reads as metadata under the name. */}
-						<div className="min-w-0 flex-1 overflow-hidden">
-							<div className="flex items-center gap-2">
-								<span
-									className="flex shrink-0 items-center text-muted-foreground"
-									title={vendor}
+						{virtualItems.map((virtualRow) => {
+							const row = rows[virtualRow.index]!
+							const session = row.original
+							return (
+								<tr
+									key={row.id}
+									ref={virtualizer.measureElement}
+									data-index={virtualRow.index}
+									onClick={() =>
+										navigate({
+											to: "/agent-sessions/$sessionId",
+											params: { sessionId: session.sessionId },
+											search: sessionLinkWindow(session),
+										})
+									}
+									className="cursor-pointer border-b transition-colors hover:bg-muted/50"
 								>
-									<VendorIcon size={15} aria-hidden />
-								</span>
-								<span className="min-w-0 truncate text-sm font-medium" title={heading}>
-									{heading}
-								</span>
-								{/* On phones the right-hand lanes are gone, so the timestamp
-								    anchors the top-right corner of the stacked row. */}
-								<span
-									className="ml-auto shrink-0 whitespace-nowrap text-xs text-muted-foreground @2xl:hidden"
-									title={absoluteTs(session.startTime, effectiveTimezone)}
-								>
-									{formatRelativeTimeOrDate(
-										session.startTime,
-										undefined,
-										effectiveTimezone,
-									)}
-								</span>
-							</div>
-							<div
-								className="mt-0.5 truncate font-mono text-xs text-muted-foreground"
-								title={session.sessionId}
+									{row.getAllCells().map((cell) => (
+										<td
+											key={cell.id}
+											className={cn("p-2 align-middle", COLUMN_LAYOUT.get(cell.column.id)?.responsive)}
+										>
+											{flexRender(cell.column.columnDef.cell, cell.getContext())}
+										</td>
+									))}
+								</tr>
+							)
+						})}
+						{lastItem && (
+							<tr
+								aria-hidden
+								style={{
+									height:
+										virtualizer.getTotalSize() -
+										(lastItem.end - virtualizer.options.scrollMargin),
+								}}
 							>
-								{sessionRowId(session.sessionId)}
-							</div>
-							{hasErrors && (
-								<div className="mt-1.5 flex flex-wrap items-center gap-1.5 @2xl:hidden">
-									<ErrorChips session={session} />
-								</div>
-							)}
-						</div>
-
-						{/* Services lane */}
-						<div className="hidden w-[10rem] shrink-0 overflow-hidden @2xl:block">
-							<span
-								className="block truncate text-xs text-muted-foreground"
-								title={session.serviceNames.join(", ")}
-							>
-								{session.serviceNames.join(" · ")}
-							</span>
-						</div>
-
-						{/* Model lane: what the session ran on. Last lane in, because it is
-						    the one a reader can also get from the filter rail — every lane's
-						    breakpoint is set so the identity lane keeps a legible ~180px
-						    even at the width where the lane appears. The first model by
-						    name and mark, the rest as a count; the raw ids gateways report
-						    stay in the title, where two models that truncate alike are
-						    still told apart. */}
-						<div className="hidden w-[9rem] shrink-0 overflow-hidden text-xs text-muted-foreground @7xl:block">
-							{firstModel !== undefined && (
-								<ModelLabel
-									detected={detect(firstModel)}
-									moreCount={otherModels.length}
-									title={session.models.join(", ")}
-								/>
-							)}
-						</div>
-
-						{/* Activity lane: duration + the work done, in the session page's
-						    colours for inference and tools. Traces and spans move to the
-						    tooltip — they describe ingestion, calls and tools describe the
-						    agent. */}
-						<div
-							className="hidden w-[15.25rem] shrink-0 grid-cols-[4.25rem_5.5rem_5.5rem] items-center overflow-hidden whitespace-nowrap @4xl:grid"
-							title={`${plural(session.traceCount, "trace")} · ${plural(session.spanCount, "span")}`}
-						>
-							<span className="font-mono text-[13px] font-semibold tabular-nums">
-								{formatSessionDuration(session.durationMs)}
-							</span>
-							<WorkCount
-								icon={PixelSparkleIcon}
-								tone={CATEGORY_TEXT.inference}
-								count={session.llmCalls}
-								noun="call"
-							/>
-							<WorkCount
-								icon={GearIcon}
-								tone={CATEGORY_TEXT.tool}
-								count={session.toolCalls}
-								noun="tool"
-							/>
-						</div>
-
-						{/* Usage lane: the token buckets as a bar, the total and the cost.
-						    Blank where nothing was reported — a "0" here would read as
-						    "measured, and it was free". */}
-						<div className="hidden w-[12rem] shrink-0 grid-cols-[4rem_4.25rem_1fr] items-center gap-2 overflow-hidden whitespace-nowrap @6xl:grid">
-							<TokenBar session={session} />
-							<span className="text-right font-mono text-xs tabular-nums text-muted-foreground">
-								{session.cost > 0 ? formatCost(session.cost) : ""}
-							</span>
-						</div>
-
-						{/* Signal lane: what failed, tools apart from turns */}
-						<div className="hidden w-[7.5rem] shrink-0 flex-col items-start justify-center gap-1 overflow-hidden @2xl:flex">
-							{hasErrors && <ErrorChips session={session} />}
-						</div>
-
-						{/* Time lane. Fixed width and right-aligned: sized to its content it
-						    is a lane whose width changes per row, which drags every lane to
-						    its left out of column with the row above. */}
-						<div className="hidden w-[4.5rem] shrink-0 items-center justify-end @2xl:flex">
-							<span
-								className="truncate text-right text-xs text-muted-foreground"
-								title={absoluteTs(session.startTime, effectiveTimezone)}
-							>
-								{formatRelativeTimeOrDate(session.startTime, undefined, effectiveTimezone)}
-							</span>
-						</div>
-					</Link>
-				)
-			})}
+								<td />
+							</tr>
+						)}
+						{loadingMore && (
+							<tr>
+								<td colSpan={SESSION_COLUMNS.length} className="p-2">
+									<div className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground">
+										<span className="size-4 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
+										Loading more sessions…
+									</div>
+								</td>
+							</tr>
+						)}
+					</tbody>
+				</table>
+			</div>
 
 			{hasMore && <SessionsSentinel onReachEnd={onReachEnd} loadingMore={loadingMore} />}
 
@@ -315,19 +541,132 @@ export function AgentSessionsList({
 					see older ones
 				</p>
 			)}
-
-			{loadingMore && (
-				<div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
-					<span className="size-4 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
-					Loading more sessions…
-				</div>
-			)}
 		</div>
 	)
 }
 
-/** "12 calls" with the kind's glyph, in its hue — the same pair the session
- *  page's waterfall and flow use for the kind of work. */
+/** An inline figure with a tooltip saying what it counts. */
+function Hint({
+	content,
+	className,
+	children,
+}: {
+	content: ReactNode
+	className?: string
+	children: ReactNode
+}) {
+	return (
+		<Tooltip>
+			<TooltipTrigger render={<span />} className={className}>
+				{children}
+			</TooltipTrigger>
+			<TooltipContent>{content}</TooltipContent>
+		</Tooltip>
+	)
+}
+
+function StartedAt({
+	startTime,
+	timeZone,
+	className,
+}: {
+	startTime: string
+	timeZone: string
+	className: string
+}) {
+	return (
+		<Hint className={className} content={absoluteTs(startTime, timeZone)}>
+			{formatRelativeTimeOrDate(startTime, undefined, timeZone)}
+		</Hint>
+	)
+}
+
+/**
+ * What the session IS on the first line — the agent it ran, beside the
+ * framework's mark — and what it is CALLED on the second. The id is how you
+ * cite a session, not how you recognise one, so it reads as metadata under the
+ * name, labelled with the kind of id it is: a framework's session key, or the
+ * one trace a framework without session keys produced.
+ */
+function SessionCell({ session, timeZone }: { session: AgentSessionRow; timeZone: string }) {
+	const VendorIcon = vendorIcon(session.vendorId)
+	const vendor = vendorLabel(session.vendorId)
+	// `sessionIdentity` reads the first name, so it is handed the one name the
+	// warehouse resolved in span order rather than the unordered `agentNames`
+	// set — see `firstAgentName`.
+	const { heading } = sessionIdentity({
+		agentNames: session.firstAgentName === "" ? [] : [session.firstAgentName],
+		vendorIds: [session.vendorId],
+	})
+	const id = sessionRowIdParts(session.sessionId)
+	return (
+		<div className="min-w-0">
+			<div className="flex min-w-0 items-center gap-2">
+				<Tooltip>
+					<TooltipTrigger
+						render={<span />}
+						role="img"
+						aria-label={vendor}
+						className="flex shrink-0 items-center text-muted-foreground"
+					>
+						<VendorIcon size={15} aria-hidden />
+					</TooltipTrigger>
+					<TooltipContent>{vendor}</TooltipContent>
+				</Tooltip>
+				<Tooltip>
+					<TooltipTrigger
+						render={
+							<Link
+								to="/agent-sessions/$sessionId"
+								params={{ sessionId: session.sessionId }}
+								// The session's own bounds, not the list's window — its agent spans'
+								// extent until the row's details land, the true one after — so the
+								// detail page reads straight from these.
+								search={sessionLinkWindow(session)}
+								// The row navigates on its own; the link is for a new tab and the
+								// keyboard, and must not navigate twice.
+								onClick={(event) => event.stopPropagation()}
+							/>
+						}
+						className="min-w-0 truncate text-sm font-medium hover:underline focus-visible:underline focus-visible:outline-none"
+					>
+						{heading}
+					</TooltipTrigger>
+					<TooltipContent>
+						{session.agentNames.length > 0
+							? `Agents: ${session.agentNames.join(", ")}`
+							: "No agent name was reported"}
+					</TooltipContent>
+				</Tooltip>
+				{/* Until the Started column fits, the time anchors the cell's top-right corner. */}
+				<StartedAt
+					startTime={session.startTime}
+					timeZone={timeZone}
+					className="ml-auto shrink-0 whitespace-nowrap text-xs text-muted-foreground @min-[400px]/page:hidden"
+				/>
+			</div>
+			<Tooltip>
+				<TooltipTrigger render={<div />} className="mt-0.5 flex min-w-0 items-baseline gap-1.5 text-xs">
+					<span className="shrink-0 text-muted-foreground/70">
+						{id.kind === "trace" ? "Trace" : "Session"}
+					</span>
+					<span className="min-w-0 truncate font-mono text-muted-foreground">{id.short}</span>
+				</TooltipTrigger>
+				<TooltipContent>
+					<p>
+						{id.kind === "trace"
+							? "No session key was reported, so this session is this one trace"
+							: "The session ID the framework reported"}
+					</p>
+					<p className="mt-0.5 break-all font-mono">{id.id}</p>
+				</TooltipContent>
+			</Tooltip>
+		</div>
+	)
+}
+
+/** A count with the kind's glyph, in its hue — the same pair the session page's
+ *  waterfall and flow use for the kind of work. The header names the unit. */
 function WorkCount({
 	icon: Icon,
 	tone,
@@ -339,19 +678,25 @@ function WorkCount({
 	count: number
 	noun: string
 }) {
-	// Compact: a busy session runs to four and five figures, and the lane's slot
-	// is sized for the label, not for the widest count it will ever hold.
+	// Compact: a busy session runs to four and five figures, and the column is
+	// sized for its header, not for the widest count it will ever hold.
 	return (
-		<span
-			className={cn("inline-flex items-center gap-1 text-xs tabular-nums", tone)}
-			title={plural(count, noun)}
+		<Hint
+			className={cn(
+				"inline-flex items-center gap-1 text-xs tabular-nums",
+				count > 0 ? tone : "text-muted-foreground",
+			)}
+			content={plural(count, noun)}
 		>
 			<Icon size={12} className="shrink-0" aria-hidden />
-			{formatCount(count)} {noun}
-			{count === 1 ? "" : "s"}
-		</span>
+			{formatCount(count)}
+		</Hint>
 	)
 }
+
+/** The share of the index's total the buckets must reach to be drawn — the
+ *  dedupe can leave the two a little apart, never this far. */
+const BUCKET_COVERAGE_MIN = 0.9
 
 /**
  * The detail page's Tokens rail at row height: one segment per non-empty
@@ -362,10 +707,6 @@ function WorkCount({
  * index sums the reported figures as stamped, the buckets carve the cache back
  * out of an inclusive prompt figure, and the sort and filter read the index.
  */
-/** The share of the index's total the buckets must reach to be drawn — the
- *  dedupe can leave the two a little apart, never this far. */
-const BUCKET_COVERAGE_MIN = 0.9
-
 function TokenBar({ session }: { session: AgentSessionRow }) {
 	const buckets = rowTokenBuckets(session)
 	const drawn = TOKEN_BUCKETS.filter((bucket) => buckets[bucket.key] > 0)
@@ -376,39 +717,44 @@ function TokenBar({ session }: { session: AgentSessionRow }) {
 	// row falls back to the total rather than draw the slice as the whole.
 	const bucketTotal = drawnTotal >= session.totalTokens * BUCKET_COVERAGE_MIN ? drawnTotal : 0
 	const total = bucketTotal > 0 ? bucketTotal : session.totalTokens
-	const title = [
-		`${total.toLocaleString()} tokens`,
-		...drawn.map((bucket) => `${bucket.label}: ${buckets[bucket.key].toLocaleString()}`),
-	].join("\n")
-	// The bar and the figure are two of the lane's grid slots rather than a
-	// nested flex row: every row's track then starts at the same x, which is the
-	// only way segment widths can be read down the list.
+	// Blank where nothing was reported — a "0" would read as "measured, and it
+	// was nothing".
+	if (total === 0) return null
+	// The bar and the figure are two grid slots rather than a nested flex row:
+	// every row's track then starts at the same x, which is the only way segment
+	// widths can be read down the list.
 	return (
-		<>
-			<span className="flex h-1.5 items-center" title={title}>
+		<Hint
+			className="grid grid-cols-[4rem_1fr] items-center gap-2"
+			content={
+				<div className="flex flex-col gap-0.5 tabular-nums">
+					<span className="font-medium">{plural(total, "token")}</span>
+					{drawn.map((bucket) => (
+						<span key={bucket.key} className="flex items-center gap-1.5">
+							<span aria-hidden className={cn("size-1.5 rounded-full", bucket.fill)} />
+							{bucket.label}: {buckets[bucket.key].toLocaleString()}
+						</span>
+					))}
+				</div>
+			}
+		>
+			<span className="flex h-1.5 items-center">
 				{/* A session that reported only a total draws no bar — an empty track
 				    would read as "measured, and it was nothing". */}
 				{bucketTotal > 0 && (
-					<span
-						aria-hidden
-						className="flex h-1.5 w-full gap-px overflow-hidden rounded-xs bg-muted"
-					>
+					<span aria-hidden className="flex h-1.5 w-full gap-px overflow-hidden rounded-xs bg-muted">
 						{drawn.map((bucket) => (
 							<span
 								key={bucket.key}
 								className={bucket.fill}
-								style={{
-									width: `${(buckets[bucket.key] / bucketTotal) * 100}%`,
-								}}
+								style={{ width: `${(buckets[bucket.key] / bucketTotal) * 100}%` }}
 							/>
 						))}
 					</span>
 				)}
 			</span>
-			<span className="text-right font-mono text-xs tabular-nums text-muted-foreground" title={title}>
-				{total > 0 ? `${formatCount(total)} tok` : ""}
-			</span>
-		</>
+			<span className="font-mono text-xs tabular-nums text-muted-foreground">{formatCount(total)}</span>
+		</Hint>
 	)
 }
 
@@ -417,18 +763,24 @@ function TokenBar({ session }: { session: AgentSessionRow }) {
  * agent may have recovered from, a turn that failed is the session not
  * answering — so they are two chips in two tones rather than one count. A
  * failure the index cannot classify (an errored span outside the agent's own)
- * still lights the row's accent, and shows here only when it is all there is.
+ * shows only when it is all there is.
  */
 function ErrorChips({ session }: { session: AgentSessionRow }) {
+	// Unlike cost, none is a measurement here — the index counts every errored
+	// span — so the cell says so rather than sitting empty.
+	if (session.errorSpanCount === 0) {
+		return <span className="text-xs text-muted-foreground/50">—</span>
+	}
 	const classified = session.toolErrorCount + session.turnErrorCount
-	const other = Math.max(0, session.errorSpanCount - classified)
+	const other = session.errorSpanCount - classified
 	return (
-		<>
+		<div className="flex flex-col items-start gap-1">
 			{session.turnErrorCount > 0 && (
 				<ErrorChip
 					icon={FaceRobotIcon}
 					count={session.turnErrorCount}
-					noun="turn error"
+					noun="turn"
+					hint={`${plural(session.turnErrorCount, "failed turn")} — a model call or agent turn errored`}
 					className="border-destructive/30 bg-destructive/10 text-destructive"
 				/>
 			)}
@@ -436,18 +788,20 @@ function ErrorChips({ session }: { session: AgentSessionRow }) {
 				<ErrorChip
 					icon={GearIcon}
 					count={session.toolErrorCount}
-					noun="tool error"
+					noun="tool"
+					hint={`${plural(session.toolErrorCount, "failed tool call")} — the agent may have recovered`}
 					className="border-severity-warn/40 bg-severity-warn/10 text-severity-warn"
 				/>
 			)}
 			{classified === 0 && other > 0 && (
 				<ErrorChip
 					count={other}
-					noun="error"
+					noun="span"
+					hint={`${plural(other, "errored span")} outside the agent's turns and tools`}
 					className="border-destructive/30 bg-destructive/10 text-destructive"
 				/>
 			)}
-		</>
+		</div>
 	)
 }
 
@@ -455,19 +809,22 @@ function ErrorChip({
 	icon: Icon,
 	count,
 	noun,
+	hint,
 	className,
 }: {
 	icon?: IconComponent
 	count: number
 	noun: string
+	hint: string
 	className: string
 }) {
 	return (
-		<span
+		<Hint
 			className={cn(
 				"inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[10px] font-medium tabular-nums",
 				className,
 			)}
+			content={hint}
 		>
 			{Icon ? (
 				<Icon size={10} className="shrink-0" aria-hidden />
@@ -475,16 +832,13 @@ function ErrorChip({
 				<span className="size-1 rounded-full bg-current" aria-hidden />
 			)}
 			{/* Two digits of room, and the noun always as wide as its plural: a
-			    row's "1 tool error" above the next row's "12 tool errors"
-			    otherwise makes two chips that never line up. Past 99 the chip does
-			    widen — a third digit costs every row space for a count almost no
-			    session reaches. */}
+			    row's "1 tool" above the next row's "12 tools" otherwise makes two
+			    chips that never line up. Past 99 the chip does widen — a third
+			    digit costs every row space for a count almost no session reaches. */}
 			<span>
 				<span className="inline-block min-w-[2ch] text-right">{count}</span>{" "}
-				<span className="inline-block" style={{ minWidth: `${noun.length + 1}ch` }}>
-					{count === 1 ? noun : `${noun}s`}
-				</span>
+				<span className="inline-block min-w-[5ch]">{count === 1 ? noun : `${noun}s`}</span>
 			</span>
-		</span>
+		</Hint>
 	)
 }

--- a/apps/web/src/components/agent-sessions/agent-sessions-toolbar.test.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-toolbar.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { AgentSessionsToolbar } from "./agent-sessions-toolbar"
+
+describe("AgentSessionsToolbar", () => {
+	afterEach(cleanup)
+
+	it("toggles the error filter and counts the loaded sessions", () => {
+		const onToggleErrorsOnly = vi.fn()
+		render(
+			<AgentSessionsToolbar
+				query=""
+				onSearch={vi.fn()}
+				errorsOnly={false}
+				onToggleErrorsOnly={onToggleErrorsOnly}
+				sessionCount={12}
+			/>,
+		)
+
+		// The error filter is a switch: on or off, never a button that looks
+		// like a warning about the list.
+		const errors = screen.getByRole("switch", { name: "With errors" })
+		expect(errors.getAttribute("aria-checked")).toBe("false")
+		fireEvent.click(errors)
+		expect(onToggleErrorsOnly).toHaveBeenCalledOnce()
+		expect(screen.getByText("12")).toBeTruthy()
+		expect(screen.getByPlaceholderText("Session or trace ID…")).toBeTruthy()
+	})
+
+	// A count that reads zero for a beat above a list about to fill is worse
+	// than one that arrives a beat late — the same call /replays makes.
+	it("holds the count back until the first page lands", () => {
+		render(
+			<AgentSessionsToolbar
+				query=""
+				onSearch={vi.fn()}
+				errorsOnly={false}
+				onToggleErrorsOnly={vi.fn()}
+				sessionCount={undefined}
+			/>,
+		)
+		expect(screen.queryByText("sessions")).toBeNull()
+	})
+})

--- a/apps/web/src/components/agent-sessions/agent-sessions-toolbar.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-toolbar.tsx
@@ -1,51 +1,8 @@
 import type { ReactNode } from "react"
 import { ToolbarSearch, ToolbarStat } from "@maple/ui/components/toolbar"
-import { StopwatchIcon } from "@maple/ui/components/icons"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@maple/ui/components/ui/select"
 import { Switch } from "@maple/ui/components/ui/switch"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@maple/ui/components/ui/tooltip"
 import { cn } from "@maple/ui/lib/utils"
-import {
-	CreditCardIcon,
-	GearIcon,
-	HistoryIcon,
-	LayersIcon,
-	PixelSparkleIcon,
-	PixelTriangleWarningIcon,
-	type IconComponent,
-} from "@/components/icons"
-import { CATEGORY_TEXT } from "./session-detail/span-visuals"
-import {
-	AGENT_SESSIONS_SORT_OPTIONS,
-	DEFAULT_SORT_OPTION,
-	type AgentSessionsSortOption,
-} from "./agent-sessions-filter-inputs"
-
-/**
- * Each sort's glyph and hue: the measure the list is ordered by reads at a
- * glance, and in the same colours the rows draw that measure in — calls and
- * tools from the session page's vocabulary, errors in the destructive tone,
- * time in the neutral.
- */
-const SORT_VISUALS = {
-	newest: { icon: HistoryIcon, tone: "text-muted-foreground" },
-	oldest: { icon: HistoryIcon, tone: "text-muted-foreground" },
-	longest: { icon: StopwatchIcon, tone: "text-chart-1" },
-	cost: { icon: CreditCardIcon, tone: "text-chart-3" },
-	tokens: { icon: LayersIcon, tone: "text-chart-5" },
-	errors: { icon: PixelTriangleWarningIcon, tone: "text-destructive" },
-	"llm-calls": { icon: PixelSparkleIcon, tone: CATEGORY_TEXT.inference },
-	"tool-calls": { icon: GearIcon, tone: CATEGORY_TEXT.tool },
-} satisfies Record<string, { icon: IconComponent; tone: string }>
-
-function SortLabel({ option }: { option: AgentSessionsSortOption }) {
-	const { icon: Icon, tone } = SORT_VISUALS[option.key as keyof typeof SORT_VISUALS] ?? SORT_VISUALS.newest
-	return (
-		<span className="inline-flex items-center gap-2">
-			<Icon size={14} className={cn("shrink-0", tone)} aria-hidden />
-			{option.label}
-		</span>
-	)
-}
 
 interface AgentSessionsToolbarProps {
 	/** Current `q` search param (session / trace id prefix). */
@@ -54,33 +11,28 @@ interface AgentSessionsToolbarProps {
 	/** `hasErrors` URL filter state — the switch toggles it. */
 	errorsOnly: boolean
 	onToggleErrorsOnly: () => void
-	sortKey: string
-	onSortChange: (option: AgentSessionsSortOption) => void
-	/** Sessions loaded so far, for the count beside the controls. */
-	sessionCount: number
+	/** Sessions loaded so far, for the count beside the controls; `undefined`
+	 *  until the first page lands. */
+	sessionCount: number | undefined
 	/** Dim the controls while the list is refetching. */
 	waiting?: boolean
-	/** Trailing controls after the sort — the route's Reload button. */
+	/** Trailing controls — the route's Reload button. */
 	actions?: ReactNode
 }
 
 /**
- * Search, the loaded count, the one-click error triage switch, and the sort.
- * This row answers "which of these first".
+ * Search, the loaded count and the one-click error triage switch. The order
+ * is the table's to set: its column headers sort it.
  */
 export function AgentSessionsToolbar({
 	query,
 	onSearch,
 	errorsOnly,
 	onToggleErrorsOnly,
-	sortKey,
-	onSortChange,
 	sessionCount,
 	waiting = false,
 	actions,
 }: AgentSessionsToolbarProps) {
-	const sortOption =
-		AGENT_SESSIONS_SORT_OPTIONS.find((option) => option.key === sortKey) ?? DEFAULT_SORT_OPTION
 	return (
 		// Bare container rather than the shared `Toolbar`: this sits inside
 		// `DashboardLayout.Sticky`, which already supplies the border and padding.
@@ -98,43 +50,31 @@ export function AgentSessionsToolbar({
 					waiting && "opacity-60",
 				)}
 			>
-				<div className="hidden sm:block">
-					<ToolbarStat value={sessionCount} label="sessions" />
-				</div>
+				{sessionCount !== undefined && (
+					<Tooltip>
+						<TooltipTrigger render={<span />} className="hidden sm:block">
+							<ToolbarStat value={sessionCount} label="sessions" />
+						</TooltipTrigger>
+						<TooltipContent>Loaded so far — more load as you scroll</TooltipContent>
+					</Tooltip>
+				)}
 
 				{/* A switch, not a chip: it is a filter that is on or off, and a
 				    chip in the destructive tone read as a warning about the list. */}
-				<label className="inline-flex cursor-pointer items-center gap-2 text-xs font-medium">
-					<Switch
-						checked={errorsOnly}
-						onCheckedChange={onToggleErrorsOnly}
-						className="[--thumb-size:--spacing(3.5)] data-checked:bg-destructive sm:[--thumb-size:--spacing(3.5)]"
-					/>
-					With errors
-				</label>
-
-				<Select
-					value={sortKey}
-					onValueChange={(value) => {
-						const option = AGENT_SESSIONS_SORT_OPTIONS.find(
-							(candidate) => candidate.key === value,
-						)
-						if (option) onSortChange(option)
-					}}
-				>
-					<SelectTrigger size="sm" className="h-7 w-44 text-xs" aria-label="Sort sessions">
-						<SelectValue>
-							<SortLabel option={sortOption} />
-						</SelectValue>
-					</SelectTrigger>
-					<SelectContent>
-						{AGENT_SESSIONS_SORT_OPTIONS.map((option) => (
-							<SelectItem key={option.key} value={option.key}>
-								<SortLabel option={option} />
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
+				<Tooltip>
+					<TooltipTrigger
+						render={<label />}
+						className="inline-flex cursor-pointer items-center gap-2 text-xs font-medium"
+					>
+						<Switch
+							checked={errorsOnly}
+							onCheckedChange={onToggleErrorsOnly}
+							className="[--thumb-size:--spacing(3.5)] data-checked:bg-destructive sm:[--thumb-size:--spacing(3.5)]"
+						/>
+						With errors
+					</TooltipTrigger>
+					<TooltipContent>Only sessions with a failed turn, tool call or span</TooltipContent>
+				</Tooltip>
 
 				{actions}
 			</div>

--- a/apps/web/src/components/agent-sessions/model-label.test.tsx
+++ b/apps/web/src/components/agent-sessions/model-label.test.tsx
@@ -53,4 +53,9 @@ describe("ModelLabel", () => {
 		const { container } = render(<ModelLabel detected={resolved} title="gpt-4o, claude-opus-5" />)
 		expect(container.querySelector("[title]")?.getAttribute("title")).toBe("gpt-4o, claude-opus-5")
 	})
+
+	it("leaves the title off for a caller that names the model in its own tooltip", () => {
+		const { container } = render(<ModelLabel detected={resolved} title={null} />)
+		expect(container.querySelector("[title]")).toBeNull()
+	})
 })

--- a/apps/web/src/components/agent-sessions/model-label.tsx
+++ b/apps/web/src/components/agent-sessions/model-label.tsx
@@ -9,7 +9,8 @@ import { modelVendorIcon } from "@/lib/agent-sessions/model-vendor-icon"
  *
  * The name is prose (`Claude Sonnet 4.5`), so it is not set in mono the way
  * the id was — and the id is never lost, it moves to the `title` its callers
- * pass. Nothing here waits on detection: an unresolved model renders its last
+ * pass, or to their own tooltip when they pass `title={null}`. Nothing here
+ * waits on detection: an unresolved model renders its last
  * path segment beside the generic mark, at the same size, so the row does not
  * reflow when the batch lands.
  *
@@ -26,14 +27,15 @@ export function ModelLabel({
 	detected: DetectedModel
 	moreCount?: number
 	size?: number
-	title?: string
+	/** `null` leaves the title off, for a caller that names the model in a tooltip. */
+	title?: string | null
 	className?: string
 }) {
 	const Icon = modelVendorIcon(detected)
 	return (
 		<span
 			className={cn("flex min-w-0 items-center gap-1.5", className)}
-			title={title ?? modelTitle(detected)}
+			title={title === undefined ? modelTitle(detected) : (title ?? undefined)}
 		>
 			<Icon size={size} className="shrink-0" aria-hidden />
 			<span className="min-w-0 truncate">{detected.displayName}</span>

--- a/apps/web/src/components/common/service-pills.tsx
+++ b/apps/web/src/components/common/service-pills.tsx
@@ -1,0 +1,40 @@
+import { ServiceDot } from "@maple/ui/components/service-dot"
+import { Badge } from "@maple/ui/components/ui/badge"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@maple/ui/components/ui/tooltip"
+
+/** Pills drawn before the rest collapse into "+k". */
+const VISIBLE_SERVICES = 3
+
+/**
+ * A row's services as coloured pills — the first few, then "+k" for the rest.
+ * Shared by the traces and agent-sessions tables so a service reads the same in
+ * both. The tooltip names every service, which is exactly what a truncated pill
+ * and the "+k" leave out.
+ */
+export function ServicePills({ services }: { services: ReadonlyArray<string> }) {
+	if (services.length === 0) return null
+	return (
+		<Tooltip>
+			<TooltipTrigger render={<div />} className="flex min-w-0 flex-wrap gap-1">
+				{services.slice(0, VISIBLE_SERVICES).map((service) => (
+					<Badge key={service} variant="outline" className="max-w-full font-mono text-[10px]">
+						<ServiceDot serviceName={service} className="size-1.5" />
+						<span className="truncate">{service}</span>
+					</Badge>
+				))}
+				{services.length > VISIBLE_SERVICES && (
+					<Badge variant="outline" className="text-[10px]">
+						+{services.length - VISIBLE_SERVICES}
+					</Badge>
+				)}
+			</TooltipTrigger>
+			<TooltipContent>
+				<div className="flex flex-col gap-0.5 font-mono">
+					{services.map((service) => (
+						<span key={service}>{service}</span>
+					))}
+				</div>
+			</TooltipContent>
+		</Tooltip>
+	)
+}

--- a/apps/web/src/components/common/sortable-header.tsx
+++ b/apps/web/src/components/common/sortable-header.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@maple/ui/components/ui/tooltip"
+import { cn } from "@maple/ui/lib/utils"
+
+import { ArrowUpDownIcon } from "@/components/icons"
+
+/**
+ * Clickable column header. Sorting is server-side — the lists are paged, so
+ * reordering the rows already fetched would only sort the current window.
+ * `hint` explains a column whose name does not say what it measures.
+ */
+export function SortableHeader<K extends string>({
+	label,
+	sortKey,
+	activeKey,
+	dir,
+	onSort,
+	hint,
+}: {
+	label: string
+	sortKey: K
+	activeKey: K
+	dir: "asc" | "desc"
+	onSort: (key: K) => void
+	hint?: ReactNode
+}) {
+	const active = activeKey === sortKey
+	const className = cn(
+		"inline-flex items-center gap-1 transition-colors",
+		active ? "text-foreground" : "hover:text-foreground",
+	)
+	const onClick = () => onSort(sortKey)
+	const content = (
+		<>
+			{label}
+			<ArrowUpDownIcon
+				size={10}
+				className={cn(
+					"transition-opacity",
+					active ? "opacity-100" : "opacity-40",
+					active && dir === "asc" && "rotate-180",
+				)}
+			/>
+		</>
+	)
+
+	if (hint === undefined) {
+		return (
+			<button type="button" onClick={onClick} className={className}>
+				{content}
+			</button>
+		)
+	}
+	return (
+		<Tooltip>
+			<TooltipTrigger render={<button type="button" onClick={onClick} />} className={className}>
+				{content}
+			</TooltipTrigger>
+			<TooltipContent>{hint}</TooltipContent>
+		</Tooltip>
+	)
+}

--- a/apps/web/src/components/traces/traces-table.tsx
+++ b/apps/web/src/components/traces/traces-table.tsx
@@ -15,7 +15,8 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual"
 
 import { Badge } from "@maple/ui/components/ui/badge"
-import { ArrowUpDownIcon } from "@/components/icons"
+import { ServicePills } from "@/components/common/service-pills"
+import { SortableHeader } from "@/components/common/sortable-header"
 import { type Trace } from "@/api/warehouse/traces"
 import type { TracesSearchParams } from "@/routes/traces"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
@@ -25,7 +26,6 @@ import { formatRelativeTime } from "@maple/ui/lib/time-format"
 import { HttpSpanLabel } from "@maple/ui/components/traces/http-span-label"
 import { useInfiniteTraces, FETCH_THRESHOLD } from "@/hooks/use-infinite-traces"
 import { useListNavigation } from "@/hooks/use-list-navigation"
-import { ServiceDot } from "@maple/ui/components/service-dot"
 
 type TraceSortKey = NonNullable<TracesSearchParams["sortBy"]>
 type TraceSortDir = NonNullable<TracesSearchParams["sortDir"]>
@@ -94,43 +94,6 @@ function HttpStatusBadge({ statusCode }: { statusCode: number }) {
 		>
 			{statusCode}
 		</Badge>
-	)
-}
-
-/**
- * Clickable column header. Sorting is server-side — the list is paged, so
- * reordering the rows already fetched would only sort the current window.
- */
-function SortableHeader({
-	label,
-	sortKey,
-	activeKey,
-	dir,
-	onSort,
-}: {
-	label: string
-	sortKey: TraceSortKey
-	activeKey: TraceSortKey
-	dir: TraceSortDir
-	onSort: (key: TraceSortKey) => void
-}) {
-	const active = activeKey === sortKey
-	return (
-		<button
-			type="button"
-			onClick={() => onSort(sortKey)}
-			className={`inline-flex items-center gap-1 transition-colors ${
-				active ? "text-foreground" : "hover:text-foreground"
-			}`}
-		>
-			{label}
-			<ArrowUpDownIcon
-				size={10}
-				className={`transition-opacity ${active ? "opacity-100" : "opacity-40"} ${
-					active && dir === "asc" ? "rotate-180" : ""
-				}`}
-			/>
-		</button>
 	)
 }
 
@@ -319,26 +282,7 @@ function TracesTableView({
 				id: "services",
 				header: "Services",
 				size: 160,
-				cell: ({ row }) => (
-					<div className="flex min-w-0 flex-wrap gap-1">
-						{row.original.services.slice(0, 3).map((service: string) => (
-							<Badge
-								key={service}
-								variant="outline"
-								className="max-w-full font-mono text-[10px]"
-								title={service}
-							>
-								<ServiceDot serviceName={service} className="size-1.5" />
-								<span className="truncate">{service}</span>
-							</Badge>
-						))}
-						{row.original.services.length > 3 && (
-							<Badge variant="outline" className="text-[10px]">
-								+{row.original.services.length - 3}
-							</Badge>
-						)}
-					</div>
-				),
+				cell: ({ row }) => <ServicePills services={row.original.services} />,
 			},
 			{
 				accessorKey: "spanCount",

--- a/apps/web/src/lab/agent-sessions-list-lab.tsx
+++ b/apps/web/src/lab/agent-sessions-list-lab.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import { PageLayout } from "@maple/ui/components/ui/page-layout"
 
 import {
 	agentSessionsSort,
@@ -22,9 +23,10 @@ import { AgentSessionsList, type AgentSessionRow } from "@/components/agent-sess
  */
 
 /** Widths worth checking, because the columns are container queries against
- *  `@container/page`, which the frame below declares: Model leaves below
- *  1220px, Services below 1060, Tokens below 900, the call counts below
- *  760/660, and below 400 the time moves into the Session cell. */
+ *  `@container/page`, which `PageLayout.Content` declares: Model leaves below
+ *  1270px, Services below 1110, Tokens below 940, the call counts below
+ *  810/690, Cost and Duration below 580/500, and below 400 the time moves
+ *  into the Session cell. */
 const WIDTHS = [
 	{ label: "Full", value: null },
 	{ label: "1300px", value: 1300 },
@@ -198,7 +200,7 @@ export function AgentSessionsListLab() {
 	const { sortBy, sortDir } = agentSessionsSort(sortSearch)
 
 	return (
-		<div className="flex flex-col gap-4 p-6">
+		<div className="flex h-svh flex-col gap-4 p-6">
 			<div className="flex items-center gap-2">
 				{WIDTHS.map((option) => (
 					<button
@@ -215,13 +217,21 @@ export function AgentSessionsListLab() {
 					</button>
 				))}
 			</div>
-			<div className="@container/page" style={width === null ? undefined : { width }}>
-				<AgentSessionsList
-					sessions={rows}
-					sortBy={sortBy}
-					sortDir={sortDir}
-					onSortChange={(key) => setSortSearch((prev) => agentSessionsSortPatch(prev, key))}
-				/>
+			{/* The route's own layout primitives: the list virtualizes against the
+			    page's scroll area, and without one it renders no rows at all. */}
+			<div className="flex min-h-0 flex-1 flex-col" style={width === null ? undefined : { width }}>
+				<PageLayout.Root>
+					<PageLayout.Content>
+						<PageLayout.ScrollArea>
+							<AgentSessionsList
+								sessions={rows}
+								sortBy={sortBy}
+								sortDir={sortDir}
+								onSortChange={(key) => setSortSearch((prev) => agentSessionsSortPatch(prev, key))}
+							/>
+						</PageLayout.ScrollArea>
+					</PageLayout.Content>
+				</PageLayout.Root>
 			</div>
 		</div>
 	)

--- a/apps/web/src/lab/agent-sessions-list-lab.tsx
+++ b/apps/web/src/lab/agent-sessions-list-lab.tsx
@@ -1,29 +1,36 @@
 import { useMemo, useState } from "react"
 
+import {
+	agentSessionsSort,
+	agentSessionsSortPatch,
+	type AgentSessionsSearchState,
+} from "@/components/agent-sessions/agent-sessions-filter-inputs"
 import { AgentSessionsList, type AgentSessionRow } from "@/components/agent-sessions/agent-sessions-list"
 
 /**
  * `/agent-sessions` without a warehouse behind it.
  *
  * The list is the real one — the route mounts this same component — over rows
- * chosen for the shapes that break its lanes: a named agent beside an
- * unidentified vendor, a session with no agent name at all, a duration that
- * runs to minutes next to one that runs to milliseconds, a session that
- * reported a total but no buckets, one that reported no usage at all, and both
- * kinds of failure.
+ * chosen for the shapes that break its columns: a named agent beside an
+ * unidentified vendor, a session with no agent name at all, a session that is
+ * one trace, a duration that runs to minutes next to one that runs to
+ * milliseconds, a session that reported a total but no buckets, one that
+ * reported no usage at all, and both kinds of failure.
  *
  * `ai_trace_index` does not exist in the local Tinybird container, so the live
  * page renders empty here; this is where a row change gets looked at.
  */
 
-/** Widths worth checking, because the lanes are container queries: usage drops
- *  below `@5xl`, activity below `@4xl`/`@3xl`, models below `@4xl`, and
- *  everything but identity below `@2xl`. */
+/** Widths worth checking, because the columns are container queries against
+ *  `@container/page`, which the frame below declares: Model leaves below
+ *  1220px, Services below 1060, Tokens below 900, the call counts below
+ *  760/660, and below 400 the time moves into the Session cell. */
 const WIDTHS = [
 	{ label: "Full", value: null },
-	{ label: "1400px", value: 1400 },
-	{ label: "1100px", value: 1100 },
+	{ label: "1300px", value: 1300 },
+	{ label: "1000px", value: 1000 },
 	{ label: "700px", value: 700 },
+	{ label: "380px", value: 380 },
 ] as const
 
 const BASE: AgentSessionRow = {
@@ -113,7 +120,8 @@ function buildRows(nowMs: number): ReadonlyArray<AgentSessionRow> {
 		{
 			...BASE,
 			...at(51, 12_400),
-			sessionId: "wrun_01M0CSAEW96BH2W9185XZPRAB1",
+			// An unidentified vendor stamps no session key, so the session is the trace.
+			sessionId: "trace:4bf92f3577b34da6a3ce929d0e0e4736",
 			vendorId: "unknown:my-inhouse-agent",
 			agentNames: ["nightly-reconcile"],
 			firstAgentName: "nightly-reconcile",
@@ -185,6 +193,9 @@ export function AgentSessionsListLab() {
 	const [nowMs] = useState(() => Date.now())
 	const rows = useMemo(() => buildRows(nowMs), [nowMs])
 	const [width, setWidth] = useState<number | null>(null)
+	// No server to re-rank the rows: the headers only mark the order they would ask for.
+	const [sortSearch, setSortSearch] = useState<Pick<AgentSessionsSearchState, "sortBy" | "sortDir">>({})
+	const { sortBy, sortDir } = agentSessionsSort(sortSearch)
 
 	return (
 		<div className="flex flex-col gap-4 p-6">
@@ -204,8 +215,13 @@ export function AgentSessionsListLab() {
 					</button>
 				))}
 			</div>
-			<div className="rounded-lg border border-border" style={width === null ? undefined : { width }}>
-				<AgentSessionsList sessions={rows} />
+			<div className="@container/page" style={width === null ? undefined : { width }}>
+				<AgentSessionsList
+					sessions={rows}
+					sortBy={sortBy}
+					sortDir={sortDir}
+					onSortChange={(key) => setSortSearch((prev) => agentSessionsSortPatch(prev, key))}
+				/>
 			</div>
 		</div>
 	)

--- a/apps/web/src/lib/agent-sessions/session-window.test.ts
+++ b/apps/web/src/lib/agent-sessions/session-window.test.ts
@@ -6,6 +6,7 @@ import {
 	resolveWindow,
 	sessionLinkWindow,
 	sessionRowId,
+	sessionRowIdParts,
 } from "@/lib/agent-sessions/session-window"
 
 describe("resolveWindow", () => {
@@ -79,6 +80,30 @@ describe("sessionRowId", () => {
 	// trace that isn't one.
 	it("leaves a prefixed id that is not a trace id alone", () => {
 		expect(sessionRowId("trace:not-a-trace-id")).toBe("trace:not-a-trace-id")
+	})
+})
+
+describe("sessionRowIdParts", () => {
+	it("names a framework's key as a session, whole", () => {
+		expect(sessionRowIdParts("wrun_01KZTEBCDEFGHIJKLMNOPQRSTUV")).toEqual({
+			kind: "session",
+			id: "wrun_01KZTEBCDEFGHIJKLMNOPQRSTUV",
+			short: "wrun_01KZTEBCDEFGHIJKLMNOPQRSTUV",
+		})
+	})
+
+	// The label says "Trace", so the prefix it stands in for is dropped from
+	// both halves — the tooltip's id is the trace id a reader can search for.
+	it("names a synthesized id as its trace", () => {
+		expect(sessionRowIdParts("trace:7f3a4b5c6d7e8f901234567890abcdef")).toEqual({
+			kind: "trace",
+			id: "7f3a4b5c6d7e8f901234567890abcdef",
+			short: "7f3a4b5c6d7e…",
+		})
+	})
+
+	it("does not call a prefixed id that is not a trace id a trace", () => {
+		expect(sessionRowIdParts("trace:not-a-trace-id").kind).toBe("session")
 	})
 })
 

--- a/apps/web/src/lib/agent-sessions/session-window.ts
+++ b/apps/web/src/lib/agent-sessions/session-window.ts
@@ -102,7 +102,22 @@ const TRACE_SESSION_ID_CHARS = 12
  * URL.
  */
 export function sessionRowId(sessionId: string): string {
+	const { kind, short } = sessionRowIdParts(sessionId)
+	return kind === "trace" ? `${MAPLE_AI_TRACE_SESSION_PREFIX}${short}` : short
+}
+
+/**
+ * `sessionRowId` for a row with room to say what kind of id it shows: the
+ * session key a framework reported, or — for a framework with no session key —
+ * the one trace the session is. `id` is the whole of it, for a tooltip; `short`
+ * is what the row prints, without the `trace:` prefix the label replaces.
+ */
+export function sessionRowIdParts(sessionId: string): {
+	kind: "session" | "trace"
+	id: string
+	short: string
+} {
 	const traceId = traceSessionTraceId(sessionId)
-	if (traceId === undefined) return sessionId
-	return `${MAPLE_AI_TRACE_SESSION_PREFIX}${traceId.slice(0, TRACE_SESSION_ID_CHARS)}…`
+	if (traceId === undefined) return { kind: "session", id: sessionId, short: sessionId }
+	return { kind: "trace", id: traceId, short: `${traceId.slice(0, TRACE_SESSION_ID_CHARS)}…` }
 }

--- a/apps/web/src/routes/agent-sessions/index.tsx
+++ b/apps/web/src/routes/agent-sessions/index.tsx
@@ -1,16 +1,20 @@
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Schema } from "effect"
 import { AiSessionSortDir, AiSessionSortKey } from "@maple/domain/http"
 
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
-import { AgentSessionsList } from "@/components/agent-sessions/agent-sessions-list"
+import {
+	AgentSessionsList,
+	AgentSessionsListSkeleton,
+} from "@/components/agent-sessions/agent-sessions-list"
 import { AgentSessionsFilterSidebar } from "@/components/agent-sessions/agent-sessions-filter-sidebar"
 import { AgentSessionsToolbar } from "@/components/agent-sessions/agent-sessions-toolbar"
 import { AgentSessionsTabs } from "@/components/agent-sessions/tools/agent-sessions-tabs"
 import {
 	agentSessionsFilterInputs,
-	sortOptionFor,
+	agentSessionsSort,
+	agentSessionsSortPatch,
 } from "@/components/agent-sessions/agent-sessions-filter-inputs"
 import { NotFoundError } from "@/components/route-error"
 import {
@@ -25,7 +29,6 @@ import { aiSessionsFacetsResultAtom } from "@/lib/services/atoms/warehouse-query
 import { resolveEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useInfiniteAiSessions } from "@/hooks/use-infinite-ai-sessions"
 import { useOrganizationFeatureFlags } from "@/hooks/use-organization-feature-flags"
-import { Skeleton } from "@maple/ui/components/ui/skeleton"
 
 /**
  * The list's window. There is no picker: sessions are read newest-first over
@@ -137,11 +140,18 @@ function AgentSessionsBody() {
 	// is enough.
 	const facetsResult = useAtomValue(aiSessionsFacetsResultAtom({ data: { startTime, endTime } }))
 	const sessions = allData
-	const sortOption = sortOptionFor(search.sortBy, search.sortDir)
+	const { sortBy, sortDir } = agentSessionsSort(search)
+	const onSortChange = useCallback(
+		(key: AiSessionSortKey) =>
+			navigate({ search: (prev) => ({ ...prev, ...agentSessionsSortPatch(prev, key) }) }),
+		[navigate],
+	)
 
 	const toolbar = (
 		<AgentSessionsToolbar
-			sessionCount={sessions.length}
+			// Held back until the first page lands, so the count never reads zero
+			// above a list that is about to fill.
+			sessionCount={Result.isSuccess(firstPageResult) ? sessions.length : undefined}
 			query={search.q ?? ""}
 			onSearch={(value) => navigate({ search: (prev) => ({ ...prev, q: value }) })}
 			errorsOnly={search.hasErrors === true}
@@ -150,24 +160,6 @@ function AgentSessionsBody() {
 					search: (prev) => ({
 						...prev,
 						hasErrors: prev.hasErrors ? undefined : true,
-					}),
-				})
-			}
-			sortKey={sortOption.key}
-			// The default sort leaves the URL clean, so a shared link only carries
-			// a sort when one was chosen.
-			onSortChange={(option) =>
-				navigate({
-					search: (prev) => ({
-						...prev,
-						sortBy:
-							option.sortBy === "startTime" && option.sortDir === "desc"
-								? undefined
-								: option.sortBy,
-						sortDir:
-							option.sortBy === "startTime" && option.sortDir === "desc"
-								? undefined
-								: option.sortDir,
 					}),
 				})
 			}
@@ -192,25 +184,16 @@ function AgentSessionsBody() {
 				</DashboardLayout.Sticky>
 				<DashboardLayout.Scroll>
 					{Result.builder(firstPageResult)
-						.onInitial(() => (
-							<div className="divide-y divide-border">
-								{Array.from({ length: 8 }).map((_, i) => (
-									<div key={i} className="flex items-center gap-3 py-3">
-										<div className="flex-1 space-y-1.5">
-											<Skeleton className="h-3.5 w-64" />
-											<Skeleton className="h-3 w-28" />
-										</div>
-										<Skeleton className="hidden h-3.5 w-40 sm:block" />
-									</div>
-								))}
-							</div>
-						))
+						.onInitial(() => <AgentSessionsListSkeleton />)
 						.onError((error) => (
 							<QueryErrorState error={error} titleOverride="Failed to load agent sessions" />
 						))
 						.onSuccess(() => (
 							<AgentSessionsList
 								sessions={allData}
+								sortBy={sortBy}
+								sortDir={sortDir}
+								onSortChange={onSortChange}
 								hasMore={hasNextPage}
 								isCapped={isCapped}
 								loadingMore={isFetchingNextPage}


### PR DESCRIPTION
Turns the Agent Sessions list from flex lanes into a real table, modelled on the traces table.

- **Table**: TanStack table v9 with `columnSizingFeature`. One column layout drives both the table and the skeleton. Columns hide with container queries against `@container/page`. Rows are virtualized against the page's scroll area (`PageLayout.ScrollArea`), the way `/replays` does it, so the infinite-scroll sentinel, capped message and loading footer all still work. Clicking a row navigates with `sessionLinkWindow`, and the heading is a real link for new tabs and keyboard use.
- **Sorting**: click a column header to sort (Started, Duration, LLM calls, Tool calls, Tokens, Cost, Errors). The same column flips direction, a new column starts descending, and the default order leaves the URL clean. The toolbar sort select and the sort-option menu helpers are removed.
- **Columns**: Session (flex) · Services 170 @1110 · Model 160 @1270 · Duration 100 @500 · LLM calls 110 @690 · Tool calls 116 @810 · Tokens 130 @940 · Cost 80 @580 · Errors 100 (always shown) · Started 96 @400. Each sortable column is at least as wide as its label, and headers never wrap. Below 400px the relative time moves into the Session cell. A session with no errors shows a muted "—".
- **Services**: coloured pills. `ServicePills` is now shared with the traces table, and `SortableHeader` moved to `components/common` with an optional hint tooltip.
- **Session ID**: the id line now has a "Session" or "Trace" label. Its tooltip says what the id is and shows the full id; for `trace:` sessions that is the trace id.
- **Tooltips**: the app Tooltip replaces bare `title=` in the list and toolbar. Covered: vendor, agents, id, model(s) with raw ids, duration (traces/spans), call counts, token breakdown, cost, error chips, absolute time, services, non-obvious headers, the "With errors" switch and the session count.
- **Toolbar**: the session count stays hidden until the first page loads, as on `/replays`.
- **Lab**: `/lab/agent-sessions` now hosts the list in `PageLayout.Root` › `Content` › `ScrollArea`, the same way the route does. Without a page scroll area the virtualizer falls back to the tbody, which is 0px tall until it has rows, so it never rendered any.

Checked on `/lab/agent-sessions` at full width, 1000px, 700px and 380px (Playwright screenshots). The list tests run the real virtualizer inside a page scroll area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sortable agent-session table columns with clear direction indicators.
  - Improved agent-session table layout with virtualization, responsive columns, loading states, pagination, tooltips, and row navigation.
  - Added compact service badges with overflow details.
  - Added clearer session and trace identifiers, including full values in tooltips.
  - Added shared sortable table headers for consistent sorting interactions.

- **Bug Fixes**
  - Corrected sort state handling when switching columns or returning to the default order.
  - Improved model-name tooltip behavior when a custom tooltip is provided.
  - Refined empty-state, error, token, and retention-limit messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->