### PR TITLE
fix(web): polish the agent tools pages

### DIFF
--- a/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
+++ b/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
@@ -12,7 +12,6 @@ import {
 	buildToolCells,
 	buildToolDetailFixture,
 	buildToolErrorDetailFixture,
-	toolFixtureWindow,
 } from "@/lab/agent-tools-fixture"
 import type { ToolAnalyticsSearch } from "@/lib/agent-sessions/tool-search"
 
@@ -50,7 +49,6 @@ vi.mock("./tool-detail-charts", () => ({
 
 const NOW = Date.UTC(2026, 8, 10, 12, 0, 0)
 const cells = buildToolCells(NOW)
-const WINDOW = toolFixtureWindow(NOW)
 
 function renderView(search: ToolAnalyticsSearch, onSearchChange = vi.fn()) {
 	const data = buildToolAnalyticsFixture(search, NOW, cells)
@@ -59,7 +57,6 @@ function renderView(search: ToolAnalyticsSearch, onSearchChange = vi.fn()) {
 			search={search}
 			onSearchChange={onSearchChange}
 			data={data}
-			window={WINDOW}
 			serviceOptions={[]}
 			modelOptions={[]}
 			envOptions={[]}
@@ -157,7 +154,6 @@ describe("AgentToolsView", () => {
 				search={{}}
 				onSearchChange={vi.fn()}
 				data={{ ...data, tools: [], toolsFailure: new Error("boom") }}
-				window={WINDOW}
 				serviceOptions={[]}
 				modelOptions={[]}
 				envOptions={[]}
@@ -212,6 +208,11 @@ describe("ToolDetailView", () => {
 		expect(
 			screen.getAllByText(new RegExp(`${data.totals.sessions} sessions`)).length,
 		).toBeGreaterThan(0)
+	})
+
+	it("has no tool-name search — the page is one tool", () => {
+		renderDetail({})
+		expect(screen.queryByPlaceholderText("Tool name…")).toBeNull()
 	})
 
 	it("names the tool in the scope band's denominator", () => {

--- a/apps/web/src/components/agent-sessions/tools/agent-tools-view.tsx
+++ b/apps/web/src/components/agent-sessions/tools/agent-tools-view.tsx
@@ -56,8 +56,6 @@ export interface AgentToolsViewProps {
 	/** Applied to the URL by the route. Keys set to `undefined` are cleared. */
 	onSearchChange: (patch: Partial<ToolAnalyticsSearch>) => void
 	data: AgentToolsViewData
-	/** The resolved window in epoch ms — what the table's `new` badge is measured against. */
-	window: { startMs: number; endMs: number }
 	serviceOptions: ReadonlyArray<ToolFilterOption>
 	modelOptions: ReadonlyArray<ToolFilterOption>
 	envOptions: ReadonlyArray<ToolFilterOption>
@@ -93,7 +91,6 @@ export function AgentToolsView({
 	search,
 	onSearchChange,
 	data,
-	window,
 	serviceOptions,
 	modelOptions,
 	envOptions,
@@ -162,8 +159,10 @@ export function AgentToolsView({
 			/>
 
 			<ToolFilterToolbar
-				query={search.q ?? ""}
-				onSearch={(value) => onSearchChange({ q: value === "" ? undefined : value })}
+				nameSearch={{
+					query: search.q ?? "",
+					onSearch: (value) => onSearchChange({ q: value === "" ? undefined : value }),
+				}}
 				service={search.service}
 				serviceOptions={serviceOptions}
 				onServiceChange={(value) => onSearchChange({ service: value })}
@@ -218,7 +217,6 @@ export function AgentToolsView({
 			<ToolsTable
 				rows={data.tools}
 				percentile={percentile}
-				window={window}
 				detailSearch={detailSearch}
 				selected={search.tool}
 				sparkFor={(tool) => sparkByTool.get(tool) ?? []}

--- a/apps/web/src/components/agent-sessions/tools/tool-breakdown-tables.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-breakdown-tables.tsx
@@ -16,9 +16,7 @@ import {
 	errorRate,
 	formatDurationNs,
 	formatToolCount,
-	toolBadges,
 	toolsTableFooter,
-	type ToolBadge,
 	type ToolBreakdownRow,
 	type ToolPercentile,
 } from "@/lib/agent-sessions/tool-analytics"
@@ -128,7 +126,7 @@ export function TableBody({
 }) {
 	return (
 		<div
-			className={cn("overflow-y-auto overscroll-contain transition-opacity", waiting && "opacity-60")}
+			className={cn("overflow-y-auto transition-opacity", waiting && "opacity-60")}
 			style={{ maxHeight }}
 		>
 			{children}
@@ -172,7 +170,7 @@ export function errorTone(rate: number): { bar: string; text: string } {
 }
 
 export function formatRate(rate: number): string {
-	return rate === 0 ? "—" : `${(rate * 100).toFixed(rate < 0.01 ? 2 : 1)}%`
+	return rate === 0 ? "0%" : `${(rate * 100).toFixed(rate < 0.01 ? 2 : 1)}%`
 }
 
 /**
@@ -235,30 +233,12 @@ export function LineSpark({ values, className }: { values: ReadonlyArray<number>
 	)
 }
 
-/** `slowest` / `new` — one word, in the tone of what it is saying. */
-export function Badge({ badge }: { badge: ToolBadge }) {
-	return (
-		<span
-			className={cn(
-				"flex h-[17px] shrink-0 items-center rounded-[3px] px-1.5 font-mono text-2xs leading-3",
-				badge === "slowest"
-					? "bg-[var(--severity-error)]/20 text-[var(--severity-error)]"
-					: "bg-muted text-muted-foreground",
-			)}
-		>
-			{badge}
-		</span>
-	)
-}
-
 type ToolSortKey = "key" | "calls" | "p50" | "p90" | "p95" | "errorRate" | "errors" | "sessions" | "lastSeen"
 
 interface ToolsTableProps {
 	rows: ReadonlyArray<ToolBreakdownRow>
 	/** Which percentile the page is keyed on — that column is the lit one. */
 	percentile: ToolPercentile
-	/** The window, for the `new` badge and nothing else. */
-	window: { startMs: number; endMs: number }
 	/**
 	 * Carried into every row's link. The AMBIENT scope only — the toolbar's
 	 * filters and the window — never `q` or `tool`: `q` ILIKE-filters tool names,
@@ -290,7 +270,6 @@ interface ToolsTableProps {
 export function ToolsTable({
 	rows,
 	percentile,
-	window,
 	detailSearch,
 	selected,
 	sparkFor,
@@ -308,7 +287,6 @@ export function ToolsTable({
 		() => prepared.reduce((max, row) => Math.max(max, row.errorRate), 0),
 		[prepared],
 	)
-	const badges = useMemo(() => toolBadges(rows, window), [rows, window])
 	const { sorted, sortKey, sortDir, handleSort } = useTableSort(prepared, {
 		initialKey: "calls" as ToolSortKey,
 		stringKeys: ["key"],
@@ -440,7 +418,6 @@ export function ToolsTable({
 					) : (
 						sorted.map((row) => {
 							const color = colorFor(row.key)
-							const badge = badges.get(row.key)
 							const cells = (
 								<>
 									<span className="flex w-0 min-w-0 flex-1 items-center gap-[9px]">
@@ -461,7 +438,6 @@ export function ToolsTable({
 										>
 											{breakdownKeyLabel(row.key)}
 										</span>
-										{badge === undefined ? null : <Badge badge={badge} />}
 									</span>
 									<LineSpark
 										values={sparkFor(row.key).slice(-24)}

--- a/apps/web/src/components/agent-sessions/tools/tool-detail-sessions.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-detail-sessions.tsx
@@ -137,12 +137,12 @@ export function ToolDetailSessions({
 
 								<span className="hidden w-[140px] shrink-0 @min-[900px]/panel:flex">
 									{hasErrors ? (
-										<span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--severity-error)]/30 bg-[var(--severity-error)]/10 px-2 py-0.5">
+										<span className="inline-flex items-center gap-1 rounded-full border border-[var(--severity-error)]/30 bg-[var(--severity-error)]/10 px-1.5 py-0.5">
 											<span
 												aria-hidden
 												className="size-1 shrink-0 rounded-full bg-[var(--severity-error)]"
 											/>
-											<span className="font-mono text-2xs font-medium leading-3 text-[var(--severity-error)]">
+											<span className="font-mono text-[11px] font-medium leading-3 text-[var(--severity-error)]">
 												{plural(session.errorSpanCount, "error")}
 											</span>
 										</span>

--- a/apps/web/src/components/agent-sessions/tools/tool-detail-view.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-detail-view.tsx
@@ -44,8 +44,8 @@ export interface ToolDetailViewData {
  *
  * The overview ranks tools against each other; this page stops comparing. Four
  * charts of one tool, then the two things a reader came for once a tool is
- * suspect: how it fails, and which sessions it failed in. The toolbar and the
- * scope band are the overview's, unchanged — the window and the filters travel
+ * suspect: how it fails, and which sessions it failed in. The toolbar (minus the
+ * tool-name search) and the scope band are the overview's — the window and the filters travel
  * with the reader, and the scope band states the tool as the denominator it now
  * is ("1,942 of 3,908 run_tests calls match").
  */
@@ -107,8 +107,6 @@ export function ToolDetailView({
 			</header>
 
 			<ToolFilterToolbar
-				query={search.q ?? ""}
-				onSearch={(value) => onSearchChange({ q: value === "" ? undefined : value })}
 				service={search.service}
 				serviceOptions={serviceOptions}
 				onServiceChange={(value) => onSearchChange({ service: value })}

--- a/apps/web/src/components/agent-sessions/tools/tool-filter-toolbar.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-filter-toolbar.tsx
@@ -12,8 +12,8 @@ export interface ToolFilterOption {
 const ALL = "__all__"
 
 interface ToolFilterToolbarProps {
-	query: string
-	onSearch: (value: string | undefined) => void
+	/** The tool-name search. Absent on the tool detail page, which is one tool. */
+	nameSearch?: { query: string; onSearch: (value: string | undefined) => void }
 	service: string | undefined
 	serviceOptions: ReadonlyArray<ToolFilterOption>
 	onServiceChange: (value: string | undefined) => void
@@ -29,8 +29,8 @@ interface ToolFilterToolbarProps {
 }
 
 /**
- * Which calls the page is about: a tool-name search, the service and
- * environment they ran in, and the one-chip triage filter.
+ * Which calls the page is about: a tool-name search (overview only), the
+ * service and environment they ran in, and the one-chip triage filter.
  *
  * Model is one of the three selects rather than a table of its own: the page
  * is about tools, and "which model ran them" is a lens on that list, not a
@@ -42,8 +42,7 @@ interface ToolFilterToolbarProps {
  * a glance.
  */
 export function ToolFilterToolbar({
-	query,
-	onSearch,
+	nameSearch,
 	service,
 	serviceOptions,
 	onServiceChange,
@@ -59,12 +58,14 @@ export function ToolFilterToolbar({
 }: ToolFilterToolbarProps) {
 	return (
 		<div className="flex flex-wrap items-center gap-2 border-b border-border px-6 py-3">
-			<ToolbarSearch
-				query={query}
-				onSearch={onSearch}
-				placeholder="Tool name…"
-				className="w-full font-mono sm:w-[260px]"
-			/>
+			{nameSearch ? (
+				<ToolbarSearch
+					query={nameSearch.query}
+					onSearch={nameSearch.onSearch}
+					placeholder="Tool name…"
+					className="w-full font-mono sm:w-[260px]"
+				/>
+			) : null}
 
 			<div
 				className={cn(

--- a/apps/web/src/lab/agent-tools-fixture.ts
+++ b/apps/web/src/lab/agent-tools-fixture.ts
@@ -430,11 +430,6 @@ export function buildToolAnalyticsFixture(
 	}
 }
 
-/** The window the fixture covers, which the `new` badge is measured against. */
-export function toolFixtureWindow(nowMs: number): { startMs: number; endMs: number } {
-	return { startMs: nowMs - BUCKETS * BUCKET_MS, endMs: nowMs }
-}
-
 /** The service / model / env options the toolbar's selects offer, counted like
  *  the real facets. */
 export function toolFixtureFacets(cells: ReadonlyArray<ToolFixtureCell>) {

--- a/apps/web/src/lab/agent-tools-lab.tsx
+++ b/apps/web/src/lab/agent-tools-lab.tsx
@@ -11,7 +11,6 @@ import {
 	buildToolDetailFixture,
 	buildToolErrorDetailFixture,
 	toolFixtureFacets,
-	toolFixtureWindow,
 } from "./agent-tools-fixture"
 
 /**
@@ -50,7 +49,6 @@ export function AgentToolsLab() {
 	const [nowMs] = useState(() => Date.now())
 	const cells = useMemo(() => buildToolCells(nowMs), [nowMs])
 	const facets = useMemo(() => toolFixtureFacets(cells), [cells])
-	const window = useMemo(() => toolFixtureWindow(nowMs), [nowMs])
 
 	// Stands in for the URL. Same shape, same defaults-stay-absent rule.
 	const [search, setSearch] = useState<ToolAnalyticsSearch>({})
@@ -125,7 +123,6 @@ export function AgentToolsLab() {
 						search={search}
 						onSearchChange={onSearchChange}
 						data={overview}
-						window={window}
 						serviceOptions={facets.services}
 						modelOptions={facets.models}
 						envOptions={facets.environments}

--- a/apps/web/src/lib/agent-sessions/tool-analytics.test.ts
+++ b/apps/web/src/lib/agent-sessions/tool-analytics.test.ts
@@ -11,7 +11,6 @@ import {
 	metricValue,
 	rankSeriesKeys,
 	scopeSummary,
-	toolBadges,
 	toolChartTitle,
 	toolDelta,
 	toolMetricLabel,
@@ -125,47 +124,6 @@ describe("toolDelta", () => {
 	it("has no percentage against a window of zero, and none without one at all", () => {
 		expect(toolDelta(measures({ calls: 150 }), measures({ calls: 0 }), "calls", "p90")).toBeNull()
 		expect(toolDelta(measures({ calls: 150 }), undefined, "calls", "p90")).toBeNull()
-	})
-})
-
-describe("toolBadges", () => {
-	const window = { startMs: 0, endMs: 1000 }
-	const row = (over: Partial<ToolBreakdownRow>): ToolBreakdownRow => ({
-		key: "k",
-		...EMPTY_MEASURES,
-		lastSeen: 0,
-		firstSeen: 0,
-		...over,
-	})
-
-	it("calls the slowest only among rows carrying real volume", () => {
-		// A tool called nine times in a week has the worst p90 in most windows
-		// and is never what the badge is for.
-		const badges = toolBadges(
-			[
-				row({ key: "busy", calls: 1000, p90: 5 }),
-				row({ key: "rare", calls: 1, p90: 5000 }),
-			],
-			window,
-		)
-		expect(badges.get("busy")).toBe("slowest")
-		expect(badges.get("rare")).toBeUndefined()
-	})
-
-	it("names no slowest when nothing has a measured p90", () => {
-		expect(toolBadges([row({ key: "a", calls: 100, p90: 0 })], window).get("a")).toBeUndefined()
-	})
-
-	it("calls a tool new when its first call lands well after the window opened", () => {
-		const badges = toolBadges(
-			[
-				row({ key: "old", calls: 10, firstSeen: 50 }),
-				row({ key: "fresh", calls: 10, firstSeen: 900 }),
-			],
-			window,
-		)
-		expect(badges.get("fresh")).toBe("new")
-		expect(badges.get("old")).toBeUndefined()
 	})
 })
 

--- a/apps/web/src/lib/agent-sessions/tool-analytics.ts
+++ b/apps/web/src/lib/agent-sessions/tool-analytics.ts
@@ -405,54 +405,6 @@ export function toolDelta(
 }
 
 /* -------------------------------------------------------------------------------------------------
- * Table badges
- * -----------------------------------------------------------------------------------------------*/
-
-export type ToolBadge = "slowest" | "new"
-
-/** Volume floor a row must clear to be called the slowest, as a share of the
- *  busiest row. A tool called nine times in a week has the slowest p90 in most
- *  windows and is never what the badge is for. */
-const SLOWEST_MIN_VOLUME_SHARE = 0.1
-
-/** How far into the window a tool's first call has to land before it reads as
- *  new. Bounded by the window, so this is "new in this range". */
-const NEW_AFTER_WINDOW_SHARE = 0.2
-
-/**
- * The one-word annotations the Tools table puts beside a name.
- *
- * `slowest` is the worst P90 among the rows that carry real volume, not the
- * worst P90 outright. `new` is a tool whose first call in the window lands well
- * after the window opened — the honest version of "new" available without a
- * lookback read.
- */
-export function toolBadges(
-	rows: ReadonlyArray<ToolBreakdownRow>,
-	window: { readonly startMs: number; readonly endMs: number },
-): ReadonlyMap<string, ToolBadge> {
-	const out = new Map<string, ToolBadge>()
-	if (rows.length === 0) return out
-
-	const busiest = rows.reduce((max, row) => Math.max(max, row.calls), 0)
-	const contenders = rows.filter((row) => row.calls >= busiest * SLOWEST_MIN_VOLUME_SHARE)
-	const slowest = contenders.reduce<ToolBreakdownRow | undefined>(
-		(worst, row) => (worst === undefined || row.p90 > worst.p90 ? row : worst),
-		undefined,
-	)
-	if (slowest !== undefined && slowest.p90 > 0) out.set(slowest.key, "slowest")
-
-	const span = window.endMs - window.startMs
-	if (span > 0) {
-		const cutoff = window.startMs + span * NEW_AFTER_WINDOW_SHARE
-		for (const row of rows) {
-			if (row.firstSeen > cutoff && !out.has(row.key)) out.set(row.key, "new")
-		}
-	}
-	return out
-}
-
-/* -------------------------------------------------------------------------------------------------
  * Footers
  * -----------------------------------------------------------------------------------------------*/
 

--- a/apps/web/src/routes/agent-sessions/tools/$toolName.tsx
+++ b/apps/web/src/routes/agent-sessions/tools/$toolName.tsx
@@ -143,9 +143,10 @@ function ToolDetailBody({
 	headerControls: ReactNode
 }) {
 	// Memoized like the overview's: it is the cache key of five atoms, and a
-	// fresh object each render re-subscribes all of them.
+	// fresh object each render re-subscribes all of them. No name search: this
+	// page has no box for one, and a `?q=` would filter the tool's own name out.
 	const selection = useMemo(
-		() => ({ ...toolAnalyticsSelection(search, window), tool }),
+		() => ({ ...toolAnalyticsSelection(search, window), tool, search: undefined }),
 		[search, window, tool],
 	)
 	const bucketSeconds = chartBucketSeconds(window.startTime, window.endTime)

--- a/apps/web/src/routes/agent-sessions/tools/index.tsx
+++ b/apps/web/src/routes/agent-sessions/tools/index.tsx
@@ -3,7 +3,6 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Schema } from "effect"
 
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
-import { toEpochMs } from "@maple/ui/lib/time-format"
 
 import { AgentToolsView } from "@/components/agent-sessions/tools/agent-tools-view"
 import { ToolMetricStripLoading } from "@/components/agent-sessions/tools/tool-metric-strip"
@@ -135,13 +134,7 @@ function AgentToolsBody({
 	headerControls: ReactNode
 }) {
 	const results = useToolAnalytics(search, window)
-	// A fresh object literal per render would defeat the `new`-badge memo in the
-	// Tools table, which keys on this identity.
-	const windowMs = useMemo(
-		() => ({ startMs: toEpochMs(window.startTime), endMs: toEpochMs(window.endTime) }),
-		[window.startTime, window.endTime],
-	)
-	// Same reason: it is memo input for the detail links the table builds.
+	// Memoized: it is memo input for the detail links the table builds.
 	const timeRange = useMemo(
 		() => ({
 			startTime: search.startTime,
@@ -196,7 +189,6 @@ function AgentToolsBody({
 			<AgentToolsView
 				search={search}
 				onSearchChange={onSearchChange}
-				window={windowMs}
 				data={{
 					series: series.data,
 					seriesKind: series.seriesKind,


### PR DESCRIPTION
- Tables no longer trap the wheel at their edges: dropped `overscroll-contain` from `TableBody` (tools + errors tables)
- Removed the `slowest`/`new` badges, `toolBadges`, and the `window` prop that only fed them (route, lab, fixture, tests)
- A listed tool's zero error rate now reads `0%` instead of `—`
- Tool detail page: no tool-name search; its reads also ignore a stray `?q=`
- Sessions list error pill: `text-2xs` is not defined in the theme, so it inherited the body size. Now `text-[11px]` with tighter padding

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725342&installation_model_id=427786&pr_number=849&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F849&signature=2d0c91ea3f2242042eaf4ec08690a3f5b5c17ec877d2bef97541868ec15165ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->