### PR TITLE
fix(infra): resume cold-isolate waiters in their own request context

### DIFF
--- a/packages/infra/src/cloudflare/cached-recoverable.ts
+++ b/packages/infra/src/cloudflare/cached-recoverable.ts
@@ -1,4 +1,4 @@
-import { Deferred, Effect, Exit } from "effect"
+import { Effect, Exit } from "effect"
 
 /**
  * `Effect.cached`, except a failed run is forgotten: `cached` pins its exit,
@@ -7,28 +7,41 @@ import { Deferred, Effect, Exit } from "effect"
  * later event rather than answer with the same failure until the isolate is
  * replaced.
  *
- * Single-flight: callers arriving while a run is in flight wait on that run's
- * Deferred and observe its exit, whatever it is — the failed generation is
- * evicted only after its Deferred is complete, so no waiter can find the slot
+ * Single-flight: callers arriving while a run is in flight wait on that run
+ * and observe its exit, whatever it is — the failed generation is evicted in
+ * the same step that settles its waiters, so no waiter can find the slot
  * empty. The next caller after a failure starts a fresh run.
+ *
+ * Waiters await a promise, never the run's fiber: workerd delivers a promise's
+ * continuations to the request that awaited it. Resumed by a `Deferred`
+ * instead, every request that reached a cold isolate while the build ran
+ * continued synchronously inside the FIRST request's I/O context — its body
+ * unreadable, its response never delivered, and the runtime's own 500 (no
+ * CORS headers) in its place.
  */
 export const cachedRecoverable = <A, E, R>(
 	self: Effect.Effect<A, E, R>,
 ): Effect.Effect<Effect.Effect<A, E, R>> =>
 	Effect.sync(() => {
 		let success: Exit.Exit<A, E> | undefined
-		let inFlight: Deferred.Deferred<A, E> | undefined
+		let inFlight: Promise<Exit.Exit<A, E>> | undefined
 		return Effect.gen(function* () {
 			if (success !== undefined) return yield* success
-			if (inFlight !== undefined) return yield* Deferred.await(inFlight)
-			const run = yield* Deferred.make<A, E>()
-			inFlight = run
+			if (inFlight !== undefined) {
+				const run = inFlight
+				return yield* Effect.flatten(Effect.promise(() => run))
+			}
+			let settle!: (exit: Exit.Exit<A, E>) => void
+			inFlight = new Promise((resolve) => {
+				settle = resolve
+			})
 			return yield* self.pipe(
 				Effect.onExit((exit) =>
 					Effect.sync(() => {
 						if (Exit.isSuccess(exit)) success = exit
 						inFlight = undefined
-					}).pipe(Effect.andThen(Deferred.done(run, exit))),
+						settle(exit)
+					}),
 				),
 			)
 		})


### PR DESCRIPTION
## Symptom

Since 2026-09-07, bursts of browser `fetch` failures reported as CORS errors (`No 'Access-Control-Allow-Origin' header`) against `api.maple.dev`, e.g. `/internal/query-engine/web-analytics-timeseries`. Web spans show `Transport error`; the matching api server spans are 500s with `RequestParseError`, always at `maple.isolate.request_ordinal` ≥ 2 and `maple.isolate.age_ms` < 60 — concurrent requests reaching a cold isolate while the route graph builds.

## Cause

#772 replaced the api Worker's promise memo with `cachedRecoverable`, whose waiters awaited the in-flight build through a `Deferred`. Completing the Deferred resumes waiting fibers synchronously inside the **first** request's fiber, i.e. inside that request's workerd I/O context. The waiter then touches its own request (body read, response) from the wrong context: the read fails, workerd cancels the request as hung, and the runtime's own 500 — no CORS headers — reaches the browser.

## Fix

Waiters await a promise instead. workerd delivers a promise's continuations to the request that awaited it (`handle_cross_request_promise_resolution`, default since 2024-10-14), so each waiter resumes in its own context. Same single-flight and failure-eviction semantics. Also covers `electric-sync` and `alerting`, which use the same helper.

## Verification

- Local `workerd serve` repro: 6 concurrent POSTs to a cold cache that builds with I/O, then read their bodies.
  - old `Deferred` impl: 1× 200, 5× 500 + `A promise was resolved or rejected from a different request context` / `canceled this request because … hung`
  - this change: 6× 200, no warnings
- `packages/infra` `cached-recoverable.test.ts` and `apps/api` `worker-bridge.test.ts` pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725217&installation_model_id=427786&pr_number=848&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F848&signature=078fd7f3f1578415bc220f631e9e418bd1c8a2ffd26ba7feedb10fccc44c8723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->