### PR TITLE
feat(agent-sessions): draw tool charts as bars instead of smoothed lines

### DIFF
--- a/apps/web/src/components/agent-sessions/tools/tool-detail-charts.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-detail-charts.tsx
@@ -210,7 +210,9 @@ function Cell({
 					},
 				},
 			},
-			margin: { left: 44, right: 8, top: 6 },
+			// `left` unset: the frame measures the tick labels, and a fixed width
+			// clipped duration ticks ("5.7min" drew as ".7min").
+			margin: { right: 8, top: 6 },
 			focus: "group-x",
 			// Sparse buckets sit far apart; keep the whole column live between them.
 			maxFocusDistance: UNBOUNDED_FOCUS_DISTANCE,

--- a/apps/web/src/components/agent-sessions/tools/tool-detail-charts.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-detail-charts.tsx
@@ -1,18 +1,18 @@
 import { useMemo } from "react"
-import { d3Curve, defineChart, lineY } from "@tanstack/charts"
+import { barY, defineChart, group } from "@tanstack/charts"
 import { scaleLinear } from "@tanstack/charts-scales/linear"
-import { curveMonotoneX } from "d3-shape"
 
 import { formatWarehouseDateTime } from "@maple/query-engine"
 import {
 	PlotFrame,
 	PlotTooltipBody,
+	UNBOUNDED_FOCUS_DISTANCE,
 	createTooltipFocusStore,
 	cursorTooltip,
 	dashedGridY,
-	focusCrosshair,
-	focusDot,
-	usePlotChromeColors,
+	linearYDomain,
+	minBarLength,
+	niceLinearDomain,
 	type PlotTooltipSeries,
 } from "@maple/ui/components/plot"
 import { ChartEmpty } from "@maple/ui/components/charts"
@@ -24,7 +24,9 @@ import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { errorRate, formatDurationNs, type ToolSeriesPoint } from "@/lib/agent-sessions/tool-analytics"
 
 const PLOT_HEIGHT = 160
-const STROKE_WIDTH = 1.75
+const BAR_RADIUS = 2
+const MAX_BAR_THICKNESS = 48
+const DIMMED_FILL_OPACITY = 0.3
 
 // Hoisted, not written at the call site: every `Cell` memo below keys on these,
 // and a fresh array (or arrow) per render rebuilds the chart definition on every
@@ -44,7 +46,7 @@ const CALLS_PER_SESSION_SERIES = [
 
 const formatOneDecimal = (value: number): string => value.toFixed(1)
 
-/** One line of one cell. `key` is the column it reads off the row. */
+/** One bar series of one cell. `key` is the column it reads off the row. */
 interface ChartSeries {
 	readonly key: string
 	readonly label: string
@@ -56,6 +58,18 @@ interface ChartRow extends Record<string, string | number | Date | null> {
 	date: Date
 }
 
+/** One bar: a series at a bucket. `row` carries the whole bucket for the tooltip. */
+interface BarCell {
+	readonly row: ChartRow
+	readonly key: string
+	readonly color: string
+}
+
+function valueAt(row: ChartRow, key: string): number | null {
+	const value = row[key]
+	return typeof value === "number" ? value : null
+}
+
 /**
  * The tool detail page's four readings of one tool, as a 2×2 grid divided by
  * hairlines.
@@ -65,6 +79,9 @@ interface ChartRow extends Record<string, string | number | Date | null> {
  * is flat while its error rate climbs is a different story from one where both
  * rise together, and a selector makes that story something you have to
  * remember rather than see.
+ *
+ * Bars, not smoothed lines: a tool's calls are sparse, and a curve through a
+ * handful of buckets reads as a trend the samples do not support.
  *
  * The series read behind this page asks for `split: "none"`, so a point is
  * already the whole tool's bucket — its quantiles are measured and its session
@@ -139,7 +156,6 @@ function Cell({
 	series: ReadonlyArray<ChartSeries>
 	format: (value: number) => string
 }) {
-	const chromeColors = usePlotChromeColors()
 	const focusStore = useMemo(() => createTooltipFocusStore(), [])
 	const { effectiveTimezone } = useTimezonePreference()
 
@@ -149,32 +165,38 @@ function Cell({
 	)
 
 	const definition = useMemo(() => {
-		const at = (row: ChartRow) => row.date
-		const valueOf = (key: string) => (row: ChartRow) => {
-			const value = row[key]
-			return typeof value === "number" ? value : null
-		}
-		const curve = d3Curve(curveMonotoneX)
+		const yDomain = niceLinearDomain(linearYDomain({ rows, keys: series.map((entry) => entry.key) }))
+		// One call against a peak of hundreds paints sub-pixel — see `minBarLength`.
+		const lift = minBarLength(yDomain)
+		// Long-form: `barY` groups side by side off `z` within ONE mark. Grouped,
+		// never stacked — the duration percentiles do not add.
+		const cells = rows.flatMap((row) =>
+			series.map((entry) => ({ row, key: entry.key, color: entry.color })),
+		)
 		return defineChart({
 			marks: [
 				dashedGridY(),
-				...series.map((line) =>
-					lineY(rows, {
-						id: line.key,
-						x: at,
-						y: valueOf(line.key),
-						stroke: line.color,
-						strokeWidth: STROKE_WIDTH,
-						curve,
-					}),
-				),
-				...series.map((line) => focusDot(rows, at, valueOf(line.key), line.color, chromeColors)),
-				focusCrosshair(chromeColors),
+				barY(cells, {
+					x: (cell: BarCell) => cell.row.date,
+					y: (cell: BarCell) => lift(valueAt(cell.row, cell.key)),
+					z: (cell: BarCell) => cell.key,
+					fill: (cell: BarCell) => cell.color,
+					layout: group(),
+					radius: BAR_RADIUS,
+					maxThickness: MAX_BAR_THICKNESS,
+					// The hovered bucket keeps its fill and every other one dims.
+					states: [
+						{
+							when: (context: { matches: (match: "x") => boolean }) => !context.matches("x"),
+							style: { fillOpacity: DIMMED_FILL_OPACITY },
+						},
+					],
+				}),
 			],
 			scales: {
-				x: axis.x,
+				x: axis.xBand,
 				y: {
-					scale: scaleLinear,
+					scale: scaleLinear().domain(yDomain),
 					axis: {
 						line: false,
 						ticks: {
@@ -190,20 +212,19 @@ function Cell({
 			},
 			margin: { left: 44, right: 8, top: 6 },
 			focus: "group-x",
+			// Sparse buckets sit far apart; keep the whole column live between them.
+			maxFocusDistance: UNBOUNDED_FOCUS_DISTANCE,
 			focusRing: false,
 			tooltip: cursorTooltip(focusStore.anchor),
 		})
-	}, [rows, series, chromeColors, axis, format, focusStore])
+	}, [rows, series, axis, format, focusStore])
 
-	const tooltipSeries = useMemo<PlotTooltipSeries<ChartRow>[]>(
+	const tooltipSeries = useMemo<PlotTooltipSeries<BarCell>[]>(
 		() =>
-			series.map((line) => ({
-				label: line.label,
-				color: line.color,
-				value: (row: ChartRow) => {
-					const value = row[line.key]
-					return typeof value === "number" ? value : null
-				},
+			series.map((entry) => ({
+				label: entry.label,
+				color: entry.color,
+				value: (cell: BarCell) => valueAt(cell.row, entry.key),
 				format,
 			})),
 		[series, format],
@@ -218,14 +239,14 @@ function Cell({
 				<span className="grow" />
 				{series.length > 1 ? (
 					<span className="flex items-center gap-4 font-mono text-[11px] leading-3.5">
-						{series.map((line) => (
-							<span key={line.key} className="flex items-center gap-1.5">
+						{series.map((entry) => (
+							<span key={entry.key} className="flex items-center gap-1.5">
 								<span
 									aria-hidden
-									className="h-[2.5px] w-3 shrink-0 rounded-full"
-									style={{ backgroundColor: line.color }}
+									className="size-2 shrink-0 rounded-[2px]"
+									style={{ backgroundColor: entry.color }}
 								/>
-								<span className="text-foreground/75">{line.label}</span>
+								<span className="text-foreground/75">{entry.label}</span>
 							</span>
 						))}
 					</span>
@@ -245,7 +266,7 @@ function Cell({
 								points={points}
 								series={tooltipSeries}
 								focusStore={focusStore}
-								heading={(row: ChartRow) => axis.heading(row.bucket)}
+								heading={(cell: BarCell) => axis.heading(cell.row.bucket)}
 							/>
 						)}
 					/>

--- a/apps/web/src/components/agent-sessions/tools/tool-series-chart.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-series-chart.tsx
@@ -17,7 +17,6 @@ import {
 } from "@maple/ui/components/plot"
 import { ChartEmpty } from "@maple/ui/components/charts"
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
-import { useMediaQuery } from "@maple/ui/hooks/use-media-query"
 import { cn } from "@maple/ui/lib/utils"
 
 import { QueryErrorState } from "@/components/common/query-error-state"
@@ -125,7 +124,6 @@ export function ToolSeriesChart({
 }: ToolSeriesChartProps) {
 	const focusStore = useMemo(() => createTooltipFocusStore(), [])
 	const { effectiveTimezone } = useTimezonePreference()
-	const narrow = useMediaQuery("max-sm")
 
 	const bars = useMemo<ReadonlyArray<ChartSeries>>(
 		() =>
@@ -216,14 +214,16 @@ export function ToolSeriesChart({
 					},
 				},
 			},
-			margin: { left: narrow ? 40 : 48, right: 8, top: 4 },
+			// `left` unset: the frame measures the tick labels, and a fixed width
+			// clipped duration ticks ("5.7min" drew as ".7min").
+			margin: { right: 8, top: 4 },
 			focus: "group-x",
 			// Sparse buckets sit far apart; keep the whole column live between them.
 			maxFocusDistance: UNBOUNDED_FOCUS_DISTANCE,
 			focusRing: false,
 			tooltip: cursorTooltip(focusStore.anchor),
 		})
-	}, [rows, bars, axis, metric, narrow, focusStore])
+	}, [rows, bars, axis, metric, focusStore])
 
 	const title = toolChartTitle({
 		metric,

--- a/apps/web/src/components/agent-sessions/tools/tool-series-chart.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-series-chart.tsx
@@ -1,18 +1,18 @@
 import { useMemo } from "react"
-import { d3Curve, defineChart, lineY } from "@tanstack/charts"
+import { barY, defineChart, group } from "@tanstack/charts"
 import { scaleLinear } from "@tanstack/charts-scales/linear"
-import { curveMonotoneX } from "d3-shape"
 
 import { formatWarehouseDateTime } from "@maple/query-engine"
 import {
 	PlotFrame,
 	PlotTooltipBody,
+	UNBOUNDED_FOCUS_DISTANCE,
 	createTooltipFocusStore,
 	cursorTooltip,
 	dashedGridY,
-	focusCrosshair,
-	focusDot,
-	usePlotChromeColors,
+	linearYDomain,
+	minBarLength,
+	niceLinearDomain,
 	type PlotTooltipSeries,
 } from "@maple/ui/components/plot"
 import { ChartEmpty } from "@maple/ui/components/charts"
@@ -33,10 +33,12 @@ import {
 	type ToolSeriesPoint,
 } from "@/lib/agent-sessions/tool-analytics"
 
-const STROKE_WIDTH = 1.5
 const PLOT_HEIGHT = 220
+const BAR_RADIUS = 2
+const MAX_BAR_THICKNESS = 48
+const DIMMED_FILL_OPACITY = 0.3
 
-/** One line of the chart. `key` is the column it reads off a row. */
+/** One bar series of the chart. `key` is the column it reads off a row. */
 interface ChartSeries {
 	readonly key: string
 	readonly label: string
@@ -69,6 +71,18 @@ interface ToolChartRow extends Record<string, string | number | Date | null> {
 	date: Date
 }
 
+/** One bar: a series at a bucket. `row` carries the whole bucket for the tooltip. */
+interface ToolBarCell {
+	readonly row: ToolChartRow
+	readonly key: string
+	readonly color: string
+}
+
+function valueAt(row: ToolChartRow, key: string): number | null {
+	const value = row[key]
+	return typeof value === "number" ? value : null
+}
+
 interface ToolSeriesChartProps {
 	/** One point per bucket — the selection merged inside the query. */
 	series: ReadonlyArray<ToolSeriesPoint>
@@ -86,12 +100,17 @@ interface ToolSeriesChartProps {
 }
 
 /**
- * The selected metric over the window, as one trend for the whole scope.
+ * The selected metric over the window, as bars for the whole scope.
+ *
+ * Bars, not a smoothed line: agent sessions are low volume, and a curve through
+ * a handful of buckets reads as a trend the samples do not support. A bar per
+ * bucket shows exactly where readings exist.
  *
  * The series arrives already merged by the warehouse (`split: "none"`), never
  * folded here: a bucket's sessions do not add across tools and its percentiles
- * do not average. Duration draws P50, P90 and P95 together, since "is the tail
- * moving while the median holds?" is the question the metric is picked for.
+ * do not average. Duration draws P50, P90 and P95 side by side — grouped, never
+ * stacked, since percentiles do not add — because "is the tail moving while the
+ * median holds?" is the question the metric is picked for.
  */
 export function ToolSeriesChart({
 	series,
@@ -104,12 +123,11 @@ export function ToolSeriesChart({
 	modelLabel,
 	waiting,
 }: ToolSeriesChartProps) {
-	const chromeColors = usePlotChromeColors()
 	const focusStore = useMemo(() => createTooltipFocusStore(), [])
 	const { effectiveTimezone } = useTimezonePreference()
 	const narrow = useMediaQuery("max-sm")
 
-	const lines = useMemo<ReadonlyArray<ChartSeries>>(
+	const bars = useMemo<ReadonlyArray<ChartSeries>>(
 		() =>
 			metric === "duration"
 				? DURATION_SERIES[percentile]
@@ -144,48 +162,48 @@ export function ToolSeriesChart({
 		[rows, effectiveTimezone],
 	)
 
-	const tooltipSeries = useMemo<PlotTooltipSeries<ToolChartRow>[]>(
+	const tooltipSeries = useMemo<PlotTooltipSeries<ToolBarCell>[]>(
 		() =>
-			lines.map((line) => ({
-				label: line.label,
-				color: line.color,
-				value: (row: ToolChartRow) => {
-					const value = row[line.key]
-					return typeof value === "number" ? value : null
-				},
+			bars.map((bar) => ({
+				label: bar.label,
+				color: bar.color,
+				value: (cell: ToolBarCell) => valueAt(cell.row, bar.key),
 				format: (value: number) => formatToolMetric(value, metric),
 			})),
-		[lines, metric],
+		[bars, metric],
 	)
 
 	const definition = useMemo(() => {
-		const at = (row: ToolChartRow) => row.date
-		const valueOf = (key: string) => (row: ToolChartRow) => {
-			const value = row[key]
-			return typeof value === "number" ? value : null
-		}
-		const curve = d3Curve(curveMonotoneX)
+		const yDomain = niceLinearDomain(linearYDomain({ rows, keys: bars.map((bar) => bar.key) }))
+		// One call against a peak of hundreds paints sub-pixel — see `minBarLength`.
+		const lift = minBarLength(yDomain)
+		// Long-form: `barY` groups side by side off `z` within ONE mark.
+		const cells = rows.flatMap((row) => bars.map((bar) => ({ row, key: bar.key, color: bar.color })))
 
 		return defineChart({
 			marks: [
 				dashedGridY(),
-				...lines.map((line) =>
-					lineY(rows, {
-						id: line.key,
-						x: at,
-						y: valueOf(line.key),
-						stroke: line.color,
-						strokeWidth: STROKE_WIDTH,
-						curve,
-					}),
-				),
-				...lines.map((line) => focusDot(rows, at, valueOf(line.key), line.color, chromeColors)),
-				focusCrosshair(chromeColors),
+				barY(cells, {
+					x: (cell: ToolBarCell) => cell.row.date,
+					y: (cell: ToolBarCell) => lift(valueAt(cell.row, cell.key)),
+					z: (cell: ToolBarCell) => cell.key,
+					fill: (cell: ToolBarCell) => cell.color,
+					layout: group(),
+					radius: BAR_RADIUS,
+					maxThickness: MAX_BAR_THICKNESS,
+					// The hovered bucket keeps its fill and every other one dims.
+					states: [
+						{
+							when: (context: { matches: (match: "x") => boolean }) => !context.matches("x"),
+							style: { fillOpacity: DIMMED_FILL_OPACITY },
+						},
+					],
+				}),
 			],
 			scales: {
-				x: axis.x,
+				x: axis.xBand,
 				y: {
-					scale: scaleLinear,
+					scale: scaleLinear().domain(yDomain),
 					axis: {
 						line: false,
 						ticks: {
@@ -200,10 +218,12 @@ export function ToolSeriesChart({
 			},
 			margin: { left: narrow ? 40 : 48, right: 8, top: 4 },
 			focus: "group-x",
+			// Sparse buckets sit far apart; keep the whole column live between them.
+			maxFocusDistance: UNBOUNDED_FOCUS_DISTANCE,
 			focusRing: false,
 			tooltip: cursorTooltip(focusStore.anchor),
 		})
-	}, [rows, lines, chromeColors, axis, metric, narrow, focusStore])
+	}, [rows, bars, axis, metric, narrow, focusStore])
 
 	const title = toolChartTitle({
 		metric,
@@ -243,18 +263,18 @@ export function ToolSeriesChart({
 				</span>
 			</div>
 
-			{/* Only where there is more than one line to tell apart — a single
+			{/* Only where there is more than one series to tell apart — a single
 			    series is already named by the head. */}
-			{lines.length > 1 ? (
+			{bars.length > 1 ? (
 				<div className="-mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[11px] leading-3.5">
-					{lines.map((line) => (
-						<span key={line.key} className="flex items-center gap-1.5">
+					{bars.map((bar) => (
+						<span key={bar.key} className="flex items-center gap-1.5">
 							<span
 								aria-hidden
-								className="h-[2.5px] w-3 shrink-0 rounded-full"
-								style={{ backgroundColor: line.color }}
+								className="size-2 shrink-0 rounded-[2px]"
+								style={{ backgroundColor: bar.color }}
 							/>
-							<span className="text-foreground/75">{line.label}</span>
+							<span className="text-foreground/75">{bar.label}</span>
 						</span>
 					))}
 				</div>
@@ -277,7 +297,7 @@ export function ToolSeriesChart({
 								points={points}
 								series={tooltipSeries}
 								focusStore={focusStore}
-								heading={(row: ToolChartRow) => axis.heading(row.bucket)}
+								heading={(cell: ToolBarCell) => axis.heading(cell.row.bucket)}
 							/>
 						)}
 					/>

--- a/apps/web/src/components/infra/chart-utils.ts
+++ b/apps/web/src/components/infra/chart-utils.ts
@@ -204,6 +204,21 @@ export function makeBucketAxis(bucketIsos: ReadonlyArray<string>, timeZone?: str
 						scale: bucketTimeScale([new Date(domainMs[0]), new Date(domainMs[1])], timeZone),
 					}
 				: axis,
+		/**
+		 * `x` padded by half a bucket each way, for marks with WIDTH (bars): they
+		 * are centred on the bucket, so the unpadded extent cuts the end bars in
+		 * half — see `timeseriesBandXAxis`.
+		 */
+		xBand:
+			domainMs && stepMs !== undefined
+				? {
+						...axis,
+						scale: bucketTimeScale(
+							[new Date(domainMs[0] - stepMs / 2), new Date(domainMs[1] + stepMs / 2)],
+							timeZone,
+						),
+					}
+				: axis,
 		/** `[first, last]` epoch ms, absent when there is nothing to plot. */
 		domainMs,
 		/** The bucket width in ms — the smallest positive gap — absent under two buckets. */


### PR DESCRIPTION
- Agent Sessions → Tools overview chart and tool-detail 2×2 grid: `lineY` + `curveMonotoneX` → `barY` (low-volume data read as a false trend)
- Multi-series (duration P50/P90/P95) grouped side by side via `z` + `group()`, not stacked
- Focus: hovered bucket keeps fill, others dim (replaces focusDot/crosshair); unbounded focus distance for sparse buckets
- Explicit zero-anchored y domain + `minBarLength` so a 1-call bucket stays visible
- `makeBucketAxis` gains `xBand` (half-bucket padded) so end bars aren't cut off
- Legend swatches now squares; d3-shape import dropped

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725441&installation_model_id=427786&pr_number=850&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F850&signature=4ae5506cd962eb0522fc13de5f1d4d180ad5fb49122da7527490ff0951e77f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->