### PR TITLE
ci(ios): build against a generic simulator destination

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -72,13 +72,18 @@ jobs:
             # host app, which needs a Clerk publishable key and a Keychain
             # entitlement that an unsigned CI build does not have. Every test
             # worth having is in the MapleAPI package above, which needs neither.
+            #
+            # The destination is generic on purpose. A build needs an SDK, not a
+            # bootable device, and the runtimes on the runner follow whatever
+            # Xcode `latest-stable` currently resolves to — a named device pin
+            # breaks the moment an image roll stops shipping that model.
             - name: Build app
               run: |
                   set -o pipefail
                   xcodebuild build \
                     -project Maple.xcodeproj \
                     -scheme Maple \
-                    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+                    -destination 'generic/platform=iOS Simulator' \
                     -skipPackagePluginValidation \
                     -skipMacroValidation \
                     CODE_SIGNING_ALLOWED=NO \


### PR DESCRIPTION
## Problem

The "Build and test" job failed on run `34624004698` with:

```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
{ platform:iOS Simulator, name:iPhone 17 Pro }
```

A re-run of the identical commit passed, and the same job had been green a few hours earlier on another branch. Nothing in the repo changed, so this is runner drift rather than a code failure.

## Cause

The "Build app" step pinned a named device while "Select Xcode" resolves `latest-stable` on `macos-15`. The simulator runtimes and pre-created devices follow whatever Xcode the runner image currently calls latest-stable, so an image or Xcode roll can remove that device name and break the build with no commit behind it.

## Fix

That step runs `xcodebuild build`, not `test` — deliberately, per the comment directly above it. A build resolves an SDK and never boots anything, so the destination only has to name a platform:

```
-destination 'generic/platform=iOS Simulator'
```

Verified the step is still build-only and that it is the last step in the job, so nothing downstream depends on a concrete booted device. The `swift test` step for the MapleAPI package runs earlier and needs no simulator, so it is untouched.

## On pinning `xcode-version`

Left at `latest-stable` on purpose, and not bundled into this change.

A hard pin does not fix this failure: a pinned Xcode still needs the named device to exist, so the destination change is what actually removes the flake. It also trades a rare flake for a guaranteed hard failure later, because `setup-xcode` can only select versions the runner image still carries, and images retire older Xcodes on a schedule. The app targets iOS 18.0 and builds unsigned with no version-sensitive tooling, so there is little reproducibility to gain here.

If reproducible CI is wanted later, the right shape is a pin plus a scheduled bump, which is a separate decision from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MapleTechLabs/codesmith/maple/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791738245&installation_model_id=427786&pr_number=858&repository=MapleTechLabs%2Fmaple&return_to=https%3A%2F%2Fgithub.com%2FMapleTechLabs%2Fmaple%2Fpull%2F858&signature=3693aca152dac1ff1e52913c9f8d50f816694e56a719a279260e166fc74560f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved iOS build compatibility by targeting a generic iOS Simulator instead of a specific device model.
  - Reduced the risk of build failures when available simulator models change on CI runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->