### PR TITLE
fix(agent-sessions): tint brand marks instead of drawing a swatch

### DIFF
--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.test.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.test.tsx
@@ -113,12 +113,17 @@ describe("AgentSessionsFilterSidebar", () => {
 	})
 
 	it("paints services and frameworks in their colors, and explains the sections named for a concept", () => {
-		search = { services: ["billing-worker"] }
+		search = { services: ["billing-worker"], vendors: ["crewai"] }
 		render(<Sidebar />)
 
 		const swatchBeside = (label: string) =>
 			screen.getByText(label).parentElement?.querySelector<HTMLElement>("span[style]")
-		expect(swatchBeside("Claude Agent SDK")?.style.backgroundColor).toBe("rgb(217, 119, 87)")
+		const markBeside = (label: string) => screen.getByText(label).parentElement?.querySelector("svg")
+		// A framework wears its brand on its mark, not on a swatch beside it.
+		expect(markBeside("Claude Agent SDK")?.style.color).toBe("rgb(217, 119, 87)")
+		expect(swatchBeside("Claude Agent SDK")).toBeNull()
+		// A selected framework the window no longer offers keeps its color too.
+		expect(markBeside("CrewAI")?.style.color).toBe("rgb(255, 90, 80)")
 		expect(swatchBeside("agent-runner")).toBeTruthy()
 		// A selected service the window no longer offers keeps its swatch.
 		expect(swatchBeside("billing-worker")).toBeTruthy()

--- a/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-filter-sidebar.tsx
@@ -26,7 +26,7 @@ import { Separator } from "@maple/ui/components/ui/separator"
 import { getServiceColor } from "@maple/ui/lib/colors"
 import { modelVendorIcon } from "@/lib/agent-sessions/model-vendor-icon"
 import { useDetectedModels } from "@/hooks/use-detected-models"
-import { vendorColor } from "@/lib/agent-sessions/vendor-color"
+import { modelVendorColor, vendorColor } from "@/lib/agent-sessions/vendor-color"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
 import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
 import {
@@ -225,9 +225,9 @@ export function AgentSessionsFilterSidebar({
 							options={value.vendors}
 							selected={search.vendors ?? []}
 							onChange={(vals) => setList("vendors", vals)}
-							colorMap={swatches(value.vendors, search.vendors, vendorColor)}
 							getOptionLabel={vendorLabel}
 							getOptionIcon={vendorIcon}
+							getOptionIconColor={vendorColor}
 						/>
 
 						<SearchableFilterSection
@@ -238,6 +238,7 @@ export function AgentSessionsFilterSidebar({
 							onChange={(vals) => setList("models", vals)}
 							getOptionLabel={(name) => detectModel(name).displayName}
 							getOptionIcon={(name) => modelVendorIcon(detectModel(name))}
+							getOptionIconColor={(name) => modelVendorColor(detectModel(name))}
 						/>
 
 						<FilterSection

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.test.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.test.tsx
@@ -170,6 +170,15 @@ describe("AgentSessionsList", () => {
 		expect(view.getByText("maple-slack-agent")).toBeTruthy()
 	})
 
+	it("draws the framework's mark in its brand color", () => {
+		const view = renderList(
+			<AgentSessionsList {...sort} sessions={[{ ...session, vendorId: "claude_agent_sdk" }]} />,
+		)
+		expect(view.getByRole("img", { name: "Claude Agent SDK" }).querySelector("svg")?.style.color).toBe(
+			"rgb(217, 119, 87)",
+		)
+	})
+
 	it("says a session without errors has none, rather than leaving the cell blank", () => {
 		const view = renderList(<AgentSessionsList {...sort} sessions={[session]} />)
 		const errors = view.getAllByRole("cell")[8]!

--- a/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
+++ b/apps/web/src/components/agent-sessions/agent-sessions-list.tsx
@@ -31,6 +31,7 @@ import { usePageScrollMargin } from "@/hooks/use-page-scroll-margin"
 import { useTimezonePreference } from "@/hooks/use-timezone-preference"
 import { formatTimestampInTimezone } from "@/lib/timezone-format"
 import { formatCost } from "@/lib/agent-sessions/session-summary"
+import { vendorColor } from "@/lib/agent-sessions/vendor-color"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
 import { sessionLinkWindow, sessionRowIdParts } from "@/lib/agent-sessions/session-window"
 import { TOKEN_BUCKETS, type TokenBucketKey } from "@/lib/agent-sessions/token-buckets"
@@ -608,9 +609,9 @@ function SessionCell({ session, timeZone }: { session: AgentSessionRow; timeZone
 						render={<span />}
 						role="img"
 						aria-label={vendor}
-						className="flex shrink-0 items-center text-muted-foreground"
+						className="flex shrink-0 items-center"
 					>
-						<VendorIcon size={15} aria-hidden />
+						<VendorIcon size={15} style={{ color: vendorColor(session.vendorId) }} aria-hidden />
 					</TooltipTrigger>
 					<TooltipContent>{vendor}</TooltipContent>
 				</Tooltip>

--- a/apps/web/src/components/agent-sessions/model-label.test.tsx
+++ b/apps/web/src/components/agent-sessions/model-label.test.tsx
@@ -28,18 +28,19 @@ const unresolved: DetectedModel = {
 }
 
 describe("ModelLabel", () => {
-	it("names the model and draws a mark beside it", () => {
+	it("names the model and draws a mark beside it, in the vendor's brand color", () => {
 		const { container } = render(<ModelLabel detected={resolved} />)
 
 		expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy()
-		expect(container.querySelector("svg")).toBeTruthy()
+		expect(container.querySelector("svg")?.style.color).toBe("rgb(217, 119, 87)")
 	})
 
 	it("draws the same shape for a model nothing resolved, so the row does not reflow", () => {
 		const { container } = render(<ModelLabel detected={unresolved} />)
 
 		expect(screen.getByText("my-deployment")).toBeTruthy()
-		expect(container.querySelector("svg")).toBeTruthy()
+		// No brand, so the mark keeps the color of the text it labels.
+		expect(container.querySelector("svg")?.style.color).toBe("")
 	})
 
 	it("counts the models a lane has no room for, outside the truncating name", () => {

--- a/apps/web/src/components/agent-sessions/model-label.tsx
+++ b/apps/web/src/components/agent-sessions/model-label.tsx
@@ -2,6 +2,7 @@ import { cn } from "@maple/ui/lib/utils"
 
 import type { DetectedModel } from "@/hooks/use-detected-models"
 import { modelVendorIcon } from "@/lib/agent-sessions/model-vendor-icon"
+import { modelVendorColor } from "@/lib/agent-sessions/vendor-color"
 
 /**
  * A model as a reader should see it: the vendor's mark and the model's name,
@@ -12,7 +13,8 @@ import { modelVendorIcon } from "@/lib/agent-sessions/model-vendor-icon"
  * pass, or to their own tooltip when they pass `title={null}`. Nothing here
  * waits on detection: an unresolved model renders its last
  * path segment beside the generic mark, at the same size, so the row does not
- * reflow when the batch lands.
+ * reflow when the batch lands. The mark takes the vendor's brand color once
+ * detection names one, and the text's color until then.
  *
  * `moreCount` is the "+2" a lane too narrow for a list falls back to. It sits
  * outside the truncating name so it survives a long first model.
@@ -37,7 +39,12 @@ export function ModelLabel({
 			className={cn("flex min-w-0 items-center gap-1.5", className)}
 			title={title === undefined ? modelTitle(detected) : (title ?? undefined)}
 		>
-			<Icon size={size} className="shrink-0" aria-hidden />
+			<Icon
+				size={size}
+				className="shrink-0"
+				style={{ color: modelVendorColor(detected) }}
+				aria-hidden
+			/>
 			<span className="min-w-0 truncate">{detected.displayName}</span>
 			{moreCount > 0 && <span className="shrink-0 tabular-nums">+{moreCount}</span>}
 		</span>

--- a/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
+++ b/apps/web/src/components/agent-sessions/session-detail/session-header.tsx
@@ -10,6 +10,7 @@ import { CopyableValue } from "@/components/attributes"
 import { CopyIcon } from "@/components/icons"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import type { SessionSummary } from "@/lib/agent-sessions/session-summary"
+import { vendorColor } from "@/lib/agent-sessions/vendor-color"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
 import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
 
@@ -34,7 +35,12 @@ export function SessionHeader({ sessionId, summary }: { sessionId: string; summa
 	return (
 		<div className="flex min-w-0 flex-col gap-2">
 			<div className="flex min-w-0 items-center gap-2">
-				<VendorIcon size={18} className="shrink-0 text-muted-foreground" aria-hidden />
+				<VendorIcon
+					size={18}
+					className="shrink-0"
+					style={{ color: vendorColor(summary.vendorIds[0] ?? "") }}
+					aria-hidden
+				/>
 				<DashboardLayout.Title title={identity.heading}>{identity.heading}</DashboardLayout.Title>
 				{summary.failed && <Badge variant="error">Failed</Badge>}
 			</div>

--- a/apps/web/src/components/agent-sessions/session-name.tsx
+++ b/apps/web/src/components/agent-sessions/session-name.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@maple/ui/lib/utils"
 
+import { vendorColor } from "@/lib/agent-sessions/vendor-color"
 import { vendorIcon } from "@/lib/agent-sessions/vendor-icon"
 import { vendorLabel } from "@/lib/agent-sessions/vendor-label"
 import { sessionIdentity } from "./session-detail/session-header"
@@ -34,8 +35,8 @@ export function SessionName({
 	const heading = sessionHeading(agentName, vendorId)
 	return (
 		<span className={cn("flex min-w-0 items-center gap-2", className)}>
-			<span className="flex shrink-0 items-center text-muted-foreground" title={vendorLabel(vendorId)}>
-				<VendorIcon size={iconSize} aria-hidden />
+			<span className="flex shrink-0 items-center" title={vendorLabel(vendorId)}>
+				<VendorIcon size={iconSize} style={{ color: vendorColor(vendorId) }} aria-hidden />
 			</span>
 			<span className="min-w-0 truncate" title={heading}>
 				{heading}

--- a/apps/web/src/lib/agent-sessions/vendor-color.test.ts
+++ b/apps/web/src/lib/agent-sessions/vendor-color.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { vendorColor } from "./vendor-color"
+import { modelVendorColor, vendorColor } from "./vendor-color"
 
 describe("vendorColor", () => {
 	it("gives a framework its publisher's brand, shared with that publisher's models", () => {
@@ -20,5 +20,15 @@ describe("vendorColor", () => {
 		expect(vendorColor("unknown:genai")).toBe("var(--muted-foreground)")
 		expect(vendorColor("")).toBe("var(--muted-foreground)")
 		expect(vendorColor("constructor")).toBe("var(--muted-foreground)")
+	})
+})
+
+describe("modelVendorColor", () => {
+	it("builds a detected brand the way a framework's is built, and leaves an unbranded model uncolored", () => {
+		expect(modelVendorColor({ brandColor: { light: "#4285F4", dark: "#4285F4" } })).toBe("#4285F4")
+		expect(modelVendorColor({ brandColor: { light: "#000000", dark: "#FFFFFF" } })).toBe(
+			"light-dark(#000000, #FFFFFF)",
+		)
+		expect(modelVendorColor({ brandColor: null })).toBeUndefined()
 	})
 })

--- a/apps/web/src/lib/agent-sessions/vendor-color.ts
+++ b/apps/web/src/lib/agent-sessions/vendor-color.ts
@@ -48,12 +48,24 @@ const isListedVendor = (vendorId: string): vendorId is keyof typeof VENDOR_COLOR
 	Object.hasOwn(VENDOR_COLORS, vendorId)
 
 /**
- * The CSS color for `vendorLabel(vendorId)`'s brand — a `light-dark()` pair
- * where the canvases differ, which resolves against the `color-scheme` the
- * theme pins. Tint with `color-mix()`, never hex-alpha concatenation.
+ * A brand as one CSS color — a `light-dark()` pair where the canvases differ,
+ * which resolves against the `color-scheme` the theme pins. Tint with
+ * `color-mix()`, never hex-alpha concatenation.
  */
+const brandColorCss = (brand: BrandColor): string =>
+	brand.light === brand.dark ? brand.light : `light-dark(${brand.light}, ${brand.dark})`
+
+/** The CSS color for `vendorLabel(vendorId)`'s brand; see `brandColorCss`. */
 export function vendorColor(vendorId: string): string {
-	if (!isListedVendor(vendorId)) return NEUTRAL
-	const brand: BrandColor = VENDOR_COLORS[vendorId]
-	return brand.light === brand.dark ? brand.light : `light-dark(${brand.light}, ${brand.dark})`
+	return isListedVendor(vendorId) ? brandColorCss(VENDOR_COLORS[vendorId]) : NEUTRAL
+}
+
+/**
+ * The CSS color for `modelVendorIcon(detected)`'s mark, from the brand the
+ * detect endpoint returns — the catalog holds those pairs to the same 3:1 on
+ * both canvases. `undefined` where it lists none, not the neutral: an unbranded
+ * model mark keeps the color of the text it labels.
+ */
+export function modelVendorColor(detected: { readonly brandColor: BrandColor | null }): string | undefined {
+	return detected.brandColor === null ? undefined : brandColorCss(detected.brandColor)
 }

--- a/packages/ui/src/components/filters/filter-section.tsx
+++ b/packages/ui/src/components/filters/filter-section.tsx
@@ -107,6 +107,12 @@ interface FilterSectionBaseProps {
 	/** Option-name → icon, rendered before the label (like colorMap's swatch). */
 	getOptionIcon?: (name: string) => IconComponent | undefined
 	/**
+	 * Option-name → CSS color for its `getOptionIcon` mark, for brand marks that
+	 * carry their brand's color. The mark itself is the color, never a swatch
+	 * beside it; `undefined` leaves it in the label's color.
+	 */
+	getOptionIconColor?: (name: string) => string | undefined
+	/**
 	 * Option-name → an already-rendered icon node, in the same slot as
 	 * `getOptionIcon`. Separate from it rather than a widening of it, because
 	 * `IconComponent` is `ComponentType<SVGProps<SVGSVGElement>>` and the icons
@@ -155,6 +161,7 @@ function FilterSectionBase({
 	searchable,
 	colorMap,
 	getOptionIcon,
+	getOptionIconColor,
 	renderOptionIcon,
 	getOptionLabel,
 	excluded = EMPTY,
@@ -382,6 +389,7 @@ function FilterSectionBase({
 													"size-3.5 shrink-0",
 													isExcluded && "opacity-40",
 												)}
+												style={{ color: getOptionIconColor?.(option.name) }}
 											/>
 										) : (
 											renderOptionIcon?.(option.name)


### PR DESCRIPTION
- Framework filter: the brand color is now the icon's color; the square swatch next to it is gone (service swatches unchanged)
- Model filter + `ModelLabel` (sessions list, overview, waterfall, tool error modal): vendor marks use the `brandColor` the detect endpoint already returns; unbranded models keep the text color
- Sessions list Session cell, session header, `SessionName`: framework mark in `vendorColor` instead of `text-muted-foreground` (unlisted vendors still resolve to the muted neutral)
- `FilterSection` gets `getOptionIconColor`; no other caller passes it, and excluded rows still dim the icon to 40%
- One `brandColorCss` helper builds both framework and model colors (`light-dark()` pair where the canvases differ)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791732374&installation_model_id=427786&pr_number=854&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F854&signature=60aeb5fb60872ed65ab7b1131b813613db785e82601adf8a3e23cfe475449374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Visual Improvements**
  * Vendor and model icons now display their associated brand colors throughout agent session lists, filters, session details, and labels.
  * Framework and model icons retain appropriate colors even when options are selected or unavailable.
  * Brand colors now adapt correctly across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->