### PR TITLE
feat(api): restore Gen-AI semconv content on agent spans

### DIFF
--- a/apps/api/src/mcp/tools/llm-tools.test.ts
+++ b/apps/api/src/mcp/tools/llm-tools.test.ts
@@ -11,7 +11,8 @@ import { Effect, Result, Schema } from "effect"
 import { assert, describe, it } from "vitest"
 import type { McpToolExecutorApi } from "@/mcp/dispatcher"
 import type { TenantContext } from "@/services/auth/tenant-context"
-import { buildMapleToolkit } from "./llm-tools"
+import { makeRecordingTracer } from "@/testing/recording-tracer"
+import { APPROVAL_NOTE, buildMapleToolkit } from "./llm-tools"
 
 const TENANT: TenantContext = {
 	orgId: Schema.decodeSync(OrgId)("org_test"),
@@ -39,6 +40,22 @@ const handlerFor = (executor: McpToolExecutorApi, name: string) => {
 }
 
 describe("buildMapleToolkit", () => {
+	it("records a gated tool's description on its span as the model saw it", async () => {
+		const { executor } = countingExecutor()
+		const handler = buildMapleToolkit(executor, TENANT, { gate: () => true }).handlers.list_services
+		assert.isDefined(handler, "no handler for list_services")
+		const { spans, tracer } = makeRecordingTracer()
+
+		await Effect.runPromise(
+			Effect.result(handler!({ limit: 10 }, {} as never)).pipe(
+				Effect.withSpan("execute_tool list_services"),
+				Effect.withTracer(tracer),
+			),
+		)
+
+		assert.isTrue(String(spans[0]?.attributes.get("gen_ai.tool.description")).endsWith(APPROVAL_NOTE))
+	})
+
 	it("refuses the identical call once it has run three times", async () => {
 		const { executor, dispatched } = countingExecutor()
 		const handler = handlerFor(executor, "list_services")

--- a/apps/api/src/mcp/tools/llm-tools.ts
+++ b/apps/api/src/mcp/tools/llm-tools.ts
@@ -17,6 +17,7 @@ import { Tool, Toolkit } from "effect/unstable/ai"
 import type { McpToolExecutorApi, McpToolSurface } from "@/mcp/dispatcher"
 import { mapleToolCatalog, toInputSchema } from "@/mcp/tools/registry"
 import { truncateToolOutput } from "@/mcp/tools/tool-output"
+import { withToolCallContent } from "@/platform/genai-spans"
 import type { TenantContext } from "@/services/auth/tenant-context"
 
 /**
@@ -160,18 +161,20 @@ export const buildMapleToolkit = (
 					// hand the model the message and let it route around.
 					Effect.catchCause((cause) => fail(`Tool failed: ${summarizeToolFailure(cause)}`)),
 				)
+			const handle = (params: unknown) => {
+				if (gated) return fail(`${definition.name} requires user approval and was not executed.`)
+				if (repeats(dispatched, definition.name, params) > IDENTICAL_CALL_LIMIT) {
+					return fail(
+						`${definition.name} has already been called ${IDENTICAL_CALL_LIMIT} times with these ` +
+							"exact arguments in this turn. Read the result you already have, or call it differently.",
+					)
+				}
+				return dispatch(params)
+			}
 			return [
 				definition.name,
-				(params: unknown) => {
-					if (gated) return fail(`${definition.name} requires user approval and was not executed.`)
-					if (repeats(dispatched, definition.name, params) > IDENTICAL_CALL_LIMIT) {
-						return fail(
-							`${definition.name} has already been called ${IDENTICAL_CALL_LIMIT} times with these ` +
-								"exact arguments in this turn. Read the result you already have, or call it differently.",
-						)
-					}
-					return dispatch(params)
-				},
+				(params: unknown) =>
+					withToolCallContent(handle(params), { description: definition.description, params }),
 			]
 			// A dynamic tool's shape is known only at runtime, so the model's arguments arrive
 			// unparsed and the handler parses them.

--- a/apps/api/src/mcp/tools/llm-tools.ts
+++ b/apps/api/src/mcp/tools/llm-tools.ts
@@ -61,6 +61,10 @@ export const APPROVAL_NOTE =
 	"\n\nThis is an approval-gated action. Calling it proposes the change for the user to approve; " +
 	"it does NOT take effect until they do. Call it once with the intended arguments and stop."
 
+/** The description the model sees, which is also the one its tool span records. */
+const describe = (definition: { readonly description: string }, gated: boolean): string =>
+	gated ? `${definition.description}${APPROVAL_NOTE}` : definition.description
+
 export interface BuildMapleToolsOptions {
 	/** Which registry tools to expose. Defaults to all of them. */
 	readonly include?: (name: string) => boolean
@@ -137,7 +141,7 @@ export const buildMapleToolkit = (
 	const tools = definitions.map((definition) => {
 		const gated = options.gate?.(definition.name) ?? false
 		return Tool.dynamic(definition.name, {
-			description: gated ? `${definition.description}${APPROVAL_NOTE}` : definition.description,
+			description: describe(definition, gated),
 			parameters: toInputSchema(definition.schema),
 			success: Schema.String,
 			failure: MapleToolFailure,
@@ -174,7 +178,10 @@ export const buildMapleToolkit = (
 			return [
 				definition.name,
 				(params: unknown) =>
-					withToolCallContent(handle(params), { description: definition.description, params }),
+					withToolCallContent(
+						Effect.suspend(() => handle(params)),
+						{ description: describe(definition, gated), params },
+					),
 			]
 			// A dynamic tool's shape is known only at runtime, so the model's arguments arrive
 			// unparsed and the handler parses them.

--- a/apps/api/src/platform/Llm.ts
+++ b/apps/api/src/platform/Llm.ts
@@ -17,7 +17,7 @@ import { Effect, Layer, Option, Redacted, Schema } from "effect"
 import * as LanguageModel from "effect/unstable/ai/LanguageModel"
 import * as AiModel from "effect/unstable/ai/Model"
 import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest } from "effect/unstable/http"
-import { type ModelCallTelemetry, withModelCallTelemetry } from "./genai-spans"
+import { type ModelCallTelemetry, instrumentLanguageModel } from "./genai-spans"
 import { layerWorkersAi } from "./WorkersAiHttpClient"
 
 /** Default triage/chat model on OpenRouter — the provider agents run on by default. */
@@ -72,8 +72,12 @@ export const DEFAULT_LLM_PROVIDER: LlmProvider = "openrouter"
  * `gen_ai.provider.name` for a provider path. Cloudflare has no well-known value in the convention,
  * so it takes the convention's `vendor.product` shape (`aws.bedrock`, `gcp.vertex_ai`).
  */
-export const genAiProviderName = (provider: LlmProvider): string =>
-	provider === "workers-ai" ? "cloudflare.workers_ai" : "openrouter"
+export const genAiProviderName = (provider: LlmProvider): string => GEN_AI_PROVIDER_NAMES[provider]
+
+const GEN_AI_PROVIDER_NAMES = {
+	openrouter: "openrouter",
+	"workers-ai": "cloudflare.workers_ai",
+} as const satisfies Record<LlmProvider, string>
 
 /**
  * Workers AI has no per-request API key when reached through the `AI` binding, but the client still
@@ -266,10 +270,7 @@ const instrumentedModel = <R>(
 	AiModel.make(
 		"openai",
 		name,
-		Layer.effect(
-			LanguageModel.LanguageModel,
-			Effect.map(make, (service) => withModelCallTelemetry(service, telemetry)),
-		),
+		Layer.effect(LanguageModel.LanguageModel, instrumentLanguageModel(make, telemetry)),
 	)
 
 const openRouterModel = (

--- a/apps/api/src/platform/Llm.ts
+++ b/apps/api/src/platform/Llm.ts
@@ -14,10 +14,10 @@ import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai-compat"
 import { OpenRouterClient, OpenRouterLanguageModel } from "@effect/ai-openrouter"
 import { MAPLE_NATIVE_SESSION_ID_ATTR, MAPLE_NATIVE_TURN_ID_ATTR } from "@maple/domain/gen-ai"
 import { Effect, Layer, Option, Redacted, Schema } from "effect"
-import type * as LanguageModel from "effect/unstable/ai/LanguageModel"
-import type * as AiModel from "effect/unstable/ai/Model"
-import * as Telemetry from "effect/unstable/ai/Telemetry"
+import * as LanguageModel from "effect/unstable/ai/LanguageModel"
+import * as AiModel from "effect/unstable/ai/Model"
 import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest } from "effect/unstable/http"
+import { type ModelCallTelemetry, withModelCallTelemetry } from "./genai-spans"
 import { layerWorkersAi } from "./WorkersAiHttpClient"
 
 /** Default triage/chat model on OpenRouter — the provider agents run on by default. */
@@ -40,7 +40,7 @@ const OPENROUTER_APP_TITLE = "Maple"
  * Broadcast destination.
  *
  * The session, turn and workflow also go on Maple's own model-call span, on either provider — see
- * {@link withAgentSessionSpans}. One set of tags feeds both, so a call and its Broadcast twin cannot
+ * {@link instrumentedModel}. One set of tags feeds both, so a call and its Broadcast twin cannot
  * be filed under different sessions.
  */
 export interface LlmCallTags {
@@ -67,6 +67,13 @@ export const DEFAULT_WORKERS_AI_MODEL = "@cf/moonshotai/kimi-k2.6"
 export type LlmProvider = "openrouter" | "workers-ai"
 
 export const DEFAULT_LLM_PROVIDER: LlmProvider = "openrouter"
+
+/**
+ * `gen_ai.provider.name` for a provider path. Cloudflare has no well-known value in the convention,
+ * so it takes the convention's `vendor.product` shape (`aws.bedrock`, `gcp.vertex_ai`).
+ */
+export const genAiProviderName = (provider: LlmProvider): string =>
+	provider === "workers-ai" ? "cloudflare.workers_ai" : "openrouter"
 
 /**
  * Workers AI has no per-request API key when reached through the `AI` binding, but the client still
@@ -221,7 +228,7 @@ const sessionIdFor = (tags: LlmCallTags): string | undefined => tags.sessionId?.
  * The ingest gateway files a GenAI span under a session only when the span carries
  * `maple_ai.session.id` (its `maple` vendor), and takes the key alone as proof of an agent span.
  * So it goes on exactly two spans: every model-call span the model opens (see
- * {@link withAgentSessionSpans}) and the span that roots the turn — a pass, in a workflow — which the
+ * {@link instrumentedModel}) and the span that roots the turn — a pass, in a workflow — which the
  * session view partitions turns by, walking each span up to its nearest tagged ancestor. Nothing
  * wider: an `Effect.annotateSpans` over the run would file every HTTP and database span as one.
  * Empty without a session.
@@ -239,29 +246,31 @@ export const agentSessionSpanAttributes = (
 }
 
 /**
- * Stamp the agent-session identity onto every model-call span the model opens.
+ * A provider's language model, with every model-call span carrying the full Gen-AI content.
  *
- * Effect AI's own span carries no session key, so without this every trace became a session of its
- * own (`trace:<TraceId>`) — one per chat turn, one per investigation pass. The session list reads a
- * trace's session off any one of its spans, so the model-call span is enough to file the tool and
- * engine spans around it too.
+ * Effect AI's own span carries the model, the response id and two token totals. The rest — messages,
+ * system instructions, cache and reasoning tokens, cost, time to first chunk — and the agent-session
+ * identity are written by `./genai-spans.ts`. The session key matters most: without it every trace
+ * became a session of its own (`trace:<TraceId>`), one per chat turn and one per investigation pass.
+ * The session list reads a trace's session off any one of its spans, so the model-call span is enough
+ * to file the tool and engine spans around it too.
  *
- * Effect AI applies the transformer before the span ends: for `streamText` (the only call Maple
- * makes) as the stream finishes, including when it fails; `generateText` would skip it on failure.
+ * Built with `AiModel.make` exactly as the providers' own `model()` constructors are — `"openai"` is
+ * the provider identity both of them declare — so the only difference is the wrapped service.
  */
-const withAgentSessionSpans = <A, R>(
-	layer: Layer.Layer<A, never, R>,
-	tags: LlmCallTags | undefined,
-): Layer.Layer<A, never, R> => {
-	const attributes = Object.entries(agentSessionSpanAttributes(tags))
-	if (attributes.length === 0) return layer
-	return Layer.provide(
-		layer,
-		Layer.succeed(Telemetry.CurrentSpanTransformer, ({ span }) => {
-			for (const [key, value] of attributes) span.attribute(key, value)
-		}),
+const instrumentedModel = <R>(
+	name: string,
+	make: Effect.Effect<LanguageModel.Service, never, R>,
+	telemetry: ModelCallTelemetry,
+): Layer.Layer<ModelServices, never, R> =>
+	AiModel.make(
+		"openai",
+		name,
+		Layer.effect(
+			LanguageModel.LanguageModel,
+			Effect.map(make, (service) => withModelCallTelemetry(service, telemetry)),
+		),
 	)
-}
 
 const openRouterModel = (
 	env: LlmEnv,
@@ -269,24 +278,32 @@ const openRouterModel = (
 	effortKey: keyof LlmEnv,
 	fallbackEffort: ReasoningEffort | undefined,
 	tags: LlmCallTags | undefined,
-): ResolvedModel => ({
-	provider: "openrouter",
-	name,
-	layer: withAgentSessionSpans(
-		OpenRouterLanguageModel.model(
+): ResolvedModel => {
+	const effort = readReasoningEffort(env, effortKey) ?? fallbackEffort
+	return {
+		provider: "openrouter",
+		name,
+		layer: instrumentedModel(
 			name,
-			openRouterConfig(readReasoningEffort(env, effortKey) ?? fallbackEffort, tags),
+			OpenRouterLanguageModel.make({ model: name, config: openRouterConfig(effort, tags) }),
+			{
+				providerName: genAiProviderName("openrouter"),
+				...(effort === undefined || effort === "off" ? undefined : { reasoningLevel: effort }),
+				sessionAttributes: agentSessionSpanAttributes(tags),
+			},
 		),
+		limits: limitsFor(env, name),
 		tags,
-	),
-	limits: limitsFor(env, name),
-	tags,
-})
+	}
+}
 
 const workersAiModel = (env: LlmEnv, name: string, tags: LlmCallTags | undefined): ResolvedModel => ({
 	provider: "workers-ai",
 	name,
-	layer: withAgentSessionSpans(OpenAiLanguageModel.model(name), tags),
+	layer: instrumentedModel(name, OpenAiLanguageModel.make({ model: name }), {
+		providerName: genAiProviderName("workers-ai"),
+		sessionAttributes: agentSessionSpanAttributes(tags),
+	}),
 	limits: limitsFor(env, name),
 	tags,
 })

--- a/apps/api/src/platform/Llm.ts
+++ b/apps/api/src/platform/Llm.ts
@@ -259,8 +259,12 @@ export const agentSessionSpanAttributes = (
  * The session list reads a trace's session off any one of its spans, so the model-call span is enough
  * to file the tool and engine spans around it too.
  *
- * Built with `AiModel.make` exactly as the providers' own `model()` constructors are — `"openai"` is
- * the provider identity both of them declare — so the only difference is the wrapped service.
+ * Built with `AiModel.make` exactly as the providers' own `model()` constructors are, so the only
+ * difference is the wrapped service.
+ *
+ * The provider string passed to `AiModel.make` does not matter, on either path. It only fills
+ * `AiModel.ProviderName`, which nothing in Maple reads; effect-agent only copies it into usage
+ * summaries Maple never looks at. Span `gen_ai.provider.name` comes from `telemetry.providerName`.
  */
 const instrumentedModel = <R>(
 	name: string,
@@ -268,7 +272,7 @@ const instrumentedModel = <R>(
 	telemetry: ModelCallTelemetry,
 ): Layer.Layer<ModelServices, never, R> =>
 	AiModel.make(
-		"openai",
+		"openrouter",
 		name,
 		Layer.effect(LanguageModel.LanguageModel, instrumentLanguageModel(make, telemetry)),
 	)

--- a/apps/api/src/platform/genai-spans.test.ts
+++ b/apps/api/src/platform/genai-spans.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The budgets on Gen-AI content attributes. Input messages replay the whole transcript on every step
+ * and tool results run to 50k, so these paths run in production far more often than the happy one.
+ */
+import { assert, describe, it } from "@effect/vitest"
+import { messagesJson, toolCallJson } from "./genai-spans"
+
+const TRUNCATION_MARKER = "…[truncated]"
+
+const userText = (content: string) => ({ role: "user", parts: [{ type: "text" as const, content }] })
+
+describe("messagesJson", () => {
+	it("drops whole oldest messages to fit, and counts them", () => {
+		const { json, dropped } = messagesJson(
+			[userText("a".repeat(600)), userText("b".repeat(600)), userText("c")],
+			1_000,
+		)
+
+		assert.strictEqual(dropped, 1)
+		assert.deepStrictEqual(
+			JSON.parse(json).map(
+				(message: { readonly parts: ReadonlyArray<{ readonly content: string }> }) =>
+					message.parts[0]?.content[0],
+			),
+			["b", "c"],
+		)
+	})
+
+	it("truncates the payloads of a newest message that outweighs the budget, rather than dropping it", () => {
+		const { json, dropped } = messagesJson(
+			[
+				{
+					role: "tool",
+					parts: [{ type: "tool_call_response", id: "t1", response: "x".repeat(5_000) }],
+				},
+			],
+			1_000,
+		)
+
+		assert.strictEqual(dropped, 0)
+		assert.isBelow(json.length, 1_000)
+		assert.isTrue(String(JSON.parse(json)[0].parts[0].response).endsWith(TRUNCATION_MARKER))
+	})
+
+	it("replaces a payload JSON cannot encode instead of throwing", () => {
+		const cyclic: Record<string, unknown> = {}
+		cyclic.self = cyclic
+
+		const { json } = messagesJson(
+			[
+				{
+					role: "assistant",
+					parts: [{ type: "tool_call", id: "t1", name: "query_data", arguments: cyclic }],
+				},
+			],
+			1_000,
+		)
+
+		assert.strictEqual(JSON.parse(json)[0].parts[0].arguments, "[object Object]")
+	})
+})
+
+describe("toolCallJson", () => {
+	it("wraps a string result, truncating the text before wrapping it", () => {
+		const result = String(JSON.parse(toolCallJson("x".repeat(20_000))).result)
+
+		assert.isTrue(result.startsWith("xxx"))
+		assert.isTrue(result.endsWith(TRUNCATION_MARKER))
+	})
+
+	it("holds an oversized object to the budget as a truncated prefix", () => {
+		const json = toolCallJson({ rows: '"quoted"'.repeat(5_000) })
+
+		assert.isAtMost(json.length, 8_000)
+		assert.strictEqual(JSON.parse(json).truncated, true)
+	})
+})

--- a/apps/api/src/platform/genai-spans.test.ts
+++ b/apps/api/src/platform/genai-spans.test.ts
@@ -3,7 +3,10 @@
  * and tool results run to 50k, so these paths run in production far more often than the happy one.
  */
 import { assert, describe, it } from "@effect/vitest"
-import { messagesJson, toolCallJson } from "./genai-spans"
+import { Effect, Schema } from "effect"
+import { Tool } from "effect/unstable/ai"
+import { makeRecordingTracer } from "@/testing/recording-tracer"
+import { invokeAgentAttributes, messagesJson, toolCallJson, withToolCallContent } from "./genai-spans"
 
 const TRUNCATION_MARKER = "…[truncated]"
 
@@ -40,6 +43,25 @@ describe("messagesJson", () => {
 		assert.strictEqual(dropped, 0)
 		assert.isBelow(json.length, 1_000)
 		assert.isTrue(String(JSON.parse(json)[0].parts[0].response).endsWith(TRUNCATION_MARKER))
+	})
+
+	it("splits a message's allowance across its parts, so parallel tool results share one", () => {
+		const { json, dropped } = messagesJson(
+			[
+				{
+					role: "tool",
+					parts: Array.from({ length: 20 }, (_, index) => ({
+						type: "tool_call_response" as const,
+						id: `t${index}`,
+						response: "x".repeat(5_000),
+					})),
+				},
+			],
+			20_000,
+		)
+
+		assert.strictEqual(dropped, 0)
+		assert.isAtMost(json.length, 20_000)
 	})
 
 	it("replaces a payload JSON cannot encode instead of throwing", () => {
@@ -97,4 +119,44 @@ describe("toolCallJson", () => {
 		assert.isAtMost(json.length, 8_000)
 		assert.strictEqual(JSON.parse(json).truncated, true)
 	})
+})
+
+describe("invokeAgentAttributes", () => {
+	it("drops schemas and shortens descriptions when the definitions outweigh their budget", () => {
+		const attributes = invokeAgentAttributes({
+			agentName: "lens",
+			agentDescription: "",
+			conversationId: "pass-1",
+			providerName: "openrouter",
+			model: "test-model",
+			tools: Array.from({ length: 40 }, (_, index) =>
+				Tool.make(`tool_${index}`, {
+					description: "d".repeat(1_000),
+					parameters: Schema.Struct({ query: Schema.String }),
+				}),
+			),
+		})
+		const definitions = JSON.parse(String(attributes["gen_ai.tool.definitions"]))
+
+		assert.strictEqual(definitions.length, 40)
+		assert.notProperty(definitions[0], "parameters")
+		assert.strictEqual(definitions[0].description, `${"d".repeat(128)}${TRUNCATION_MARKER}`)
+		assert.notProperty(attributes, "gen_ai.agent.description")
+	})
+})
+
+describe("withToolCallContent", () => {
+	it.effect("leaves the handler and its span alone when there is no tool span to describe", () =>
+		Effect.gen(function* () {
+			const { spans, tracer } = makeRecordingTracer()
+
+			const result = yield* withToolCallContent(Effect.succeed("done"), {
+				description: "a tool",
+				params: {},
+			}).pipe(Effect.withSpan("not_a_tool"), Effect.withTracer(tracer))
+
+			assert.strictEqual(result, "done")
+			assert.strictEqual(spans[0]?.attributes.size, 0)
+		}),
+	)
 })

--- a/apps/api/src/platform/genai-spans.test.ts
+++ b/apps/api/src/platform/genai-spans.test.ts
@@ -68,8 +68,31 @@ describe("toolCallJson", () => {
 		assert.isTrue(result.endsWith(TRUNCATION_MARKER))
 	})
 
+	it("holds a string result to the budget once escaped", () => {
+		// Maple's tool results are JSON and tables: quotes and newlines double in length when wrapped.
+		const json = toolCallJson('{"row":"a"}\n'.repeat(2_000))
+
+		assert.isAtMost(json.length, 8_000)
+		assert.isTrue(String(JSON.parse(json).result).endsWith(TRUNCATION_MARKER))
+	})
+
 	it("holds an oversized object to the budget as a truncated prefix", () => {
 		const json = toolCallJson({ rows: '"quoted"'.repeat(5_000) })
+
+		assert.isAtMost(json.length, 8_000)
+		assert.strictEqual(JSON.parse(json).truncated, true)
+		assert.isAbove(JSON.parse(json).prefix.length, 4_000)
+	})
+
+	it("cuts an escape-heavy object by what its encoding costs, not to nothing", () => {
+		const json = toolCallJson({ rows: '\\"'.repeat(6_000) })
+
+		assert.isAtMost(json.length, 8_000)
+		assert.isAbove(JSON.parse(json).prefix.length, 3_000)
+	})
+
+	it("holds an oversized array to the budget too", () => {
+		const json = toolCallJson(Array.from({ length: 3_000 }, (_, index) => ({ index })))
 
 		assert.isAtMost(json.length, 8_000)
 		assert.strictEqual(JSON.parse(json).truncated, true)

--- a/apps/api/src/platform/genai-spans.ts
+++ b/apps/api/src/platform/genai-spans.ts
@@ -165,9 +165,13 @@ const summarizeResponse = (response: ResponseParts) => {
 	return { message, finish, failed: errored || finish?.reason === "error" }
 }
 
-/** The payload's JSON prefix when it outweighs `cap`, or nothing when it fits unchanged. */
+/**
+ * The payload's JSON prefix when it outweighs `cap`, or nothing when it fits unchanged. A payload
+ * JSON cannot encode is always replaced — left in place, it would throw in `encodeMessage`.
+ */
 const oversizedPayloadPrefix = (value: unknown, cap: number): string | undefined => {
-	const json = stringify(value) ?? String(value)
+	const json = stringify(value)
+	if (json === undefined) return truncated(String(value), cap)
 	return json.length > cap ? json.slice(0, cap) + TRUNCATION_MARKER : undefined
 }
 
@@ -242,7 +246,7 @@ const reportedCost = (metadata: unknown): number | undefined => {
 		return undefined
 	}
 	const cost = openrouter.usage.cost
-	return typeof cost === "number" && Number.isFinite(cost) && cost >= 0 ? cost : undefined
+	return Predicate.isNumber(cost) && Number.isFinite(cost) && cost >= 0 ? cost : undefined
 }
 
 export interface ModelCallTelemetry {
@@ -261,8 +265,9 @@ interface CallTiming {
 	finishedMs: number | undefined
 }
 
+/** `timing` is absent for a non-streaming call, which has neither a first chunk nor a stream. */
 const modelCallTransformer =
-	(telemetry: ModelCallTelemetry, timing: CallTiming): Telemetry.SpanTransformer =>
+	(telemetry: ModelCallTelemetry, timing: CallTiming | undefined): Telemetry.SpanTransformer =>
 	({ span, prompt, responseFormat, response }) => {
 		const input = messagesJson(inputMessages(prompt), INPUT_MESSAGES_BUDGET)
 		const system = systemInstructionsJson(prompt)
@@ -270,7 +275,7 @@ const modelCallTransformer =
 		const cost = finish === undefined ? undefined : reportedCost(finish.metadata)
 		const attributes = {
 			"gen_ai.provider.name": telemetry.providerName,
-			"gen_ai.request.stream": true,
+			"gen_ai.request.stream": timing !== undefined,
 			...(telemetry.reasoningLevel === undefined
 				? undefined
 				: { "gen_ai.request.reasoning.level": telemetry.reasoningLevel }),
@@ -289,8 +294,7 @@ const modelCallTransformer =
 						"gen_ai.usage.input_tokens": finish.usage.inputTokens.total,
 						"gen_ai.usage.output_tokens": finish.usage.outputTokens.total,
 						"gen_ai.usage.cache_read.input_tokens": finish.usage.inputTokens.cacheRead,
-						// The registry spelling; the read side decodes it as an alias of `cache_creation`.
-						"gen_ai.usage.cache_write.input_tokens": finish.usage.inputTokens.cacheWrite,
+						"gen_ai.usage.cache_creation.input_tokens": finish.usage.inputTokens.cacheWrite,
 						"gen_ai.usage.reasoning.output_tokens": finish.usage.outputTokens.reasoning,
 						...(cost === undefined ? undefined : { "gen_ai.usage.cost": cost }),
 					}),
@@ -298,11 +302,12 @@ const modelCallTransformer =
 			// green — these are the record of it, and what the session view's failure counting reads.
 			...(failed ? { "error.type": "provider_error", "gen_ai.response.status": "failed" } : undefined),
 			// Seconds by convention. The span's own clock covers the whole stream lifetime, including
-			// the consumer draining it, so these two are the model's honest numbers.
-			...(timing.firstChunkMs === undefined
+			// the consumer draining it, so these two are stamped as parts pass through instead — as each
+			// is pulled, which is as close to the model as this side of the stream gets.
+			...(timing?.firstChunkMs === undefined
 				? undefined
 				: { "gen_ai.response.time_to_first_chunk": (timing.firstChunkMs - timing.startedMs) / 1000 }),
-			...(timing.finishedMs === undefined
+			...(timing?.finishedMs === undefined
 				? undefined
 				: { [MAPLE_GENAI_MODEL_DURATION_MS_ATTR]: timing.finishedMs - timing.startedMs }),
 			...telemetry.sessionAttributes,
@@ -313,47 +318,62 @@ const modelCallTransformer =
 	}
 
 /**
- * The language model, with every `streamText` call annotating its own span.
+ * Build a provider's language model so that every call annotates its own span.
  *
- * The transformer is provided per call rather than once on the layer because two of its numbers are
- * per call: the first chunk and the finish are timed as they pass through, and the transformer reads
- * them when Effect AI applies it — as the stream ends, including when it fails. `streamText` is the
- * only call Maple makes; the other methods pass through unannotated.
+ * The transformer goes in twice. Once at construction, where Effect AI captures it as the default
+ * every method falls back to, so `generateText` and `generateObject` spans carry the content and the
+ * session too. And once per `streamText` call — the only call Maple makes — because two of its
+ * numbers are per call: the first chunk and the finish are timed as they pass through, and the
+ * transformer reads them when Effect AI applies it, as the stream ends, including when it fails.
  */
-export const withModelCallTelemetry = (
-	service: LanguageModel.Service,
+export const instrumentLanguageModel = <R>(
+	make: Effect.Effect<LanguageModel.Service, never, R>,
 	telemetry: ModelCallTelemetry,
-): LanguageModel.Service => ({
-	...service,
-	streamText: ((options) =>
-		Stream.unwrap(
-			Effect.map(Clock.currentTimeMillis, (startedMs) => {
-				const timing: CallTiming = { startedMs, firstChunkMs: undefined, finishedMs: undefined }
-				return service.streamText(options).pipe(
-					Stream.tap((part) =>
-						timing.firstChunkMs === undefined || part.type === "finish"
-							? Effect.map(Clock.currentTimeMillis, (now) => {
-									timing.firstChunkMs ??= now
-									if (part.type === "finish") timing.finishedMs = now
-								})
-							: Effect.void,
-					),
-					Stream.provideService(
-						Telemetry.CurrentSpanTransformer,
-						modelCallTransformer(telemetry, timing),
-					),
-				)
-			}),
-		)) as LanguageModel.Service["streamText"],
-})
+): Effect.Effect<LanguageModel.Service, never, R> =>
+	make.pipe(
+		Effect.provideService(Telemetry.CurrentSpanTransformer, modelCallTransformer(telemetry, undefined)),
+		Effect.map((service) => ({
+			...service,
+			streamText: ((options: Parameters<LanguageModel.Service["streamText"]>[0]) =>
+				Stream.unwrap(
+					Effect.map(Clock.currentTimeMillis, (startedMs) => {
+						const timing: CallTiming = {
+							startedMs,
+							firstChunkMs: undefined,
+							finishedMs: undefined,
+						}
+						return service.streamText(options).pipe(
+							Stream.tap((part) =>
+								timing.firstChunkMs === undefined || part.type === "finish"
+									? Effect.map(Clock.currentTimeMillis, (now) => {
+											timing.firstChunkMs ??= now
+											if (part.type === "finish") timing.finishedMs = now
+										})
+									: Effect.void,
+							),
+							Stream.provideService(
+								Telemetry.CurrentSpanTransformer,
+								modelCallTransformer(telemetry, timing),
+							),
+						)
+					}),
+				)) as LanguageModel.Service["streamText"],
+		})),
+	)
 
 /**
  * Bounded JSON for tool arguments and results; always an object or array, because the read side's
  * `json` decoder drops scalars and Maple's own tool results are strings. Exported for tests.
  */
 export const toolCallJson = (value: unknown): string => {
-	const wrapped = typeof value === "object" && value !== null ? value : { result: value }
-	const json = stringify(wrapped)
+	// A scalar is truncated before it is wrapped, so an oversized string result still reads as its text
+	// rather than as an escaped JSON prefix.
+	if (!Predicate.isObject(value)) {
+		return JSON.stringify({
+			result: Predicate.isString(value) ? truncated(value, TOOL_JSON_BUDGET) : value,
+		})
+	}
+	const json = stringify(value)
 	if (json === undefined) return JSON.stringify({ result: truncated(String(value), TOOL_JSON_BUDGET) })
 	if (json.length <= TOOL_JSON_BUDGET) return json
 	let prefix = json.slice(0, TOOL_JSON_BUDGET)
@@ -437,25 +457,23 @@ const EXECUTE_TOOL_SPAN_PREFIX = "execute_tool "
  * name, not the engine's internal one, so a handler that already runs directly under the tool span
  * works the same.
  */
-const executeToolSpan = (span: Tracer.AnySpan): Tracer.Span | undefined => {
-	if (span._tag !== "Span") return undefined
-	if (span.name.startsWith(EXECUTE_TOOL_SPAN_PREFIX)) return span
-	return Option.match(span.parent, {
-		onNone: () => undefined,
-		onSome: (parent) =>
-			parent._tag === "Span" && parent.name.startsWith(EXECUTE_TOOL_SPAN_PREFIX) ? parent : undefined,
-	})
-}
+const isExecuteToolSpan = (span: Tracer.AnySpan): span is Tracer.Span =>
+	span._tag === "Span" && span.name.startsWith(EXECUTE_TOOL_SPAN_PREFIX)
 
-const annotateExecuteToolSpan = (attributes: Readonly<Record<string, string>>): Effect.Effect<void> =>
-	Effect.currentSpan.pipe(
-		Effect.map((current) => {
-			const span = executeToolSpan(current)
-			if (span === undefined) return
-			for (const [key, value] of Object.entries(attributes)) span.attribute(key, value)
-		}),
-		Effect.ignore,
-	)
+const executeToolSpan = (span: Tracer.Span): Option.Option<Tracer.Span> =>
+	span.name.startsWith(EXECUTE_TOOL_SPAN_PREFIX)
+		? Option.some(span)
+		: Option.filter(span.parent, isExecuteToolSpan)
+
+/**
+ * Untraced on purpose: a span of its own would become the current span, one level further from the
+ * `execute_tool` span this looks for.
+ */
+const annotateExecuteToolSpan = Effect.fnUntraced(function* (attributes: Readonly<Record<string, string>>) {
+	const span = Option.flatMap(yield* Effect.option(Effect.currentSpan), executeToolSpan)
+	if (Option.isNone(span)) return
+	for (const [key, value] of Object.entries(attributes)) span.value.attribute(key, value)
+})
 
 /** Record a tool call's description, arguments and result — or failure — on its `execute_tool` span. */
 export const withToolCallContent = <A, E extends { readonly message: string }, R>(

--- a/apps/api/src/platform/genai-spans.ts
+++ b/apps/api/src/platform/genai-spans.ts
@@ -1,0 +1,474 @@
+/**
+ * Gen-AI semconv content for Maple's own agents: the model call, the tool call and the agent pass.
+ *
+ * Effect AI's providers annotate the model-call span with the requested and served model, the
+ * response id, the finish reasons and two token totals. Everything else the convention defines —
+ * the provider name, the messages, the system instructions, the tool definitions, the cache and
+ * reasoning buckets, the cost the provider billed, time to first chunk — is added here. Agent
+ * Sessions reads all of it off the spans, and without it an investigation renders as a list of
+ * models with no conversation in between.
+ *
+ * Message and tool payloads are capped, and a capped value keeps its *shape*: the read side's
+ * `json` decoder admits objects and arrays only, so degrading an over-budget value to a string would
+ * make the attribute vanish rather than render truncated. Message lists drop whole oldest messages
+ * first (counted in `maple_ai.input_messages_dropped`), then truncate oversized part payloads in
+ * place; tool values are wrapped and truncated as objects.
+ */
+import {
+	MAPLE_GENAI_INPUT_MESSAGES_DROPPED_ATTR,
+	MAPLE_GENAI_MODEL_DURATION_MS_ATTR,
+} from "@maple/domain/gen-ai"
+import { Clock, Effect, Option, Predicate, Stream } from "effect"
+import type { Tracer } from "effect"
+import type * as LanguageModel from "effect/unstable/ai/LanguageModel"
+import type * as Prompt from "effect/unstable/ai/Prompt"
+import * as Telemetry from "effect/unstable/ai/Telemetry"
+import * as Tool from "effect/unstable/ai/Tool"
+
+/**
+ * Per-attribute size budgets, in JSON characters.
+ *
+ * Input messages replay the whole transcript on every step, so that is the one that meets real
+ * pressure. The tool budget is the primary limiter for tool results, not a backstop: upstream bounds
+ * them at `MAX_TOOL_OUTPUT_BYTES` (50k, `mcp/tools/tool-output.ts`), six times this cap.
+ */
+const INPUT_MESSAGES_BUDGET = 20_000
+const OUTPUT_MESSAGES_BUDGET = 8_000
+const TOOL_JSON_BUDGET = 8_000
+const SYSTEM_INSTRUCTIONS_BUDGET = 8_000
+const TOOL_DEFINITIONS_BUDGET = 16_000
+const AGENT_DESCRIPTION_BUDGET = 1_024
+
+type SerializedPart =
+	| { readonly type: "text"; readonly content: string }
+	| { readonly type: "tool_call"; readonly id: string; readonly name: string; readonly arguments: unknown }
+	| { readonly type: "tool_call_response"; readonly id: string; readonly response: unknown }
+
+interface SerializedMessage {
+	readonly role: string
+	readonly parts: ReadonlyArray<SerializedPart>
+	readonly finish_reason?: string
+}
+
+const TRUNCATION_MARKER = "…[truncated]"
+
+const truncated = (text: string, cap: number): string =>
+	text.length > cap ? text.slice(0, cap) + TRUNCATION_MARKER : text
+
+/** `JSON.stringify` that reports an unserializable value (a cycle, a bigint) as nothing. */
+const stringify = (value: unknown): string | undefined => {
+	try {
+		return JSON.stringify(value)
+	} catch {
+		return undefined
+	}
+}
+
+/**
+ * The convention's message part for one prompt part. Media is size and reasoning is
+ * provider-hidden thought — neither is the conversation, so both are dropped.
+ */
+const promptPart = (
+	part: Prompt.UserMessagePart | Prompt.AssistantMessagePart | Prompt.ToolMessagePart,
+): ReadonlyArray<SerializedPart> => {
+	switch (part.type) {
+		case "text":
+			return part.text === "" ? [] : [{ type: "text", content: part.text }]
+		case "tool-call":
+			return [{ type: "tool_call", id: part.id, name: part.name, arguments: part.params }]
+		case "tool-result":
+			return [{ type: "tool_call_response", id: part.id, response: part.result }]
+		default:
+			return []
+	}
+}
+
+/** The prompt as `gen_ai.input.messages` documents it. System messages go to their own attribute. */
+const inputMessages = (prompt: Prompt.Prompt): Array<SerializedMessage> => {
+	const messages: Array<SerializedMessage> = []
+	for (const message of prompt.content) {
+		if (message.role === "system") continue
+		const parts: Array<SerializedPart> = []
+		for (const part of message.content) parts.push(...promptPart(part))
+		messages.push({ role: message.role, parts })
+	}
+	return messages
+}
+
+/** `gen_ai.system_instructions`: an array of `{type, content}` parts, bounded like the messages. */
+const systemInstructionsJson = (prompt: Prompt.Prompt): string | undefined => {
+	const parts = prompt.content.flatMap((message) =>
+		message.role === "system" && message.content !== ""
+			? [{ type: "text", content: message.content }]
+			: [],
+	)
+	if (parts.length === 0) return undefined
+	const json = JSON.stringify(parts)
+	if (json.length <= SYSTEM_INSTRUCTIONS_BUDGET) return json
+	const cap = Math.max(256, Math.floor(SYSTEM_INSTRUCTIONS_BUDGET / parts.length))
+	return JSON.stringify(parts.map((part) => ({ ...part, content: truncated(part.content, cap) })))
+}
+
+/**
+ * The finish reason in the convention's underscore form. Effect AI hyphenates; the read side matches
+ * `content_filter` as a refusal and normalises `tool_calls`.
+ */
+export const semconvFinishReason = (reason: string): string =>
+	reason === "tool-calls" ? "tool_calls" : reason === "content-filter" ? "content_filter" : reason
+
+type ResponseParts = Parameters<Telemetry.SpanTransformer>[0]["response"]
+
+/**
+ * What the model sent back, folded into one assistant message.
+ *
+ * A streamed response arrives as deltas, a generated one as whole parts; both are handled because
+ * the transformer receives whichever the call produced. The finish part is returned alongside —
+ * absent when the stream ended early, which is exactly when the partial message is worth keeping.
+ */
+const summarizeResponse = (response: ResponseParts) => {
+	const parts: Array<SerializedPart> = []
+	const open = new Map<string, { readonly type: "text"; content: string }>()
+	let finish: Extract<ResponseParts[number], { readonly type: "finish" }> | undefined
+	let errored = false
+	for (const part of response) {
+		switch (part.type) {
+			case "text":
+				parts.push({ type: "text", content: part.text })
+				break
+			case "text-delta": {
+				const text = open.get(part.id)
+				if (text === undefined) {
+					const created = { type: "text" as const, content: part.delta }
+					open.set(part.id, created)
+					parts.push(created)
+				} else {
+					text.content += part.delta
+				}
+				break
+			}
+			case "tool-call":
+				parts.push({ type: "tool_call", id: part.id, name: part.name, arguments: part.params })
+				break
+			case "finish":
+				finish = part
+				break
+			case "error":
+				errored = true
+				break
+		}
+	}
+	const message: SerializedMessage = {
+		role: "assistant",
+		parts: parts.filter((part) => part.type !== "text" || part.content !== ""),
+		...(finish === undefined ? undefined : { finish_reason: semconvFinishReason(finish.reason) }),
+	}
+	return { message, finish, failed: errored || finish?.reason === "error" }
+}
+
+/** The payload's JSON prefix when it outweighs `cap`, or nothing when it fits unchanged. */
+const oversizedPayloadPrefix = (value: unknown, cap: number): string | undefined => {
+	const json = stringify(value) ?? String(value)
+	return json.length > cap ? json.slice(0, cap) + TRUNCATION_MARKER : undefined
+}
+
+const boundPart = (part: SerializedPart, cap: number): SerializedPart => {
+	switch (part.type) {
+		case "text":
+			return part.content.length > cap ? { ...part, content: truncated(part.content, cap) } : part
+		case "tool_call": {
+			const prefix = oversizedPayloadPrefix(part.arguments, cap)
+			return prefix === undefined ? part : { ...part, arguments: prefix }
+		}
+		case "tool_call_response": {
+			const prefix = oversizedPayloadPrefix(part.response, cap)
+			return prefix === undefined ? part : { ...part, response: prefix }
+		}
+	}
+}
+
+/** First message the encoded list can start at and still fit — the newest is never dropped. */
+const fitFrom = (encoded: ReadonlyArray<string>, budget: number): number => {
+	let total = encoded.reduce((sum, json) => sum + json.length + 1, 1)
+	let start = 0
+	while (total > budget && start < encoded.length - 1) {
+		total -= encoded[start]!.length + 1
+		start += 1
+	}
+	return start
+}
+
+const encodeMessage = (message: SerializedMessage): string =>
+	stringify(message) ??
+	JSON.stringify({ ...message, parts: message.parts.map((part) => boundPart(part, 256)) })
+
+/** Exported for tests. */
+export const messagesJson = (
+	messages: ReadonlyArray<SerializedMessage>,
+	budget: number,
+): { readonly json: string; readonly dropped: number } => {
+	let rendered = messages
+	// One serialization per message, so trimming to budget is a prefix-sum walk rather than a
+	// re-stringify of the whole array per dropped message.
+	let encoded = rendered.map(encodeMessage)
+	let start = fitFrom(encoded, budget)
+	// A single message can outweigh the whole budget — routinely, since a tool result may run to 50k
+	// against the 20k input cap. Bound each surviving part's payload and re-fit. A soft budget: JSON
+	// escaping and a message with many parts can overshoot it, bounded, which beats losing the
+	// attribute.
+	if (encoded.slice(start).reduce((sum, json) => sum + json.length + 1, 1) > budget) {
+		const cap = Math.max(256, Math.floor(budget / 8))
+		rendered = rendered.map((message, index) =>
+			index < start
+				? message
+				: { ...message, parts: message.parts.map((part) => boundPart(part, cap)) },
+		)
+		encoded = rendered.map(encodeMessage)
+		start = fitFrom(encoded, budget)
+	}
+	return { json: `[${encoded.slice(start).join(",")}]`, dropped: start }
+}
+
+/**
+ * The dollar cost OpenRouter reported for the call, or nothing.
+ *
+ * OpenRouter is the only provider that prices a call in-band: with usage accounting on (see
+ * `withPerCallFields` in `./Llm.ts`) the final usage object carries `cost`, and the provider passes
+ * the raw usage through on the finish part. Maple never prices tokens itself.
+ */
+const reportedCost = (metadata: unknown): number | undefined => {
+	if (!Predicate.hasProperty(metadata, "openrouter")) return undefined
+	const openrouter = metadata.openrouter
+	if (!Predicate.hasProperty(openrouter, "usage") || !Predicate.hasProperty(openrouter.usage, "cost")) {
+		return undefined
+	}
+	const cost = openrouter.usage.cost
+	return typeof cost === "number" && Number.isFinite(cost) && cost >= 0 ? cost : undefined
+}
+
+export interface ModelCallTelemetry {
+	/** `gen_ai.provider.name`. */
+	readonly providerName: string
+	/** `gen_ai.request.reasoning.level`, when the call asks for one. */
+	readonly reasoningLevel?: string
+	/** The agent-session identity every model-call span carries — see `agentSessionSpanAttributes`. */
+	readonly sessionAttributes: Readonly<Record<string, string>>
+}
+
+/** One call's clock, read by the transformer when the stream ends. */
+interface CallTiming {
+	readonly startedMs: number
+	firstChunkMs: number | undefined
+	finishedMs: number | undefined
+}
+
+const modelCallTransformer =
+	(telemetry: ModelCallTelemetry, timing: CallTiming): Telemetry.SpanTransformer =>
+	({ span, prompt, responseFormat, response }) => {
+		const input = messagesJson(inputMessages(prompt), INPUT_MESSAGES_BUDGET)
+		const system = systemInstructionsJson(prompt)
+		const { message, finish, failed } = summarizeResponse(response)
+		const cost = finish === undefined ? undefined : reportedCost(finish.metadata)
+		const attributes = {
+			"gen_ai.provider.name": telemetry.providerName,
+			"gen_ai.request.stream": true,
+			...(telemetry.reasoningLevel === undefined
+				? undefined
+				: { "gen_ai.request.reasoning.level": telemetry.reasoningLevel }),
+			"gen_ai.output.type": responseFormat.type,
+			"gen_ai.input.messages": input.json,
+			...(input.dropped > 0 ? { [MAPLE_GENAI_INPUT_MESSAGES_DROPPED_ATTR]: input.dropped } : undefined),
+			...(system === undefined ? undefined : { "gen_ai.system_instructions": system }),
+			...(message.parts.length === 0
+				? undefined
+				: { "gen_ai.output.messages": messagesJson([message], OUTPUT_MESSAGES_BUDGET).json }),
+			...(finish === undefined
+				? undefined
+				: {
+						// The provider already wrote these in Effect AI's hyphenated form; this runs after it.
+						"gen_ai.response.finish_reasons": [semconvFinishReason(finish.reason)],
+						"gen_ai.usage.input_tokens": finish.usage.inputTokens.total,
+						"gen_ai.usage.output_tokens": finish.usage.outputTokens.total,
+						"gen_ai.usage.cache_read.input_tokens": finish.usage.inputTokens.cacheRead,
+						// The registry spelling; the read side decodes it as an alias of `cache_creation`.
+						"gen_ai.usage.cache_write.input_tokens": finish.usage.inputTokens.cacheWrite,
+						"gen_ai.usage.reasoning.output_tokens": finish.usage.outputTokens.reasoning,
+						...(cost === undefined ? undefined : { "gen_ai.usage.cost": cost }),
+					}),
+			// A provider failure surfaced as a stream part completes the stream, so the span exit stays
+			// green — these are the record of it, and what the session view's failure counting reads.
+			...(failed ? { "error.type": "provider_error", "gen_ai.response.status": "failed" } : undefined),
+			// Seconds by convention. The span's own clock covers the whole stream lifetime, including
+			// the consumer draining it, so these two are the model's honest numbers.
+			...(timing.firstChunkMs === undefined
+				? undefined
+				: { "gen_ai.response.time_to_first_chunk": (timing.firstChunkMs - timing.startedMs) / 1000 }),
+			...(timing.finishedMs === undefined
+				? undefined
+				: { [MAPLE_GENAI_MODEL_DURATION_MS_ATTR]: timing.finishedMs - timing.startedMs }),
+			...telemetry.sessionAttributes,
+		}
+		for (const [key, value] of Object.entries(attributes)) {
+			if (value !== undefined) span.attribute(key, value)
+		}
+	}
+
+/**
+ * The language model, with every `streamText` call annotating its own span.
+ *
+ * The transformer is provided per call rather than once on the layer because two of its numbers are
+ * per call: the first chunk and the finish are timed as they pass through, and the transformer reads
+ * them when Effect AI applies it — as the stream ends, including when it fails. `streamText` is the
+ * only call Maple makes; the other methods pass through unannotated.
+ */
+export const withModelCallTelemetry = (
+	service: LanguageModel.Service,
+	telemetry: ModelCallTelemetry,
+): LanguageModel.Service => ({
+	...service,
+	streamText: ((options) =>
+		Stream.unwrap(
+			Effect.map(Clock.currentTimeMillis, (startedMs) => {
+				const timing: CallTiming = { startedMs, firstChunkMs: undefined, finishedMs: undefined }
+				return service.streamText(options).pipe(
+					Stream.tap((part) =>
+						timing.firstChunkMs === undefined || part.type === "finish"
+							? Effect.map(Clock.currentTimeMillis, (now) => {
+									timing.firstChunkMs ??= now
+									if (part.type === "finish") timing.finishedMs = now
+								})
+							: Effect.void,
+					),
+					Stream.provideService(
+						Telemetry.CurrentSpanTransformer,
+						modelCallTransformer(telemetry, timing),
+					),
+				)
+			}),
+		)) as LanguageModel.Service["streamText"],
+})
+
+/**
+ * Bounded JSON for tool arguments and results; always an object or array, because the read side's
+ * `json` decoder drops scalars and Maple's own tool results are strings. Exported for tests.
+ */
+export const toolCallJson = (value: unknown): string => {
+	const wrapped = typeof value === "object" && value !== null ? value : { result: value }
+	const json = stringify(wrapped)
+	if (json === undefined) return JSON.stringify({ result: truncated(String(value), TOOL_JSON_BUDGET) })
+	if (json.length <= TOOL_JSON_BUDGET) return json
+	let prefix = json.slice(0, TOOL_JSON_BUDGET)
+	let out = JSON.stringify({ truncated: true, prefix })
+	if (out.length > TOOL_JSON_BUDGET) {
+		// Re-encoding escapes quotes and backslashes, expanding the prefix; one corrective re-slice by
+		// the measured excess holds the cap, since every removed input character removes at least one
+		// output character.
+		prefix = prefix.slice(0, Math.max(0, prefix.length - (out.length - TOOL_JSON_BUDGET)))
+		out = JSON.stringify({ truncated: true, prefix })
+	}
+	return out
+}
+
+/**
+ * `gen_ai.tool.definitions`: `[{type, name, description, parameters}]`. Schemas are the bulk, so over
+ * budget they are the first thing dropped — names and the opening of each description are what the
+ * session view needs, and 128 characters keeps the chat agent's ~60 MCP tools inside the budget.
+ */
+const toolDefinitionsJson = (tools: ReadonlyArray<Tool.Any>): string | undefined => {
+	if (tools.length === 0) return undefined
+	const described = tools.map((tool) => ({
+		type: "function",
+		name: tool.name,
+		description: Tool.getDescription(tool) ?? "",
+	}))
+	let full: string | undefined
+	try {
+		// A schema that cannot be expressed as JSON Schema throws here; it degrades to the compact form.
+		full = JSON.stringify(
+			tools.map((tool, index) => ({ ...described[index], parameters: Tool.getJsonSchema(tool) })),
+		)
+	} catch {
+		full = undefined
+	}
+	if (full !== undefined && full.length <= TOOL_DEFINITIONS_BUDGET) return full
+	return JSON.stringify(
+		described.map((tool) => ({ ...tool, description: truncated(tool.description, 128) })),
+	)
+}
+
+/**
+ * The `invoke_agent` half of a headless agent pass: which agent ran, on what, with which tools.
+ *
+ * Tool definitions go here rather than on every model call: they are the same for the whole pass,
+ * and at up to 16k characters each they would otherwise be repeated on every step.
+ */
+export const invokeAgentAttributes = (options: {
+	readonly agentName: string
+	readonly agentDescription: string
+	/** The engine's thread id, which its `execute_tool` spans carry as `gen_ai.conversation.id`. */
+	readonly conversationId: string
+	readonly providerName: string
+	readonly model: string
+	readonly tools: ReadonlyArray<Tool.Any>
+}): Readonly<Record<string, string>> => {
+	const definitions = toolDefinitionsJson(options.tools)
+	return {
+		"gen_ai.operation.name": "invoke_agent",
+		"gen_ai.agent.name": options.agentName,
+		// Bounded: hypothesis agents put planner-written text there, the one description with no
+		// length guarantee.
+		...(options.agentDescription === ""
+			? undefined
+			: { "gen_ai.agent.description": truncated(options.agentDescription, AGENT_DESCRIPTION_BUDGET) }),
+		"gen_ai.conversation.id": options.conversationId,
+		"gen_ai.provider.name": options.providerName,
+		"gen_ai.request.model": options.model,
+		...(definitions === undefined ? undefined : { "gen_ai.tool.definitions": definitions }),
+	}
+}
+
+const EXECUTE_TOOL_SPAN_PREFIX = "execute_tool "
+
+/**
+ * The engine's `execute_tool` span, found from inside a tool handler.
+ *
+ * effect-agent's tool spans are content-free by design, and it runs a handler under a local span it
+ * never exports (`AgentRuntime.toolkit.handle`) whose parent is the canonical `execute_tool` one — so
+ * an `annotateCurrentSpan` there would land on a span nobody sees. Matched by the convention's span
+ * name, not the engine's internal one, so a handler that already runs directly under the tool span
+ * works the same.
+ */
+const executeToolSpan = (span: Tracer.AnySpan): Tracer.Span | undefined => {
+	if (span._tag !== "Span") return undefined
+	if (span.name.startsWith(EXECUTE_TOOL_SPAN_PREFIX)) return span
+	return Option.match(span.parent, {
+		onNone: () => undefined,
+		onSome: (parent) =>
+			parent._tag === "Span" && parent.name.startsWith(EXECUTE_TOOL_SPAN_PREFIX) ? parent : undefined,
+	})
+}
+
+const annotateExecuteToolSpan = (attributes: Readonly<Record<string, string>>): Effect.Effect<void> =>
+	Effect.currentSpan.pipe(
+		Effect.map((current) => {
+			const span = executeToolSpan(current)
+			if (span === undefined) return
+			for (const [key, value] of Object.entries(attributes)) span.attribute(key, value)
+		}),
+		Effect.ignore,
+	)
+
+/** Record a tool call's description, arguments and result — or failure — on its `execute_tool` span. */
+export const withToolCallContent = <A, E extends { readonly message: string }, R>(
+	handler: Effect.Effect<A, E, R>,
+	call: { readonly description: string; readonly params: unknown },
+): Effect.Effect<A, E, R> =>
+	annotateExecuteToolSpan({
+		"gen_ai.tool.description": call.description,
+		"gen_ai.tool.call.arguments": toolCallJson(call.params),
+	}).pipe(
+		Effect.andThen(handler),
+		Effect.tap((result) => annotateExecuteToolSpan({ "gen_ai.tool.call.result": toolCallJson(result) })),
+		Effect.tapError((error) =>
+			annotateExecuteToolSpan({ "gen_ai.tool.call.result": toolCallJson(error.message) }),
+		),
+	)

--- a/apps/api/src/platform/genai-spans.ts
+++ b/apps/api/src/platform/genai-spans.ts
@@ -118,23 +118,21 @@ export const semconvFinishReason = (reason: string): string =>
 
 type ResponseParts = Parameters<Telemetry.SpanTransformer>[0]["response"]
 
+type FinishPart = Extract<ResponseParts[number], { readonly type: "finish" }>
+
 /**
- * What the model sent back, folded into one assistant message.
+ * What the model streamed back, folded into one assistant message.
  *
- * A streamed response arrives as deltas, a generated one as whole parts; both are handled because
- * the transformer receives whichever the call produced. The finish part is returned alongside —
- * absent when the stream ended early, which is exactly when the partial message is worth keeping.
+ * The finish part is returned alongside — absent when the stream ended early, which is exactly when
+ * the partial message is worth keeping.
  */
 const summarizeResponse = (response: ResponseParts) => {
 	const parts: Array<SerializedPart> = []
 	const open = new Map<string, { readonly type: "text"; content: string }>()
-	let finish: Extract<ResponseParts[number], { readonly type: "finish" }> | undefined
+	let finish: FinishPart | undefined
 	let errored = false
 	for (const part of response) {
 		switch (part.type) {
-			case "text":
-				parts.push({ type: "text", content: part.text })
-				break
 			case "text-delta": {
 				const text = open.get(part.id)
 				if (text === undefined) {
@@ -216,16 +214,16 @@ export const messagesJson = (
 	let encoded = rendered.map(encodeMessage)
 	let start = fitFrom(encoded, budget)
 	// A single message can outweigh the whole budget — routinely, since a tool result may run to 50k
-	// against the 20k input cap. Bound each surviving part's payload and re-fit. A soft budget: JSON
-	// escaping and a message with many parts can overshoot it, bounded, which beats losing the
-	// attribute.
+	// against the 20k input cap. Bound each surviving message's payloads, splitting its allowance
+	// across its parts so a batch of parallel tool results shares one, and re-fit. A soft budget: JSON
+	// escaping and the per-part floor can overshoot it, bounded, which beats losing the attribute.
 	if (encoded.slice(start).reduce((sum, json) => sum + json.length + 1, 1) > budget) {
-		const cap = Math.max(256, Math.floor(budget / 8))
-		rendered = rendered.map((message, index) =>
-			index < start
-				? message
-				: { ...message, parts: message.parts.map((part) => boundPart(part, cap)) },
-		)
+		const perMessage = Math.floor(budget / 8)
+		rendered = rendered.map((message, index) => {
+			if (index < start) return message
+			const cap = Math.max(256, Math.floor(perMessage / Math.max(1, message.parts.length)))
+			return { ...message, parts: message.parts.map((part) => boundPart(part, cap)) }
+		})
 		encoded = rendered.map(encodeMessage)
 		start = fitFrom(encoded, budget)
 	}
@@ -239,13 +237,8 @@ export const messagesJson = (
  * `withPerCallFields` in `./Llm.ts`) the final usage object carries `cost`, and the provider passes
  * the raw usage through on the finish part. Maple never prices tokens itself.
  */
-const reportedCost = (metadata: unknown): number | undefined => {
-	if (!Predicate.hasProperty(metadata, "openrouter")) return undefined
-	const openrouter = metadata.openrouter
-	if (!Predicate.hasProperty(openrouter, "usage") || !Predicate.hasProperty(openrouter.usage, "cost")) {
-		return undefined
-	}
-	const cost = openrouter.usage.cost
+const reportedCost = (finish: FinishPart): number | undefined => {
+	const cost = finish.metadata.openrouter?.usage?.cost
 	return Predicate.isNumber(cost) && Number.isFinite(cost) && cost >= 0 ? cost : undefined
 }
 
@@ -265,17 +258,16 @@ interface CallTiming {
 	finishedMs: number | undefined
 }
 
-/** `timing` is absent for a non-streaming call, which has neither a first chunk nor a stream. */
 const modelCallTransformer =
-	(telemetry: ModelCallTelemetry, timing: CallTiming | undefined): Telemetry.SpanTransformer =>
+	(telemetry: ModelCallTelemetry, timing: CallTiming): Telemetry.SpanTransformer =>
 	({ span, prompt, responseFormat, response }) => {
 		const input = messagesJson(inputMessages(prompt), INPUT_MESSAGES_BUDGET)
 		const system = systemInstructionsJson(prompt)
 		const { message, finish, failed } = summarizeResponse(response)
-		const cost = finish === undefined ? undefined : reportedCost(finish.metadata)
+		const cost = finish === undefined ? undefined : reportedCost(finish)
 		const attributes = {
 			"gen_ai.provider.name": telemetry.providerName,
-			"gen_ai.request.stream": timing !== undefined,
+			"gen_ai.request.stream": true,
 			...(telemetry.reasoningLevel === undefined
 				? undefined
 				: { "gen_ai.request.reasoning.level": telemetry.reasoningLevel }),
@@ -304,10 +296,10 @@ const modelCallTransformer =
 			// Seconds by convention. The span's own clock covers the whole stream lifetime, including
 			// the consumer draining it, so these two are stamped as parts pass through instead — as each
 			// is pulled, which is as close to the model as this side of the stream gets.
-			...(timing?.firstChunkMs === undefined
+			...(timing.firstChunkMs === undefined
 				? undefined
 				: { "gen_ai.response.time_to_first_chunk": (timing.firstChunkMs - timing.startedMs) / 1000 }),
-			...(timing?.finishedMs === undefined
+			...(timing.finishedMs === undefined
 				? undefined
 				: { [MAPLE_GENAI_MODEL_DURATION_MS_ATTR]: timing.finishedMs - timing.startedMs }),
 			...telemetry.sessionAttributes,
@@ -318,20 +310,18 @@ const modelCallTransformer =
 	}
 
 /**
- * Build a provider's language model so that every call annotates its own span.
+ * Build a provider's language model so that every `streamText` call — the only call Maple makes, and
+ * the only one effect-agent makes — annotates its own span.
  *
- * The transformer goes in twice. Once at construction, where Effect AI captures it as the default
- * every method falls back to, so `generateText` and `generateObject` spans carry the content and the
- * session too. And once per `streamText` call — the only call Maple makes — because two of its
- * numbers are per call: the first chunk and the finish are timed as they pass through, and the
- * transformer reads them when Effect AI applies it, as the stream ends, including when it fails.
+ * The transformer is provided per call because two of its numbers are per call: the first chunk and
+ * the finish are timed as they pass through, and the transformer reads them when Effect AI applies
+ * it, as the stream ends, including when it fails.
  */
 export const instrumentLanguageModel = <R>(
 	make: Effect.Effect<LanguageModel.Service, never, R>,
 	telemetry: ModelCallTelemetry,
 ): Effect.Effect<LanguageModel.Service, never, R> =>
 	make.pipe(
-		Effect.provideService(Telemetry.CurrentSpanTransformer, modelCallTransformer(telemetry, undefined)),
 		Effect.map((service) => ({
 			...service,
 			streamText: ((options: Parameters<LanguageModel.Service["streamText"]>[0]) =>

--- a/apps/api/src/platform/genai-spans.ts
+++ b/apps/api/src/platform/genai-spans.ts
@@ -110,11 +110,11 @@ const systemInstructionsJson = (prompt: Prompt.Prompt): string | undefined => {
 }
 
 /**
- * The finish reason in the convention's underscore form. Effect AI hyphenates; the read side matches
- * `content_filter` as a refusal and normalises `tool_calls`.
+ * The finish reason in the convention's form. Effect AI hyphenates and pluralises tool calls; the
+ * convention's enum is `tool_call`, and the read side matches `content_filter` as a refusal.
  */
 export const semconvFinishReason = (reason: string): string =>
-	reason === "tool-calls" ? "tool_calls" : reason === "content-filter" ? "content_filter" : reason
+	reason === "tool-calls" ? "tool_call" : reason === "content-filter" ? "content_filter" : reason
 
 type ResponseParts = Parameters<Telemetry.SpanTransformer>[0]["response"]
 
@@ -362,30 +362,39 @@ export const instrumentLanguageModel = <R>(
 	)
 
 /**
+ * `wrap` of the longest prefix of `text` that holds the tool budget once encoded.
+ *
+ * Encoding expands a character up to six-fold (a quote or backslash two-fold), so the prefix is re-cut
+ * by half the measured excess until it fits: exact for quotes and backslashes, converging otherwise,
+ * and never cutting to nothing because the text happened to be escape-heavy.
+ */
+const withinToolBudget = (text: string, wrap: (prefix: string) => string): string => {
+	let prefix = text.slice(0, TOOL_JSON_BUDGET)
+	let out = wrap(prefix)
+	while (out.length > TOOL_JSON_BUDGET) {
+		prefix = prefix.slice(0, prefix.length - Math.ceil((out.length - TOOL_JSON_BUDGET) / 2))
+		out = wrap(prefix)
+	}
+	return out
+}
+
+/** `{result: text}`, truncated so an oversized string still reads as its text, not an escaped prefix. */
+const resultJson = (text: string): string =>
+	withinToolBudget(text, (prefix) =>
+		JSON.stringify({ result: prefix.length < text.length ? prefix + TRUNCATION_MARKER : prefix }),
+	)
+
+/**
  * Bounded JSON for tool arguments and results; always an object or array, because the read side's
  * `json` decoder drops scalars and Maple's own tool results are strings. Exported for tests.
  */
 export const toolCallJson = (value: unknown): string => {
-	// A scalar is truncated before it is wrapped, so an oversized string result still reads as its text
-	// rather than as an escaped JSON prefix.
-	if (!Predicate.isObject(value)) {
-		return JSON.stringify({
-			result: Predicate.isString(value) ? truncated(value, TOOL_JSON_BUDGET) : value,
-		})
-	}
+	if (Predicate.isString(value)) return resultJson(value)
+	if (!Predicate.isObjectOrArray(value)) return JSON.stringify({ result: value })
 	const json = stringify(value)
-	if (json === undefined) return JSON.stringify({ result: truncated(String(value), TOOL_JSON_BUDGET) })
+	if (json === undefined) return resultJson(String(value))
 	if (json.length <= TOOL_JSON_BUDGET) return json
-	let prefix = json.slice(0, TOOL_JSON_BUDGET)
-	let out = JSON.stringify({ truncated: true, prefix })
-	if (out.length > TOOL_JSON_BUDGET) {
-		// Re-encoding escapes quotes and backslashes, expanding the prefix; one corrective re-slice by
-		// the measured excess holds the cap, since every removed input character removes at least one
-		// output character.
-		prefix = prefix.slice(0, Math.max(0, prefix.length - (out.length - TOOL_JSON_BUDGET)))
-		out = JSON.stringify({ truncated: true, prefix })
-	}
-	return out
+	return withinToolBudget(json, (prefix) => JSON.stringify({ truncated: true, prefix }))
 }
 
 /**

--- a/apps/api/src/platform/model-call-span.test.ts
+++ b/apps/api/src/platform/model-call-span.test.ts
@@ -75,6 +75,43 @@ const recordingTracer = () => {
 	return { spans, tracer }
 }
 
+/** One OpenRouter stream frame. */
+const chunk = (delta: Record<string, unknown>, finishReason: string | null) => ({
+	id: "gen-3",
+	object: "chat.completion.chunk",
+	created: 1730000000,
+	model: "z-ai/glm-5.3-flash",
+	choices: [{ index: 0, delta, finish_reason: finishReason }],
+})
+
+/** The model-call span's attributes as it ended, for one call answered by `frames`. */
+const endedModelCall = (
+	prompt: Parameters<typeof LanguageModel.streamText>[0]["prompt"],
+	frames: ReadonlyArray<unknown>,
+) =>
+	Effect.gen(function* () {
+		const recorder = recordingTracer()
+		const body = `${frames.map((frame) => `data: ${JSON.stringify(frame)}\n\n`).join("")}data: [DONE]\n\n`
+
+		yield* LanguageModel.streamText({ prompt }).pipe(
+			Stream.runDrain,
+			Effect.ignore,
+			Effect.provide(Layer.provideMerge(resolveTriageModel(ENV).layer, layerLlm(ENV))),
+			Effect.provideService(FetchHttpClient.Fetch, () =>
+				Promise.resolve(
+					new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+				),
+			),
+			Effect.withTracer(recorder.tracer),
+		)
+
+		const span = recorder.spans.find(
+			(candidate) => candidate.attributes.get("gen_ai.operation.name") === "chat",
+		)
+		assert.isDefined(span, "no model-call span was opened")
+		return span?.endedWith ?? new Map<string, unknown>()
+	})
+
 describe("the model-call span", () => {
 	it.live("carries the served response id and model, from the provider itself", () =>
 		Effect.gen(function* () {
@@ -200,6 +237,83 @@ describe("the model-call span", () => {
 			assert.strictEqual(attributes?.get("gen_ai.usage.cost"), 0.0042)
 			assert.isAtLeast(Number(attributes?.get("gen_ai.response.time_to_first_chunk")), 0)
 			assert.isAtLeast(Number(attributes?.get("maple_ai.model_duration_ms")), 0)
+		}),
+	)
+
+	it.live("carries the prompt's tool calls and results, with the finish reason in semconv form", () =>
+		Effect.gen(function* () {
+			const attributes = yield* endedModelCall(
+				[
+					{ role: "user", content: [{ type: "text", text: "why is checkout slow?" }] },
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool-call",
+								id: "call_0",
+								name: "service_map",
+								params: {},
+								providerExecuted: false,
+							},
+						],
+					},
+					{
+						role: "tool",
+						content: [
+							{
+								type: "tool-result",
+								id: "call_0",
+								name: "service_map",
+								isFailure: false,
+								result: "checkout -> db",
+								providerExecuted: false,
+							},
+						],
+					},
+				],
+				// Text rather than a tool call: decoding a streamed tool call needs the toolkit that declared
+				// it, which a bare `streamText` does not have.
+				[
+					chunk({ role: "assistant", content: "Checking the database." }, null),
+					{
+						...chunk({}, "tool_calls"),
+						usage: { prompt_tokens: 4, completion_tokens: 1, total_tokens: 5 },
+					},
+				],
+			)
+
+			assert.deepStrictEqual(JSON.parse(String(attributes.get("gen_ai.input.messages"))), [
+				{ role: "user", parts: [{ type: "text", content: "why is checkout slow?" }] },
+				{
+					role: "assistant",
+					parts: [{ type: "tool_call", id: "call_0", name: "service_map", arguments: {} }],
+				},
+				{
+					role: "tool",
+					parts: [{ type: "tool_call_response", id: "call_0", response: "checkout -> db" }],
+				},
+			])
+			assert.deepStrictEqual(JSON.parse(String(attributes.get("gen_ai.output.messages"))), [
+				{
+					role: "assistant",
+					parts: [{ type: "text", content: "Checking the database." }],
+					finish_reason: "tool_calls",
+				},
+			])
+			assert.deepStrictEqual(attributes.get("gen_ai.response.finish_reasons"), ["tool_calls"])
+		}),
+	)
+
+	/** A provider failure delivered as a finish reason completes the stream, so the span exit stays green. */
+	it.live("marks a call the provider failed", () =>
+		Effect.gen(function* () {
+			const attributes = yield* endedModelCall("hi", [
+				chunk({ role: "assistant", content: "partial" }, null),
+				{ ...chunk({}, "error"), usage: { prompt_tokens: 4, completion_tokens: 1, total_tokens: 5 } },
+			])
+
+			assert.strictEqual(attributes.get("error.type"), "provider_error")
+			assert.strictEqual(attributes.get("gen_ai.response.status"), "failed")
 		}),
 	)
 

--- a/apps/api/src/platform/model-call-span.test.ts
+++ b/apps/api/src/platform/model-call-span.test.ts
@@ -137,6 +137,72 @@ describe("the model-call span", () => {
 		}),
 	)
 
+	/**
+	 * The regression from the move onto Effect AI: its providers annotate the model and two token
+	 * totals, and every investigation span lost its messages, cache and reasoning tokens and cost.
+	 */
+	it.live("carries the conversation, the usage buckets, the cost and the timings", () =>
+		Effect.gen(function* () {
+			const recorder = recordingTracer()
+			const env = { ...ENV, MAPLE_TRIAGE_REASONING_EFFORT: "high" }
+			const sse = [
+				'data: {"id":"gen-2","object":"chat.completion.chunk","created":1730000000,"model":"z-ai/glm-5.3-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"Look"},"finish_reason":null}]}',
+				"",
+				'data: {"id":"gen-2","object":"chat.completion.chunk","created":1730000000,"model":"z-ai/glm-5.3-flash","choices":[{"index":0,"delta":{"content":"ing"},"finish_reason":null}]}',
+				"",
+				'data: {"id":"gen-2","object":"chat.completion.chunk","created":1730000000,"model":"z-ai/glm-5.3-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":40,"completion_tokens":12,"total_tokens":52,"cost":0.0042,"prompt_tokens_details":{"cached_tokens":30},"completion_tokens_details":{"reasoning_tokens":5}}}',
+				"",
+				"data: [DONE]",
+				"",
+			].join("\n")
+
+			yield* LanguageModel.streamText({
+				prompt: [
+					{ role: "system", content: "Be brief." },
+					{ role: "user", content: [{ type: "text", text: "hi" }] },
+				],
+			}).pipe(
+				Stream.runDrain,
+				Effect.ignore,
+				Effect.provide(Layer.provideMerge(resolveTriageModel(env).layer, layerLlm(env))),
+				Effect.provideService(FetchHttpClient.Fetch, () =>
+					Promise.resolve(
+						new Response(sse, { status: 200, headers: { "content-type": "text/event-stream" } }),
+					),
+				),
+				Effect.withTracer(recorder.tracer),
+			)
+
+			const attributes = recorder.spans.find(
+				(span) => span.attributes.get("gen_ai.operation.name") === "chat",
+			)?.endedWith
+			assert.isDefined(attributes, "no model-call span was opened")
+			const json = (key: string) => JSON.parse(String(attributes?.get(key)))
+
+			assert.strictEqual(attributes?.get("gen_ai.provider.name"), "openrouter")
+			assert.strictEqual(attributes?.get("gen_ai.request.stream"), true)
+			assert.strictEqual(attributes?.get("gen_ai.request.reasoning.level"), "high")
+			assert.strictEqual(attributes?.get("gen_ai.output.type"), "text")
+			assert.deepStrictEqual(json("gen_ai.system_instructions"), [
+				{ type: "text", content: "Be brief." },
+			])
+			assert.deepStrictEqual(json("gen_ai.input.messages"), [
+				{ role: "user", parts: [{ type: "text", content: "hi" }] },
+			])
+			assert.deepStrictEqual(json("gen_ai.output.messages"), [
+				{ role: "assistant", parts: [{ type: "text", content: "Looking" }], finish_reason: "stop" },
+			])
+			assert.deepStrictEqual(attributes?.get("gen_ai.response.finish_reasons"), ["stop"])
+			assert.strictEqual(attributes?.get("gen_ai.usage.input_tokens"), 40)
+			assert.strictEqual(attributes?.get("gen_ai.usage.output_tokens"), 12)
+			assert.strictEqual(attributes?.get("gen_ai.usage.cache_read.input_tokens"), 30)
+			assert.strictEqual(attributes?.get("gen_ai.usage.reasoning.output_tokens"), 5)
+			assert.strictEqual(attributes?.get("gen_ai.usage.cost"), 0.0042)
+			assert.isAtLeast(Number(attributes?.get("gen_ai.response.time_to_first_chunk")), 0)
+			assert.isAtLeast(Number(attributes?.get("maple_ai.model_duration_ms")), 0)
+		}),
+	)
+
 	it.live("carries no session when the caller has none", () =>
 		Effect.gen(function* () {
 			const recorder = recordingTracer()

--- a/apps/api/src/platform/model-call-span.test.ts
+++ b/apps/api/src/platform/model-call-span.test.ts
@@ -235,8 +235,9 @@ describe("the model-call span", () => {
 			assert.strictEqual(attributes?.get("gen_ai.usage.cache_read.input_tokens"), 30)
 			assert.strictEqual(attributes?.get("gen_ai.usage.reasoning.output_tokens"), 5)
 			assert.strictEqual(attributes?.get("gen_ai.usage.cost"), 0.0042)
-			assert.isAtLeast(Number(attributes?.get("gen_ai.response.time_to_first_chunk")), 0)
-			assert.isAtLeast(Number(attributes?.get("maple_ai.model_duration_ms")), 0)
+			const firstChunkMs = Math.round(Number(attributes?.get("gen_ai.response.time_to_first_chunk")) * 1000)
+			assert.isAtLeast(firstChunkMs, 0)
+			assert.isAtMost(firstChunkMs, Number(attributes?.get("maple_ai.model_duration_ms")))
 		}),
 	)
 
@@ -297,10 +298,10 @@ describe("the model-call span", () => {
 				{
 					role: "assistant",
 					parts: [{ type: "text", content: "Checking the database." }],
-					finish_reason: "tool_calls",
+					finish_reason: "tool_call",
 				},
 			])
-			assert.deepStrictEqual(attributes.get("gen_ai.response.finish_reasons"), ["tool_calls"])
+			assert.deepStrictEqual(attributes.get("gen_ai.response.finish_reasons"), ["tool_call"])
 		}),
 	)
 
@@ -329,6 +330,10 @@ describe("the model-call span", () => {
 				Effect.withTracer(recorder.tracer),
 			)
 
+			assert.isTrue(
+				recorder.spans.some((span) => span.attributes.get("gen_ai.operation.name") === "chat"),
+				"no model-call span was opened",
+			)
 			assert.isFalse(recorder.spans.some((span) => span.attributes.has(MAPLE_NATIVE_SESSION_ID_ATTR)))
 		}),
 	)

--- a/apps/api/src/platform/model-call-span.test.ts
+++ b/apps/api/src/platform/model-call-span.test.ts
@@ -88,6 +88,8 @@ const chunk = (delta: Record<string, unknown>, finishReason: string | null) => (
 const endedModelCall = (
 	prompt: Parameters<typeof LanguageModel.streamText>[0]["prompt"],
 	frames: ReadonlyArray<unknown>,
+	env: Parameters<typeof resolveTriageModel>[0] = ENV,
+	status = 200,
 ) =>
 	Effect.gen(function* () {
 		const recorder = recordingTracer()
@@ -96,11 +98,9 @@ const endedModelCall = (
 		yield* LanguageModel.streamText({ prompt }).pipe(
 			Stream.runDrain,
 			Effect.ignore,
-			Effect.provide(Layer.provideMerge(resolveTriageModel(ENV).layer, layerLlm(ENV))),
+			Effect.provide(Layer.provideMerge(resolveTriageModel(env).layer, layerLlm(env))),
 			Effect.provideService(FetchHttpClient.Fetch, () =>
-				Promise.resolve(
-					new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
-				),
+				Promise.resolve(new Response(body, { status, headers: { "content-type": "text/event-stream" } })),
 			),
 			Effect.withTracer(recorder.tracer),
 		)
@@ -315,6 +315,37 @@ describe("the model-call span", () => {
 
 			assert.strictEqual(attributes.get("error.type"), "provider_error")
 			assert.strictEqual(attributes.get("gen_ai.response.status"), "failed")
+		}),
+	)
+
+	it.live("asks for no reasoning level when reasoning is off", () =>
+		Effect.gen(function* () {
+			const attributes = yield* endedModelCall(
+				"hi",
+				[
+					{
+						...chunk({ role: "assistant", content: "hi" }, "stop"),
+						usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+					},
+				],
+				{ ...ENV, MAPLE_TRIAGE_REASONING_EFFORT: "off" },
+			)
+
+			assert.strictEqual(attributes.get("gen_ai.provider.name"), "openrouter")
+			assert.isFalse(attributes.has("gen_ai.request.reasoning.level"))
+		}),
+	)
+
+	/** The transformer applies as the stream ends, including when it fails before a single chunk. */
+	it.live("still carries the conversation when the provider rejects the call", () =>
+		Effect.gen(function* () {
+			const attributes = yield* endedModelCall("hi", [], ENV, 400)
+
+			assert.deepStrictEqual(JSON.parse(String(attributes.get("gen_ai.input.messages"))), [
+				{ role: "user", parts: [{ type: "text", content: "hi" }] },
+			])
+			assert.isFalse(attributes.has("gen_ai.response.time_to_first_chunk"))
+			assert.isFalse(attributes.has("maple_ai.model_duration_ms"))
 		}),
 	)
 

--- a/apps/api/src/workflows/agent-pass.test.ts
+++ b/apps/api/src/workflows/agent-pass.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it } from "@effect/vitest"
 import { assert } from "vitest"
-import { Effect, Layer, Option, Schema } from "effect"
+import { Effect, Layer, Option, Schema, Tracer } from "effect"
 import { Model, Tool, Toolkit } from "effect/unstable/ai"
 import { MapleToolFailure } from "@/mcp/tools/llm-tools"
 import {
@@ -210,6 +210,46 @@ describe("runAgentPass", () => {
 
 			assert.isTrue(result.deadlineHit)
 			assert.isTrue(Option.isNone(result.answer))
+		}),
+	)
+
+	it.effect("describes the agent on its pass span and each tool call on its own span", () =>
+		Effect.gen(function* () {
+			const spans: Array<Tracer.NativeSpan> = []
+			const tracer = Tracer.make({
+				span: (options) => {
+					const span = new Tracer.NativeSpan(options)
+					spans.push(span)
+					return span
+				},
+			})
+
+			yield* run([
+				turn(call("c1", "query_data", { sql: "select 1" })),
+				turn(call("c2", "submit_candidate", { claim: "found it" })),
+			]).pipe(Effect.withSpan("investigation.test"), Effect.withTracer(tracer))
+
+			const pass = spans.find((span) => span.name === "investigation.test")?.attributes
+			assert.strictEqual(pass?.get("gen_ai.operation.name"), "invoke_agent")
+			assert.strictEqual(pass?.get("gen_ai.agent.name"), "hypothesis-test")
+			assert.strictEqual(pass?.get("gen_ai.agent.description"), "test lane")
+			assert.strictEqual(pass?.get("gen_ai.conversation.id"), "pass-1")
+			assert.strictEqual(pass?.get("gen_ai.provider.name"), "openrouter")
+			assert.strictEqual(pass?.get("gen_ai.request.model"), "scripted/test-model")
+			const definitions = JSON.parse(String(pass?.get("gen_ai.tool.definitions")))
+			assert.includeMembers(
+				definitions.map((tool: { readonly name: string }) => tool.name),
+				["query_data", "submit_candidate"],
+			)
+
+			const tool = spans.find((span) => span.name === "execute_tool query_data")?.attributes
+			assert.deepStrictEqual(JSON.parse(String(tool?.get("gen_ai.tool.call.arguments"))), {
+				sql: "select 1",
+			})
+			assert.deepStrictEqual(JSON.parse(String(tool?.get("gen_ai.tool.call.result"))), {
+				result: "query_data completed",
+			})
+			assert.isNotEmpty(tool?.get("gen_ai.tool.description"))
 		}),
 	)
 

--- a/apps/api/src/workflows/agent-pass.test.ts
+++ b/apps/api/src/workflows/agent-pass.test.ts
@@ -145,6 +145,19 @@ const run = (turns: ReadonlyArray<ScriptedTurnInput>, deadlineAtMs?: number) =>
 		...(deadlineAtMs === undefined ? undefined : { deadlineAtMs }),
 	}).pipe(Effect.provide(Layer.merge(ToolExecutorStubLayer, IdGenerator.layer)))
 
+/** A tracer that keeps every span it opened; a native span keeps its attributes after it ends. */
+const recordSpans = () => {
+	const spans: Array<Tracer.NativeSpan> = []
+	const tracer = Tracer.make({
+		span: (options) => {
+			const span = new Tracer.NativeSpan(options)
+			spans.push(span)
+			return span
+		},
+	})
+	return { spans, tracer }
+}
+
 describe("runAgentPass", () => {
 	it.effect("reports the answer when the agent submits", () =>
 		Effect.gen(function* () {
@@ -215,14 +228,7 @@ describe("runAgentPass", () => {
 
 	it.effect("describes the agent on its pass span and each tool call on its own span", () =>
 		Effect.gen(function* () {
-			const spans: Array<Tracer.NativeSpan> = []
-			const tracer = Tracer.make({
-				span: (options) => {
-					const span = new Tracer.NativeSpan(options)
-					spans.push(span)
-					return span
-				},
-			})
+			const { spans, tracer } = recordSpans()
 
 			yield* run([
 				turn(call("c1", "query_data", { sql: "select 1" })),
@@ -250,6 +256,39 @@ describe("runAgentPass", () => {
 				result: "query_data completed",
 			})
 			assert.isNotEmpty(tool?.get("gen_ai.tool.description"))
+		}),
+	)
+
+	it.effect("records a failed tool call's message as its result", () =>
+		Effect.gen(function* () {
+			const { spans, tracer } = recordSpans()
+			const failingExecutor = Layer.succeed(McpToolExecutor, {
+				execute: () =>
+					Effect.succeed({
+						content: [{ type: "text" as const, text: "table not found" }],
+						isError: true,
+					}),
+			})
+
+			yield* runAgentPass({
+				id: "pass-1",
+				agent: AGENT,
+				tenant: TENANT,
+				model: scripted([
+					turn(call("c1", "query_data", { sql: "select 1" })),
+					turn(call("c2", "submit_candidate", { claim: "found it" })),
+				]),
+				prompt: "Is the pool exhausted?",
+				submit: SUBMIT,
+			}).pipe(
+				Effect.provide(Layer.merge(failingExecutor, IdGenerator.layer)),
+				Effect.withSpan("investigation.test"),
+				Effect.withTracer(tracer),
+			)
+
+			const tool = spans.find((span) => span.name === "execute_tool query_data")?.attributes
+			// The failure message as the model received it, prefix and all.
+			assert.include(JSON.parse(String(tool?.get("gen_ai.tool.call.result"))).result, "table not found")
 		}),
 	)
 

--- a/apps/api/src/workflows/agent-pass.test.ts
+++ b/apps/api/src/workflows/agent-pass.test.ts
@@ -22,6 +22,7 @@ import {
 	type ScriptedTurnInput,
 } from "@effect-agent/testing/ScriptedModel"
 import { IdGenerator } from "@effect-agent/core/IdGenerator"
+import { MAPLE_NATIVE_SESSION_ID_ATTR, MAPLE_NATIVE_TURN_ID_ATTR } from "@maple/domain/gen-ai"
 import { PermissionRule } from "@maple/domain/permission"
 import { OrgId, UserId } from "@maple/domain"
 import type { AgentDefinition } from "@/chat/agents"
@@ -130,6 +131,7 @@ const scripted = (turns: ReadonlyArray<ScriptedTurnInput>): ResolvedModel => ({
 	provider: "openrouter",
 	name: "scripted/test-model",
 	limits: { context: 128_000, output: 8_000 },
+	tags: { surface: "investigation-lens", orgId: "org_test", sessionId: "org_test:inv-1", turnId: "pass-1" },
 	// `Model.make` supplies the provider and model identity services alongside the language model;
 	// the scripted layer alone provides only the model itself.
 	layer: Model.make("scripted", "test-model", ScriptedModel.layer(turns)),
@@ -223,8 +225,14 @@ describe("runAgentPass", () => {
 				turn(call("c2", "submit_candidate", { claim: "found it" })),
 			]).pipe(Effect.withSpan("investigation.test"), Effect.withTracer(tracer))
 
-			const pass = spans.find((span) => span.name === "investigation.test")?.attributes
+			const pass = spans.find((span) => span.name === "invoke_agent hypothesis-test")?.attributes
 			assert.strictEqual(pass?.get("gen_ai.operation.name"), "invoke_agent")
+			// The pass span roots the turn, so it carries the session; the caller's span does not.
+			assert.strictEqual(pass?.get(MAPLE_NATIVE_SESSION_ID_ATTR), "org_test:inv-1")
+			assert.strictEqual(pass?.get(MAPLE_NATIVE_TURN_ID_ATTR), "pass-1")
+			assert.isFalse(
+				spans.some((span) => span.name === "investigation.test" && span.attributes.has(MAPLE_NATIVE_SESSION_ID_ATTR)),
+			)
 			assert.strictEqual(pass?.get("gen_ai.agent.name"), "hypothesis-test")
 			assert.strictEqual(pass?.get("gen_ai.agent.description"), "test lane")
 			assert.strictEqual(pass?.get("gen_ai.conversation.id"), "pass-1")

--- a/apps/api/src/workflows/agent-pass.test.ts
+++ b/apps/api/src/workflows/agent-pass.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it } from "@effect/vitest"
 import { assert } from "vitest"
-import { Effect, Layer, Option, Schema, Tracer } from "effect"
+import { Effect, Layer, Option, Schema } from "effect"
 import { Model, Tool, Toolkit } from "effect/unstable/ai"
 import { MapleToolFailure } from "@/mcp/tools/llm-tools"
 import {
@@ -28,6 +28,7 @@ import type { AgentDefinition } from "@/chat/agents"
 import { McpToolExecutor } from "@/mcp/dispatcher"
 import type { ResolvedModel } from "@/platform/Llm"
 import type { TenantContext } from "@/services/auth/tenant-context"
+import { makeRecordingTracer } from "@/testing/recording-tracer"
 import { runAgentPass } from "./agent-pass"
 
 const TENANT: TenantContext = {
@@ -145,19 +146,6 @@ const run = (turns: ReadonlyArray<ScriptedTurnInput>, deadlineAtMs?: number) =>
 		...(deadlineAtMs === undefined ? undefined : { deadlineAtMs }),
 	}).pipe(Effect.provide(Layer.merge(ToolExecutorStubLayer, IdGenerator.layer)))
 
-/** A tracer that keeps every span it opened; a native span keeps its attributes after it ends. */
-const recordSpans = () => {
-	const spans: Array<Tracer.NativeSpan> = []
-	const tracer = Tracer.make({
-		span: (options) => {
-			const span = new Tracer.NativeSpan(options)
-			spans.push(span)
-			return span
-		},
-	})
-	return { spans, tracer }
-}
-
 describe("runAgentPass", () => {
 	it.effect("reports the answer when the agent submits", () =>
 		Effect.gen(function* () {
@@ -228,7 +216,7 @@ describe("runAgentPass", () => {
 
 	it.effect("describes the agent on its pass span and each tool call on its own span", () =>
 		Effect.gen(function* () {
-			const { spans, tracer } = recordSpans()
+			const { spans, tracer } = makeRecordingTracer()
 
 			yield* run([
 				turn(call("c1", "query_data", { sql: "select 1" })),
@@ -261,7 +249,7 @@ describe("runAgentPass", () => {
 
 	it.effect("records a failed tool call's message as its result", () =>
 		Effect.gen(function* () {
-			const { spans, tracer } = recordSpans()
+			const { spans, tracer } = makeRecordingTracer()
 			const failingExecutor = Layer.succeed(McpToolExecutor, {
 				execute: () =>
 					Effect.succeed({

--- a/apps/api/src/workflows/agent-pass.ts
+++ b/apps/api/src/workflows/agent-pass.ts
@@ -32,7 +32,13 @@ import { agentPolicyFor, buildSystemPrompt, type AgentDefinition } from "@/chat/
 import { buildMapleToolkit } from "@/mcp/tools/llm-tools"
 import { evaluatePermission } from "@maple/domain/permission"
 import { accumulateUsage, makeRunUsage, type RunUsage } from "@/chat/tools"
-import { type LlmClients, type ResolvedModel, agentSessionSpanAttributes } from "@/platform/Llm"
+import {
+	type LlmClients,
+	type ResolvedModel,
+	agentSessionSpanAttributes,
+	genAiProviderName,
+} from "@/platform/Llm"
+import { invokeAgentAttributes } from "@/platform/genai-spans"
 import { McpToolExecutor } from "@/mcp/dispatcher"
 import type { TenantContext } from "@/services/auth/tenant-context"
 import { summarizeCause } from "@/platform/describe-cause"
@@ -129,10 +135,6 @@ export const runAgentPass = <S extends AnswerSchema, Tools extends Record<string
 	Effect.gen(function* () {
 		type A = S["Type"]
 		const toolExecutor = yield* McpToolExecutor
-		// The pass's own span roots the turn: the session view files a lane's untagged tool, HTTP and
-		// database spans by their nearest tagged ancestor, and concurrent lanes would otherwise be
-		// partitioned by start time alone. The model-call spans carry the same keys via the model.
-		yield* Effect.annotateCurrentSpan(agentSessionSpanAttributes(input.model.tags))
 		const usage = input.usage ?? makeRunUsage()
 		let answer: Option.Option<A> = Option.none()
 		let toolCalls = 0
@@ -153,6 +155,22 @@ export const runAgentPass = <S extends AnswerSchema, Tools extends Record<string
 		// of it — tool parameter encoding services, the completion declaration — resolves to the same
 		// place through the erased type.
 		const toolkit: Toolkit.Any = Toolkit.merge(tools.toolkit, input.submit.toolkit)
+
+		// The pass's own span roots the turn: the session view files a lane's untagged tool, HTTP and
+		// database spans by their nearest tagged ancestor, and concurrent lanes would otherwise be
+		// partitioned by start time alone. The model-call spans carry the same keys via the model. It
+		// is also the pass's `invoke_agent` span, which is where the agent and its tools are described.
+		yield* Effect.annotateCurrentSpan({
+			...agentSessionSpanAttributes(input.model.tags),
+			...invokeAgentAttributes({
+				agentName: input.agent.name,
+				agentDescription: input.agent.description,
+				conversationId: input.id,
+				providerName: genAiProviderName(input.model.provider),
+				model: input.model.name,
+				tools: Object.values(toolkit.tools),
+			}),
+		})
 
 		const definition = Agent.withModel(
 			Agent.make(input.agent.name, {

--- a/apps/api/src/workflows/agent-pass.ts
+++ b/apps/api/src/workflows/agent-pass.ts
@@ -160,12 +160,13 @@ export const runAgentPass = <S extends AnswerSchema, Tools extends Record<string
 		// database spans by their nearest tagged ancestor, and concurrent lanes would otherwise be
 		// partitioned by start time alone. The model-call spans carry the same keys via the model. It
 		// is also the pass's `invoke_agent` span, which is where the agent and its tools are described.
+		const threadId = decodeThreadId(input.id)
 		yield* Effect.annotateCurrentSpan({
 			...agentSessionSpanAttributes(input.model.tags),
 			...invokeAgentAttributes({
 				agentName: input.agent.name,
 				agentDescription: input.agent.description,
-				conversationId: input.id,
+				conversationId: threadId,
 				providerName: genAiProviderName(input.model.provider),
 				model: input.model.name,
 				tools: Object.values(toolkit.tools),
@@ -193,7 +194,7 @@ export const runAgentPass = <S extends AnswerSchema, Tools extends Record<string
 		)
 
 		yield* AgentRuntime.stream(definition, input.prompt, {
-			threadId: decodeThreadId(input.id),
+			threadId,
 			// The run event stream carries no token counts, so without this hook every pass reports
 			// zero and the investigation rows record no cost.
 			budget: accumulateUsage(usage),

--- a/apps/api/src/workflows/agent-pass.ts
+++ b/apps/api/src/workflows/agent-pass.ts
@@ -156,10 +156,10 @@ export const runAgentPass = <S extends AnswerSchema, Tools extends Record<string
 		// place through the erased type.
 		const toolkit: Toolkit.Any = Toolkit.merge(tools.toolkit, input.submit.toolkit)
 
-		// The pass's own span roots the turn: the session view files a lane's untagged tool, HTTP and
-		// database spans by their nearest tagged ancestor, and concurrent lanes would otherwise be
-		// partitioned by start time alone. The model-call spans carry the same keys via the model. It
-		// is also the pass's `invoke_agent` span, which is where the agent and its tools are described.
+		// The pass's own `invoke_agent` span roots the turn: the session view files a lane's untagged
+		// tool, HTTP and database spans by their nearest tagged ancestor, and concurrent lanes would
+		// otherwise be partitioned by start time alone. The model-call spans carry the same keys via the
+		// model. It is also where the agent and its tools are described.
 		const threadId = decodeThreadId(input.id)
 		yield* Effect.annotateCurrentSpan({
 			...agentSessionSpanAttributes(input.model.tags),
@@ -248,4 +248,4 @@ export const runAgentPass = <S extends AnswerSchema, Tools extends Record<string
 		)
 
 		return { answer, usage, toolCalls, deadlineHit }
-	})
+	}).pipe(Effect.withSpan(`invoke_agent ${input.agent.name}`))


### PR DESCRIPTION
## Why
- #815 moved chat + investigations onto Effect AI / effect-agent and deleted `chat/loop/genai.ts`
- Effect AI providers only write `gen_ai.request.model`, `response.id/model`, `finish_reasons`, input/output token totals, deprecated `gen_ai.system`
- Prod `maple-investigations` `LanguageModel.streamText` spans (e.g. trace `61a78d19…`) had no messages, system instructions, tool definitions, cache/reasoning tokens, cost, provider name or timings

## What
- `apps/api/src/platform/genai-spans.ts` — per-call `CurrentSpanTransformer` wrapping `streamText`:
  - `gen_ai.provider.name`, `request.stream`, `request.reasoning.level`, `output.type`
  - `input.messages`, `system_instructions`, `output.messages` (semconv parts, budgeted, shape-preserving truncation, `maple_ai.input_messages_dropped`)
  - `response.finish_reasons` in underscore form, `usage.cache_read/cache_write.input_tokens`, `usage.reasoning.output_tokens`, `usage.cost` (OpenRouter in-band)
  - `response.time_to_first_chunk`, `maple_ai.model_duration_ms`, `error.type`/`response.status` on provider error
  - session/turn/workflow stamping moved here (unchanged keys)
- `Llm.ts` — models built via `AiModel.make` around `OpenRouterLanguageModel.make` / `OpenAiLanguageModel.make`; `genAiProviderName` (`openrouter`, `cloudflare.workers_ai`)
- `agent-pass.ts` — pass span gets `invoke_agent`, `agent.name/description`, `conversation.id`, `provider.name`, `request.model`, `tool.definitions`
- `llm-tools.ts` — Maple tool handlers write `tool.description`, `tool.call.arguments`, `tool.call.result` onto the engine's `execute_tool` span

## Not covered
- Span name stays `LanguageModel.streamText` (set by Effect AI), not `chat {model}`
- Deprecated `gen_ai.system` still emitted by the provider (no attribute removal API)
- `chat.turn` root is not an `invoke_agent` span; chat model-call spans get everything above

## Tests
- `model-call-span.test.ts`: messages, system instructions, usage buckets, cost, reasoning level, timings
- `agent-pass.test.ts`: invoke_agent attrs + tool args/result on `execute_tool`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791726225&installation_model_id=427786&pr_number=853&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F853&signature=4e30fb64a3af9ac8540fc7797d091bdd46f69102229d6b650972996cfc15e23a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Review round (503e05c6c)
- Fixed: unencodable tool payload could throw inside the span transformer and fail the model stream
- Fixed: `generateText`/`generateObject` spans kept session identity (transformer also provided at construction)
- Fixed: `cache_creation.input_tokens` (registry key) instead of `cache_write`
- Fixed: string tool results truncated before wrapping (no escaped-JSON prefix in the transcript)
- Added tests for budgets, dropped-message count, provider-failed calls, prompt tool parts, failed tool results

## Decision needed
- Prompts, system prompts and tool results (customer query output, budgeted 8–20k chars) are captured on spans exported to Maple's internal self-observability org — same as the pre-#815 emitter; no opt-in gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added richer telemetry for AI model interactions, including provider, model, reasoning level, usage, timing, cost, and session details.
  - AI agent runs now capture conversation context, available tools, tool arguments, results, descriptions, and failures.
  - Added safeguards to keep recorded messages and tool data within size limits while preserving useful content.

- **Bug Fixes**
  - Improved handling of oversized, complex, or unrepresentable message and tool payloads during telemetry recording.
  - Provider failures are now recorded with clearer completion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->