### PR TITLE
fix(agent-sessions): tab counts on both tabs, aligned strip and toolbar

### DIFF
--- a/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
+++ b/apps/web/src/components/agent-sessions/tools/agent-tools-view.test.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/lab/agent-tools-fixture"
 import type { ToolAnalyticsSearch } from "@/lib/agent-sessions/tool-search"
 
-import { AgentToolsView } from "./agent-tools-view"
+import { AgentToolsView, type AgentToolsViewProps } from "./agent-tools-view"
 import { ToolDetailView } from "./tool-detail-view"
 import { ToolErrorModal } from "./tool-error-modal"
 
@@ -50,7 +50,11 @@ vi.mock("./tool-detail-charts", () => ({
 const NOW = Date.UTC(2026, 8, 10, 12, 0, 0)
 const cells = buildToolCells(NOW)
 
-function renderView(search: ToolAnalyticsSearch, onSearchChange = vi.fn()) {
+function renderView(
+	search: ToolAnalyticsSearch,
+	onSearchChange = vi.fn(),
+	props: Partial<AgentToolsViewProps> = {},
+) {
 	const data = buildToolAnalyticsFixture(search, NOW, cells)
 	render(
 		<AgentToolsView
@@ -61,6 +65,7 @@ function renderView(search: ToolAnalyticsSearch, onSearchChange = vi.fn()) {
 			modelOptions={[]}
 			envOptions={[]}
 			windowLabel="7d"
+			{...props}
 		/>,
 	)
 	return { onSearchChange, data }
@@ -162,6 +167,31 @@ describe("AgentToolsView", () => {
 		)
 		expect(screen.queryByText(/No tool calls/)).toBeNull()
 		expect(screen.getByText(/Failed to load tools/)).toBeTruthy()
+	})
+
+	it("has no page title, and ends the toolbar row with the window controls", () => {
+		renderView({}, vi.fn(), { actions: <button type="button">Reload</button> })
+		expect(screen.queryByRole("heading", { name: "Tools" })).toBeNull()
+
+		// After every filter and in the same row, before the scope band — where the
+		// Sessions list's toolbar ends in its own Reload.
+		const reload = screen.getByRole("button", { name: "Reload" })
+		const search = screen.getByPlaceholderText("Tool name…")
+		const failing = screen.getByRole("button", { name: /Failing only/ })
+		const follows = (a: Node, b: Node) =>
+			(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+		expect(follows(search, failing)).toBe(true)
+		expect(follows(failing, reload)).toBe(true)
+		expect(follows(reload, screen.getByText("Tool calls"))).toBe(true)
+		expect(reload.closest(".ml-auto")?.parentElement?.contains(search)).toBe(true)
+	})
+
+	it("counts the tabs from what it is given, not the filtered table, and never shows an unknown count", () => {
+		// A name search narrows the table; the tabs must read the same on both pages.
+		renderView({ q: "read" }, vi.fn(), { tabCounts: { sessions: 812 } })
+		expect(document.querySelector('[data-to="/agent-sessions"]')?.textContent).toBe("Sessions812")
+		// The tools count has not landed: no number, rather than a 0.
+		expect(document.querySelector('[data-to="/agent-sessions/tools"]')?.textContent).toBe("Tools")
 	})
 })
 

--- a/apps/web/src/components/agent-sessions/tools/agent-tools-view.tsx
+++ b/apps/web/src/components/agent-sessions/tools/agent-tools-view.tsx
@@ -63,8 +63,10 @@ export interface AgentToolsViewProps {
 	windowLabel: string
 	/** The window, carried by the tab strip's link to the Sessions list. */
 	timeRange?: TimeRangeSearch
-	/** The time-range picker, or whatever the host wants beside the title. */
-	headerControls?: ReactNode
+	/** The tab strip's counts — see `useAgentSessionsTabCounts`. A count left out is not shown. */
+	tabCounts?: { sessions?: number; tools?: number }
+	/** The time-range picker and Reload, at the right end of the toolbar. */
+	actions?: ReactNode
 	/** Dim the data surfaces while a refetch is in flight. */
 	waiting?: boolean
 }
@@ -82,10 +84,13 @@ export interface AgentToolsViewProps {
  *
  * One column of full-bleed sections divided by hairlines, not a stack of cards:
  * the page is one instrument, and every section is a different reading of the
- * same scope. Reading order is the order the questions get asked: what am I
- * looking at (header, window), over which calls (toolbar), narrowed to what
+ * same scope. Reading order is the order the questions get asked: which view
+ * (tabs), over which calls and window (toolbar), narrowed to what
  * (scope), how much of it (strip), how it moved (chart), and which tool — where
  * a row stops being a comparison and becomes a page of its own.
+ *
+ * No title: the tab strip names the page. The strip and the toolbar sit at the
+ * same height as on the Sessions list, so switching tabs moves neither.
  */
 export function AgentToolsView({
 	search,
@@ -96,7 +101,8 @@ export function AgentToolsView({
 	envOptions,
 	windowLabel,
 	timeRange,
-	headerControls,
+	tabCounts,
+	actions,
 	waiting,
 }: AgentToolsViewProps) {
 	const metric = selectedMetric(search)
@@ -135,26 +141,14 @@ export function AgentToolsView({
 	// tool-name search box, which on a one-tool page filters that tool's name.
 	const detailSearch = useMemo(() => toolDetailLinkSearch(search, timeRange), [search, timeRange])
 
+	// `pt-4` is the Sessions list's sticky padding, and the strip's hairline and
+	// the toolbar's `py-3` are matched there too: one height on both tabs.
 	return (
-		<div className="flex flex-col">
-			<header className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3 px-6 pt-[22px] pb-4">
-				<div className="flex min-w-0 flex-col gap-1.5">
-					<h1 className="text-[28px] font-semibold leading-8 tracking-[-0.02em] text-foreground">
-						Tools
-					</h1>
-					<p className="font-mono text-[13px] leading-[18px] text-muted-foreground">
-						How every tool your agents call is behaving — volume, latency and failures.
-					</p>
-				</div>
-				{headerControls ? (
-					<div className="flex shrink-0 items-center gap-2 pt-1">{headerControls}</div>
-				) : null}
-			</header>
-
+		<div className="flex flex-col pt-4">
 			<AgentSessionsTabs
 				active="tools"
 				search={timeRange}
-				counts={{ sessions: data.allSessions, tools: data.tools.length }}
+				counts={tabCounts}
 				className="border-b border-border px-6"
 			/>
 
@@ -177,6 +171,7 @@ export function AgentToolsView({
 					onSearchChange({ failing: search.failing === true ? undefined : true })
 				}
 				waiting={waiting}
+				actions={actions}
 			/>
 
 			<ToolScopeRow

--- a/apps/web/src/components/agent-sessions/tools/tool-filter-toolbar.tsx
+++ b/apps/web/src/components/agent-sessions/tools/tool-filter-toolbar.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react"
+
 import { ToolbarSearch } from "@maple/ui/components/toolbar"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@maple/ui/components/ui/select"
 import { cn } from "@maple/ui/lib/utils"
@@ -26,6 +28,9 @@ interface ToolFilterToolbarProps {
 	failingOnly: boolean
 	onToggleFailingOnly: () => void
 	waiting?: boolean
+	/** Trailing controls, right-aligned after the filters: the overview's
+	 *  time-range picker and Reload, where the Sessions list's toolbar ends in its own Reload. */
+	actions?: ReactNode
 }
 
 /**
@@ -55,6 +60,7 @@ export function ToolFilterToolbar({
 	failingOnly,
 	onToggleFailingOnly,
 	waiting = false,
+	actions,
 }: ToolFilterToolbarProps) {
 	return (
 		<div className="flex flex-wrap items-center gap-2 border-b border-border px-6 py-3">
@@ -103,6 +109,8 @@ export function ToolFilterToolbar({
 					Failing only
 				</button>
 			</div>
+
+			{actions ? <div className="ml-auto">{actions}</div> : null}
 		</div>
 	)
 }

--- a/apps/web/src/components/layout/dashboard-layout.tsx
+++ b/apps/web/src/components/layout/dashboard-layout.tsx
@@ -185,8 +185,8 @@ function Content({ children }: { children: React.ReactNode }) {
 }
 
 /** Pinned above the scroll area — the page header, and anything else that shouldn't scroll away. */
-function Sticky({ children }: { children: React.ReactNode }) {
-	return <PageLayout.StickyArea>{children}</PageLayout.StickyArea>
+function Sticky({ children, className }: { children: React.ReactNode; className?: string }) {
+	return <PageLayout.StickyArea className={className}>{children}</PageLayout.StickyArea>
 }
 
 /**

--- a/apps/web/src/lab/agent-sessions-list-lab.tsx
+++ b/apps/web/src/lab/agent-sessions-list-lab.tsx
@@ -7,6 +7,12 @@ import {
 	type AgentSessionsSearchState,
 } from "@/components/agent-sessions/agent-sessions-filter-inputs"
 import { AgentSessionsList, type AgentSessionRow } from "@/components/agent-sessions/agent-sessions-list"
+import { AgentSessionsToolbar } from "@/components/agent-sessions/agent-sessions-toolbar"
+import { AgentSessionsTabs } from "@/components/agent-sessions/tools/agent-sessions-tabs"
+import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
+import { ReloadControls } from "@/components/time-range-picker/reload-controls"
+
+import { buildToolAnalyticsFixture, buildToolCells } from "./agent-tools-fixture"
 
 /**
  * `/agent-sessions` without a warehouse behind it.
@@ -20,6 +26,10 @@ import { AgentSessionsList, type AgentSessionRow } from "@/components/agent-sess
  *
  * `ai_trace_index` does not exist in the local Tinybird container, so the live
  * page renders empty here; this is where a row change gets looked at.
+ *
+ * It sits under the route's tab strip and toolbar, with the route's spacing, so
+ * the pair can be lined up against `/lab/agent-tools`: switching tabs moves
+ * neither. The tab counts are the tools lab's, as the two routes share them.
  */
 
 /** Widths worth checking, because the columns are container queries against
@@ -198,6 +208,12 @@ export function AgentSessionsListLab() {
 	// No server to re-rank the rows: the headers only mark the order they would ask for.
 	const [sortSearch, setSortSearch] = useState<Pick<AgentSessionsSearchState, "sortBy" | "sortDir">>({})
 	const { sortBy, sortDir } = agentSessionsSort(sortSearch)
+	const [query, setQuery] = useState("")
+	const [errorsOnly, setErrorsOnly] = useState(false)
+	const tabCounts = useMemo(() => {
+		const all = buildToolAnalyticsFixture({}, nowMs, buildToolCells(nowMs))
+		return { sessions: all.allSessions, tools: all.tools.length }
+	}, [nowMs])
 
 	return (
 		<div className="flex h-svh flex-col gap-4 p-6">
@@ -220,18 +236,39 @@ export function AgentSessionsListLab() {
 			{/* The route's own layout primitives: the list virtualizes against the
 			    page's scroll area, and without one it renders no rows at all. */}
 			<div className="flex min-h-0 flex-1 flex-col" style={width === null ? undefined : { width }}>
-				<PageLayout.Root>
-					<PageLayout.Content>
-						<PageLayout.ScrollArea>
-							<AgentSessionsList
-								sessions={rows}
-								sortBy={sortBy}
-								sortDir={sortDir}
-								onSortChange={(key) => setSortSearch((prev) => agentSessionsSortPatch(prev, key))}
-							/>
-						</PageLayout.ScrollArea>
-					</PageLayout.Content>
-				</PageLayout.Root>
+				<PageRefreshProvider>
+					<PageLayout.Root>
+						<PageLayout.Content>
+							<PageLayout.StickyArea className="pb-3">
+								<div className="space-y-3">
+									<AgentSessionsTabs
+										active="sessions"
+										counts={tabCounts}
+										className="border-b border-border"
+									/>
+									<AgentSessionsToolbar
+										query={query}
+										onSearch={(value) => setQuery(value ?? "")}
+										errorsOnly={errorsOnly}
+										onToggleErrorsOnly={() => setErrorsOnly((on) => !on)}
+										sessionCount={rows.length}
+										actions={<ReloadControls />}
+									/>
+								</div>
+							</PageLayout.StickyArea>
+							<PageLayout.ScrollArea className="pt-0">
+								<AgentSessionsList
+									sessions={rows}
+									sortBy={sortBy}
+									sortDir={sortDir}
+									onSortChange={(key) =>
+										setSortSearch((prev) => agentSessionsSortPatch(prev, key))
+									}
+								/>
+							</PageLayout.ScrollArea>
+						</PageLayout.Content>
+					</PageLayout.Root>
+				</PageRefreshProvider>
 			</div>
 		</div>
 	)

--- a/apps/web/src/lab/agent-tools-lab.tsx
+++ b/apps/web/src/lab/agent-tools-lab.tsx
@@ -3,6 +3,8 @@ import { useMemo, useState } from "react"
 import { AgentToolsView } from "@/components/agent-sessions/tools/agent-tools-view"
 import { ToolDetailView } from "@/components/agent-sessions/tools/tool-detail-view"
 import { ToolErrorModal } from "@/components/agent-sessions/tools/tool-error-modal"
+import { PageRefreshProvider } from "@/components/time-range-picker/page-refresh-context"
+import { TimeRangeHeaderControls } from "@/components/time-range-picker/time-range-header-controls"
 import type { ToolAnalyticsSearch } from "@/lib/agent-sessions/tool-search"
 
 import {
@@ -54,6 +56,16 @@ export function AgentToolsLab() {
 	const [search, setSearch] = useState<ToolAnalyticsSearch>({})
 	const [width, setWidth] = useState<number | null>(null)
 	const [view, setView] = useState<LabView>("overview")
+	// The fixture is a fixed week: the picker is here for its place at the end of
+	// the toolbar, not to re-window the data.
+	const [preset, setPreset] = useState("7d")
+
+	// The tab counts over the unfiltered week, as the route reads them — the
+	// toolbar's filters narrow the table, never the tabs.
+	const tabCounts = useMemo(() => {
+		const all = buildToolAnalyticsFixture({}, nowMs, cells)
+		return { sessions: all.allSessions, tools: all.tools.length }
+	}, [nowMs, cells])
 
 	const overview = useMemo(
 		() => buildToolAnalyticsFixture(search, nowMs, cells),
@@ -127,6 +139,15 @@ export function AgentToolsLab() {
 						modelOptions={facets.models}
 						envOptions={facets.environments}
 						windowLabel="7d"
+						tabCounts={tabCounts}
+						actions={
+							<PageRefreshProvider>
+								<TimeRangeHeaderControls
+									presetValue={preset}
+									onTimeChange={(range) => setPreset(range.presetValue ?? preset)}
+								/>
+							</PageRefreshProvider>
+						}
 					/>
 				) : (
 					<ToolDetailView

--- a/apps/web/src/lib/agent-sessions/use-tool-analytics.ts
+++ b/apps/web/src/lib/agent-sessions/use-tool-analytics.ts
@@ -1,4 +1,5 @@
-// Every warehouse read `/agent-sessions/tools` makes, behind one hook.
+// Every warehouse read `/agent-sessions/tools` makes, behind one hook — plus
+// the tab strip's counts, which the Sessions list reads too.
 //
 // The page itself never touches an atom: it takes the `Result`s this
 // returns and renders them. That is what lets the lab mount the same page shell
@@ -9,7 +10,7 @@ import { useMemo } from "react"
 
 import type { AiToolsSeriesKind } from "@maple/domain/http"
 
-import type { Result } from "@/lib/effect-atom"
+import { Result, useAtomValue } from "@/lib/effect-atom"
 import type { QueryAtomFailure } from "@/lib/services/atoms/warehouse-query-atoms"
 import {
 	aiToolBreakdownsResultAtom,
@@ -103,4 +104,34 @@ export function useToolAnalytics(
 	const totals = useRefreshableAtomValue(aiToolTotalsResultAtom({ data: selection }))
 	const breakdowns = useRefreshableAtomValue(aiToolBreakdownsResultAtom({ data: selection }))
 	return { series, scopeSeries, totals, breakdowns }
+}
+
+/**
+ * The tab strip's counts, which both Agent Sessions pages show: the window's
+ * sessions (`allSessions`, unscoped server-side) and the tools called in it (the
+ * breakdown's rows, so capped at its limit).
+ *
+ * Read over the bare window rather than a page's selection, so neither page's
+ * filters move the numbers and switching tabs never changes them. That is also
+ * what makes them cheap: with no filters set this is the exact key the Tools
+ * page reads itself, and the Sessions list's rolling week snaps to the same
+ * window as the Tools default preset — each page finds the other's reads cached.
+ *
+ * `undefined` until a read lands, so a tab never shows a 0 it does not mean.
+ */
+export function useAgentSessionsTabCounts(window: ToolAnalyticsWindow): {
+	sessions?: number
+	tools?: number
+} {
+	const { startTime, endTime } = window
+	const selection = useMemo(
+		() => toolAnalyticsSelection({}, { startTime, endTime }),
+		[startTime, endTime],
+	)
+	const totals = useAtomValue(aiToolTotalsResultAtom({ data: selection }))
+	const breakdowns = useAtomValue(aiToolBreakdownsResultAtom({ data: selection }))
+	return {
+		sessions: Result.isSuccess(totals) ? totals.value.allSessions : undefined,
+		tools: Result.isSuccess(breakdowns) ? breakdowns.value.tools.length : undefined,
+	}
 }

--- a/apps/web/src/routes/agent-sessions/-index.test.tsx
+++ b/apps/web/src/routes/agent-sessions/-index.test.tsx
@@ -44,6 +44,10 @@ vi.mock("@/components/agent-sessions/tools/agent-sessions-tabs", () => ({
 	AgentSessionsTabs: () => null,
 }))
 
+vi.mock("@/lib/agent-sessions/use-tool-analytics", () => ({
+	useAgentSessionsTabCounts: () => ({}),
+}))
+
 vi.mock("@/hooks/use-organization-feature-flags", () => ({
 	useOrganizationFeatureFlags: () => ({ flags: { agentTracing: true }, isLoaded: true }),
 }))

--- a/apps/web/src/routes/agent-sessions/index.tsx
+++ b/apps/web/src/routes/agent-sessions/index.tsx
@@ -29,9 +29,11 @@ import {
 	aiSessionsDistributionsResultAtom,
 	aiSessionsFacetsResultAtom,
 } from "@/lib/services/atoms/warehouse-query-atoms"
-import { resolveEffectiveTimeRange } from "@/hooks/use-effective-time-range"
+import { resolveEffectiveTimeRange, useEffectiveTimeRange } from "@/hooks/use-effective-time-range"
 import { useInfiniteAiSessions } from "@/hooks/use-infinite-ai-sessions"
 import { useOrganizationFeatureFlags } from "@/hooks/use-organization-feature-flags"
+import { useTimezonePreference } from "@/hooks/use-timezone-preference"
+import { useAgentSessionsTabCounts } from "@/lib/agent-sessions/use-tool-analytics"
 
 /**
  * The list's window. There is no picker: sessions are read newest-first over
@@ -118,6 +120,9 @@ function AgentSessionsBody() {
 	// object per render would reset them every time.
 	const searchKey = JSON.stringify(search)
 	const { refreshVersion } = usePageRefreshContext()
+	// Resolved in the selected zone, as `useEffectiveTimeRange` does on the Tools
+	// tab: `7d` starts at that zone's midnight.
+	const { effectiveTimezone } = useTimezonePreference()
 	// "The last week" resolves against now once per mount and once per Reload,
 	// never snapped: the list is newest-first, and an end floored to the cache
 	// grid hid up to a grid interval of the newest sessions on every page load.
@@ -125,8 +130,12 @@ function AgentSessionsBody() {
 	// is what holds the unfiltered facets' and distributions' keys steady — the
 	// job the snap used to do.
 	const { startTime, endTime } = useMemo(
-		() => resolveEffectiveTimeRange(undefined, undefined, AGENT_SESSIONS_WINDOW, { snap: false }),
-		[refreshVersion],
+		() =>
+			resolveEffectiveTimeRange(undefined, undefined, AGENT_SESSIONS_WINDOW, {
+				snap: false,
+				timeZone: effectiveTimezone,
+			}),
+		[refreshVersion, effectiveTimezone],
 	)
 	const filterInputs = useMemo(
 		() => agentSessionsFilterInputs(search, { startTime, endTime }),
@@ -145,6 +154,11 @@ function AgentSessionsBody() {
 		aiSessionsDistributionsResultAtom({ data: { startTime, endTime } }),
 	)
 	const sessions = allData
+	// Both tabs' counts over this week, unfiltered — over the Tools tab's own
+	// resolution of its default window (snapped, unlike the list's), so the reads
+	// are the ones it makes: the numbers match there and survive the switch.
+	const tabCountsWindow = useEffectiveTimeRange(undefined, undefined, AGENT_SESSIONS_WINDOW)
+	const tabCounts = useAgentSessionsTabCounts(tabCountsWindow)
 	const { sortBy, sortDir } = agentSessionsSort(search)
 	const onSortChange = useCallback(
 		(key: AiSessionSortKey) =>
@@ -182,15 +196,23 @@ function AgentSessionsBody() {
 				/>
 			</DashboardLayout.Filters>
 			<DashboardLayout.Content>
-				<DashboardLayout.Sticky>
+				{/* `pb-3` over an unpadded scroll area: the layout's `p-4` on both
+				    stacked 32px between the toolbar and the table. */}
+				<DashboardLayout.Sticky className="pb-3">
 					{/* The Tools tab reads the same spans across every session; this
-					    page reads one session at a time. Two routes, one strip. */}
-					<div className="space-y-2">
-						<AgentSessionsTabs active="sessions" />
+					    page reads one session at a time. Two routes, one strip — with
+					    the Tools page's hairline and 12px gap, so the strip and the
+					    toolbar sit at the same height on both. */}
+					<div className="space-y-3">
+						<AgentSessionsTabs
+							active="sessions"
+							counts={tabCounts}
+							className="border-b border-border"
+						/>
 						{toolbar}
 					</div>
 				</DashboardLayout.Sticky>
-				<DashboardLayout.Scroll>
+				<DashboardLayout.Scroll className="pt-0">
 					{Result.builder(firstPageResult)
 						.onInitial(() => <AgentSessionsListSkeleton />)
 						.onError((error) => (

--- a/apps/web/src/routes/agent-sessions/tools/index.tsx
+++ b/apps/web/src/routes/agent-sessions/tools/index.tsx
@@ -4,6 +4,7 @@ import { Schema } from "effect"
 
 import { Skeleton } from "@maple/ui/components/ui/skeleton"
 
+import { AgentSessionsTabs } from "@/components/agent-sessions/tools/agent-sessions-tabs"
 import { AgentToolsView } from "@/components/agent-sessions/tools/agent-tools-view"
 import { ToolMetricStripLoading } from "@/components/agent-sessions/tools/tool-metric-strip"
 import { QueryErrorState } from "@/components/common/query-error-state"
@@ -25,7 +26,7 @@ import {
 	ToolAnalyticsSearchFields,
 	type ToolAnalyticsSearch,
 } from "@/lib/agent-sessions/tool-search"
-import { useToolAnalytics } from "@/lib/agent-sessions/use-tool-analytics"
+import { useAgentSessionsTabCounts, useToolAnalytics } from "@/lib/agent-sessions/use-tool-analytics"
 import { aiSessionsFacetsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 
 const toolsSearchSchema = Schema.Struct({
@@ -90,7 +91,7 @@ function AgentToolsPageContent() {
 								window={window}
 								preset={preset}
 								onSearchChange={onSearchChange}
-								headerControls={
+								actions={
 									<TimeRangeHeaderControls
 										startTime={search.startTime ?? startTime}
 										endTime={search.endTime ?? endTime}
@@ -125,15 +126,16 @@ function AgentToolsBody({
 	window,
 	preset,
 	onSearchChange,
-	headerControls,
+	actions,
 }: {
 	search: ToolAnalyticsSearch & TimeRangeSearch
 	window: { startTime: string; endTime: string }
 	preset: string
 	onSearchChange: (patch: Partial<ToolAnalyticsSearch>) => void
-	headerControls: ReactNode
+	actions: ReactNode
 }) {
 	const results = useToolAnalytics(search, window)
+	const tabCounts = useAgentSessionsTabCounts(window)
 	// Memoized: it is memo input for the detail links the table builds.
 	const timeRange = useMemo(
 		() => ({
@@ -175,8 +177,16 @@ function AgentToolsBody({
 
 	return Result.builder(results.totals)
 		.onInitial(() => (
-			<div className="flex flex-col gap-5">
-				<Skeleton className="mx-6 mt-6 h-14 w-full max-w-2xl" />
+			<div className="flex flex-col gap-5 pt-4">
+				{/* The real strip while the page waits: it is what must not move when
+				    a reader switches tabs. */}
+				<AgentSessionsTabs
+					active="tools"
+					search={timeRange}
+					counts={tabCounts}
+					className="border-b border-border px-6"
+				/>
+				<Skeleton className="mx-6 h-8 max-w-2xl" />
 				<ToolMetricStripLoading />
 				<Skeleton className="mx-6 h-56" />
 				<Skeleton className="mx-6 h-80" />
@@ -213,7 +223,8 @@ function AgentToolsBody({
 				envOptions={facets?.environments ?? []}
 				windowLabel={preset}
 				timeRange={timeRange}
-				headerControls={headerControls}
+				tabCounts={tabCounts}
+				actions={actions}
 				waiting={result.waiting}
 			/>
 		))


### PR DESCRIPTION
## What changed
- **Tab counts on both pages.** New `useAgentSessionsTabCounts(window)` reads totals + breakdowns over the bare window (no filters): Sessions = `allSessions` (unscoped server-side), Tools = unfiltered breakdown rows (capped at 50). Same numbers on both tabs; hidden until loaded, never a transient 0. Reads stay inside the `agent_tracing`-gated content components.
- **Cache sharing.** With no filters the key is identical to the Tools page's own reads, and the Sessions list's rolling 7d now resolves in the selected timezone like `useEffectiveTimeRange`, so both pages snap to the same window and hit the same atoms (the Sessions page also warms the Tools page's totals/table).
- **Tools page header removed.** Time range + Reload move to the right end of the filter toolbar (`ToolFilterToolbar` `actions` slot). The loading state renders the real tab strip.
- **Vertical alignment.** Hairline tab strip, 16px top inset and 12px toolbar gap on both pages. `DashboardLayout.Sticky` takes a `className`.
- **Sessions page gap.** Sticky `pb-3` + Scroll `pt-0`: about 12px between toolbar and table (was 32px).
- Tool detail page unchanged. Labs mount the strip + toolbar as the routes do.

## Verification
- `vitest` on `agent-tools-view.test.tsx` (34 pass; new: no title + controls at toolbar end, tab counts from props / hidden when unknown)
- `oxlint` on changed files: no new warnings
- Playwright on `/lab/agent-sessions` and `/lab/agent-tools` at 1440x900: tab nav top 16px / 37px tall, search top 65px / 32px tall on both; Sessions table 13px below the search

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791732783&installation_model_id=427786&pr_number=855&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F855&signature=8e86ed76b680a77fc757ee19210de2824f379863e677e7634fcc893ec48a152d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared Sessions and Tools tabs with live item counts across agent session pages.
  * Added right-aligned time-range and reload controls to the Tools toolbar.
  * Tab counts now remain consistent while filters narrow displayed results.
* **Improvements**
  * Session analytics now respect the user’s selected timezone.
  * Updated page spacing, sticky navigation, loading states, and toolbar layout for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->