### PR TITLE
fix(deps): finish an OpenRouter turn whose stream carries no usage block

### DIFF
--- a/apps/api/src/platform/Llm.test.ts
+++ b/apps/api/src/platform/Llm.test.ts
@@ -469,15 +469,18 @@ describe("streamed usage — reasoning tokens reported outside the completion to
  * declared, `reasoning-end` and `text-end` — only from a chunk carrying a `usage` block. OpenRouter
  * does not always send one, and a stream that ends without it produced no finish part at all: the
  * agent engine then rejects the turn with `ModelProtocolError: Model response ended without a
- * finish part` after the model has already answered, and the model-call span records no usage, no
- * cost and no assistant output — which is what an Agent Session shows as a call that cost nothing
- * and said nothing.
+ * finish part` after the model has already answered, and the pass it recovers has neither the
+ * assistant's message nor the tool calls in it.
  *
  * Measured in production between 2026-09-10 and 2026-09-12: 518 of 539 failed investigation passes
  * died on exactly that error, and OpenRouter's own Broadcast trace for the same
  * `gen_ai.response.id` recorded the generation as complete, `finish_reason: tool_calls`, with a
  * full token count. The patch appends a synthetic terminal chunk when the stream ends without one,
  * so the flush runs exactly once either way.
+ *
+ * What it does NOT restore is the accounting. Nothing reported usage, so the finish part carries
+ * none, and the model-call span stamps no `gen_ai.usage.*` and no `gen_ai.usage.cost` — the turn
+ * still reads as a call that cost nothing. Only the provider can close that half.
  */
 describe("streamed completion — a stream that ends without a usage block", () => {
 	it.live("still emits the finish part, carrying the reason the stream declared", () =>

--- a/apps/api/src/platform/Llm.test.ts
+++ b/apps/api/src/platform/Llm.test.ts
@@ -10,8 +10,8 @@
  * The fake responds 400, which the provider classifies as a non-retryable invalid request. That
  * keeps the run to a single request with no backoff; the resulting failure is expected and ignored.
  */
-import { Effect, Layer, Stream } from "effect"
-import { LanguageModel } from "effect/unstable/ai"
+import { Effect, Layer, Schema, Stream } from "effect"
+import { LanguageModel, Tool, Toolkit } from "effect/unstable/ai"
 import { FetchHttpClient } from "effect/unstable/http"
 import { describe, it } from "@effect/vitest"
 import { expect } from "vitest"
@@ -313,47 +313,80 @@ const disjointReasoningUsage = {
 	completion_tokens_details: { reasoning_tokens: 321 },
 }
 
-const sseBody = (usage: Record<string, unknown>): string =>
-	[
+/**
+ * A streamed completion, as chunks on the wire.
+ *
+ * `chunks` are the content chunks; `terminal` is the last one, which is where OpenRouter puts the
+ * usage block. Both are overridable because the two things these tests pin — how a usage block is
+ * folded, and whether the terminal chunk is recognised as terminal at all — are facts about
+ * different chunks.
+ */
+const sseBody = (
+	usage: Record<string, unknown>,
+	options: {
+		readonly chunks?: ReadonlyArray<Record<string, unknown>>
+		readonly terminalChoices?: ReadonlyArray<Record<string, unknown>>
+		/** Send the stream through to `[DONE]` with no usage block on any chunk. */
+		readonly omitUsage?: boolean
+	} = {},
+): string => {
+	const envelope = {
+		id: "gen-1",
+		object: "chat.completion.chunk",
+		created: 1_789_056_870,
+		model: "z-ai/glm-5.3-flash",
+	}
+	const chunks = options.chunks ?? [
+		{ choices: [{ index: 0, delta: { role: "assistant", content: "hi" } }] },
+	]
+	return [
+		...chunks.flatMap((chunk) => [`data: ${JSON.stringify({ ...envelope, ...chunk })}`, ""]),
 		`data: ${JSON.stringify({
-			id: "gen-1",
-			object: "chat.completion.chunk",
-			created: 1_789_056_870,
-			model: "z-ai/glm-5.3-flash",
-			choices: [{ index: 0, delta: { role: "assistant", content: "hi" } }],
-		})}`,
-		"",
-		`data: ${JSON.stringify({
-			id: "gen-1",
-			object: "chat.completion.chunk",
-			created: 1_789_056_870,
-			model: "z-ai/glm-5.3-flash",
-			choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
-			usage,
+			...envelope,
+			choices: options.terminalChoices ?? [{ index: 0, delta: {}, finish_reason: "stop" }],
+			...(options.omitUsage === true ? undefined : { usage }),
 		})}`,
 		"",
 		"data: [DONE]",
 		"",
 	].join("\n")
+}
 
-/** Stream one completion off a fake transport and return the run's `finish` part. */
-const streamFinishPart = (usage: Record<string, unknown>) =>
+/**
+ * The one tool the streaming fixtures declare. A `tool-call` part is decoded against the toolkit
+ * the call declared, so a stream that returns one is only readable with the tool in hand.
+ */
+const listServices = Tool.make("list_services", { parameters: Schema.Struct({}) })
+
+/** Stream one completion off a fake transport and return every part it emitted. */
+const streamParts = (usage: Record<string, unknown>, options?: Parameters<typeof sseBody>[1]) =>
 	Effect.gen(function* () {
 		const fakeFetch: typeof globalThis.fetch = async () =>
-			new Response(sseBody(usage), {
+			new Response(sseBody(usage, options), {
 				status: 200,
 				headers: { "content-type": "text/event-stream" },
 			})
 
 		const model = resolveTriageModel(openRouterEnv)
-		const parts = yield* LanguageModel.streamText({ prompt: "hi" }).pipe(
+		return yield* LanguageModel.streamText({
+			prompt: "hi",
+			toolkit: Toolkit.make(listServices),
+			// What the agent engine sends: the run owns tool execution, the model call only reports
+			// the calls it was asked for.
+			disableToolCallResolution: true,
+		}).pipe(
 			Stream.runCollect,
 			// One provide, not a chain: the model layer needs the clients the LLM stack builds, so
 			// they go in as a single merged layer rather than two lifecycles stacked on each other.
 			Effect.provide(Layer.provide(model.layer, layerLlm(openRouterEnv))),
 			Effect.provideService(FetchHttpClient.Fetch, fakeFetch),
 		)
+	})
 
+/** Stream one completion off a fake transport and return the run's `finish` part. */
+const streamFinishPart = (usage: Record<string, unknown>, options?: Parameters<typeof sseBody>[1]) =>
+	Effect.gen(function* () {
+		const parts = yield* streamParts(usage, options)
 		const finish = parts.find((part) => part.type === "finish")
 		if (finish === undefined) return yield* Effect.die("the stream carried no finish part")
 		return finish
@@ -410,3 +443,80 @@ describe("streamed usage — reasoning tokens reported outside the completion to
 		}),
 	)
 })
+
+/**
+ * Guards the second `@effect/ai-openrouter` patch in `patches/`.
+ *
+ * The stream decoder emits the turn's `finish` part — and with it the tool calls the model
+ * declared, `reasoning-end` and `text-end` — only from a chunk carrying a `usage` block. OpenRouter
+ * does not always send one, and a stream that ends without it produced no finish part at all: the
+ * agent engine then rejects the turn with `ModelProtocolError: Model response ended without a
+ * finish part` after the model has already answered, and the model-call span records no usage, no
+ * cost and no assistant output — which is what an Agent Session shows as a call that cost nothing
+ * and said nothing.
+ *
+ * Measured in production between 2026-09-10 and 2026-09-12: 518 of 539 failed investigation passes
+ * died on exactly that error, and OpenRouter's own Broadcast trace for the same
+ * `gen_ai.response.id` recorded the generation as complete, `finish_reason: tool_calls`, with a
+ * full token count. The patch appends a synthetic terminal chunk when the stream ends without one,
+ * so the flush runs exactly once either way.
+ */
+describe("streamed completion — a stream that ends without a usage block", () => {
+	it.live("still emits the finish part, carrying the reason the stream declared", () =>
+		Effect.gen(function* () {
+			const finish = yield* streamFinishPart(disjointReasoningUsage, { omitUsage: true })
+
+			expect(finish.reason).toBe("stop")
+			// Nothing reported usage, and nothing may invent it: the reader takes every field as
+			// optional, and a zero would be indistinguishable from a free call.
+			expect(finish.usage.inputTokens.total).toBeUndefined()
+			expect(finish.usage.outputTokens.total).toBeUndefined()
+		}),
+	)
+
+	it.live("flushes the tool calls the turn declared", () =>
+		Effect.gen(function* () {
+			// The tool calls are only forwarded by the same flush, so losing it loses the turn's
+			// answer as well as its accounting.
+			const parts = yield* streamParts(disjointReasoningUsage, {
+				omitUsage: true,
+				chunks: [
+					{
+						choices: [
+							{
+								index: 0,
+								delta: {
+									role: "assistant",
+									tool_calls: [
+										{
+											index: 0,
+											id: "call-1",
+											type: "function",
+											function: { name: "list_services", arguments: "{}" },
+										},
+									],
+								},
+							},
+						],
+					},
+				],
+				terminalChoices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+			})
+
+			expect(parts.find((part) => part.type === "tool-call")).toMatchObject({
+				name: "list_services",
+				params: {},
+			})
+			expect(parts.find((part) => part.type === "finish")?.reason).toBe("tool-calls")
+		}),
+	)
+
+	it.live("emits exactly one finish part when the usage block does arrive", () =>
+		Effect.gen(function* () {
+			const parts = yield* streamParts(disjointReasoningUsage)
+
+			expect(parts.filter((part) => part.type === "finish")).toHaveLength(1)
+		}),
+	)
+})
+

--- a/apps/api/src/platform/Llm.test.ts
+++ b/apps/api/src/platform/Llm.test.ts
@@ -316,10 +316,9 @@ const disjointReasoningUsage = {
 /**
  * A streamed completion, as chunks on the wire.
  *
- * `chunks` are the content chunks; `terminal` is the last one, which is where OpenRouter puts the
- * usage block. Both are overridable because the two things these tests pin — how a usage block is
- * folded, and whether the terminal chunk is recognised as terminal at all — are facts about
- * different chunks.
+ * `chunks` are the content chunks; the last chunk is the terminal one, which is where OpenRouter
+ * puts the usage block. Both halves are overridable because the two things these tests pin — how a
+ * usage block is folded, and what happens when none arrives — are facts about different chunks.
  */
 const sseBody = (
 	usage: Record<string, unknown>,
@@ -474,10 +473,13 @@ describe("streamed completion — a stream that ends without a usage block", () 
 		}),
 	)
 
-	it.live("flushes the tool calls the turn declared", () =>
+	it.live("flushes a tool call whose parameters never completed", () =>
 		Effect.gen(function* () {
-			// The tool calls are only forwarded by the same flush, so losing it loses the turn's
-			// answer as well as its accounting.
+			// A tool call is emitted as soon as its accumulated arguments parse, so a complete one
+			// survives either way. One left half-written — which is what a stream that stops early
+			// leaves behind — is only forwarded by this flush, with its parameters coerced to `{}`.
+			// Without it the turn carries no tool call at all, so the pass the engine recovers has
+			// no answer in it.
 			const parts = yield* streamParts(disjointReasoningUsage, {
 				omitUsage: true,
 				chunks: [
@@ -492,7 +494,7 @@ describe("streamed completion — a stream that ends without a usage block", () 
 											index: 0,
 											id: "call-1",
 											type: "function",
-											function: { name: "list_services", arguments: "{}" },
+											function: { name: "list_services", arguments: '{"servi' },
 										},
 									],
 								},

--- a/apps/api/src/platform/Llm.test.ts
+++ b/apps/api/src/platform/Llm.test.ts
@@ -325,8 +325,10 @@ const sseBody = (
 	options: {
 		readonly chunks?: ReadonlyArray<Record<string, unknown>>
 		readonly terminalChoices?: ReadonlyArray<Record<string, unknown>>
-		/** Send the stream through to `[DONE]` with no usage block on any chunk. */
+		/** Send the terminal chunk, and `[DONE]` after it, with no usage block on any chunk. */
 		readonly omitUsage?: boolean
+		/** Send no terminal chunk at all: content chunks, then `[DONE]`. */
+		readonly omitTerminal?: boolean
 	} = {},
 ): string => {
 	const envelope = {
@@ -338,14 +340,20 @@ const sseBody = (
 	const chunks = options.chunks ?? [
 		{ choices: [{ index: 0, delta: { role: "assistant", content: "hi" } }] },
 	]
+	const terminal =
+		options.omitTerminal === true
+			? []
+			: [
+					`data: ${JSON.stringify({
+						...envelope,
+						choices: options.terminalChoices ?? [{ index: 0, delta: {}, finish_reason: "stop" }],
+						...(options.omitUsage === true ? undefined : { usage }),
+					})}`,
+					"",
+				]
 	return [
 		...chunks.flatMap((chunk) => [`data: ${JSON.stringify({ ...envelope, ...chunk })}`, ""]),
-		`data: ${JSON.stringify({
-			...envelope,
-			choices: options.terminalChoices ?? [{ index: 0, delta: {}, finish_reason: "stop" }],
-			...(options.omitUsage === true ? undefined : { usage }),
-		})}`,
-		"",
+		...terminal,
 		"data: [DONE]",
 		"",
 	].join("\n")
@@ -357,8 +365,15 @@ const sseBody = (
  */
 const listServices = Tool.make("list_services", { parameters: Schema.Struct({}) })
 
+/**
+ * How one streaming fixture is shaped: the wire, plus whether the call declares a tool. Only a
+ * fixture that returns a tool call declares one — a `tool-call` part is decoded against the
+ * toolkit the call was made with, and the calls without one are the plain-completion shape.
+ */
+type StreamFixture = Parameters<typeof sseBody>[1] & { readonly declareTool?: boolean }
+
 /** Stream one completion off a fake transport and return every part it emitted. */
-const streamParts = (usage: Record<string, unknown>, options?: Parameters<typeof sseBody>[1]) =>
+const streamParts = (usage: Record<string, unknown>, options: StreamFixture = {}) =>
 	Effect.gen(function* () {
 		const fakeFetch: typeof globalThis.fetch = async () =>
 			new Response(sseBody(usage, options), {
@@ -369,10 +384,14 @@ const streamParts = (usage: Record<string, unknown>, options?: Parameters<typeof
 		const model = resolveTriageModel(openRouterEnv)
 		return yield* LanguageModel.streamText({
 			prompt: "hi",
-			toolkit: Toolkit.make(listServices),
-			// What the agent engine sends: the run owns tool execution, the model call only reports
-			// the calls it was asked for.
-			disableToolCallResolution: true,
+			...(options.declareTool === true
+				? {
+						toolkit: Toolkit.make(listServices),
+						// What the agent engine sends: the run owns tool execution, the model call only
+						// reports the calls it was asked for.
+						disableToolCallResolution: true,
+					}
+				: undefined),
 		}).pipe(
 			Stream.runCollect,
 			// One provide, not a chain: the model layer needs the clients the LLM stack builds, so
@@ -383,7 +402,7 @@ const streamParts = (usage: Record<string, unknown>, options?: Parameters<typeof
 	})
 
 /** Stream one completion off a fake transport and return the run's `finish` part. */
-const streamFinishPart = (usage: Record<string, unknown>, options?: Parameters<typeof sseBody>[1]) =>
+const streamFinishPart = (usage: Record<string, unknown>, options?: StreamFixture) =>
 	Effect.gen(function* () {
 		const parts = yield* streamParts(usage, options)
 		const finish = parts.find((part) => part.type === "finish")
@@ -473,6 +492,27 @@ describe("streamed completion — a stream that ends without a usage block", () 
 		}),
 	)
 
+	it.live("closes the assistant's message, which is what the session renders", () =>
+		Effect.gen(function* () {
+			// `text-end` comes from the same flush. A turn that never closes its text is the
+			// "said nothing" half of the report, and it survives a finish part on its own.
+			const parts = yield* streamParts(disjointReasoningUsage, { omitUsage: true })
+
+			expect(parts.map((part) => part.type)).toContain("text-end")
+		}),
+	)
+
+	it.live("finishes a stream that stops without a terminal chunk at all", () =>
+		Effect.gen(function* () {
+			// The truncated shape, as opposed to a terminal chunk that merely omits its usage: no
+			// chunk ever declared a reason, so the turn finishes under the decoder's own default
+			// rather than not finishing.
+			const finish = yield* streamFinishPart(disjointReasoningUsage, { omitTerminal: true })
+
+			expect(finish.reason).toBe("other")
+		}),
+	)
+
 	it.live("flushes a tool call whose parameters never completed", () =>
 		Effect.gen(function* () {
 			// A tool call is emitted as soon as its accumulated arguments parse, so a complete one
@@ -482,6 +522,7 @@ describe("streamed completion — a stream that ends without a usage block", () 
 			// no answer in it.
 			const parts = yield* streamParts(disjointReasoningUsage, {
 				omitUsage: true,
+				declareTool: true,
 				chunks: [
 					{
 						choices: [
@@ -517,6 +558,42 @@ describe("streamed completion — a stream that ends without a usage block", () 
 		Effect.gen(function* () {
 			const parts = yield* streamParts(disjointReasoningUsage)
 
+			expect(parts.filter((part) => part.type === "finish")).toHaveLength(1)
+		}),
+	)
+
+	it.live("does not re-forward a tool call the stream already completed", () =>
+		Effect.gen(function* () {
+			// A tool call whose arguments parse is emitted there and then, and dropped from the
+			// pending set. The flush re-walks that set, so a call still listed would reach the run
+			// twice — and the run would execute the tool twice.
+			const parts = yield* streamParts(disjointReasoningUsage, {
+				omitUsage: true,
+				declareTool: true,
+				chunks: [
+					{
+						choices: [
+							{
+								index: 0,
+								delta: {
+									role: "assistant",
+									tool_calls: [
+										{
+											index: 0,
+											id: "call-1",
+											type: "function",
+											function: { name: "list_services", arguments: "{}" },
+										},
+									],
+								},
+							},
+						],
+					},
+				],
+				terminalChoices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+			})
+
+			expect(parts.filter((part) => part.type === "tool-call")).toHaveLength(1)
 			expect(parts.filter((part) => part.type === "finish")).toHaveLength(1)
 		}),
 	)

--- a/patches/@effect%2Fai-openrouter@4.0.0-rc.112.patch
+++ b/patches/@effect%2Fai-openrouter@4.0.0-rc.112.patch
@@ -1,23 +1,32 @@
 diff --git a/dist/OpenRouterLanguageModel.js b/dist/OpenRouterLanguageModel.js
-index 371be3d891c1c3f901cac2622b08a34de8f25338..cd6a2fb2d31123d04eff2b2010e1017bf196918a 100644
+index 371be3d891c1c3f901cac2622b08a34de8f25338..ceee35db73ddae032e28dc240ef812bbeaf4654b 100644
 --- a/dist/OpenRouterLanguageModel.js
 +++ b/dist/OpenRouterLanguageModel.js
-@@ -717,7 +717,13 @@ const makeStreamResponse = /*#__PURE__*/Effect.fnUntraced(function* ({
+@@ -717,7 +717,22 @@ const makeStreamResponse = /*#__PURE__*/Effect.fnUntraced(function* ({
        reasoning: undefined
      }
    };
 -  return stream.pipe(Stream.mapEffect(Effect.fnUntraced(function* (event) {
 +  // Patched (maple): a stream that ends without a usage block still has to
 +  // finish. See the terminal-chunk patch at the tail of this function.
++  //
++  // The synthetic chunk carries every field a real one is required to have
++  // except `id` — which must stay absent, because a value there would emit a
++  // second `response-metadata` part naming a response the stream never
++  // identified. Every branch below is guarded against what it does not carry,
++  // and these three keep it that way the next time one of them grows a read.
 +  let finishEmitted = false;
 +  return stream.pipe(Stream.concat(Stream.suspend(() => finishEmitted ? Stream.empty : Stream.make({
++    object: "chat.completion.chunk",
++    created: 0,
++    model: "",
 +    choices: [],
 +    maple_terminal: true
 +  }))), Stream.mapEffect(Effect.fnUntraced(function* (event) {
      const parts = [];
      if (Predicate.isNotUndefined(event.error)) {
        finishReason = "error";
-@@ -993,7 +999,16 @@ const makeStreamResponse = /*#__PURE__*/Effect.fnUntraced(function* ({
+@@ -993,7 +1008,16 @@ const makeStreamResponse = /*#__PURE__*/Effect.fnUntraced(function* ({
      }
      // Usage is only emitted by the last part of the stream, so we need to
      // handle flushing any remaining text / reasoning / tool calls
@@ -35,7 +44,7 @@ index 371be3d891c1c3f901cac2622b08a34de8f25338..cd6a2fb2d31123d04eff2b2010e1017b
        // Fix for Gemini 3 thoughtSignature: when there are tool calls with encrypted
        // reasoning (thoughtSignature), the model returns 'stop' but expects continuation.
        // Override to 'tool-calls' so the SDK knows to continue the conversation.
-@@ -1071,6 +1086,8 @@ const makeStreamResponse = /*#__PURE__*/Effect.fnUntraced(function* ({
+@@ -1071,6 +1095,8 @@ const makeStreamResponse = /*#__PURE__*/Effect.fnUntraced(function* ({
          response: buildHttpResponseDetails(response),
          metadata
        });
@@ -44,7 +53,7 @@ index 371be3d891c1c3f901cac2622b08a34de8f25338..cd6a2fb2d31123d04eff2b2010e1017b
      }
      return parts;
    })), Stream.flattenIterable);
-@@ -1317,16 +1334,32 @@ const getUsage = usage => {
+@@ -1317,16 +1343,32 @@ const getUsage = usage => {
    const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
    const cacheWriteTokens = usage.prompt_tokens_details?.cache_write_tokens ?? 0;
    const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens ?? 0;

--- a/patches/@effect%2Fai-openrouter@4.0.0-rc.112.patch
+++ b/patches/@effect%2Fai-openrouter@4.0.0-rc.112.patch
@@ -1,8 +1,50 @@
 diff --git a/dist/OpenRouterLanguageModel.js b/dist/OpenRouterLanguageModel.js
-index 371be3d891c1c3f901cac2622b08a34de8f25338..9fa9a806fc65125f35212de458b788566eeb465f 100644
+index 371be3d891c1c3f901cac2622b08a34de8f25338..cd6a2fb2d31123d04eff2b2010e1017bf196918a 100644
 --- a/dist/OpenRouterLanguageModel.js
 +++ b/dist/OpenRouterLanguageModel.js
-@@ -1317,16 +1317,32 @@ const getUsage = usage => {
+@@ -717,7 +717,13 @@ const makeStreamResponse = /*#__PURE__*/Effect.fnUntraced(function* ({
+       reasoning: undefined
+     }
+   };
+-  return stream.pipe(Stream.mapEffect(Effect.fnUntraced(function* (event) {
++  // Patched (maple): a stream that ends without a usage block still has to
++  // finish. See the terminal-chunk patch at the tail of this function.
++  let finishEmitted = false;
++  return stream.pipe(Stream.concat(Stream.suspend(() => finishEmitted ? Stream.empty : Stream.make({
++    choices: [],
++    maple_terminal: true
++  }))), Stream.mapEffect(Effect.fnUntraced(function* (event) {
+     const parts = [];
+     if (Predicate.isNotUndefined(event.error)) {
+       finishReason = "error";
+@@ -993,7 +999,16 @@ const makeStreamResponse = /*#__PURE__*/Effect.fnUntraced(function* ({
+     }
+     // Usage is only emitted by the last part of the stream, so we need to
+     // handle flushing any remaining text / reasoning / tool calls
+-    if (Predicate.isNotUndefined(event.usage)) {
++    //
++    // Patched (maple): `|| event.maple_terminal`. OpenRouter does not always
++    // send the usage block, and this flush is where the turn's `finish` part,
++    // its accumulated tool calls, `reasoning-end` and `text-end` are all
++    // emitted — so a stream that ends without one used to deliver no finish
++    // part at all, and with it neither the tool calls the model declared nor
++    // any accounting. The synthetic terminal chunk concatenated above reaches
++    // this branch when nothing else did; `usage` then stays as initialized,
++    // whose fields are all optional to the reader.
++    if (Predicate.isNotUndefined(event.usage) || event.maple_terminal === true) {
+       // Fix for Gemini 3 thoughtSignature: when there are tool calls with encrypted
+       // reasoning (thoughtSignature), the model returns 'stop' but expects continuation.
+       // Override to 'tool-calls' so the SDK knows to continue the conversation.
+@@ -1071,6 +1086,8 @@ const makeStreamResponse = /*#__PURE__*/Effect.fnUntraced(function* ({
+         response: buildHttpResponseDetails(response),
+         metadata
+       });
++      // Patched (maple): tells the synthetic terminal chunk to stand down.
++      finishEmitted = true;
+     }
+     return parts;
+   })), Stream.flattenIterable);
+@@ -1317,16 +1334,32 @@ const getUsage = usage => {
    const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
    const cacheWriteTokens = usage.prompt_tokens_details?.cache_write_tokens ?? 0;
    const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens ?? 0;


### PR DESCRIPTION
Agent Sessions show most of Maple's own investigation sessions with no assistant output,
no token count and no cost. The cause is not attribution on ingest — the spans are
stamped and grouped correctly. The model calls themselves are being thrown away.

## What production says

Since the agents moved onto Effect AI and effect-agent (#815, 2026-09-10), zero-token
model calls went from 0.2–1.7% a day to 90%:

| day | `maple` LLM calls | of those, 0 tokens |
| --- | --- | --- |
| 2026-09-05 | 2039 | 5 |
| 2026-09-06 | 2137 | 11 |
| 2026-09-07 | 2230 | 38 |
| 2026-09-11 | 532 | 477 |
| 2026-09-12 | 72 | 53 |

518 of 539 failed investigation passes on 2026-09-11 failed with
`ModelProtocolError: Model response ended without a finish part` — after the model had
already answered. OpenRouter's own Broadcast trace for the same `gen_ai.response.id`
records every one of those generations as complete, `finish_reason: tool_calls`, with a
full token count and a real cost.

## The defect

`@effect/ai-openrouter` emits the turn's `finish` part only from a chunk that carries a
`usage` block, and that same branch is where the accumulated tool calls, `reasoning-end`
and `text-end` are flushed. OpenRouter does not always send one — both
`stream_options.include_usage` and `usage.include` are requested — and when it does not,
the stream ends with nothing: no finish part, so the agent engine rejects the turn, and
no `text-end` and no pending tool calls, so the pass the engine recovers has neither the
assistant's message nor the calls it declared in it.

## The fix

Patch the decoder — alongside the usage-arithmetic patch already in the same file — to
append a synthetic terminal chunk when the stream ends without one, so the flush runs
exactly once either way. When a usage block does arrive nothing changes; when it does
not, the turn finishes with the reason the stream declared and usage whose fields the
reader already takes as optional.

The Llm tests drive the real client over a fake transport and fail without the patch:
reverting the three edits in the installed dist fails 5 of 27, restoring them passes all.

## What this does not fix

- **The accounting.** Nothing reported usage, so the finish part carries none, the span
  stamps no `gen_ai.usage.*` and no `gen_ai.usage.cost`, and the engine consumes the turn
  as a real call with zero tokens. Those sessions get their answer back but still read as
  free. Only the provider — or a `/generation?id=` backfill — can close that half. No
  budget is evaded today: Maple sets `maxTurns`, never `tokenBudget` or
  `costBudgetMicrousd`. If a token budget is ever introduced, a provider omitting usage
  makes it unenforceable.
- **Error triage keyed on the old string.** A stream truncated before any `finish_reason`
  used to die on `Model response ended without a finish part`; it now finishes under the
  decoder's default reason and fails later as `Model stopped without a final answer
  (other)`, or as `Model declared Tool Calls with incompatible finish reason other`.
  Same outcome, different message.
- **Prompts.** The other half of the original report is already fixed on `main` by #853:
  model-call spans carried no `gen_ai.input.messages` on 2026-09-10 (0/24) and carry it
  on every call now (70/70 on 2026-09-12).
- **Recovered passes reading as clean.** A pass recovered from a failure annotates
  `maple.agent.recovered_failure` but leaves the `invoke_agent` span `Ok` with no
  `error.type`, so Agent Sessions counted 527 recovered failures as healthy sessions and
  this bug was invisible there. Worth its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming responses when no terminal event is received, ensuring streams finish cleanly.
  - Ensured assistant text and incomplete tool calls are properly finalized.
  - Prevented duplicate completed tool calls.
  - Corrected token usage calculations to avoid negative input or output totals.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->