### PR TITLE
fix(agent-tools): make the tool error modal legible and link errors to their sessions

### DIFF
--- a/apps/web/src/api/warehouse/ai-session-tools.ts
+++ b/apps/web/src/api/warehouse/ai-session-tools.ts
@@ -269,6 +269,7 @@ const mapErrorSessions = (
 ): ReadonlyArray<ToolErrorSessionRow> =>
 	rows.map((row) => ({
 		sessionId: row.sessionId,
+		vendorId: row.vendorId,
 		agentName: row.agentName,
 		model: row.model,
 		hits: row.hits,
@@ -283,6 +284,7 @@ const mapOccurrences = (
 		traceId: row.traceId,
 		spanId: row.spanId,
 		sessionId: row.sessionId,
+		vendorId: row.vendorId,
 		agentName: row.agentName,
 		model: row.model,
 		errorType: row.errorType,

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
@@ -17,13 +17,11 @@ import { useDetectedModels } from "@/hooks/use-detected-models"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { formatTimestampInTimezone } from "@/lib/timezone-format"
 import { formatCost } from "@/lib/agent-sessions/session-summary"
-import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
 import { sessionLinkWindow, sessionRowId } from "@/lib/agent-sessions/session-window"
 import { TOKEN_BUCKETS, type TokenBucketKey } from "@/lib/agent-sessions/token-buckets"
-import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
 import { ModelLabel } from "./model-label"
-import { sessionIdentity } from "./session-detail/session-header"
 import { CATEGORY_TEXT } from "./session-detail/span-visuals"
+import { SessionName } from "./session-name"
 
 /** The wire row from `listAiSessions` — one AI agent session, newest first. */
 export interface AgentSessionRow {
@@ -157,15 +155,6 @@ export function AgentSessionsList({
 		<div className="@container">
 			{sessions.map((session) => {
 				const hasErrors = session.errorSpanCount > 0
-				const VendorIcon = vendorIcon(session.vendorId)
-				const vendor = vendorLabel(session.vendorId)
-				// `sessionIdentity` reads the first name, so it is handed the one
-				// name the warehouse resolved in span order rather than the
-				// unordered `agentNames` set — see `firstAgentName`.
-				const { heading } = sessionIdentity({
-					agentNames: session.firstAgentName === "" ? [] : [session.firstAgentName],
-					vendorIds: [session.vendorId],
-				})
 				const [firstModel, ...otherModels] = session.models
 				return (
 					<Link
@@ -190,15 +179,12 @@ export function AgentSessionsList({
 						    recognise one, so it reads as metadata under the name. */}
 						<div className="min-w-0 flex-1 overflow-hidden">
 							<div className="flex items-center gap-2">
-								<span
-									className="flex shrink-0 items-center text-muted-foreground"
-									title={vendor}
-								>
-									<VendorIcon size={15} aria-hidden />
-								</span>
-								<span className="min-w-0 truncate text-sm font-medium" title={heading}>
-									{heading}
-								</span>
+								{/* `firstAgentName`, not the unordered `agentNames` set. */}
+								<SessionName
+									agentName={session.firstAgentName}
+									vendorId={session.vendorId}
+									className="text-sm font-medium"
+								/>
 								{/* On phones the right-hand lanes are gone, so the timestamp
 								    anchors the top-right corner of the stacked row. */}
 								<span

--- a/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-detail.test.tsx
@@ -1433,5 +1433,10 @@ describe("SessionHeader", () => {
 			heading: "planner",
 			framework: undefined,
 		})
+		// `default` is the SDK's placeholder, not a name.
+		expect(sessionIdentity({ agentNames: ["default"], vendorIds: ["claude_agent_sdk"] })).toEqual({
+			heading: "Claude Agent SDK session",
+			framework: undefined,
+		})
 	})
 })

--- a/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
@@ -65,11 +65,16 @@ export function SessionHeader({ sessionId, summary }: { sessionId: string; summa
 	)
 }
 
+const PLACEHOLDER_AGENT_NAME = "default"
+
 /**
  * What to call the session. A named agent is the best name there is; without
  * one the framework stands in, and without even that the page says "Agent
  * session" rather than parroting an unidentified vendor id. The framework is
  * returned separately only when it is not already the heading.
+ *
+ * `default` is what an SDK stamps when the app named no agent, so it is treated
+ * as no name: a list of sessions all headed "default" identifies none of them.
  */
 export function sessionIdentity(summary: Pick<SessionSummary, "agentNames" | "vendorIds">): {
 	heading: string
@@ -77,7 +82,7 @@ export function sessionIdentity(summary: Pick<SessionSummary, "agentNames" | "ve
 } {
 	const vendorId = summary.vendorIds[0]
 	const framework = vendorId === undefined ? undefined : vendorLabel(vendorId)
-	const agentName = summary.agentNames[0]
+	const agentName = summary.agentNames.find((name) => name !== PLACEHOLDER_AGENT_NAME)
 	if (agentName !== undefined) return { heading: agentName, framework }
 	if (framework !== undefined && framework !== "Unidentified") {
 		return { heading: `${framework} session`, framework: undefined }

--- a/apps/web/src/components/agent-sessions/session-name.tsx
+++ b/apps/web/src/components/agent-sessions/session-name.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@maple/ui/lib/utils"
+
+import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
+import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
+import { sessionIdentity } from "./session-detail/session-header"
+
+/**
+ * A session by what it is rather than what it is keyed by: the framework's mark
+ * beside the agent it ran, or the framework where no agent was named. Shared so
+ * every surface that names a session calls it what the Sessions list does.
+ *
+ * `agentName` is ONE name the warehouse resolved in span order, never an
+ * unordered set — `sessionIdentity` reads the first name it is handed.
+ */
+export function SessionName({
+	agentName,
+	vendorId,
+	iconSize = 15,
+	className,
+}: {
+	agentName: string
+	vendorId: string
+	iconSize?: number
+	className?: string
+}) {
+	const VendorIcon = vendorIcon(vendorId)
+	const { heading } = sessionIdentity({
+		agentNames: agentName === "" ? [] : [agentName],
+		vendorIds: [vendorId],
+	})
+	return (
+		<span className={cn("flex min-w-0 items-center gap-2", className)}>
+			<span className="flex shrink-0 items-center text-muted-foreground" title={vendorLabel(vendorId)}>
+				<VendorIcon size={iconSize} aria-hidden />
+			</span>
+			<span className="min-w-0 truncate" title={heading}>
+				{heading}
+			</span>
+		</span>
+	)
+}

--- a/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
+++ b/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
@@ -4,7 +4,7 @@
 // pages' own wiring — which control writes which search param, which row links
 // where, and what the tables say about the rows they are given.
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
@@ -343,7 +343,12 @@ describe("ToolErrorModal", () => {
 		})
 		// A session with no agent name is headed by its framework, not left blank
 		// and never titled by its raw id.
-		expect(screen.queryAllByText(/ session$/).length).toBeGreaterThan(0)
+		const unnamed = detail.sessions.find((candidate) => candidate.agentName === "")!
+		expect(unnamed.vendorId).toBe("eve")
+		const unnamedRow = screen.getByRole("button", {
+			name: `Show occurrences in ${unnamed.sessionId}`,
+		}).parentElement!
+		expect(within(unnamedRow).getByText("eve session")).toBeTruthy()
 	})
 
 	it("links an occurrence to its span inside the session", () => {

--- a/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
+++ b/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
@@ -315,13 +315,45 @@ describe("ToolErrorModal", () => {
 
 	it("narrows the occurrences to a session, and back out again", () => {
 		const { onSelectSession } = renderModal()
-		fireEvent.click(screen.getAllByText(detail.sessions[0]!.sessionId)[0]!)
+		fireEvent.click(
+			screen.getByRole("button", { name: `Show occurrences in ${detail.sessions[0]!.sessionId}` }),
+		)
 		expect(onSelectSession).toHaveBeenCalledWith(detail.sessions[0]!.sessionId)
 
 		cleanup()
 		const second = renderModal(detail.sessions[0]!.sessionId).onSelectSession
 		fireEvent.click(screen.getByText("All sessions"))
 		expect(second).toHaveBeenCalledWith(undefined)
+	})
+
+	it("names each session as the Sessions list does, and links to it on the trace view", () => {
+		renderModal()
+		const named = detail.sessions.find((candidate) => candidate.agentName === "planner")!
+		const link = screen
+			.getAllByText("planner")
+			.map((element) => element.closest("a"))
+			.find((anchor) => JSON.parse(anchor?.getAttribute("data-search") ?? "{}").span === undefined)
+		expect(link?.getAttribute("data-to")).toBe("/agent-sessions/$sessionId")
+		expect(JSON.parse(link?.getAttribute("data-params") ?? "{}")).toEqual({ sessionId: named.sessionId })
+		// No window: the failures' extent is not the session's, and the detail page
+		// would read it as the session's.
+		expect(JSON.parse(link?.getAttribute("data-search") ?? "{}")).toEqual({
+			tool: "run_tests",
+			view: "trace",
+		})
+		// A session with no agent name is headed by its framework, not left blank
+		// and never titled by its raw id.
+		expect(screen.queryAllByText(/ session$/).length).toBeGreaterThan(0)
+	})
+
+	it("links an occurrence to its span inside the session", () => {
+		renderModal()
+		const first = detail.occurrences[0]!
+		// The mocked `Link` renders no `href`, so its anchors carry no link role.
+		const spans = Array.from(document.querySelectorAll("a"))
+			.map((anchor) => JSON.parse(anchor.getAttribute("data-search") ?? "{}"))
+			.filter((search) => search.span !== undefined)
+		expect(spans[0]).toMatchObject({ span: first.spanId, tool: "run_tests", view: "trace" })
 	})
 
 	it("totals a session's occurrences by that session's hits, not the error's", () => {

--- a/apps/web/src/components/agent-sessions/tools/tool-error-modal.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-error-modal.tsx
@@ -10,6 +10,7 @@ import { formatRelativeTimeOrDate } from "@maple/ui/lib/time-format"
 
 import { ChevronDownIcon, ChevronRightIcon, ExternalLinkIcon, XmarkIcon } from "@/components/icons"
 import { QueryErrorState } from "@/components/common/query-error-state"
+import { useDetectedModels, type DetectedModel } from "@/hooks/use-detected-models"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { formatTimestampInTimezone } from "@/lib/timezone-format"
 import { sessionRowId } from "@/lib/agent-sessions/session-window"
@@ -21,11 +22,15 @@ import {
 	type ToolErrorRow,
 	type ToolErrorSessionRow,
 } from "@/lib/agent-sessions/tool-analytics"
+import { ModelLabel } from "../model-label"
+import { SessionName } from "../session-name"
 
 export interface ToolErrorDetailData {
 	readonly sessions: ReadonlyArray<ToolErrorSessionRow>
 	readonly occurrences: ReadonlyArray<ToolErrorOccurrenceRow>
 }
+
+type Detect = (model: string) => DetectedModel
 
 /**
  * One error type of one tool, in full: which sessions hit it, and the calls
@@ -38,7 +43,8 @@ export interface ToolErrorDetailData {
  *
  * Two panes, and only the right one is filtered by the left: picking a session
  * narrows the occurrences, and the session list stays whole so the reader can
- * pick a different one without closing anything.
+ * pick a different one without closing anything. A session's NAME is the way
+ * out to the session itself, in both panes.
  */
 export function ToolErrorModal({
 	tool,
@@ -70,6 +76,9 @@ export function ToolErrorModal({
 	loading?: boolean
 }) {
 	const { effectiveTimezone } = useTimezonePreference()
+	const detect = useDetectedModels(
+		[...data.sessions, ...data.occurrences].map((row) => row.model).filter((model) => model !== ""),
+	)
 	const share = toolFailures > 0 ? Math.round((error.calls / toolFailures) * 100) : 0
 	// Narrowed to a session, the occurrences are that session's, so their total is
 	// its hits rather than the error's.
@@ -95,28 +104,31 @@ export function ToolErrorModal({
 			>
 				<div data-slot="tool-error-modal" className="flex min-h-0 min-w-0 grow flex-col">
 					<header className="flex shrink-0 items-start justify-between gap-6 border-b border-border px-6 pt-5 pb-4">
-						<div className="flex min-w-0 flex-col gap-2">
-							<div className="flex items-center gap-2.5 font-mono text-[11px] leading-3.5">
-								<span className="text-muted-foreground/80">{tool}</span>
+						<div className="flex min-w-0 flex-col gap-1.5">
+							<div className="flex items-center gap-2.5 font-mono text-[11px] leading-3.5 text-muted-foreground/80">
+								<span>{tool}</span>
 								<span className="text-muted-foreground/40">/</span>
-								<span className="text-muted-foreground/80">error</span>
+								<span>error</span>
 							</div>
-							<div className="flex min-w-0 flex-wrap items-baseline gap-3">
-								<h2
-									className={cn(
-										"font-mono text-[22px] font-semibold leading-[26px] tracking-[-0.01em]",
-										error.errorType === ""
-											? "text-muted-foreground"
-											: "text-[var(--severity-error)]",
-									)}
+							<h2
+								className={cn(
+									"font-mono text-[22px] font-semibold leading-[26px] tracking-[-0.01em]",
+									error.errorType === "" ? "text-muted-foreground" : "text-[var(--severity-error)]",
+								)}
+							>
+								{errorTypeLabel(error.errorType)}
+							</h2>
+							{/* The message on a line of its own: beside the type it wrapped
+							    under it anyway, and a long one pushed the facts off-screen. */}
+							{error.message === "" ? null : (
+								<p
+									className="line-clamp-3 max-w-[100ch] break-words font-mono text-[13px] leading-[18px] text-foreground/85"
+									title={error.message}
 								>
-									{errorTypeLabel(error.errorType)}
-								</h2>
-								<p className="min-w-0 font-mono text-[13px] leading-[18px] text-foreground">
 									{error.message}
 								</p>
-							</div>
-							<div className="flex flex-wrap items-center gap-3.5 font-mono text-[11.5px] leading-3.5 text-muted-foreground">
+							)}
+							<div className="mt-1 flex flex-wrap items-center gap-3.5 font-mono text-[11.5px] leading-3.5 text-muted-foreground">
 								<Fact>{formatToolCount(error.calls)} occurrences</Fact>
 								<Fact>{formatToolCount(error.sessions)} sessions</Fact>
 								<Fact>
@@ -137,8 +149,8 @@ export function ToolErrorModal({
 							<Link
 								to="/agent-sessions"
 								// The sessions list reads `tools`, not `toolNames` — see its
-							// own search schema.
-							search={{ tools: [tool], hasErrors: true }}
+								// own search schema.
+								search={{ tools: [tool], hasErrors: true }}
 								className="inline-flex h-[30px] items-center gap-2 rounded-md border border-border bg-card px-2.5 font-mono text-[11.5px] text-foreground transition-colors hover:bg-muted/50"
 							>
 								Open in Sessions
@@ -161,29 +173,33 @@ export function ToolErrorModal({
 							titleOverride={`Failed to load ${errorTypeLabel(error.errorType)} occurrences`}
 						/>
 					) : (
-					<div
-						className={cn(
-							"flex min-h-0 grow transition-opacity max-md:flex-col",
-							waiting && "opacity-60",
-						)}
-					>
-						<SessionsPane
-							rows={data.sessions}
-							total={error.sessions}
-							occurrences={error.calls}
-							lastSeen={error.lastSeen}
-							selected={session}
-							onSelect={onSelectSession}
-						/>
-						{/* Keyed by session: a different session is a different list, and
-						    its first occurrence opens as the first one did. */}
-						<OccurrencesPane
-							key={session ?? ""}
-							rows={data.occurrences}
-							total={occurrencesTotal}
-							loading={loading}
-						/>
-					</div>
+						<div
+							className={cn(
+								"flex min-h-0 grow transition-opacity max-md:flex-col",
+								waiting && "opacity-60",
+							)}
+						>
+							<SessionsPane
+								tool={tool}
+								rows={data.sessions}
+								total={error.sessions}
+								occurrences={error.calls}
+								lastSeen={error.lastSeen}
+								selected={session}
+								onSelect={onSelectSession}
+								detect={detect}
+							/>
+							{/* Keyed by session: a different session is a different list, and
+							    its first occurrence opens as the first one did. */}
+							<OccurrencesPane
+								key={session ?? ""}
+								tool={tool}
+								rows={data.occurrences}
+								total={occurrencesTotal}
+								loading={loading}
+								detect={detect}
+							/>
+						</div>
 					)}
 				</div>
 			</DialogPopup>
@@ -202,25 +218,82 @@ function Fact({ children }: { children: React.ReactNode }) {
 	)
 }
 
+/**
+ * The session's name, linking to the session: the trace view, filtered to this
+ * tool, as the tool page's own sessions list opens it.
+ *
+ * No `t`/`end`, unlike that list: its rows carry the session's bounds, and these
+ * carry only the failures'. The detail page reads a window hint AS the window,
+ * so the failures' extent would cut every session that ran on past them; left
+ * off, the page resolves the session's true bounds once and stamps them.
+ *
+ * Positioned, so it sits above the row's stretched button: the rest of the row
+ * is that button, and an anchor inside a button is invalid nesting.
+ */
+function SessionLink({
+	tool,
+	sessionId,
+	vendorId,
+	agentName,
+	spanId,
+	className,
+}: {
+	tool: string
+	sessionId: string
+	vendorId: string
+	agentName: string
+	/** The failed call, opened in the detail page's span panel. */
+	spanId?: string
+	className?: string
+}) {
+	return (
+		<Link
+			to="/agent-sessions/$sessionId"
+			params={{ sessionId }}
+			search={{ tool, view: "trace", ...(spanId !== undefined && { span: spanId }) }}
+			className={cn(
+				"relative flex min-w-0 items-center gap-1.5 rounded-sm text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+				className,
+			)}
+		>
+			<SessionName agentName={agentName} vendorId={vendorId} iconSize={13} />
+			<ExternalLinkIcon
+				size={10}
+				className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+				aria-hidden
+			/>
+		</Link>
+	)
+}
+
 /** Which sessions hit this error, and how hard. `All sessions` is the way back
  *  out of a selection, and is what the pane opens on. */
 function SessionsPane({
+	tool,
 	rows,
 	total,
 	occurrences,
 	lastSeen,
 	selected,
 	onSelect,
+	detect,
 }: {
+	tool: string
 	rows: ReadonlyArray<ToolErrorSessionRow>
 	total: number
 	occurrences: number
 	lastSeen: number
 	selected: string | undefined
 	onSelect: (session: string | undefined) => void
+	detect: Detect
 }) {
 	const { effectiveTimezone } = useTimezonePreference()
 	const relative = (ms: number) => formatRelativeTimeOrDate(ms, undefined, effectiveTimezone)
+	const rowClass = (isSelected: boolean) =>
+		cn(
+			"group relative flex w-full shrink-0 items-center gap-3 border-b border-l-2 border-border/50 pr-4 pl-3.5 text-left transition-colors",
+			isSelected ? "border-l-primary bg-primary/10" : "border-l-transparent hover:bg-muted/30",
+		)
 
 	return (
 		<div className="flex w-[400px] shrink-0 flex-col overflow-hidden border-r border-border bg-sidebar max-md:h-56 max-md:w-full max-md:border-r-0 max-md:border-b">
@@ -242,16 +315,9 @@ function SessionsPane({
 					type="button"
 					aria-pressed={selected === undefined}
 					onClick={() => onSelect(undefined)}
-					className={cn(
-						"flex h-10 w-full shrink-0 items-center gap-3 border-b border-border/50 border-l-2 px-4 pl-3.5 text-left transition-colors",
-						selected === undefined
-							? "border-l-primary bg-primary/10"
-							: "border-l-transparent hover:bg-muted/30",
-					)}
+					className={cn(rowClass(selected === undefined), "h-10")}
 				>
-					<span className="grow font-mono text-[12.5px] font-medium text-foreground">
-						All sessions
-					</span>
+					<span className="grow font-mono text-[12.5px] font-medium text-foreground">All sessions</span>
 					<span className="w-12 shrink-0 text-right font-mono text-xs tabular-nums text-foreground">
 						{formatToolCount(occurrences)}
 					</span>
@@ -263,27 +329,45 @@ function SessionsPane({
 				{rows.map((row) => {
 					const isSelected = row.sessionId === selected
 					return (
-						<button
-							key={row.sessionId}
-							type="button"
-							aria-pressed={isSelected}
-							onClick={() => onSelect(isSelected ? undefined : row.sessionId)}
-							className={cn(
-								"flex h-[52px] w-full shrink-0 items-center gap-3 border-b border-border/50 border-l-2 px-4 text-left transition-colors",
-								isSelected
-									? "border-l-primary bg-primary/10 pl-3.5"
-									: "border-l-transparent hover:bg-muted/30",
-							)}
-						>
-							<span className="flex w-0 min-w-0 grow flex-col gap-[3px]">
-								<span
-									className="truncate font-mono text-[12.5px] text-primary"
-									title={row.sessionId}
-								>
-									{sessionRowId(row.sessionId)}
-								</span>
-								<span className="truncate font-mono text-[11px] leading-3.5 text-muted-foreground">
-									{[row.agentName, row.model].filter((part) => part !== "").join(" · ")}
+						<div key={row.sessionId} className={cn(rowClass(isSelected), "h-14")}>
+							{/* Stretched under the row: a click anywhere but the name
+							    narrows the occurrences to this session. */}
+							<button
+								type="button"
+								aria-pressed={isSelected}
+								aria-label={`Show occurrences in ${sessionRowId(row.sessionId)}`}
+								onClick={() => onSelect(isSelected ? undefined : row.sessionId)}
+								className="absolute inset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+							/>
+							<span className="flex w-0 min-w-0 grow flex-col items-start gap-1">
+								<SessionLink
+									tool={tool}
+									sessionId={row.sessionId}
+									vendorId={row.vendorId}
+									agentName={row.agentName}
+									className="max-w-full font-mono text-[12.5px] font-medium"
+								/>
+								{/* Under the name, past its mark: what it ran on, and the id
+								    it is cited by. */}
+								<span className="flex w-full min-w-0 items-center gap-1.5 pl-[21px] text-[11px] leading-3.5 text-muted-foreground">
+									{row.model === "" ? null : (
+										<>
+											<ModelLabel
+												detected={detect(row.model)}
+												size={11}
+												className="max-w-[60%] shrink-0"
+											/>
+											<span aria-hidden className="text-muted-foreground/40">
+												·
+											</span>
+										</>
+									)}
+									<span
+										className="min-w-0 truncate font-mono text-muted-foreground/70"
+										title={row.sessionId}
+									>
+										{sessionRowId(row.sessionId)}
+									</span>
 								</span>
 							</span>
 							<span className="w-12 shrink-0 text-right font-mono text-xs tabular-nums text-foreground">
@@ -292,7 +376,7 @@ function SessionsPane({
 							<span className="w-[72px] shrink-0 text-right font-mono text-[11.5px] tabular-nums text-muted-foreground/70">
 								{relative(row.lastSeen)}
 							</span>
-						</button>
+						</div>
 					)
 				})}
 
@@ -312,13 +396,17 @@ function SessionsPane({
 /** The calls themselves. The first is open, because a modal that opens onto a
  *  list of collapsed rows makes the reader click to see the thing they asked for. */
 function OccurrencesPane({
+	tool,
 	rows,
 	total,
 	loading,
+	detect,
 }: {
+	tool: string
 	rows: ReadonlyArray<ToolErrorOccurrenceRow>
 	total: number
 	loading?: boolean
+	detect: Detect
 }) {
 	// `null` until the reader touches a row: the pane is mounted before its rows
 	// arrive (the modal opens on the row behind it and fills in), so a set seeded
@@ -358,9 +446,11 @@ function OccurrencesPane({
 					rows.map((row) => (
 						<Occurrence
 							key={row.spanId}
+							tool={tool}
 							row={row}
 							open={isOpen(row.spanId)}
 							onToggle={() => toggle(row.spanId)}
+							detect={detect}
 						/>
 					))
 				)}
@@ -379,57 +469,65 @@ function OccurrencesPane({
 }
 
 function Occurrence({
+	tool,
 	row,
 	open,
 	onToggle,
+	detect,
 }: {
+	tool: string
 	row: ToolErrorOccurrenceRow
 	open: boolean
 	onToggle: () => void
+	detect: Detect
 }) {
 	const { effectiveTimezone } = useTimezonePreference()
 	const Chevron = open ? ChevronDownIcon : ChevronRightIcon
+	const time = formatTimestampInTimezone(row.timestamp, { timeZone: effectiveTimezone })
 	return (
 		<div className="border-b border-border/50">
-			{/* The link is a SIBLING of the toggle, not a child: an anchor inside a
-			    button is invalid nesting, and browsers reparent it out of the
-			    button rather than rendering what was written. */}
-			<div className="flex h-10 w-full items-center gap-3.5 px-6 font-mono transition-colors hover:bg-muted/30">
+			{/* The toggle is stretched under the row and the two links sit above it,
+			    as siblings: an anchor inside a button is invalid nesting, and
+			    browsers reparent it out of the button rather than rendering what
+			    was written. The error type is not repeated — the modal is one type. */}
+			<div className="group relative flex h-10 w-full items-center gap-3.5 px-6 font-mono transition-colors hover:bg-muted/30">
 				<button
 					type="button"
 					aria-expanded={open}
+					aria-label={`Occurrence at ${time}`}
 					onClick={onToggle}
-					className="flex min-w-0 grow items-center gap-3.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
-				>
-					<Chevron size={12} className="shrink-0 text-muted-foreground" aria-hidden />
-					<span className="shrink-0 text-[12.5px] text-foreground">
-						{formatTimestampInTimezone(row.timestamp, { timeZone: effectiveTimezone })}
-					</span>
-					<span className="truncate text-xs text-primary" title={row.sessionId}>
-						{sessionRowId(row.sessionId)}
-					</span>
-					{/* A plain breakpoint, not a container query: the dialog is portalled
-					    out of the page's container, so `@min-…/page` never matches here. */}
-					<span className="hidden truncate text-xs text-muted-foreground lg:inline">
-						{[row.agentName, row.model].filter((part) => part !== "").join(" · ")}
-					</span>
-					<span className="grow" />
-					<span className="shrink-0 text-xs tabular-nums text-foreground/85">
-						{formatDurationNs(row.durationNs)}
-					</span>
-					{row.errorType === "" ? null : (
-						<span className="hidden h-[17px] shrink-0 items-center rounded-[3px] bg-[var(--severity-error)]/20 px-1.5 text-2xs leading-3 text-[var(--severity-error)] sm:flex">
-							{row.errorType}
-						</span>
-					)}
-				</button>
+					className="absolute inset-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+				/>
+				<Chevron size={12} className="shrink-0 text-muted-foreground" aria-hidden />
+				<span className="shrink-0 text-[12.5px] text-foreground">{time}</span>
+				<SessionLink
+					tool={tool}
+					sessionId={row.sessionId}
+					vendorId={row.vendorId}
+					agentName={row.agentName}
+					spanId={row.spanId}
+					className="text-xs"
+				/>
+				{/* A plain breakpoint, not a container query: the dialog is portalled
+				    out of the page's container, so `@min-…/page` never matches here. */}
+				{row.model === "" ? null : (
+					<ModelLabel
+						detected={detect(row.model)}
+						size={11}
+						className="hidden shrink text-xs text-muted-foreground lg:flex"
+					/>
+				)}
+				<span className="grow" />
+				<span className="shrink-0 text-xs tabular-nums text-foreground/85">
+					{formatDurationNs(row.durationNs)}
+				</span>
 				<Link
 					to="/traces/$traceId"
 					params={{ traceId: row.traceId }}
 					// The call's own timestamp narrows the trace read to one partition;
 					// without it the detail page scans every retained day.
 					search={{ spanId: row.spanId, t: formatWarehouseDateTime(row.timestamp) }}
-					className="flex shrink-0 items-center gap-[5px] text-[11.5px] text-muted-foreground transition-colors hover:text-foreground"
+					className="relative flex shrink-0 items-center gap-[5px] text-[11.5px] text-muted-foreground transition-colors hover:text-foreground"
 				>
 					Open trace
 					<ExternalLinkIcon size={11} aria-hidden />

--- a/apps/web/src/lab/agent-tools-fixture.ts
+++ b/apps/web/src/lab/agent-tools-fixture.ts
@@ -654,6 +654,7 @@ export function buildToolErrorDetailFixture(
 
 	const sessions: ReadonlyArray<ToolErrorSessionRow> = seeds.map((seed, index) => ({
 		sessionId: seed.sessionId,
+		vendorId: ["eve", "claude_agent_sdk", "vercel_ai_sdk", "langchain"][index % 4]!,
 		agentName: seed.agentName,
 		model: seed.model,
 		hits: Math.max(1, Math.round(hits / (index + 2))),
@@ -662,7 +663,7 @@ export function buildToolErrorDetailFixture(
 
 	const occurrences: ReadonlyArray<ToolErrorOccurrenceRow> = Array.from({ length: 6 }).map(
 		(_, index) => {
-			const seed = seeds[index % Math.max(seeds.length, 1)]
+			const seed = sessions[index % Math.max(sessions.length, 1)]
 			const args = ARGUMENTS_BY_TOOL.get(tool) ?? '{\n  "input": "…"\n}'
 			const result =
 				RESULT_BY_TYPE.get(errorType) ??
@@ -672,6 +673,7 @@ export function buildToolErrorDetailFixture(
 				traceId: `7f3a4b5c6d7e8f9012345678${index.toString().padStart(8, "0")}`,
 				spanId: `a1b2c3d4e5f6${index.toString().padStart(4, "0")}`,
 				sessionId: seed?.sessionId ?? "trace:7f3a4b5c",
+				vendorId: seed?.vendorId ?? "",
 				agentName: seed?.agentName ?? "",
 				model: seed?.model ?? "",
 				errorType,

--- a/apps/web/src/lib/agent-sessions/tool-analytics.ts
+++ b/apps/web/src/lib/agent-sessions/tool-analytics.ts
@@ -71,6 +71,7 @@ export interface ToolErrorRow {
 /** One session that hit an error type — the modal's left pane. */
 export interface ToolErrorSessionRow {
 	readonly sessionId: string
+	readonly vendorId: string
 	readonly agentName: string
 	readonly model: string
 	readonly hits: number
@@ -85,6 +86,7 @@ export interface ToolErrorOccurrenceRow {
 	readonly traceId: string
 	readonly spanId: string
 	readonly sessionId: string
+	readonly vendorId: string
 	readonly agentName: string
 	readonly model: string
 	readonly errorType: string

--- a/packages/domain/src/http/ai-sessions.ts
+++ b/packages/domain/src/http/ai-sessions.ts
@@ -757,6 +757,8 @@ export class AiToolErrorsResponse extends Schema.Class<AiToolErrorsResponse>("Ai
 /** One session that hit an error type, for the modal's left pane. */
 export const AiToolErrorSessionItem = Schema.Struct({
 	sessionId: Schema.String,
+	/** The framework, derived per trace as the sessions list derives it. */
+	vendorId: Schema.String,
 	agentName: Schema.String,
 	model: Schema.String,
 	/** Occurrences of this error type in this session. */
@@ -771,6 +773,7 @@ export const AiToolErrorOccurrence = Schema.Struct({
 	traceId: Schema.String,
 	spanId: Schema.String,
 	sessionId: Schema.String,
+	vendorId: Schema.String,
 	agentName: Schema.String,
 	model: Schema.String,
 	errorType: Schema.String,

--- a/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
+++ b/packages/query-engine-integrations/src/__sql_baseline__/integrations.sql
@@ -932,7 +932,8 @@ SELECT
           trace_detail_spans.TraceId AS traceId,
           trace_detail_spans.SpanId AS spanId,
           if(ifNull(trace.rawSessionId, '') = '', concat('trace:', trace_detail_spans.TraceId), ifNull(trace.rawSessionId, '')) AS sessionId,
-          coalesce(nullIf(trace_detail_spans.SpanAttributes['gen_ai.agent.name'], ''), nullIf(trace_detail_spans.SpanAttributes['ai.telemetry.functionId'], ''), '') AS agentName,
+          ifNull(trace.traceVendorId, '') AS vendorId,
+          ifNull(trace.traceAgentName, '') AS agentName,
           ifNull(trace.traceModel, '') AS model,
           coalesce(nullIf(trace_detail_spans.SpanAttributes['error.type'], ''), '') AS errorType,
           leftUTF8(trace_detail_spans.StatusMessage, 400) AS message,
@@ -946,7 +947,9 @@ SELECT
         LEFT JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -983,7 +986,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1009,6 +1014,7 @@ SELECT
 -- builder:ai-tools:aiToolErrorSessionsQuery:default
 SELECT
           session AS sessionId,
+          anyIf(vendor, vendor != '') AS vendorId,
           anyIf(agent, agent != '') AS agentName,
           anyIf(model, model != '') AS model,
           count() AS hits,
@@ -1020,7 +1026,8 @@ SELECT
           if(ifNull(trace.rawSessionId, '') = '', concat('trace:', trace_detail_spans.TraceId), ifNull(trace.rawSessionId, '')) AS session,
           coalesce(nullIf(trace_detail_spans.SpanAttributes['error.type'], ''), '') AS errorType,
           leftUTF8(trace_detail_spans.StatusMessage, 400) AS message,
-          coalesce(nullIf(trace_detail_spans.SpanAttributes['gen_ai.agent.name'], ''), nullIf(trace_detail_spans.SpanAttributes['ai.telemetry.functionId'], ''), '') AS agent,
+          ifNull(trace.traceVendorId, '') AS vendor,
+          ifNull(trace.traceAgentName, '') AS agent,
           ifNull(trace.traceModel, '') AS model,
           trace_detail_spans.ServiceName AS svc,
           trace_detail_spans.Duration AS durationNs
@@ -1028,7 +1035,9 @@ SELECT
         LEFT JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1065,7 +1074,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1103,7 +1114,8 @@ SELECT
           if(ifNull(trace.rawSessionId, '') = '', concat('trace:', trace_detail_spans.TraceId), ifNull(trace.rawSessionId, '')) AS session,
           coalesce(nullIf(trace_detail_spans.SpanAttributes['error.type'], ''), '') AS errorType,
           leftUTF8(trace_detail_spans.StatusMessage, 400) AS message,
-          coalesce(nullIf(trace_detail_spans.SpanAttributes['gen_ai.agent.name'], ''), nullIf(trace_detail_spans.SpanAttributes['ai.telemetry.functionId'], ''), '') AS agent,
+          ifNull(trace.traceVendorId, '') AS vendor,
+          ifNull(trace.traceAgentName, '') AS agent,
           ifNull(trace.traceModel, '') AS model,
           trace_detail_spans.ServiceName AS svc,
           trace_detail_spans.Duration AS durationNs
@@ -1111,7 +1123,9 @@ SELECT
         LEFT JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1148,7 +1162,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1206,7 +1222,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1257,7 +1275,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1301,7 +1321,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1348,7 +1370,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1394,7 +1418,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1445,7 +1471,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1493,7 +1521,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1538,7 +1568,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1589,7 +1621,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'
@@ -1639,7 +1673,9 @@ SELECT
         INNER JOIN (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2025-12-30 06:45:00'
@@ -1667,7 +1703,9 @@ SELECT
         FROM (SELECT
           TraceId AS TraceId,
           max(SessionId) AS rawSessionId,
-          anyIf(Model, Model != '') AS traceModel
+          anyIf(Model, Model != '') AS traceModel,
+          argMin(VendorId, tuple(if(SessionId != '', 0, 1), Timestamp)) AS traceVendorId,
+          argMin(AgentName, if(AgentName != '', Timestamp, toDateTime('2106-01-01 00:00:00'))) AS traceAgentName
         FROM ai_trace_index
         WHERE OrgId = 'org_sql_catalog'
           AND Timestamp >= '2026-01-01 10:30:00'

--- a/packages/query-engine-integrations/src/ai/ai-sessions.ts
+++ b/packages/query-engine-integrations/src/ai/ai-sessions.ts
@@ -186,7 +186,7 @@ const FAILED_RESPONSE_STATUSES = ["failed", "error"]
  * String. That wrapper is also why the sentinel is 2106 and not 3000: `DateTime`
  * tops out at 2106-02-07 and anything past it fails to parse.
  */
-const SESSION_ORDER_SENTINEL = "2106-01-01 00:00:00"
+export const SESSION_ORDER_SENTINEL = "2106-01-01 00:00:00"
 
 /**
  * How far past the page's own agent-span bounds the `trace_detail_spans`
@@ -225,7 +225,7 @@ const fromUnixTimestamp64Nano = (nanos: CH.Expr<number>): CH.Expr<string> =>
 /** Lexicographic ordering key — ClickHouse compares tuples element by element,
  *  which is how one `argMin` expresses "lowest rank, then earliest". Not in the
  *  builder's function set, and never selected: it only ever orders an argMin. */
-const orderTuple = (...parts: ReadonlyArray<unknown>): CH.Expr<unknown> =>
+export const orderTuple = (...parts: ReadonlyArray<unknown>): CH.Expr<unknown> =>
 	compileFnCall<unknown>("tuple", ...parts)
 
 /**

--- a/packages/query-engine-integrations/src/ai/ai-tools.test.ts
+++ b/packages/query-engine-integrations/src/ai/ai-tools.test.ts
@@ -396,6 +396,7 @@ describe("the tool detail reads", () => {
 			decodeRows(sessions, [
 				{
 					sessionId: "s1",
+					vendorId: "eve",
 					agentName: "agent",
 					model: "gpt-5",
 					// Quoted on a gateway that refuses the 64-bit setting, which is
@@ -416,6 +417,7 @@ describe("the tool detail reads", () => {
 					traceId: "t1",
 					spanId: "s1",
 					sessionId: "sess",
+					vendorId: "eve",
 					agentName: "agent",
 					model: "gpt-5",
 					errorType: "TimeoutError",

--- a/packages/query-engine-integrations/src/ai/ai-tools.ts
+++ b/packages/query-engine-integrations/src/ai/ai-tools.ts
@@ -65,7 +65,7 @@ import { AiTraceIndex, TraceDetailSpans } from "@maple/query-engine/ch/tables"
 import { finiteOrZero, isoBucket, leftUTF8 } from "@maple/query-engine/ch/format"
 import { CHNumber } from "@maple/query-engine/ch/schema"
 import { aiFieldSourceKeys } from "./ai-integrations"
-import { sessionKey } from "./ai-sessions"
+import { SESSION_ORDER_SENTINEL, orderTuple, sessionKey } from "./ai-sessions"
 
 /**
  * The page's selection, as every read here takes it.
@@ -167,6 +167,12 @@ const parentModels = (window: AiToolsWindow) =>
  * one answer, and the fallback exists for traces whose tool spans carry no
  * model lineage at all — where any model of the trace is a better answer than
  * none. Tool calls attributed this way are the vercel/unknown minority.
+ *
+ * `traceVendorId` and `traceAgentName` name the session the way the sessions
+ * list does — the same `argMin` orderings as `aiSessionsListQuery`'s per-trace
+ * level — for the failure modal, which links each failure to its session. The
+ * aggregates below never select them, and ClickHouse prunes unselected columns
+ * of a derived table.
  */
 const traceFacts = (window: AiToolsWindow) =>
 	from(AiTraceIndex)
@@ -174,6 +180,14 @@ const traceFacts = (window: AiToolsWindow) =>
 			TraceId: $.TraceId,
 			rawSessionId: CH.max_($.SessionId),
 			traceModel: CH.anyIf($.Model, $.Model.neq("")),
+			traceVendorId: CH.argMin(
+				$.VendorId,
+				orderTuple(CH.if_($.SessionId.neq(""), CH.lit(0), CH.lit(1)), $.Timestamp),
+			),
+			traceAgentName: CH.argMin(
+				$.AgentName,
+				CH.if_($.AgentName.neq(""), $.Timestamp, CH.toDateTime(CH.lit(SESSION_ORDER_SENTINEL))),
+			),
 		}))
 		.where(($) => [
 			$.OrgId.eq(param.string("orgId")),
@@ -580,7 +594,8 @@ const toolErrorSpans = (opts: AiToolErrorsOpts) =>
 			// A status message and nothing else is what most failures carry, so the
 			// message is the identity of the group as often as the type is.
 			message: leftUTF8($.StatusMessage, CH.lit(AI_TOOL_ERROR_MESSAGE_MAX)),
-			agent: spanField($, "agentName"),
+			vendor: CH.ifNull($.trace.traceVendorId, CH.lit("")),
+			agent: CH.ifNull($.trace.traceAgentName, CH.lit("")),
 			model: CH.ifNull($.trace.traceModel, CH.lit("")),
 			svc: $.ServiceName,
 			durationNs: $.Duration,
@@ -640,6 +655,7 @@ export function aiToolErrorsQuery(opts: AiToolErrorsOpts = {}) {
 /** The modal's left pane: which sessions hit this error type, and how often. */
 export interface AiToolErrorSessionsOutput {
 	readonly sessionId: string
+	readonly vendorId: string
 	readonly agentName: string
 	readonly model: string
 	readonly hits: number
@@ -649,6 +665,7 @@ export interface AiToolErrorSessionsOutput {
 export const aiToolErrorSessionsRowSchema: CompiledQueryRowSchema<AiToolErrorSessionsOutput> =
 	Schema.Struct({
 		sessionId: Schema.String,
+		vendorId: Schema.String,
 		agentName: Schema.String,
 		model: Schema.String,
 		hits: CHNumber,
@@ -659,6 +676,7 @@ export function aiToolErrorSessionsQuery(opts: AiToolErrorsOpts = {}) {
 	return fromQuery(toolErrorSpans(opts), "tool_error_spans")
 		.select(($) => ({
 			sessionId: $.session,
+			vendorId: CH.anyIf($.vendor, $.vendor.neq("")),
 			agentName: CH.anyIf($.agent, $.agent.neq("")),
 			model: CH.anyIf($.model, $.model.neq("")),
 			hits: CH.count(),
@@ -684,6 +702,7 @@ export interface AiToolErrorOccurrencesOutput {
 	readonly traceId: string
 	readonly spanId: string
 	readonly sessionId: string
+	readonly vendorId: string
 	readonly agentName: string
 	readonly model: string
 	readonly errorType: string
@@ -703,6 +722,7 @@ export const aiToolErrorOccurrencesRowSchema: CompiledQueryRowSchema<AiToolError
 		traceId: Schema.String,
 		spanId: Schema.String,
 		sessionId: Schema.String,
+		vendorId: Schema.String,
 		agentName: Schema.String,
 		model: Schema.String,
 		errorType: Schema.String,
@@ -726,7 +746,8 @@ export function aiToolErrorOccurrencesQuery(opts: AiToolErrorsOpts = {}) {
 				traceId: $.TraceId,
 				spanId: $.SpanId,
 				sessionId: sessionKey(CH.ifNull($.trace.rawSessionId, CH.lit("")), $.TraceId),
-				agentName: spanField($, "agentName"),
+				vendorId: CH.ifNull($.trace.traceVendorId, CH.lit("")),
+				agentName: CH.ifNull($.trace.traceAgentName, CH.lit("")),
 				model: CH.ifNull($.trace.traceModel, CH.lit("")),
 				errorType: spanField($, "errorType"),
 				message: leftUTF8($.StatusMessage, CH.lit(AI_TOOL_ERROR_MESSAGE_MAX)),


### PR DESCRIPTION
- Sessions pane + occurrence rows name sessions like the Sessions list (vendor mark + agent/framework) via a shared `SessionName`; raw id moves to a muted second line
- Session name links to `/agent-sessions/$sessionId` (`tool`, `view: trace`; occurrences also open their `span`). Row click still filters (stretched button, no anchor-in-button)
- No `t`/`end` on these links: the rows only know the failures' extent and the detail page reads a hint as the window, so it would clip longer sessions; the page resolves + stamps true bounds instead
- `default` agent name treated as no name in `sessionIdentity` (list, detail header, modal)
- Models via `ModelLabel`; error message on its own line; redundant per-occurrence error-type pill (and its undefined `text-2xs`) dropped
- Error detail reads now carry `vendorId` + the trace's first agent name, derived with the sessions list's `argMin` orderings (`traceFacts`)
- Verified: scoped web vitest, query-engine-integrations tests + SQL baseline, ClickHouse analyzer sweep (CLICKHOUSE_E2E=1), lab screenshot

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725961&installation_model_id=427786&pr_number=852&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F852&signature=bd61f1df9f66d5f1e1dde85d3dd0fb10897b5d9adeae3660040fc1aa945f12ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool error sessions and occurrences now show vendor and model information.
  - Session entries link directly to the relevant trace, with occurrences linking to their specific spans.
  - Session names consistently display the agent name or framework name, with clearer vendor branding.

- **Bug Fixes**
  - Sessions using the SDK’s default placeholder name now display “Claude Agent SDK session” instead of “default.”
  - Tool error details now use consistent trace-level session and agent metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->