### PR TITLE
feat(agent-sessions): poll for new sessions every 5s

### DIFF
--- a/apps/web/src/hooks/use-infinite-ai-sessions.test.tsx
+++ b/apps/web/src/hooks/use-infinite-ai-sessions.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+// TEST-SEAM: The pagination hook consumes a module-global runtime and route-backed atoms.
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { Result } from "@/lib/effect-atom"
+import type { AgentSessionRow } from "@/components/agent-sessions/agent-sessions-list"
+import { AI_SESSIONS_LIVE_POLL_MS, useInfiniteAiSessions } from "./use-infinite-ai-sessions"
+
+const mocks = vi.hoisted(() => ({
+	list: vi.fn(),
+	firstPage: vi.fn(),
+	logClientError: vi.fn(),
+}))
+
+// Details never land here: the rows keep the index's figures, which is all these tests read.
+vi.mock("@/lib/registry", () => ({
+	mapleRuntime: {
+		runPromise: (effect: { list?: unknown }) =>
+			effect.list === undefined ? new Promise(() => {}) : mocks.list(effect.list),
+	},
+}))
+vi.mock("@/lib/services/common/telemetry", () => ({ logClientError: mocks.logClientError }))
+vi.mock("@/api/warehouse/ai-sessions", () => ({
+	listAiSessions: (input: { data: unknown }) => ({ list: input.data }),
+	getAiSessionDetails: (input: { data: unknown }) => ({ details: input.data }),
+}))
+vi.mock("@/lib/services/atoms/warehouse-query-atoms", () => ({
+	listAiSessionsResultAtom: (input: unknown) => input,
+}))
+vi.mock("./use-refreshable-atom-value", () => ({ useRefreshableAtomValue: mocks.firstPage }))
+
+const filters = { startTime: "2026-09-04 12:00:00", endTime: "2026-09-11 12:00:00" }
+const NOW = "2026-09-11T12:10:00Z"
+
+function row(sessionId: string, startTime = "2026-09-11 11:00:00.000000000"): AgentSessionRow {
+	return {
+		sessionId,
+		vendorId: "eve",
+		traceCount: 1,
+		spanCount: 1,
+		errorSpanCount: 0,
+		toolErrorCount: 0,
+		turnErrorCount: 0,
+		serviceNames: [],
+		models: [],
+		agentNames: [],
+		firstAgentName: "",
+		llmCalls: 0,
+		toolCalls: 0,
+		totalTokens: 0,
+		inputTokens: 0,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		outputTokens: 0,
+		reasoningTokens: 0,
+		cost: 0,
+		startTime,
+		endTime: startTime,
+		durationMs: 0,
+	}
+}
+
+const ids = (rows: ReadonlyArray<AgentSessionRow>) => rows.map((r) => r.sessionId)
+const tick = () => act(async () => vi.advanceTimersByTime(AI_SESSIONS_LIVE_POLL_MS))
+
+let visibility: DocumentVisibilityState = "visible"
+
+beforeEach(() => {
+	vi.resetAllMocks()
+	vi.useFakeTimers({ now: new Date(NOW) })
+	visibility = "visible"
+	vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibility)
+	mocks.firstPage.mockReturnValue(Result.success({ data: [row("listed")] }))
+	mocks.list.mockResolvedValue({ data: [] })
+})
+
+afterEach(() => {
+	cleanup()
+	vi.restoreAllMocks()
+	vi.useRealTimers()
+})
+
+describe("useInfiniteAiSessions live poll", () => {
+	it("prepends sessions that started after the list's window, and only those", async () => {
+		mocks.list.mockResolvedValueOnce({
+			data: [
+				row("new", "2026-09-11 12:05:00.000000000"),
+				// Active before the list's end: its figures would be the poll window's slice.
+				row("running", "2026-09-11 11:30:00.000000000"),
+				row("listed", "2026-09-11 12:01:00.000000000"),
+			],
+		})
+		const { result } = renderHook(() => useInfiniteAiSessions({ ...filters, search: "abc" }))
+
+		await tick()
+		expect(mocks.list).toHaveBeenCalledWith({
+			...filters,
+			search: "abc",
+			startTime: "2026-09-11 11:00:00",
+			endTime: "2026-09-11 12:10:05",
+			limit: 50,
+			offset: 0,
+		})
+		expect(ids(result.current.allData)).toEqual(["new", "listed"])
+
+		mocks.list.mockResolvedValueOnce({
+			data: [row("newer", "2026-09-11 12:09:00.000000000"), row("new", "2026-09-11 12:05:00.000000000")],
+		})
+		await tick()
+		expect(ids(result.current.allData)).toEqual(["newer", "new", "listed"])
+	})
+
+	it("pages past the ranked rows only, and drops a live copy a page also holds", async () => {
+		const firstPage = Array.from({ length: 50 }, (_, i) => row(`page-${i}`))
+		mocks.firstPage.mockReturnValue(Result.success({ data: firstPage }))
+		mocks.list.mockResolvedValueOnce({ data: [row("new", "2026-09-11 12:05:00.000000000")] })
+		const { result } = renderHook(() => useInfiniteAiSessions(filters))
+		await tick()
+		expect(result.current.allData).toHaveLength(51)
+
+		mocks.list.mockResolvedValueOnce({ data: [row("new")] })
+		await act(async () => result.current.fetchNextPage())
+		expect(mocks.list).toHaveBeenLastCalledWith({ ...filters, limit: 50, offset: 50 })
+		expect(ids(result.current.allData).filter((id) => id === "new")).toEqual(["new"])
+		expect(ids(result.current.allData).at(-1)).toBe("new")
+	})
+
+	it("skips ticks while hidden or in flight, and polls as the tab becomes visible", async () => {
+		visibility = "hidden"
+		renderHook(() => useInfiniteAiSessions(filters))
+		await tick()
+		expect(mocks.list).not.toHaveBeenCalled()
+
+		let settle!: (page: { data: [] }) => void
+		mocks.list.mockReturnValueOnce(new Promise((resolve) => (settle = resolve)))
+		visibility = "visible"
+		act(() => void document.dispatchEvent(new Event("visibilitychange")))
+		expect(mocks.list).toHaveBeenCalledTimes(1)
+
+		await tick()
+		expect(mocks.list).toHaveBeenCalledTimes(1)
+
+		await act(async () => settle({ data: [] }))
+		await tick()
+		expect(mocks.list).toHaveBeenCalledTimes(2)
+	})
+
+	it("does not poll under another sort or while the first page is waiting", async () => {
+		const { rerender } = renderHook(({ sortBy }) => useInfiniteAiSessions({ ...filters, sortBy }), {
+			initialProps: { sortBy: "cost" as "cost" | undefined },
+		})
+		await tick()
+		mocks.firstPage.mockReturnValue(Result.success({ data: [row("listed")] }, { waiting: true }))
+		rerender({ sortBy: undefined })
+		await tick()
+		expect(mocks.list).not.toHaveBeenCalled()
+	})
+
+	it("logs a failed poll and asks again on the next tick", async () => {
+		const failure = new Error("warehouse down")
+		mocks.list.mockRejectedValueOnce(failure)
+		const { result } = renderHook(() => useInfiniteAiSessions(filters))
+		await tick()
+		expect(mocks.logClientError).toHaveBeenCalledWith("ai_session.live_poll_failed", failure)
+		expect(ids(result.current.allData)).toEqual(["listed"])
+
+		await tick()
+		expect(mocks.list).toHaveBeenCalledTimes(2)
+	})
+
+	it("drops the live sessions when the filters change", async () => {
+		mocks.list.mockResolvedValueOnce({ data: [row("new", "2026-09-11 12:05:00.000000000")] })
+		const { result, rerender } = renderHook(({ search }) => useInfiniteAiSessions({ ...filters, search }), {
+			initialProps: { search: "a" as string | undefined },
+		})
+		await tick()
+		expect(ids(result.current.allData)).toEqual(["new", "listed"])
+
+		rerender({ search: undefined })
+		expect(ids(result.current.allData)).toEqual(["listed"])
+	})
+})

--- a/apps/web/src/hooks/use-infinite-ai-sessions.ts
+++ b/apps/web/src/hooks/use-infinite-ai-sessions.ts
@@ -1,10 +1,12 @@
 import * as React from "react"
 import { Result } from "@/lib/effect-atom"
 import { AI_SESSION_DETAILS_MAX_SESSIONS, type AiSessionDetailsItem } from "@maple/domain/http"
+import { formatWarehouseDateTime, parseWarehouseDateTime } from "@maple/query-engine"
 
 import { getAiSessionDetails, listAiSessions, type ListAiSessionsInput } from "@/api/warehouse/ai-sessions"
 import { listAiSessionsResultAtom } from "@/lib/services/atoms/warehouse-query-atoms"
 import { useRefreshableAtomValue } from "@/hooks/use-refreshable-atom-value"
+import { useMountEffect } from "@/hooks/use-mount-effect"
 import type { AgentSessionRow } from "@/components/agent-sessions/agent-sessions-list"
 import { logClientError } from "@/lib/services/common/telemetry"
 import { mapleRuntime } from "@/lib/registry"
@@ -12,6 +14,17 @@ import { mapleRuntime } from "@/lib/registry"
 export const AI_SESSIONS_PAGE_SIZE = 50
 const PAGE_SIZE = AI_SESSIONS_PAGE_SIZE
 export const MAX_RETAINED_AI_SESSIONS = 500
+export const AI_SESSIONS_LIVE_POLL_MS = 5_000
+/**
+ * How far before the list's end the live poll reads. The page measures a
+ * session — its start and every figure — over the spans inside the window it
+ * is given, so a session already running when the list was read would come
+ * back from a window starting at the list's end looking new, with only its
+ * later spans counted. Read from an hour earlier, such a session starts before
+ * the list's end and is dropped; one idle for longer than that still slips
+ * through, the gap the list has at its own window's start.
+ */
+const LIVE_POLL_LOOKBACK_MS = 60 * 60 * 1000
 
 /**
  * The filter inputs the agent-sessions route assembles (resolved time window +
@@ -41,7 +54,15 @@ interface AdditionalPages {
 	pages: ReadonlyArray<AiSessionsPage>
 }
 
+/** Sessions the live poll found that started after the list's window, newest
+ *  first — tagged like `AdditionalPages`, and for the same reason. */
+interface LiveRows {
+	key: string
+	rows: ReadonlyArray<AgentSessionRow>
+}
+
 const NO_PAGES: ReadonlyArray<AiSessionsPage> = []
+const NO_ROWS: ReadonlyArray<AgentSessionRow> = []
 
 /** A page's ranked count, falling back to its row count for a server that
  *  predates the field. */
@@ -61,6 +82,11 @@ const rankedOf = (page: { data: ReadonlyArray<unknown>; ranked?: number }) => pa
  *
  * Details depend on the session and the counted filters alone, so they
  * outlive a sort or window change: only a counted-filter change discards them.
+ *
+ * Newest first, the list also grows at the top: while the tab is visible, a
+ * poll every few seconds reads the sessions that started since the window's
+ * end and prepends the ones it has not seen. They are not ranked by any page,
+ * so paging never counts them. A row already shown is not refreshed.
  */
 export function useInfiniteAiSessions(filterInputs: AiSessionsFilterInputs) {
 	const filterKey = React.useMemo(() => JSON.stringify(filterInputs), [filterInputs])
@@ -79,12 +105,16 @@ export function useInfiniteAiSessions(filterInputs: AiSessionsFilterInputs) {
 	)
 
 	const [additionalPages, setAdditionalPages] = React.useState<AdditionalPages>({ key: filterKey, pages: NO_PAGES })
+	const [liveRows, setLiveRows] = React.useState<LiveRows>({ key: filterKey, rows: NO_ROWS })
 	const [isFetchingNextPage, setIsFetchingNextPage] = React.useState(false)
 	const [paginationStopped, setPaginationStopped] = React.useState(false)
 	const [details, setDetails] = React.useState<ReadonlyMap<string, AiSessionDetailsItem>>(() => new Map())
 	const filterKeyRef = React.useRef(filterKey)
 	const detailsKeyRef = React.useRef(detailsKey)
 	const isFetchingRef = React.useRef(false)
+	// Not reset on a filter change: a poll still out for the previous filters
+	// holds the next one back until it settles, rather than running beside it.
+	const isPollingRef = React.useRef(false)
 	// Sessions whose details have been asked for under the current counted
 	// filters — a page is detailed once, not on every render its rows are part
 	// of. A request that fails gives its ids back, so the next render retries.
@@ -93,6 +123,7 @@ export function useInfiniteAiSessions(filterInputs: AiSessionsFilterInputs) {
 	React.useEffect(() => {
 		filterKeyRef.current = filterKey
 		setAdditionalPages({ key: filterKey, pages: NO_PAGES })
+		setLiveRows({ key: filterKey, rows: NO_ROWS })
 		setIsFetchingNextPage(false)
 		setPaginationStopped(false)
 		isFetchingRef.current = false
@@ -107,13 +138,74 @@ export function useInfiniteAiSessions(filterInputs: AiSessionsFilterInputs) {
 	// The previous filters' pages are still in state for the render a filter
 	// change lands on; they are not this filter's rows.
 	const pages = additionalPages.key === filterKey ? additionalPages.pages : NO_PAGES
+	const live = liveRows.key === filterKey ? liveRows.rows : NO_ROWS
 
 	// The rows as the pages returned them, before their details.
 	const pageRows = React.useMemo<ReadonlyArray<AgentSessionRow>>(() => {
 		const firstPageData = Result.isSuccess(firstPageResult) ? firstPageResult.value.data : []
-		const additionalData = pages.flatMap((p) => p.data)
-		return [...firstPageData, ...additionalData].slice(0, MAX_RETAINED_AI_SESSIONS)
-	}, [firstPageResult, pages])
+		const paged = [...firstPageData, ...pages.flatMap((p) => p.data)]
+		// A page read after the poll can hold a session the poll found first; the
+		// page's copy is the one measured over the list's window.
+		const pagedIds = new Set(paged.map((row) => row.sessionId))
+		return [...live.filter((row) => !pagedIds.has(row.sessionId)), ...paged].slice(0, MAX_RETAINED_AI_SESSIONS)
+	}, [firstPageResult, pages, live])
+
+	// Prepending is only right for the order new sessions sort first in, and a
+	// retained or failed first page has no window of its own to poll past.
+	const livePollEnabled =
+		Result.isSuccess(firstPageResult) &&
+		!firstPageResult.waiting &&
+		(filterInputs.sortBy ?? "startTime") === "startTime" &&
+		(filterInputs.sortDir ?? "desc") === "desc"
+
+	const pollLive = React.useEffectEvent(() => {
+		if (!livePollEnabled || document.visibilityState !== "visible" || isPollingRef.current) return
+		isPollingRef.current = true
+		const currentKey = filterKey
+		const listEnd = filterInputs.endTime
+		mapleRuntime
+			.runPromise(
+				listAiSessions({
+					data: {
+						...filterInputs,
+						startTime: formatWarehouseDateTime(parseWarehouseDateTime(listEnd) - LIVE_POLL_LOOKBACK_MS),
+						endTime: formatWarehouseDateTime(Date.now()),
+						limit: PAGE_SIZE,
+						offset: 0,
+					},
+				}),
+			)
+			.then((result) => {
+				if (filterKeyRef.current !== currentKey) return
+				setLiveRows((prev) => {
+					const known = new Set(prev.rows.map((row) => row.sessionId))
+					// Started after the list's end, so every span was in the poll's
+					// window. A row's start is a fixed-width warehouse literal and the
+					// end its second-precision prefix, so the string order is the
+					// instant order.
+					const added = result.data.filter((row) => row.startTime > listEnd && !known.has(row.sessionId))
+					if (added.length === 0) return prev
+					return { key: currentKey, rows: [...added, ...prev.rows].slice(0, MAX_RETAINED_AI_SESSIONS) }
+				})
+			})
+			// The list is still the list; the next tick asks again.
+			.catch((error) => logClientError("ai_session.live_poll_failed", error))
+			.finally(() => {
+				isPollingRef.current = false
+			})
+	})
+
+	useMountEffect(() => {
+		// react-doctor-disable-next-line react-doctor/rules-of-hooks -- React Doctor does not recognize useMountEffect as an Effect Event boundary.
+		const poll = () => pollLive()
+		const interval = setInterval(poll, AI_SESSIONS_LIVE_POLL_MS)
+		// A tab coming back catches up at once rather than on the next tick.
+		document.addEventListener("visibilitychange", poll)
+		return () => {
+			clearInterval(interval)
+			document.removeEventListener("visibilitychange", poll)
+		}
+	})
 
 	React.useEffect(() => {
 		// A retained result is the previous filters' page, shown dimmed while the


### PR DESCRIPTION
- Agent Sessions list polls every 5s while the tab is visible (and at once when it becomes visible again); sessions that started after the list's window are prepended, newest first
- No overlapping polls; failures log `ai_session.live_poll_failed` and the next tick retries; no UI change
- Live rows are keyed to the filters (reset on filter change / Reload), don't count toward the pagination offset, are deduped against pages, go through the details fetch, and respect the 500-row cap
- Poll window is `[list end - 1h, now]`, keeping only rows whose first agent span is after the list's end: `aiSessionPageQuery` measures a session's start and every figure over the spans inside the window, so a window starting exactly at the list's end would return an already-running session as "new" with partial figures
- Limitations: default sort (`startTime desc`) only; rows already shown are not refreshed; a session idle for over an hour before the list's end can still come back as new with partial figures (same gap the list has at its window start); more than a page (50) of new sessions between two polls leaves a hole until Reload; scroll position is not anchored when rows are prepended while scrolled down

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791733004&installation_model_id=427786&pr_number=857&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F857&signature=40c65d14b74a554a5a67e096a0b8be7f557cbeca2eda01981600e3b2cf038be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI session lists now automatically surface newly started sessions while the page is visible.
  - New sessions appear at the top of the list without duplicating entries already loaded through pagination.
  - Live updates pause when the page is hidden, during active polling, or when the selected sorting and loading conditions are unsupported.
  - Newly discovered sessions are cleared when list filters change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->