### PR TITLE
feat(agent-sessions): show the tool's description on the tool detail page

### DIFF
--- a/apps/api/src/routes/internal/ai-sessions.http.test.ts
+++ b/apps/api/src/routes/internal/ai-sessions.http.test.ts
@@ -1220,6 +1220,49 @@ describe("POST /internal/ai-sessions/tools/totals", () => {
 			await harness.dispose()
 		}
 	})
+
+	it("reads the selected tool's description beside the totals, and only for a selected tool", async () => {
+		const contexts: Array<string | undefined> = []
+		let description = "Search traces by attribute."
+		const harness = makeHarness({
+			compiledQuery: (_tenant, compiled, options) => {
+				contexts.push(options?.context)
+				return compiledQueryOf(compiled)
+					.decodeRows(
+						options?.context === "aiToolDescription"
+							? [{ description }]
+							: [{ period: "current", ...toolsMeasures, ...toolsSeen }],
+					)
+					.pipe(Effect.orDie)
+			},
+		})
+
+		try {
+			const selected = await harness.post("/internal/ai-sessions/tools/totals", {
+				...TOOLS_WINDOW,
+				tool: "search_traces",
+			})
+			expect(selected.status).toBe(200)
+			expect(selected.body.description).toBe("Search traces by attribute.")
+			expect([...contexts].sort()).toEqual(["aiToolDescription", "aiToolsTotals"])
+
+			// No call stamped one: the key is left out, so the header renders nothing.
+			description = ""
+			const unstamped = await harness.post("/internal/ai-sessions/tools/totals", {
+				...TOOLS_WINDOW,
+				tool: "run_sql",
+			})
+			expect("description" in unstamped.body).toBe(false)
+
+			// The overview selects no tool, so there is nothing to describe.
+			contexts.length = 0
+			const overview = await harness.post("/internal/ai-sessions/tools/totals", TOOLS_WINDOW)
+			expect(overview.status).toBe(200)
+			expect(contexts).toEqual(["aiToolsTotals"])
+		} finally {
+			await harness.dispose()
+		}
+	})
 })
 
 describe("POST /internal/ai-sessions/tools/breakdowns", () => {

--- a/apps/api/src/routes/internal/ai-sessions.http.ts
+++ b/apps/api/src/routes/internal/ai-sessions.http.ts
@@ -440,16 +440,40 @@ export const HttpAiSessionsInternalLive = HttpApiBuilder.group(
 						// length: `previous` ends where `current` begins, so the two
 						// never overlap and the delta is over equal spans.
 						const previous = previousWindow(payload.startTime, payload.endTime)
-						const rows = yield* warehouse.compiledQuery(
-							tenant,
-							CH.compileUnion(Integrations.aiToolsTotalsQuery(toolsSelection(payload)), {
-								orgId: tenant.orgId,
-								startTime: payload.startTime,
-								endTime: payload.endTime,
-								...previous,
-							}),
-							{ context: "aiToolsTotals" },
+						const [rows, descriptionRows] = yield* Effect.all(
+							[
+								warehouse.compiledQuery(
+									tenant,
+									CH.compileUnion(Integrations.aiToolsTotalsQuery(toolsSelection(payload)), {
+										orgId: tenant.orgId,
+										startTime: payload.startTime,
+										endTime: payload.endTime,
+										...previous,
+									}),
+									{ context: "aiToolsTotals" },
+								),
+								// The detail page's header names the tool, so only a selected
+								// tool has a description to look up.
+								payload.tool === undefined
+									? Effect.succeed([])
+									: warehouse.compiledQuery(
+											tenant,
+											CH.compile(
+												Integrations.aiToolDescriptionQuery(),
+												{
+													orgId: tenant.orgId,
+													startTime: payload.startTime,
+													endTime: payload.endTime,
+													toolName: payload.tool,
+												},
+												{ rowSchema: Integrations.aiToolDescriptionRowSchema },
+											),
+											{ profile: "list", context: "aiToolDescription" },
+										),
+							],
+							{ concurrency: 2 },
 						)
+						const description = descriptionRows[0]?.description ?? ""
 						// An aggregate over no rows still yields one row per branch, so a
 						// missing period is a shape failure rather than an empty window.
 						// The query already reports `''` for a period that matched
@@ -462,6 +486,7 @@ export const HttpAiSessionsInternalLive = HttpApiBuilder.group(
 							allSessions: rows.find((row) => row.period === "window")?.sessions ?? 0,
 							firstSeen: current?.firstSeen ?? "",
 							lastSeen: current?.lastSeen ?? "",
+							...(description !== "" && { description }),
 						})
 					}),
 				)

--- a/apps/api/src/services/warehouse/ai-tools.clickhouse.e2e.test.ts
+++ b/apps/api/src/services/warehouse/ai-tools.clickhouse.e2e.test.ts
@@ -114,6 +114,7 @@ const SEED_SPANS: ReadonlyArray<SeedSpan> = [
 		attrs: agentSpan({
 			"gen_ai.operation.name": "execute_tool",
 			"gen_ai.tool.name": "search_traces",
+			"gen_ai.tool.description": "Search traces.",
 			"gen_ai.agent.name": "slack-agent",
 		}),
 	},
@@ -149,7 +150,11 @@ const SEED_SPANS: ReadonlyArray<SeedSpan> = [
 		ms: BASE_MS + 500,
 		durationNs: 3_000_000,
 		status: "Ok",
-		attrs: agentSpan({ "gen_ai.operation.name": "execute_tool", "gen_ai.tool.name": "search_traces" }),
+		attrs: agentSpan({
+			"gen_ai.operation.name": "execute_tool",
+			"gen_ai.tool.name": "search_traces",
+			"gen_ai.tool.description": "Search traces by attribute.",
+		}),
 	},
 	// TRACE_UNATTRIBUTED — a tool call with no model anywhere in its trace, at a
 	// zero duration (the structured-output pseudo-tool shape). It is a call: it
@@ -173,7 +178,11 @@ const FOREIGN_SPAN: SeedSpan = {
 	ms: BASE_MS + 600,
 	durationNs: 7_000_000,
 	status: "Ok",
-	attrs: agentSpan({ "gen_ai.operation.name": "execute_tool", "gen_ai.tool.name": "search_traces" }),
+	attrs: agentSpan({
+		"gen_ai.operation.name": "execute_tool",
+		"gen_ai.tool.name": "search_traces",
+		"gen_ai.tool.description": "Another org's search.",
+	}),
 }
 
 const quote = (value: string): string => `'${value.replaceAll("'", "\\'")}'`
@@ -376,5 +385,24 @@ describe.skipIf(!clickhouseE2eEnabled)("agent tools reads", () => {
 				{ key: "search_traces", calls: 1 },
 			],
 		)
+	})
+
+	it("reads a tool's latest non-empty description, and nobody else's", async () => {
+		const describeTool = async (toolName: string) => {
+			const compiled = compileUnsafe(
+				Integrations.aiToolDescriptionQuery(),
+				{ ...window, toolName },
+				{ rowSchema: Integrations.aiToolDescriptionRowSchema },
+			)
+			return Effect.runSync(compiled.decodeRows(await runJson(compiled.sql)))
+		}
+
+		// The latest `search_traces` call stamps none and an older one stamps an
+		// older text; the foreign org's is newer than both and must not win.
+		assert.deepStrictEqual(await describeTool("search_traces"), [
+			{ description: "Search traces by attribute." },
+		])
+		// No call stamped one: a single `''` row, which the route leaves out.
+		assert.deepStrictEqual(await describeTool("run_sql"), [{ description: "" }])
 	})
 })

--- a/apps/web/src/api/warehouse/ai-session-tools.ts
+++ b/apps/web/src/api/warehouse/ai-session-tools.ts
@@ -192,6 +192,7 @@ export const getAiToolTotals = Effect.fn("AiSessionTools.totals")(function* ({
 		// drops the clause rather than printing an Invalid Date.
 		firstSeen: toEpochMs(result.firstSeen),
 		lastSeen: toEpochMs(result.lastSeen),
+		description: result.description,
 	}
 })
 

--- a/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
+++ b/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
@@ -214,6 +214,29 @@ describe("ToolDetailView", () => {
 		).toBeGreaterThan(0)
 	})
 
+	it("describes the tool beside its name on one muted, truncated line, and says nothing without one", () => {
+		const data = buildToolDetailFixture("run_tests", {}, NOW, cells)
+		const view = (description: string | undefined) => (
+			<ToolDetailView
+				tool="run_tests"
+				search={{}}
+				onSearchChange={vi.fn()}
+				data={{ ...data, description }}
+				serviceOptions={[]}
+				modelOptions={[]}
+				envOptions={[]}
+			/>
+		)
+		const text = data.description!
+		const { rerender } = render(view(text))
+		const line = screen.getByText(text)
+		expect(line.className).toContain("truncate")
+		expect(line.className).toContain("text-muted-foreground")
+
+		rerender(view(undefined))
+		expect(screen.queryByText(text)).toBeNull()
+	})
+
 	it("names the tool in the scope band's denominator", () => {
 		renderDetail({ model: "claude-opus-5" })
 		expect(screen.getByText(/run_tests calls/)).toBeTruthy()

--- a/apps/web/src/components/agent-sessions/tools/tool-detail-view.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-detail-view.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
 
+import { Tooltip, TooltipContent, TooltipTrigger } from "@maple/ui/components/ui/tooltip"
 import { formatRelativeTimeOrDate } from "@maple/ui/lib/time-format"
 
 import type { AgentSessionRow } from "@/components/agent-sessions/agent-sessions-list"
@@ -28,6 +29,8 @@ export interface ToolDetailViewData {
 	/** Epoch ms of the tool's first and last call in the window; 0 where it never ran. */
 	readonly firstSeen: number
 	readonly lastSeen: number
+	/** The tool's latest `gen_ai.tool.description`; absent where no call stamped one. */
+	readonly description?: string
 	readonly errors: ReadonlyArray<ToolErrorRow>
 	/** The Errors read's state, so an empty table is only ever a finding. */
 	readonly errorsLoading: boolean
@@ -93,10 +96,25 @@ export function ToolDetailView({
 	return (
 		<div className="flex flex-col">
 			<header className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3 px-6 pt-[22px] pb-4">
-				<div className="flex min-w-0 flex-col gap-1.5">
-					<h1 className="truncate font-mono text-[26px] font-semibold leading-8 tracking-[-0.01em] text-foreground">
-						{tool}
-					</h1>
+				<div className="flex min-w-0 flex-1 flex-col gap-1.5">
+					<div className="flex min-w-0 items-baseline gap-3">
+						<h1 className="truncate font-mono text-[26px] font-semibold leading-8 tracking-[-0.01em] text-foreground">
+							{tool}
+						</h1>
+						{data.description !== undefined && (
+							<Tooltip>
+								{/* `w-0 flex-1`: fills the row beside the name without its own
+								    width pushing the header controls onto the next line. */}
+								<TooltipTrigger
+									render={<span />}
+									className="w-0 min-w-0 flex-1 cursor-default truncate text-[13px] leading-[18px] text-muted-foreground"
+								>
+									{data.description}
+								</TooltipTrigger>
+								<TooltipContent className="max-w-md">{data.description}</TooltipContent>
+							</Tooltip>
+						)}
+					</div>
 					<p className="font-mono text-[13px] leading-[18px] text-muted-foreground">
 						{subtitle.join(" · ")}
 					</p>

--- a/apps/web/src/components/agent-sessions/tools/tool-detail-view.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-detail-view.tsx
@@ -107,6 +107,7 @@ export function ToolDetailView({
 								    width pushing the header controls onto the next line. */}
 								<TooltipTrigger
 									render={<span />}
+									tabIndex={0}
 									className="w-0 min-w-0 flex-1 cursor-default truncate text-[13px] leading-[18px] text-muted-foreground"
 								>
 									{data.description}

--- a/apps/web/src/lab/agent-tools-fixture.ts
+++ b/apps/web/src/lab/agent-tools-fixture.ts
@@ -631,6 +631,7 @@ export function buildToolDetailFixture(
 			.reduce((sum, cell) => sum + cell.calls, 0),
 		firstSeen: scoped.reduce((min, cell) => (min === 0 ? cell.bucket : Math.min(min, cell.bucket)), 0),
 		lastSeen: scoped.reduce((max, cell) => Math.max(max, cell.bucket), 0),
+		description: `Runs ${tool} in the agent's workspace and returns its output, truncated to the last 4,000 characters.`,
 		errors: buildToolErrorsFixture(tool, totals.errors, nowMs),
 		errorsLoading: false,
 		errorsFailure: undefined,

--- a/apps/web/src/routes/agent-sessions/tools/$toolName.tsx
+++ b/apps/web/src/routes/agent-sessions/tools/$toolName.tsx
@@ -233,6 +233,7 @@ function ToolDetailBody({
 					scopeCalls: resolved.current.calls,
 					firstSeen: resolved.firstSeen,
 					lastSeen: resolved.lastSeen,
+					description: resolved.description,
 					errors: errorRows,
 					errorsLoading: Result.isInitial(errors),
 					errorsFailure,

--- a/packages/domain/src/http/ai-sessions.ts
+++ b/packages/domain/src/http/ai-sessions.ts
@@ -671,6 +671,9 @@ export class AiToolsTotalsResponse extends Schema.Class<AiToolsTotalsResponse>("
 	 * which the client renders as "no comparison" rather than a -100%.
 	 */
 	previous: AiToolsAggregate,
+	/** The selected tool's latest non-empty `gen_ai.tool.description` in the
+	 *  window. Absent when no tool is selected or no call stamped one. */
+	description: Schema.optionalKey(Schema.String),
 }) {}
 
 /** Rows the Tools breakdown returns, busiest first — the same cap the query

--- a/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
+++ b/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
@@ -926,6 +926,31 @@ SELECT
           AND TraceId = '7f3a4b5c6d7e8f901234567890abcdef'
         FORMAT JSON
 
+-- builder:ai-tools:aiToolDescriptionQuery:default
+SELECT
+          argMax(coalesce(nullIf(SpanAttributes['gen_ai.tool.description'], ''), nullIf(SpanAttributes['tool.description'], ''), ''), Timestamp) AS description
+        FROM trace_detail_spans
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND (trace_detail_spans.TraceId, trace_detail_spans.SpanId) IN (SELECT
+          traceId AS traceId,
+          spanId AS spanId
+        FROM (SELECT
+          TraceId AS traceId,
+          SpanId AS spanId,
+          Timestamp AS ts
+        FROM ai_trace_index
+        WHERE OrgId = 'org_sql_catalog'
+          AND Timestamp >= '2026-01-01 10:30:00'
+          AND Timestamp <= '2026-01-03 14:15:00'
+          AND IsToolCall = 1
+          AND ToolName = 'search_traces'
+        ORDER BY ts DESC
+        LIMIT 100) AS recent_tool_calls)
+          AND coalesce(nullIf(SpanAttributes['gen_ai.tool.description'], ''), nullIf(SpanAttributes['tool.description'], ''), '') != ''
+        FORMAT JSON
+
 -- builder:ai-tools:aiToolErrorOccurrencesQuery:default
 SELECT
           toString(trace_detail_spans.Timestamp) AS timestamp,

--- a/packages/query-engine-integrations/src/ai/ai-tools.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-tools.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest"
 import { Effect } from "effect"
 import { compileUnionUnsafe, compileUnsafe, type CompiledQuery } from "@maple-dev/effect-clickhouse"
 import {
+	aiToolDescriptionQuery,
+	aiToolDescriptionRowSchema,
 	aiToolErrorOccurrencesQuery,
 	aiToolErrorOccurrencesRowSchema,
 	aiToolErrorSessionsQuery,
@@ -12,6 +14,7 @@ import {
 	aiToolsSeriesKind,
 	aiToolsSeriesQuery,
 	aiToolsTotalsQuery,
+	AI_TOOL_DESCRIPTION_CALLS,
 	AI_TOOLS_BREAKDOWN_LIMIT,
 	AI_TOOLS_SERIES_MAX_KEYS,
 } from "./ai-tools"
@@ -429,5 +432,29 @@ describe("the tool detail reads", () => {
 				},
 			])[0],
 		).toMatchObject({ durationNs: 1_500_000, argumentsBytes: 2, resultBytes: 0 })
+	})
+})
+
+describe("aiToolDescriptionQuery", () => {
+	const compiled = compileUnsafe(aiToolDescriptionQuery(), errorParams, {
+		rowSchema: aiToolDescriptionRowSchema,
+	})
+
+	it("reads spans inside the tool's most recent calls only", () => {
+		expect(compiled.tenantScope).toBe("single-tenant")
+		expect(orgPredicateCount(compiled.sql)).toBe(2)
+		expect(compiled.sql).toContain("(trace_detail_spans.TraceId, trace_detail_spans.SpanId) IN (SELECT")
+		expect(compiled.sql).toContain("ToolName = 'search_traces'")
+		// Bounded however busy the tool is — the span read is a seek per call.
+		expect(compiled.sql).toContain(`LIMIT ${AI_TOOL_DESCRIPTION_CALLS}`)
+	})
+
+	it("keeps the latest non-empty description, across the vendor dialects", () => {
+		expect(compiled.sql).toContain("argMax(")
+		expect(compiled.sql).toContain("'gen_ai.tool.description'")
+		expect(compiled.sql).toContain("'tool.description'")
+		expect(decodeRows(compiled, [{ description: "Search traces." }])).toEqual([
+			{ description: "Search traces." },
+		])
 	})
 })

--- a/packages/query-engine-integrations/src/ai/ai-tools.ts
+++ b/packages/query-engine-integrations/src/ai/ai-tools.ts
@@ -759,3 +759,59 @@ export function aiToolErrorOccurrencesQuery(opts: AiToolErrorsOpts = {}) {
 		.limit(opts.limit ?? AI_TOOL_OCCURRENCES_LIMIT)
 		.format("JSON")
 }
+
+/* -------------------------------------------------------------------------------------------------
+ * Tool detail — the header's description
+ * -----------------------------------------------------------------------------------------------*/
+
+/** The tool's most recent calls the description read looks at. A tool that
+ *  stamps a description stamps it on every call, so the latest few answer, and
+ *  the bound keeps the span read to that many primary-key seeks however busy the
+ *  tool is. */
+export const AI_TOOL_DESCRIPTION_CALLS = 100
+
+export interface AiToolDescriptionOutput {
+	/** `''` where none of those calls stamped one. */
+	readonly description: string
+}
+
+export const aiToolDescriptionRowSchema: CompiledQueryRowSchema<AiToolDescriptionOutput> = Schema.Struct({
+	description: Schema.String,
+})
+
+/**
+ * The latest non-empty `gen_ai.tool.description` (or a dialect's equivalent) on
+ * one tool's recent calls in the window. The tool is a param, like the error
+ * reads'; the toolbar does not narrow it, because a description is the tool's
+ * and not the selection's.
+ */
+export function aiToolDescriptionQuery() {
+	const recentCalls = from(AiTraceIndex)
+		.select(($) => ({ traceId: $.TraceId, spanId: $.SpanId, ts: $.Timestamp }))
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.Timestamp.gte(param.dateTimeString("startTime")),
+			$.Timestamp.lte(param.dateTimeString("endTime")),
+			$.IsToolCall.eq(1),
+			$.ToolName.eq(param.string("toolName")),
+		])
+		.orderBy(["ts", "desc"])
+		.limit(AI_TOOL_DESCRIPTION_CALLS)
+
+	return from(TraceDetailSpans)
+		.select(($) => ({ description: CH.argMax(spanField($, "toolDescription"), $.Timestamp) }))
+		.where(($) => [
+			$.OrgId.eq(param.string("orgId")),
+			$.Timestamp.gte(param.dateTimeString("startTime")),
+			$.Timestamp.lte(param.dateTimeString("endTime")),
+			inSubquery(
+				traceSpanKey,
+				fromQuery(recentCalls, "recent_tool_calls").select(($) => ({
+					traceId: $.traceId,
+					spanId: $.spanId,
+				})),
+			),
+			spanField($, "toolDescription").neq(""),
+		])
+		.format("JSON")
+}

--- a/packages/query-engine-integrations/src/ai/index.ts
+++ b/packages/query-engine-integrations/src/ai/index.ts
@@ -41,6 +41,8 @@ export {
 } from "./ai-sessions"
 
 export {
+	aiToolDescriptionQuery,
+	aiToolDescriptionRowSchema,
 	aiToolErrorOccurrencesQuery,
 	aiToolErrorOccurrencesRowSchema,
 	aiToolErrorSessionsQuery,
@@ -56,6 +58,7 @@ export {
 	AI_TOOL_OCCURRENCES_LIMIT,
 	AI_TOOLS_BREAKDOWN_LIMIT,
 	AI_TOOLS_SERIES_MAX_KEYS,
+	type AiToolDescriptionOutput,
 	type AiToolErrorOccurrencesOutput,
 	type AiToolErrorSessionsOutput,
 	type AiToolErrorsOpts,

--- a/packages/query-engine-integrations/src/benchmark/index.ts
+++ b/packages/query-engine-integrations/src/benchmark/index.ts
@@ -279,6 +279,17 @@ export const integrationFixtures: ReadonlyArray<IntegrationFixture> = [
 		compile: () => compileUnsafe(CH.aiToolsBreakdownsQuery(AI_TOOLS_SELECTION), window),
 	},
 	{
+		// The tool detail header's description: a span read inside the tool's
+		// most recent calls, which the baseline pins as a bounded subquery.
+		module: "ai-tools",
+		name: "aiToolDescriptionQuery",
+		label: "default",
+		compile: () =>
+			compileUnsafe(CH.aiToolDescriptionQuery(), toolWindow, {
+				rowSchema: CH.aiToolDescriptionRowSchema,
+			}),
+	},
+	{
 		// The tool detail page's failures. The only tools reads that touch
 		// `trace_detail_spans`, and the baseline is what proves the span scan
 		// stays inside the trace-id subquery the index answers.


### PR DESCRIPTION
- Tool detail header: shows the latest non-empty tool description next to the name, muted, one line, truncated, full text in a tooltip; shows nothing if the tool has no description
- Source: `gen_ai.tool.description` on execute_tool spans (plus OpenInference `tool.description`, via the existing vendor coalesce)
- New `aiToolDescriptionQuery`: `argMax` over `trace_detail_spans`, prefiltered to the tool's 100 most recent calls in `ai_trace_index`
- `/tools/totals` runs it in parallel with the totals read when `tool` is set; `description` is an `optionalKey` in the response
- Tests: unit, route, web render, ClickHouse e2e (latest non-empty wins, no leak from other orgs), SQL baseline + catalog fixture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725668&installation_model_id=427786&pr_number=851&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F851&signature=82f37109c01caae225cd1af0eea75b570e5f0701892010d790448d66331f7954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tool detail views now display the selected tool’s description when available.
  - Descriptions are truncated inline, with the full text available via tooltip.
  - Tool descriptions are retrieved from recent tool activity and omitted when unavailable.

- **Bug Fixes**
  - Improved handling ensures descriptions are only requested when a tool is selected and excludes unrelated tool activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->