### PR TITLE
fix(agent-sessions): include sessions up to now on page load

### DIFF
--- a/apps/web/src/routes/agent-sessions/-index.test.tsx
+++ b/apps/web/src/routes/agent-sessions/-index.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+// TEST-SEAM: This focused test replaces process-global modules that have no instance-level injection seam.
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const windows = {
+	list: [] as Array<{ startTime?: string; endTime?: string }>,
+	facets: [] as Array<{ startTime: string; endTime: string }>,
+}
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router")
+	return { ...actual, useNavigate: () => vi.fn() }
+})
+
+vi.mock("@/components/layout/dashboard-layout", () => {
+	const passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>
+	return {
+		DashboardLayout: {
+			Root: passthrough,
+			Breadcrumbs: () => null,
+			Body: passthrough,
+			Filters: passthrough,
+			Content: passthrough,
+			Sticky: passthrough,
+			Scroll: passthrough,
+		},
+	}
+})
+
+vi.mock("@/components/agent-sessions/agent-sessions-list", () => ({
+	AgentSessionsList: () => null,
+	AgentSessionsListSkeleton: () => null,
+}))
+vi.mock("@/components/agent-sessions/agent-sessions-filter-sidebar", () => ({
+	AgentSessionsFilterSidebar: () => null,
+}))
+vi.mock("@/components/agent-sessions/agent-sessions-toolbar", () => ({
+	AgentSessionsToolbar: ({ actions }: { actions: ReactNode }) => <div>{actions}</div>,
+}))
+vi.mock("@/components/agent-sessions/tools/agent-sessions-tabs", () => ({
+	AgentSessionsTabs: () => null,
+}))
+
+vi.mock("@/hooks/use-organization-feature-flags", () => ({
+	useOrganizationFeatureFlags: () => ({ flags: { agentTracing: true }, isLoaded: true }),
+}))
+
+vi.mock("@/hooks/use-infinite-ai-sessions", async () => {
+	const { Result } = await vi.importActual<typeof import("@/lib/effect-atom")>("@/lib/effect-atom")
+	return {
+		useInfiniteAiSessions: (inputs: { startTime?: string; endTime?: string }) => {
+			windows.list.push(inputs)
+			return { firstPageResult: Result.initial(), allData: [], hasNextPage: false }
+		},
+	}
+})
+
+vi.mock("@/lib/services/atoms/warehouse-query-atoms", () => ({
+	aiSessionsFacetsResultAtom: ({ data }: { data: { startTime: string; endTime: string } }) => {
+		windows.facets.push(data)
+		return "facets"
+	},
+	aiSessionsDistributionsResultAtom: () => "distributions",
+}))
+
+vi.mock("@/lib/effect-atom", async () => {
+	const actual = await vi.importActual<typeof import("@/lib/effect-atom")>("@/lib/effect-atom")
+	return { ...actual, useAtomValue: () => actual.Result.initial() }
+})
+
+import * as AgentSessionsRoute from "./index"
+import { component as AgentSessionsPage } from "./index?tsr-split=component"
+
+const lastListWindow = () => {
+	const { startTime, endTime } = windows.list.at(-1)!
+	return { startTime, endTime }
+}
+
+describe("AgentSessionsPage window", () => {
+	beforeEach(() => {
+		windows.list = []
+		windows.facets = []
+		vi.useFakeTimers({ toFake: ["Date"] })
+		vi.setSystemTime(new Date("2026-09-11T10:07:30Z"))
+		vi.spyOn(AgentSessionsRoute.Route, "useSearch").mockReturnValue({})
+	})
+
+	afterEach(() => {
+		cleanup()
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	it("ends at now on a fresh mount, not at the cache grid", () => {
+		render(<AgentSessionsPage />)
+
+		expect(lastListWindow().endTime).toBe("2026-09-11 10:07:30")
+		expect(windows.facets.at(-1)).toEqual(lastListWindow())
+	})
+
+	it("keeps the window across a filter change and rolls it on Reload", () => {
+		const { rerender } = render(<AgentSessionsPage />)
+		const mounted = lastListWindow()
+
+		vi.setSystemTime(new Date("2026-09-11T10:09:00Z"))
+		vi.spyOn(AgentSessionsRoute.Route, "useSearch").mockReturnValue({ hasErrors: true })
+		rerender(<AgentSessionsPage />)
+
+		expect(windows.list.at(-1)).toMatchObject({ ...mounted, hasErrors: true })
+		expect(windows.facets.at(-1)).toEqual(mounted)
+
+		act(() => fireEvent.click(screen.getByRole("button")))
+
+		expect(lastListWindow().endTime).toBe("2026-09-11 10:09:00")
+		expect(windows.facets.at(-1)).toEqual(lastListWindow())
+	})
+})

--- a/apps/web/src/routes/agent-sessions/index.tsx
+++ b/apps/web/src/routes/agent-sessions/index.tsx
@@ -118,18 +118,15 @@ function AgentSessionsBody() {
 	// object per render would reset them every time.
 	const searchKey = JSON.stringify(search)
 	const { refreshVersion } = usePageRefreshContext()
-	// The window rolls forward with every navigation — a filter or sort change
-	// re-resolves "the last week" against now, snapped to the cache grid so a
-	// change within the grid interval keeps its key — and with every Reload.
-	// Once Reload has been pressed the window stops snapping, as in
-	// `useEffectiveTimeRange`: a snapped end would keep the newest sessions out
-	// however many times it is clicked.
+	// "The last week" resolves against now once per mount and once per Reload,
+	// never snapped: the list is newest-first, and an end floored to the cache
+	// grid hid up to a grid interval of the newest sessions on every page load.
+	// A filter or sort change keeps the window rather than re-resolving it, which
+	// is what holds the unfiltered facets' and distributions' keys steady — the
+	// job the snap used to do.
 	const { startTime, endTime } = useMemo(
-		() =>
-			resolveEffectiveTimeRange(undefined, undefined, AGENT_SESSIONS_WINDOW, {
-				snap: refreshVersion === 0,
-			}),
-		[searchKey, refreshVersion],
+		() => resolveEffectiveTimeRange(undefined, undefined, AGENT_SESSIONS_WINDOW, { snap: false }),
+		[refreshVersion],
 	)
 	const filterInputs = useMemo(
 		() => agentSessionsFilterInputs(search, { startTime, endTime }),


### PR DESCRIPTION
- Root cause: `AgentSessionsBody` resolved the 7d window with `snap: refreshVersion === 0`, so every fresh mount floored the end to the 15m cache grid — sessions from the last ≤15m were outside the list/facets/distributions window until Reload, and came back hidden after a browser reload.
- Fix: resolve the window unsnapped, memoized on `refreshVersion` only — once per mount and per Reload. Filter/sort changes reuse the window, so the unfiltered facets/distributions atoms keep their key (what the snap was for).
- Test: `routes/agent-sessions/-index.test.tsx` — mount ends at now (fails on main: `10:00:00` vs `10:07:30`); filter change keeps the window; Reload rolls it.
- No server-side response cache on `aiSessionsInternal.list` (executor caches clients/capabilities only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791732802&installation_model_id=427786&pr_number=856&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F856&signature=9cbe77bbe44bb4c69e03a57fd0858a83543b9bbc42f55e26c3107ffa0fac137c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent session results now keep a consistent time window when filters or sorting change.
  * Initial session searches use the current time without snapping to a cache interval.
  * Selecting **Reload** advances the time window to include the latest data.

* **Tests**
  * Added coverage verifying stable time windows across filtering and correct updates after reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->